### PR TITLE
Add test that shows memory leak

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "collector",
     "condensator",
     "fib",
+    "mem",
     "meta",
     "minimal",
     "panicker",

--- a/examples/mem/Cargo.toml
+++ b/examples/mem/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "demo-mem"
+version = "0.1.0"
+authors = ["Gear Technologies"]
+edition = "2018"
+license = "GPL-3.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+gstd = { path = "../../gstd", features = ["debug"] }

--- a/examples/mem/src/lib.rs
+++ b/examples/mem/src/lib.rs
@@ -1,0 +1,23 @@
+#![no_std]
+#![feature(default_alloc_error_handler)]
+
+use gstd::{msg, prelude::*};
+
+#[no_mangle]
+pub unsafe extern "C" fn handle() {
+    let data = vec![0u8; 32768];
+    msg::reply(&data, 0, 0);
+    panic!()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn handle_reply() {
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn init() {}
+
+#[panic_handler]
+fn panic(_info: &panic::PanicInfo) -> ! {
+    unsafe { core::arch::wasm32::unreachable(); }
+}

--- a/test/code/test_mem.yaml
+++ b/test/code/test_mem.yaml
@@ -1,0 +1,24 @@
+title: Memory test
+
+programs:
+- id: 1
+  path: examples/target/wasm32-unknown-unknown/release/demo_mem.wasm
+
+fixtures:
+- title: Test for memory result
+  messages:
+  - destination: 1
+    payload:
+      kind: utf-8
+      value: empty here
+  - destination: 1
+    payload:
+      kind: utf-8
+      value: empty here
+  expected:
+    - allocations:
+      - page_num: 17
+        program_id: 1
+      - page_num: 18
+        program_id: 1
+


### PR DESCRIPTION
The result of this message sequence should never allocate more than one page for program (and it happens so when there is no `panic!()` at the end of the program)