### PR TITLE
Update parity-db to v0.2.4 due to compilation problem with rustc v1.54+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4344,9 +4344,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495197c078e54b8735181aa35c00a327f7f3a3cc00a1ee8c95926dd010f0ec6b"
+checksum = "2e337f62db341435f0da05b8f6b97e984ef4ea5800510cd07c2d624688c40b47"
 dependencies = [
  "blake2-rfc",
  "crc32fast",


### PR DESCRIPTION
- Update `parity-db` from v0.2.3 to v0.2.4 to make compile with Rust's newer version.