### PR TITLE
Use wasm intristic for panic handler

### DIFF
--- a/examples/async/src/lib.rs
+++ b/examples/async/src/lib.rs
@@ -22,5 +22,5 @@ async fn handle_async() {
 
 #[panic_handler]
 fn panic(_info: &panic::PanicInfo) -> ! {
-    loop {}
+    unsafe { core::arch::wasm32::unreachable(); }
 }

--- a/examples/collector/src/lib.rs
+++ b/examples/collector/src/lib.rs
@@ -36,5 +36,5 @@ pub unsafe extern "C" fn init() {}
 
 #[panic_handler]
 fn panic(_info: &panic::PanicInfo) -> ! {
-    loop {}
+    unsafe { core::arch::wasm32::unreachable(); }
 }

--- a/examples/condensator/src/lib.rs
+++ b/examples/condensator/src/lib.rs
@@ -53,5 +53,5 @@ pub unsafe extern "C" fn init() {
 
 #[panic_handler]
 fn panic(_info: &panic::PanicInfo) -> ! {
-    loop {}
+    unsafe { core::arch::wasm32::unreachable(); }
 }

--- a/examples/fib/src/lib.rs
+++ b/examples/fib/src/lib.rs
@@ -42,5 +42,5 @@ pub unsafe extern "C" fn init() {}
 
 #[panic_handler]
 fn panic(_info: &panic::PanicInfo) -> ! {
-    loop {}
+    unsafe { core::arch::wasm32::unreachable(); }
 }

--- a/examples/minimal/src/lib.rs
+++ b/examples/minimal/src/lib.rs
@@ -13,5 +13,5 @@ pub unsafe extern "C" fn init() {}
 
 #[panic_handler]
 fn panic(_info: &panic::PanicInfo) -> ! {
-    loop {}
+    unsafe { core::arch::wasm32::unreachable(); }
 }

--- a/examples/ping/src/lib.rs
+++ b/examples/ping/src/lib.rs
@@ -30,5 +30,5 @@ pub unsafe extern "C" fn init() {}
 
 #[panic_handler]
 fn panic(_info: &panic::PanicInfo) -> ! {
-    loop {}
+    unsafe { core::arch::wasm32::unreachable(); }
 }

--- a/examples/sum/src/lib.rs
+++ b/examples/sum/src/lib.rs
@@ -63,5 +63,5 @@ pub unsafe extern "C" fn init() {
 
 #[panic_handler]
 fn panic(_info: &panic::PanicInfo) -> ! {
-    loop {}
+    unsafe { core::arch::wasm32::unreachable(); }
 }

--- a/examples/vec/src/lib.rs
+++ b/examples/vec/src/lib.rs
@@ -34,5 +34,5 @@ pub unsafe extern "C" fn init() {}
 
 #[panic_handler]
 fn panic(_info: &panic::PanicInfo) -> ! {
-    loop {}
+    unsafe { core::arch::wasm32::unreachable(); }
 }


### PR DESCRIPTION
If explicit panic occurs, this `loop {}` just exhausts all gas and panics due to out-of-gas