### PR TITLE
Add GitHub Actions workflow, skip CI

### DIFF
--- a/.github/workflows/pr-core.yml
+++ b/.github/workflows/pr-core.yml
@@ -53,5 +53,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install toolchains
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        target: wasm32-unknown-unknown
+
     - name: Test examples
       run: ./scripts/test.sh

--- a/.github/workflows/pr-gstd.yml
+++ b/.github/workflows/pr-gstd.yml
@@ -45,5 +45,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install toolchains
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        target: wasm32-unknown-unknown
+
     - name: Test examples
       run: ./scripts/test.sh


### PR DESCRIPTION
- Add CI config for PRs to `gstd`.
- Add examples testing stage to the core's CI.