### PR TITLE
Tracking overall gas allowance for a block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4216,6 +4216,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "gear-common",
+ "gear-core",
  "gear-node-rti",
  "pallet-authorship",
  "pallet-balances",

--- a/core-runner/src/runner.rs
+++ b/core-runner/src/runner.rs
@@ -37,6 +37,8 @@ impl Default for Config {
     }
 }
 
+type GasRequest = (ProgramId, ProgramId, u64);
+
 /// Result of one or more message handling.
 #[derive(Debug, Default, Clone)]
 pub struct RunNextResult {
@@ -49,7 +51,7 @@ pub struct RunNextResult {
     /// Gas that was spent.
     pub gas_spent: Vec<(ProgramId, u64)>,
     /// Gas transfer requests.
-    pub gas_requests: Vec<(ProgramId, ProgramId, u64)>,
+    pub gas_requests: Vec<GasRequest>,
 }
 
 impl RunNextResult {
@@ -66,6 +68,16 @@ impl RunNextResult {
         RunNextResult {
             handled: 1,
             traps: 1,
+            ..Default::default()
+        }
+    }
+
+    /// Add request all the gas to be reserved for the destination
+    pub(crate) fn refund(gas_request: GasRequest) -> Self {
+        RunNextResult {
+            handled: 1,
+            traps: 1,
+            gas_requests: vec![gas_request],
             ..Default::default()
         }
     }
@@ -155,7 +167,7 @@ impl<MQ: MessageQueue, PS: ProgramStorage> Runner<MQ, PS> {
     ///
     /// Runner will return actual number of messages that was handled.
     /// Messages with no destination won't be handled.
-    pub fn run_next(&mut self) -> RunNextResult {
+    pub fn run_next(&mut self, max_gas_limit: u64) -> RunNextResult {
         let next_message = match self.message_queue.dequeue() {
             Some(msg) => msg,
             None => {
@@ -172,12 +184,32 @@ impl<MQ: MessageQueue, PS: ProgramStorage> Runner<MQ, PS> {
             }
             RunNextResult::log()
         } else {
-            let mut program = match self.program_storage.get(next_message.dest()) {
+            let gas_limit = next_message.gas_limit();
+            let next_message_source = next_message.source();
+            let next_message_dest = next_message.dest();
+
+            let mut program = match self.program_storage.get(next_message_dest) {
                 Some(program) => program,
                 None => {
-                    return RunNextResult::trap();
+                    // Reserve the entire `gas_limit` so that it is transferred to the addressee eventually
+                    return RunNextResult::refund((
+                        next_message_source,
+                        next_message_dest,
+                        gas_limit,
+                    ));
                 }
             };
+
+            if gas_limit > max_gas_limit {
+                // Re-queue the message to be processed in one of the following blocks
+                log::info!(
+                    "Message gas limit of {} exceeds the remaining block gas allowance of {}",
+                    gas_limit,
+                    max_gas_limit
+                );
+                self.message_queue.queue(next_message);
+                return RunNextResult::empty();
+            }
 
             let instrumeted_code = match gas::instrument(program.code()) {
                 Ok(code) => code,
@@ -194,11 +226,7 @@ impl<MQ: MessageQueue, PS: ProgramStorage> Runner<MQ, PS> {
                 .collect();
 
             let mut context = self.create_context(allocations);
-
-            let gas_limit = next_message.gas_limit();
             let next_message_id = next_message.id();
-            let next_message_source = next_message.source();
-            let next_message_dest = next_message.dest();
 
             let run_result = run(
                 &mut self.env,
@@ -698,7 +726,7 @@ mod tests {
 
         runner.queue_message(1001.into(), 1, 1.into(), Vec::new(), u64::max_value(), 0);
 
-        assert_eq!(runner.run_next().traps, 1);
+        assert_eq!(runner.run_next(u64::MAX).traps, 1);
 
         let msg = vec![
             1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 2, 4, 6, 8, 10, 12, 14, 16,
@@ -716,8 +744,8 @@ mod tests {
             0,
         );
 
-        assert_eq!(runner.run_next().traps, 1); // this is handling of automatic reply when first message was trapped; it will also fail
-        runner.run_next();
+        assert_eq!(runner.run_next(u64::MAX).traps, 1); // this is handling of automatic reply when first message was trapped; it will also fail
+        runner.run_next(u64::MAX);
 
         let InMemoryStorage {
             program_storage, ..
@@ -798,7 +826,7 @@ mod tests {
             )
             .expect("failed to init program");
 
-        runner.run_next();
+        runner.run_next(u64::MAX);
 
         assert_eq!(
             runner
@@ -817,7 +845,7 @@ mod tests {
             0,
         );
 
-        runner.run_next();
+        runner.run_next(u64::MAX);
 
         assert_eq!(
             runner
@@ -898,7 +926,7 @@ mod tests {
             )
             .expect("Failed to init program");
 
-        runner.run_next();
+        runner.run_next(u64::MAX);
 
         assert_eq!(
             runner
@@ -918,7 +946,7 @@ mod tests {
             0,
         );
 
-        runner.run_next();
+        runner.run_next(u64::MAX);
 
         assert_eq!(
             runner
@@ -967,7 +995,7 @@ mod tests {
 
         runner.queue_message(caller_id, 1, 1.into(), vec![0], gas_limit, 0);
 
-        let result = runner.run_next();
+        let result = runner.run_next(u64::MAX);
         assert_eq!(result.gas_spent.len(), 1);
         assert_eq!(result.gas_left.len(), 1);
         assert_eq!(result.gas_requests.len(), 1);

--- a/examples/async/src/lib.rs
+++ b/examples/async/src/lib.rs
@@ -38,12 +38,12 @@ fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
 }
 
 async fn handle_async() {
-    msg::send(0.into(), b"LOG", u64::MAX);
+    msg::send(0.into(), b"LOG", 10_000_000);
     let dest = unsafe { PING_PROGRAM_ID };
-    let another_reply = msg_async::send_and_wait_for_reply(dest, b"PING", u64::MAX, 0).await;
+    let another_reply = msg_async::send_and_wait_for_reply(dest, b"PING", 30_000_000, 0).await;
     let another_reply = String::from_utf8(another_reply).expect("Invalid reply: should be utf-8");
     if another_reply == "PONG" {
-        msg::reply(b"PING", u64::MAX, 0);
+        msg::reply(b"PING", 20_000_000, 0);
     }
 }
 

--- a/examples/chat/bot/src/lib.rs
+++ b/examples/chat/bot/src/lib.rs
@@ -62,7 +62,7 @@ fn bot(message: MemberMessage) {
 pub fn send_room(id: ProgramId, msg: RoomMessage) {
     let mut encoded = vec![];
     msg.encode_to(&mut encoded);
-    msg::send(id, &encoded, u64::MAX);
+    msg::send(id, &encoded, 10_000_000);
 }
 
 #[no_mangle]

--- a/examples/chat/room/src/lib.rs
+++ b/examples/chat/room/src/lib.rs
@@ -35,7 +35,7 @@ static mut STATE: State = State {
 pub fn send_member(id: ProgramId, msg: MemberMessage) {
     let mut encoded = vec![];
     msg.encode_to(&mut encoded);
-    msg::send(id, &encoded, u64::MAX);
+    msg::send(id, &encoded, 10_000_000);
 }
 
 #[no_mangle]

--- a/examples/collector/src/lib.rs
+++ b/examples/collector/src/lib.rs
@@ -22,7 +22,7 @@ pub unsafe extern "C" fn handle() {
                 acc
             });
 
-        msg::send(msg::source(), collapsed.as_bytes(), 1000000000);
+        msg::send(msg::source(), collapsed.as_bytes(), 10_000_000);
 
         COUNTER = 0;
     } else {

--- a/examples/condensator/src/lib.rs
+++ b/examples/condensator/src/lib.rs
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn handle() {
         msg::send(
             0.into(),
             format!("Discharged: {}", CHARGE).as_bytes(),
-            1000000000,
+            10_000_000,
         );
         DISCHARGE_HISTORY.push(CHARGE);
         CHARGE = 0;

--- a/examples/fib/src/lib.rs
+++ b/examples/fib/src/lib.rs
@@ -23,7 +23,7 @@ pub unsafe extern "C" fn handle() {
     msg::send(
         msg::source(),
         &make_fib(new_msg as usize)[new_msg as usize - 1].to_ne_bytes(),
-        u64::MAX,
+        10_000_000,
     );
 
     ext::debug(&format!(

--- a/examples/ping/src/lib.rs
+++ b/examples/ping/src/lib.rs
@@ -10,7 +10,7 @@ pub unsafe extern "C" fn handle() {
     let new_msg = String::from_utf8(msg::load()).expect("Invalid message: should be utf-8");
 
     if new_msg == "PING" {
-        msg::reply(b"PONG", u64::MAX, 0);
+        msg::reply(b"PONG", 10_000_000, 0);
     }
 
     MESSAGE_LOG.push(new_msg);
@@ -27,7 +27,7 @@ pub unsafe extern "C" fn handle() {
 
 #[no_mangle]
 pub unsafe extern "C" fn handle_reply() {
-    msg::reply(b"PONG", u64::MAX, 0);
+    msg::reply(b"PONG", 10_000_000, 0);
 }
 
 #[no_mangle]

--- a/examples/sum/src/lib.rs
+++ b/examples/sum/src/lib.rs
@@ -38,7 +38,7 @@ pub unsafe extern "C" fn handle() {
     msg::send(
         STATE.send_to(),
         &(new_msg + new_msg).to_ne_bytes(),
-        u64::MAX,
+        4_000_000_000,
     );
 
     ext::debug(&format!(

--- a/examples/vec/src/lib.rs
+++ b/examples/vec/src/lib.rs
@@ -18,7 +18,7 @@ pub unsafe extern "C" fn handle() {
         &v[new_msg as usize - 1],
         v[new_msg as usize - 1]
     ));
-    msg::send(msg::source(), &(v.len() as i32).to_ne_bytes(), u64::MAX);
+    msg::send(msg::source(), &(v.len() as i32).to_ne_bytes(), 10_000_000);
     ext::debug(&format!(
         "{:?} total message(s) stored: ",
         MESSAGE_LOG.len()

--- a/node-rti/src/lib.rs
+++ b/node-rti/src/lib.rs
@@ -96,10 +96,10 @@ impl ExecutionReport {
 
 #[runtime_interface]
 pub trait GearExecutor {
-    fn process() -> Result<ExecutionReport, Error> {
+    fn process(max_gas_limit: u64) -> Result<ExecutionReport, Error> {
         let mut runner = crate::runner::new();
 
-        let result = runner.run_next();
+        let result = runner.run_next(max_gas_limit);
 
         let Storage { message_queue, .. } = runner.complete();
 
@@ -153,7 +153,7 @@ pub trait GearExecutor {
             value,
         );
 
-        let result = runner.run_next();
+        let result = runner.run_next(u64::MAX);
 
         runner.complete();
 

--- a/pallets/gear/Cargo.toml
+++ b/pallets/gear/Cargo.toml
@@ -34,6 +34,7 @@ pallet-authorship = { version = "3.0.0", default-features = false, git = "https:
 serde = "1.0.101"
 env_logger = "0.8"
 wabt = "0.10"
+gear-core = { path = "../../core" }
 
 [features]
 default = ['std']

--- a/pallets/gear/src/mock.rs
+++ b/pallets/gear/src/mock.rs
@@ -17,9 +17,10 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate as pallet_gear;
-use frame_support::traits::FindAuthor;
+use frame_support::traits::{FindAuthor, OnFinalize, OnInitialize};
 use frame_support::{construct_runtime, parameter_types};
 use frame_system as system;
+use frame_system::RawOrigin;
 use sp_core::H256;
 use sp_runtime::testing::Header;
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
@@ -87,11 +88,16 @@ impl system::Config for Test {
     type OnSetCode = ();
 }
 
+parameter_types! {
+    pub const BlockGasLimit: u64 = 100_000;
+}
+
 impl pallet_gear::Config for Test {
     type Event = Event;
     type Currency = Balances;
     type SubmitWeightPerByte = SubmitWeightPerByte;
     type MessagePerByte = MessagePerByte;
+    type BlockGasLimit = BlockGasLimit;
 }
 
 pub struct FixedBlockAuthor;
@@ -119,11 +125,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
         .unwrap();
 
     pallet_balances::GenesisConfig::<Test> {
-        balances: vec![
-            (1, 1_000_000_000_000_u128),
-            (2, 1_u128),
-            (BLOCK_AUTHOR, 1_u128),
-        ],
+        balances: vec![(1, 100_000_u128), (2, 1_u128), (BLOCK_AUTHOR, 1_u128)],
     }
     .assimilate_storage(&mut t)
     .unwrap();
@@ -131,4 +133,14 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
     let mut ext = sp_io::TestExternalities::new(t);
     ext.execute_with(|| System::set_block_number(1));
     ext
+}
+
+pub fn run_to_block(n: u64) {
+    while System::block_number() < n {
+        System::on_finalize(System::block_number());
+        System::set_block_number(System::block_number() + 1);
+        System::on_initialize(System::block_number());
+        Gear::on_initialize(System::block_number());
+        Gear::process_queue(RawOrigin::None.into()).expect("Failed to process queue");
+    }
 }

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -22,6 +22,7 @@ use codec::Encode;
 use common::{self, IntermediateMessage, Origin as _};
 use frame_support::{assert_noop, assert_ok};
 use frame_system::RawOrigin;
+use gear_core::program::{Program, ProgramId};
 use sp_core::H256;
 
 pub(crate) fn init_logger() {
@@ -41,7 +42,7 @@ fn parse_wat(source: &str) -> Vec<u8> {
 }
 
 #[test]
-fn submit_program_enqueues_message() {
+fn submit_program_works() {
     let wat = r#"
     (module
     )"#;
@@ -74,13 +75,12 @@ fn submit_program_enqueues_message() {
         };
         assert_eq!(msg_origin, 1_u64.into_origin());
         assert_eq!(msg_code, code);
-
         System::assert_last_event(crate::Event::NewProgram(id).into());
     })
 }
 
 #[test]
-fn submit_program_fails_with_insufficient_balance() {
+fn submit_program_expected_failure() {
     let wat = r#"
     (module
     )"#;
@@ -89,29 +89,98 @@ fn submit_program_fails_with_insufficient_balance() {
     new_test_ext().execute_with(|| {
         let code = parse_wat(wat);
 
+        // Insufficient account balance to reserve gas
         assert_noop!(
             Pallet::<Test>::submit_program(
                 Origin::signed(2),
                 code.clone(),
                 b"salt".to_vec(),
                 Vec::new(),
-                10_000u64,
+                10_000_u64,
                 10_u128
             ),
             Error::<Test>::NotEnoughBalanceForReserve
+        );
+
+        // Gas limit is too high
+        assert_noop!(
+            Pallet::<Test>::submit_program(
+                Origin::signed(1),
+                code.clone(),
+                b"salt".to_vec(),
+                Vec::new(),
+                100_001_u64,
+                0_u128
+            ),
+            Error::<Test>::GasLimitTooHigh
+        );
+    })
+}
+#[test]
+fn submit_program_fails_on_duplicate_id() {
+    let wat = r#"(module
+        (import "env" "memory" (memory 1))
+        (export "init" (func $init))
+        (func $init)
+    )"#;
+
+    init_logger();
+    new_test_ext().execute_with(|| {
+        let code = parse_wat(wat);
+
+        assert_ok!(Pallet::<Test>::submit_program(
+            Origin::signed(1).into(),
+            code.clone(),
+            b"salt".to_vec(),
+            Vec::new(),
+            10_000u64,
+            0_u128
+        ));
+
+        // Finalize block to let queue processing run
+        run_to_block(2);
+
+        // By now this program id is already in the storage
+        assert_noop!(
+            Pallet::<Test>::submit_program(
+                Origin::signed(1),
+                code.clone(),
+                b"salt".to_vec(),
+                Vec::new(),
+                10_000_u64,
+                0_u128
+            ),
+            Error::<Test>::ProgramAlreadyExists
         );
     })
 }
 
 #[test]
-fn send_message_adds_to_queue() {
+fn send_message_works() {
     init_logger();
+
     new_test_ext().execute_with(|| {
+        // Make sure we have a program in the program storage
+        let program_id = H256::from_low_u64_be(1001);
+        let program = Program::new(
+            ProgramId::from_slice(&program_id[..]),
+            parse_wat(
+                r#"(module
+                    (import "env" "memory" (memory 1))
+                    (export "handle" (func $handle))
+                    (func $handle)
+                )"#,
+            ),
+            Default::default(),
+        )
+        .unwrap();
+        common::native::set_program(program);
+
         assert_ok!(Pallet::<Test>::send_message(
             Origin::signed(1).into(),
-            H256::from_low_u64_be(255),
+            program_id,
             b"payload".to_vec(),
-            10_000u64,
+            10_000_u64,
             0_u128
         ));
 
@@ -128,42 +197,77 @@ fn send_message_adds_to_queue() {
             _ => Default::default(),
         };
         assert_eq!(msg_id, id);
-    })
-}
 
-#[test]
-fn send_message_transfers_value() {
-    init_logger();
-    new_test_ext().execute_with(|| {
-        assert_eq!(Balances::free_balance(1), 1_000_000_000_000);
+        // Sending message to a non-program address works as a simple value transfer
+        assert_eq!(Balances::free_balance(1), 90_000);
         assert_eq!(Balances::free_balance(2), 1);
-
         assert_ok!(Pallet::<Test>::send_message(
             Origin::signed(1).into(),
             2.into_origin(),
             Vec::new(),
-            0_u64,
-            1000000_u128,
+            10_000_u64,
+            20_000_u128,
         ));
-
-        assert_eq!(Balances::free_balance(1), 999_999_000_000);
-        assert_eq!(Balances::free_balance(2), 1000001);
+        // `value + gas_limit` have been deducted from the sender's balance
+        assert_eq!(Balances::free_balance(1), 60_000);
+        // However, only `value` has been transferred to the recepient yet
+        assert_eq!(Balances::free_balance(2), 20_001);
+        // The `gas_limit` part will be released to the recepient in the next block
+        run_to_block(2);
+        assert_eq!(Balances::free_balance(2), 30_001);
     })
 }
 
 #[test]
-fn send_message_fails_with_insufficient_balance() {
+fn send_message_expected_failure() {
     init_logger();
     new_test_ext().execute_with(|| {
+        let program_id = H256::from_low_u64_be(1001);
+        let program = Program::new(
+            ProgramId::from_slice(&program_id[..]),
+            parse_wat(
+                r#"(module
+                    (import "env" "memory" (memory 1))
+                )"#,
+            ),
+            Default::default(),
+        )
+        .unwrap();
+        common::native::set_program(program);
+
         assert_noop!(
             Pallet::<Test>::send_message(
                 Origin::signed(2).into(),
-                H256::from_low_u64_be(255),
+                program_id,
                 b"payload".to_vec(),
-                10_000u64,
+                10_000_u64,
                 0_u128
             ),
             Error::<Test>::NotEnoughBalanceForReserve
+        );
+
+        // Sending message to a non-program address triggers balance tansfer
+        assert_noop!(
+            Pallet::<Test>::send_message(
+                Origin::signed(2).into(),
+                H256::from_low_u64_be(1002),
+                b"payload".to_vec(),
+                0_u64,
+                100_u128
+            ),
+            pallet_balances::Error::<Test>::InsufficientBalance
+        );
+
+        // Gas limit too high
+        assert_noop!(
+            Pallet::<Test>::send_message(
+                Origin::signed(1).into(),
+                program_id,
+                b"payload".to_vec(),
+                100_001_u64,
+                0_u128
+            ),
+            Error::<Test>::GasLimitTooHigh
         );
     })
 }
@@ -192,7 +296,6 @@ fn messages_processing_works() {
         let code = parse_wat(wat);
         let program_id = H256::from_low_u64_be(1001);
 
-        // Normal use-case: program initialized first, then called
         MessageQueue::<Test>::put(vec![
             IntermediateMessage::InitProgram {
                 origin: 1.into_origin(),
@@ -225,30 +328,6 @@ fn messages_processing_works() {
 
         // `InitProgram` doesn't increase the counter, but the reply message does; hence 1.
         assert_eq!(Gear::messages_processed(), 1);
-
-        // First message is sent to a non-existing program - and should get into log.
-        // Second message still gets processed thereby adding 1 to the total processed messages counter.
-        MessageQueue::<Test>::put(vec![
-            IntermediateMessage::DispatchMessage {
-                id: H256::from_low_u64_be(102),
-                origin: 1.into_origin(),
-                destination: 2.into_origin(),
-                payload: Vec::new(),
-                gas_limit: 10000,
-                value: 100,
-            },
-            IntermediateMessage::DispatchMessage {
-                id: H256::from_low_u64_be(103),
-                origin: 1.into_origin(),
-                destination: program_id,
-                payload: Vec::new(),
-                gas_limit: 10000,
-                value: 0,
-            },
-        ]);
-        crate::Pallet::<Test>::process_queue(none_origin.clone()).expect("Failed to process queue");
-        System::assert_last_event(crate::Event::MessagesDequeued(2).into());
-        assert_eq!(Gear::messages_processed(), 3); // Counter not reset, 1 added
     })
 }
 
@@ -448,5 +527,174 @@ fn unused_gas_released_back_works() {
             Balances::free_balance(1),
             external_origin_initial_balance.saturating_sub(6_000)
         );
+    })
+}
+
+#[test]
+fn block_gas_limit_works() {
+    // A module with $handle function being worth 6000 gas
+    let wat1 = r#"
+	(module
+		(import "env" "gr_send" (func $send (param i32 i32 i32 i64 i32)))
+		(import "env" "memory" (memory 1))
+		(export "handle" (func $handle))
+		(export "init" (func $init))
+		(func $handle
+			i32.const 0
+			i32.const 32
+			i32.const 32
+			i64.const 1000000000
+			i32.const 1024
+			call $send
+		)
+		(func $init)
+	)"#;
+
+    // A module with $handle function being worth 94000 gas
+    let wat2 = r#"
+	(module
+		(import "env" "gr_send" (func $send (param i32 i32 i32 i64 i32)))
+        (import "env" "gr_charge" (func $charge (param i64)))
+		(import "env" "memory" (memory 1))
+		(export "handle" (func $handle))
+		(export "init" (func $init))
+		(func $init)
+        (func $doWork (param $size i32)
+            (local $counter i32)
+            i32.const 0
+            set_local $counter
+            loop $while
+                get_local $counter
+                i32.const 1
+                i32.add
+                set_local $counter
+                get_local $counter
+                get_local $size
+                i32.lt_s
+                if
+                    br $while
+                end
+            end $while
+        )
+        (func $handle
+            i32.const 10
+            call $doWork
+		)
+	)"#;
+
+    init_logger();
+    new_test_ext().execute_with(|| {
+        let code1 = parse_wat(wat1);
+        let code2 = parse_wat(wat2);
+        let pid1 = H256::from_low_u64_be(1001);
+        let pid2 = H256::from_low_u64_be(1002);
+
+        MessageQueue::<Test>::put(vec![
+            IntermediateMessage::InitProgram {
+                origin: 1.into_origin(),
+                code: code1,
+                program_id: pid1,
+                payload: Vec::new(),
+                gas_limit: 10_000,
+                value: 0,
+            },
+            IntermediateMessage::DispatchMessage {
+                id: H256::from_low_u64_be(102),
+                origin: 1.into_origin(),
+                destination: pid1,
+                payload: Vec::new(),
+                gas_limit: 10_000,
+                value: 0,
+            },
+            IntermediateMessage::DispatchMessage {
+                id: H256::from_low_u64_be(103),
+                origin: 1.into_origin(),
+                destination: pid1,
+                payload: Vec::new(),
+                gas_limit: 10_000,
+                value: 100,
+            },
+            IntermediateMessage::InitProgram {
+                origin: 1.into_origin(),
+                code: code2,
+                program_id: pid2,
+                payload: Vec::new(),
+                gas_limit: 10_000,
+                value: 0,
+            },
+        ]);
+
+        // Run to block #2 where the queue processing takes place
+        run_to_block(2);
+
+        System::assert_last_event(crate::Event::MessagesDequeued(4).into());
+        assert_eq!(Gear::gas_allowance(), 88_000);
+
+        // Run to the next block to reset the gas limit
+        run_to_block(3);
+        assert_eq!(Gear::gas_allowance(), 100_000);
+        assert!(MessageQueue::<Test>::get().is_none());
+
+        // Add more messages to queue
+        // Total `gas_limit` of three messages exceeds the block gas limit
+        // Messages #1 abd #3 take 6000 gas
+        // Message #2 takes 94000 gas
+        MessageQueue::<Test>::put(vec![
+            IntermediateMessage::DispatchMessage {
+                id: H256::from_low_u64_be(104),
+                origin: 1.into_origin(),
+                destination: pid1,
+                payload: Vec::new(),
+                gas_limit: 10_000,
+                value: 0,
+            },
+            IntermediateMessage::DispatchMessage {
+                id: H256::from_low_u64_be(105),
+                origin: 1.into_origin(),
+                destination: pid2,
+                payload: Vec::new(),
+                gas_limit: 95_000,
+                value: 100,
+            },
+            IntermediateMessage::DispatchMessage {
+                id: H256::from_low_u64_be(106),
+                origin: 1.into_origin(),
+                destination: pid1,
+                payload: Vec::new(),
+                gas_limit: 20_000,
+                value: 200,
+            },
+        ]);
+
+        run_to_block(4);
+        // Message #2 steps beyond the block gas allowance and is requeued
+        // Message #1 is dequeued and processed, message #3 stays in the queue:
+        //
+        // | 1 |        | 3 |
+        // | 2 |  ===>  | 2 |
+        // | 3 |        |   |
+        //
+        System::assert_last_event(crate::Event::MessagesDequeued(1).into());
+        assert_eq!(Gear::gas_allowance(), 94_000);
+
+        // Run to the next block to reset the gas limit
+        run_to_block(5);
+        // Message #3 get dequeued and processed
+        // Message #2 gas limit still exceeds the remaining allowance:
+        //
+        // | 3 |        | 2 |
+        // | 2 |  ===>  |   |
+        //
+        System::assert_last_event(crate::Event::MessagesDequeued(1).into());
+        assert_eq!(Gear::gas_allowance(), 94_000);
+
+        run_to_block(6);
+        // This time message #2 makes it into the block:
+        //
+        // | 2 |        |   |
+        // |   |  ===>  |   |
+        //
+        System::assert_last_event(crate::Event::MessagesDequeued(1).into());
+        assert_eq!(Gear::gas_allowance(), 6_000);
     })
 }

--- a/rpc-tests/index.js
+++ b/rpc-tests/index.js
@@ -176,7 +176,7 @@ function submitProgram(api, sudoPair, program, salt, programs) {
       initMessage = program.init_message.value;
     }
   }
-  return api.tx.gear.submitProgram(api.createType('Bytes', Array.from(binary)), salt, initMessage, 1000000000, 0);
+  return api.tx.gear.submitProgram(api.createType('Bytes', Array.from(binary)), salt, initMessage, 10000000000, 0);
 }
 
 function runWithTimeout(promise, time) {
@@ -291,7 +291,7 @@ async function processFixture(api, sudoPair, fixture, programs) {
     } else {
       msg = message.payload.value;
     }
-    txs.push(api.tx.gear.sendMessage(programs[message.destination], msg, 1000000000, 0));
+    txs.push(api.tx.gear.sendMessage(programs[message.destination], msg, 10000000000, 0));
   }
 
   await api.tx.utility.batch(txs).signAndSend(sudoPair, { nonce: -1 });
@@ -368,7 +368,7 @@ async function main() {
       "IntermediateMessage": {
         "_enum": {
           "InitProgram": {
-            "external_origin": "H256",
+            "origin": "H256",
             "program_id": "H256",
             "code": "Vec<u8>",
             "payload": "Vec<u8>",
@@ -377,15 +377,16 @@ async function main() {
           },
           "DispatchMessage": {
             "id": "H256",
-            "route": "MessageRoute",
+            "origin": "H256",
+            "destination": "H256",
             "payload": "Vec<u8>",
             "gas_limit": "u64",
             "value": "u128",
           }
         }
       },
-      "MessageError": {
-        "_enum": ["ValueTransfer", "Dispatch"]
+      "Reason": {
+        "_enum": ["ValueTransfer", "Dispatch", "BlockGasLimitExceeded"]
       },
     },
   });

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -57,7 +57,7 @@ pub use pallet_timestamp::Call as TimestampCall;
 use pallet_transaction_payment::CurrencyAdapter;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
-pub use sp_runtime::{Perbill, Permill};
+pub use sp_runtime::{Perbill, Percent, Permill};
 
 /// Import the template pallet.
 pub use pallet_gear;
@@ -318,12 +318,16 @@ impl pallet_utility::Config for Runtime {
     type WeightInfo = ();
 }
 
-/// Configure the pallet template in pallets/template.
+parameter_types! {
+    pub const GasLimitMaxPercentage: Percent = Percent::from_percent(75);
+    pub BlockGasLimit: u64 = GasLimitMaxPercentage::get() * BlockWeights::get().max_block;
+}
 impl pallet_gear::Config for Runtime {
     type Event = Event;
     type Currency = Balances;
     type SubmitWeightPerByte = SubmitWeightPerByte;
     type MessagePerByte = MessagePerByte;
+    type BlockGasLimit = BlockGasLimit;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/test/src/runner.rs
+++ b/test/src/runner.rs
@@ -155,7 +155,7 @@ where
     let mut result = Ok(());
     if let Some(steps) = steps {
         for step_no in 0..steps {
-            let run_result = runner.run_next();
+            let run_result = runner.run_next(u64::MAX);
 
             log::info!("step: {}", step_no + 1);
             log::info!("{:#?}", run_result);
@@ -166,7 +166,7 @@ where
         }
     } else {
         loop {
-            let run_result = runner.run_next();
+            let run_result = runner.run_next(u64::MAX);
 
             if run_result.handled == 0 {
                 break;


### PR DESCRIPTION
Aims to implement the feature https://github.com/gear-tech/gear/issues/26.

- for `InitProgram` messages gas allowance is checked in the pallet: if exceeded, the message is put back in pallet storage to be attempted again in future blocks;
- for `DispatchMessage` type of messages the allowance is checked once a message has been popped from the message queue before actual computations take place; the total allowance is updated upon the computations completion;
- the runner's `run_next()` function now takes a parameter indicating the current remaining gas allowance (that is, the maximum `gas_limit` a message can have); if a message's gas_limit exceeds the remaining allowance the message is put back in the queue and `Ok(RunNextResult::empty())` is returned to break the processing loop (to avoid an infinite cycle if this "large" message gets to be processed again in the same block).