### PR TITLE
Show only warns and errors in node

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Run rpc-test
         run: |
-          ./target/release/gear-node --dev & sleep 5
+          ./target/release/gear-node --dev -l 2 & sleep 5
           node rpc-tests/index.js ./test/code/*.yaml
       
       - name: Run metadata test


### PR DESCRIPTION
Remove the unnecessary output as mentioned here #71 .

@gear-tech/dev 
