### PR TITLE
demo-chat: Send message with member name or room name instead of ProgramId.

### DIFF
--- a/examples/chat/bot/src/lib.rs
+++ b/examples/chat/bot/src/lib.rs
@@ -21,7 +21,7 @@ struct State {
 
 impl State {
     fn set_name(&mut self, name: &'static str) {
-        self.name = &name;
+        self.name = name;
     }
     fn name(&self) -> &'static str {
         self.name

--- a/examples/chat/room/src/lib.rs
+++ b/examples/chat/room/src/lib.rs
@@ -14,10 +14,13 @@ struct State {
 
 impl State {
     fn set_room_name(&mut self, name: &'static str) {
-        self.room_name = &name;
+        self.room_name = name;
     }
     fn add_member(&mut self, member: (ProgramId, String)) {
         self.members.push(member);
+    }
+    fn get_member(&self, id: ProgramId) -> Option<&(ProgramId, String)> {
+        self.members.iter().find(|(member, _name)| *member == id)
     }
     fn room_name(&self) -> &'static str {
         ext::debug(&format!("room_name ptr -> {:p}", self.room_name));
@@ -60,8 +63,11 @@ unsafe fn room(room_msg: RoomMessage) {
                     send_member(
                         *id,
                         MemberMessage::Room(format!(
-                            "#{}: {}",
-                            u64::from_le_bytes(msg::source().as_slice()[0..8].try_into().unwrap()),
+                            "{}: {}",
+                            STATE
+                                .get_member(msg::source())
+                                .unwrap_or(&(ProgramId::default(), STATE.room_name().to_string()))
+                                .1,
                             text
                         )),
                     )

--- a/test/json/test_chat.json
+++ b/test/json/test_chat.json
@@ -50,9 +50,17 @@
                     "step": 4,
                     "messages": [
                         {
-                            "destination": 2  
+                            "payload": {
+                                "kind": "bytes",
+                                "value": "0x012c746573743a2068656c6c6f"
+                            },
+                            "destination": 2
                         },
                         {
+                            "payload": {
+                                "kind": "bytes",
+                                "value": "0x012c746573743a2068656c6c6f"
+                            },
                             "destination": 3
                         }
                     ],


### PR DESCRIPTION
Fixes gear-node tests for message external origin.
payload:
old -`#0: hello`
new - `test: hello`
@gear-tech/dev 
