### PR TITLE
Allow to actually skip continuous integration

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Run testsuite
         run: |
-          cargo run --package gear-node --release -- runtests ./test/json/*.json 
+          cargo run --package gear-node --release -- runtests ./test/json/*.json
 
       - name: Run rpc-test
         run: |


### PR DESCRIPTION
Suddenly, it turned out that since Feb '21:
> GitHub Actions now supports skipping push and pull_request workflows by looking for some common keywords in your commit message.

So here is nothing to fix to be able to bypass CI on commit by writing some custom word pairs.

To skip CI on `push` or `pull request` into `master`, commit message in the `push` or the head commit of the `pull request` should **contain** one of these strings:
- `[skip ci]`
- `[ci skip]`
- `[no ci]`
- `[skip actions]`
- `[actions skip]`

To maintain one coding style, I suggest using the `[skip ci]` option at the **beginning** of the commit message.

Source:
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/

@gear-tech/dev 