### PR TITLE
Use Randomness for message id generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4189,6 +4189,7 @@ dependencies = [
  "gear-node-rti",
  "pallet-authorship",
  "pallet-balances",
+ "pallet-randomness-collective-flip",
  "parity-scale-codec",
  "serde",
  "sp-core",

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -178,18 +178,6 @@ pub fn dealloc(page: u32) {
     sp_io::storage::clear(&page_key(page))
 }
 
-pub fn nonce_fetch_inc() -> u128 {
-    let original_nonce = sp_io::storage::get(b"g::msg::nonce")
-        .map(|val| u128::decode(&mut &val[..]).expect("nonce decode fail"))
-        .unwrap_or(0u128);
-
-    let new_nonce = original_nonce.wrapping_add(1);
-
-    sp_io::storage::set(b"g::msg::nonce", &new_nonce.encode());
-
-    original_nonce
-}
-
 pub fn caller_nonce_fetch_inc(caller_id: H256) -> u64 {
     let mut key_id = b"g::msg::user_nonce".to_vec();
     key_id.extend(&caller_id[..]);

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -198,15 +198,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn nonce_incremented() {
-        sp_io::TestExternalities::new_empty().execute_with(|| {
-            assert_eq!(nonce_fetch_inc(), 0_u128);
-            assert_eq!(nonce_fetch_inc(), 1_u128);
-            assert_eq!(nonce_fetch_inc(), 2_u128);
-        });
-    }
-
-    #[test]
     fn program_decoded() {
         sp_io::TestExternalities::new_empty().execute_with(|| {
             let code = b"pretended wasm code".to_vec();

--- a/pallets/gear/Cargo.toml
+++ b/pallets/gear/Cargo.toml
@@ -31,6 +31,7 @@ pallet-balances = { version = "3.0.0", default-features = false, git = "https://
 pallet-authorship = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
 
 [dev-dependencies]
+pallet-randomness-collective-flip = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
 serde = "1.0.101"
 env_logger = "0.8"
 wabt = "0.10"

--- a/pallets/gear/src/mock.rs
+++ b/pallets/gear/src/mock.rs
@@ -40,6 +40,7 @@ construct_runtime!(
         Gear: pallet_gear::{Pallet, Call, Storage, Event<T>},
         Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
         Authorship: pallet_authorship::{Pallet, Storage},
+        RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Call, Storage},
     }
 );
 
@@ -92,6 +93,7 @@ impl pallet_gear::Config for Test {
     type Currency = Balances;
     type SubmitWeightPerByte = SubmitWeightPerByte;
     type MessagePerByte = MessagePerByte;
+    type RandomnessSource = RandomnessCollectiveFlip;
 }
 
 pub struct FixedBlockAuthor;

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -18,7 +18,6 @@
 
 use super::*;
 use crate::mock::*;
-use codec::Encode;
 use common::{self, IntermediateMessage, Origin as _};
 use frame_support::{assert_noop, assert_ok};
 use frame_system::RawOrigin;
@@ -119,15 +118,11 @@ fn send_message_adds_to_queue() {
             Gear::message_queue().expect("There should be a message in the queue");
         assert_eq!(messages.len(), 1);
 
-        let mut id = b"payload".to_vec().encode();
-        id.extend_from_slice(&0_u128.to_le_bytes());
-        let id: H256 = sp_io::hashing::blake2_256(&id).into();
-
-        let msg_id = match &messages[0] {
-            IntermediateMessage::DispatchMessage { id, .. } => *id,
-            _ => Default::default(),
+        let msg_payload = match &messages[0] {
+            IntermediateMessage::DispatchMessage { payload, .. } => payload.clone(),
+            _ => vec![],
         };
-        assert_eq!(msg_id, id);
+        assert_eq!(msg_payload, b"payload");
     })
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -321,6 +321,7 @@ impl pallet_gear::Config for Runtime {
     type Currency = Balances;
     type SubmitWeightPerByte = SubmitWeightPerByte;
     type MessagePerByte = MessagePerByte;
+    type RandomnessSource = RandomnessCollectiveFlip;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.


### PR DESCRIPTION

Fixes #32.

- Use `pallet-randomness-collective-flip` as `RandomnessSource`
- Remove `msg::nonce`

Maybe we can use `pallet-babe` as mentioned [here](https://substrate.dev/recipes/randomness.html#babe-vrf-output).

@gear-tech/dev 
