### PR TITLE
Fix gear-test and add a correspondent stage to CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,6 +10,28 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check fmt
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: | # TODO: Expand clippy to be workspace-wide
+          cargo clippy --package gear-core --all-features -- -D warnings
+          cargo clippy --package gear-core-backend --all-features -- -D warnings
+          echo cargo clippy --package gear-core-runner --all-features -- -D warnings # TODO: Fix
+          echo cargo clippy --package gear-node --all-features -- -D warnings # TODO: Fix
+          echo cargo clippy --package gear-node-rti --all-features -- -D warnings # TODO: Fix
+          echo cargo clippy --package gear-runtime --all-features -- -D warnings # TODO: Fix
+          cargo clippy --package gstd --all-features -- -D warnings
+          cargo clippy --package gstd-async --all-features -- -D warnings
+          echo cargo clippy --package pallet-gear --all-features -- -D warnings # TODO: Fix
+
   build:
     runs-on: ubuntu-latest
 
@@ -26,9 +48,6 @@ jobs:
       - name: Artifact cache
         uses: Swatinem/rust-cache@v1
 
-      - name: Check fmt
-        run: cargo fmt --all -- --check
-
       - name: Build
         run: cargo build --workspace --release
 
@@ -40,6 +59,9 @@ jobs:
           ./scripts/build-wasm.sh
           cp -r ./examples/target/wasm32-unknown-unknown ./target/
 
+      - name: Run gear-test
+        run: ./target/release/gtest test/json/*.json
+
       - name: Install nodejs
         uses: actions/setup-node@v2
         with:
@@ -48,9 +70,9 @@ jobs:
 
       - name: Run testsuite
         run: |
-          cargo run --package gear-node --release -- runtests ./test/json/*.json
+          ./target/release/gear-node runtests ./test/json/*.json
 
       - name: Run rpc-test
         run: |
-          cargo run --package gear-node --release -- --dev & sleep 5
+          ./target/release/gear-node --dev & sleep 5
           node rpc-tests/index.js ./test/json/*.json

--- a/test/src/runner.rs
+++ b/test/src/runner.rs
@@ -85,7 +85,7 @@ pub fn init_fixture(test: &Test, fixture_no: usize) -> anyhow::Result<InMemoryRu
                 .unwrap_or_default(),
         };
         runner.queue_message(
-            SOME_FIXED_USER.into(),
+            0.into(),
             nonce,
             message.destination.into(),
             payload,


### PR DESCRIPTION
- Fix gear-test for demo-collector and demo-ping.
- Add gear-test stage to CI.
- Make fmt and clippy checks in parallel to build.
