### PR TITLE
Add different allocation checks to gtest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,9 +2136,11 @@ dependencies = [
 name = "gear-node-rti"
 version = "0.1.0"
 dependencies = [
+ "frame-system",
  "gear-common",
  "gear-core",
  "gear-core-runner",
+ "gear-runtime",
  "log",
  "parity-scale-codec",
  "sp-core",
@@ -2146,6 +2148,7 @@ dependencies = [
  "sp-io",
  "sp-runtime-interface",
  "sp-std",
+ "wabt",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ node-test:
 
 .PHONY: ntest
 ntest:
+	@./scripts/build-wasm.sh
 	@cargo run --package gear-node --release -- runtests ./gtest/spec/*.yaml
 
 .PHONY: pre-commit

--- a/gtest/spec/test_condensator.yaml
+++ b/gtest/spec/test_condensator.yaml
@@ -34,8 +34,8 @@ fixtures:
               value: "101"
             destination: 1
         allocations:
-          - page_num: 17
-            program_id: 1
+          - program_id: 1
+            contains_pages: [17]
       - step: 2
         messages:
           - payload:
@@ -48,5 +48,5 @@ fixtures:
               value: "Discharged: 202"
             destination: 0
         allocations:
-          - page_num: 17
-            program_id: 1
+          - program_id: 1
+            contains_pages: [17]

--- a/gtest/spec/test_mem.yaml
+++ b/gtest/spec/test_mem.yaml
@@ -17,7 +17,7 @@ fixtures:
           value: empty here
     expected:
       - allocations:
-          - page_num: 17
-            program_id: 1
-          - page_num: 18
-            program_id: 1
+        - program_id: 1
+          filter: dynamic
+          # TODO: should be 1 with correct memory deallocation on panic
+          page_count: 2

--- a/gtest/spec/test_vec.yaml
+++ b/gtest/spec/test_vec.yaml
@@ -25,12 +25,12 @@ fixtures:
               kind: i32
               value: 20000
         allocations:
-          - page_num: 17
-            program_id: 1
-          - page_num: 17
-            program_id: 2
-          - page_num: 18
-            program_id: 2
+          - program_id: 1
+            filter: dynamic
+            exact_pages: [17]
+          - program_id: 2
+            filter: dynamic
+            exact_pages: [17, 18]
         memory:
           - program_id: 2
             at: "0x1238d4"

--- a/gtest/src/runner.rs
+++ b/gtest/src/runner.rs
@@ -62,7 +62,8 @@ impl CollectState for Storage<ExtMessageQueue, ExtProgramStorage, ExtWaitList> {
         let program_storage = self.program_storage;
 
         let mut messages = Vec::new();
-        let mut message_queue = common::storage_queue::StorageQueue::get(b"g::msg::".as_ref());
+        let mut message_queue =
+            common::storage_queue::StorageQueue::get(common::STORAGE_MESSAGE_PREFIX);
         while let Some(message) = message_queue.dequeue() {
             messages.push(message);
         }

--- a/gtest/src/runner.rs
+++ b/gtest/src/runner.rs
@@ -59,11 +59,10 @@ impl CollectState for Storage<InMemoryMessageQueue, InMemoryProgramStorage, InMe
 impl CollectState for Storage<ExtMessageQueue, ExtProgramStorage, ExtWaitList> {
     fn collect(self) -> FinalState {
         let log = self.message_queue.log;
+        let program_storage = self.program_storage;
 
         let mut messages = Vec::new();
-
-        let mut message_queue =
-            common::storage_queue::StorageQueue::get("g::msg::".as_bytes().to_vec());
+        let mut message_queue = common::storage_queue::StorageQueue::get(b"g::msg::".as_ref());
         while let Some(message) = message_queue.dequeue() {
             messages.push(message);
         }
@@ -71,8 +70,7 @@ impl CollectState for Storage<ExtMessageQueue, ExtProgramStorage, ExtWaitList> {
         FinalState {
             log,
             messages,
-            // TODO: iterate program storage to list programs here
-            program_storage: Vec::new(),
+            program_storage: program_storage.iter().collect(),
             wait_list: self.wait_list.into(),
         }
     }
@@ -85,18 +83,18 @@ pub fn init_fixture<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList>(
 ) -> anyhow::Result<Runner<MQ, PS, WL>> {
     let mut runner = Runner::new(&Config::default(), storage);
     let mut nonce = 0;
+    let program_id_regex = Regex::new(r"\{(?P<id>[0-9]+)\}").unwrap();
     for program in test.programs.iter() {
         let code = std::fs::read(program.path.clone())?;
         let mut init_message = Vec::new();
         if let Some(init_msg) = &program.init_message {
-            let re = Regex::new(r"\{(?P<id>[0-9]*)\}").unwrap();
             init_message = match init_msg {
                 PayloadVariant::Utf8(s) => {
                     // Insert ProgramId
-                    if let Some(caps) = re.captures(s) {
+                    if let Some(caps) = program_id_regex.captures(s) {
                         let id = caps["id"].parse::<u64>().unwrap();
                         let s = s.replace(&caps[0], &encode_hex(ProgramId::from(id).as_slice()));
-                        (s.clone().into_bytes()).to_vec()
+                        s.into_bytes()
                     } else {
                         init_msg.clone().into_raw()
                     }
@@ -121,11 +119,10 @@ pub fn init_fixture<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList>(
 
     let fixture = &test.fixtures[fixture_no];
     for message in fixture.messages.iter() {
-        let re = Regex::new(r"\{(?P<id>[0-9]*)\}").unwrap();
         let payload = match &message.payload {
             Some(PayloadVariant::Utf8(s)) => {
                 // Insert ProgramId
-                if let Some(caps) = re.captures(s) {
+                if let Some(caps) = program_id_regex.captures(s) {
                     let id = caps["id"].parse::<u64>().unwrap();
                     let s = s.replace(&caps[0], &encode_hex(ProgramId::from(id).as_slice()));
                     (s.clone().into_bytes()).to_vec()

--- a/gtest/src/sample.rs
+++ b/gtest/src/sample.rs
@@ -53,7 +53,7 @@ pub struct Program {
 pub struct Expectation {
     pub step: Option<u64>,
     pub messages: Option<Vec<Message>>,
-    pub allocations: Option<Vec<AllocationStorage>>,
+    pub allocations: Option<Vec<Allocations>>,
     pub memory: Option<Vec<BytesAt>>,
     pub log: Option<Vec<Message>>,
     #[serde(rename = "allowError")]
@@ -123,9 +123,26 @@ pub struct BytesAt {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct AllocationStorage {
-    pub page_num: u32,
+pub struct Allocations {
     pub program_id: u64,
+    pub filter: Option<AllocationFilter>,
+    #[serde(flatten)]
+    pub kind: AllocationCheckKind,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AllocationCheckKind {
+    PageCount(u64),
+    ExactPages(Vec<u32>),
+    ContainsPages(Vec<u32>),
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AllocationFilter {
+    Static,
+    Dynamic,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/gtest/src/sample.rs
+++ b/gtest/src/sample.rs
@@ -127,12 +127,12 @@ pub struct Allocations {
     pub program_id: u64,
     pub filter: Option<AllocationFilter>,
     #[serde(flatten)]
-    pub kind: AllocationCheckKind,
+    pub kind: AllocationExpectationKind,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum AllocationCheckKind {
+pub enum AllocationExpectationKind {
     PageCount(u64),
     ExactPages(Vec<u32>),
     ContainsPages(Vec<u32>),

--- a/node-rti/Cargo.toml
+++ b/node-rti/Cargo.toml
@@ -27,6 +27,11 @@ sp-core = { version = "3.0.0", git = "https://github.com/paritytech/substrate.gi
 sp-io = { version = "3.0", git = "https://github.com/paritytech/substrate.git", default-features = false }
 sp-std = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", default-features = false }
 
+[dev-dependencies]
+gear-runtime = { path = "../runtime" }
+frame-system = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git" }
+wabt = "0.10"
+
 [features]
 default = ["std"]
 std = [

--- a/utils/gear-test-cli/src/command.rs
+++ b/utils/gear-test-cli/src/command.rs
@@ -36,11 +36,11 @@ impl GearTestCmd {
         new_test_ext()
             .execute_with(|| {
                 gear_test::check::check_main(self.input.to_vec(), true, false, false, || {
-                    sp_io::storage::clear_prefix(b"g::code");
-                    sp_io::storage::clear_prefix(b"g::alloc");
-                    sp_io::storage::clear_prefix(b"g::msg");
-                    sp_io::storage::clear_prefix(b"g::prog");
-                    sp_io::storage::clear_prefix(b"g::wait");
+                    sp_io::storage::clear_prefix(gear_common::STORAGE_CODE_PREFIX);
+                    sp_io::storage::clear_prefix(gear_common::STORAGE_ALLOCATION_PREFIX);
+                    sp_io::storage::clear_prefix(gear_common::STORAGE_MESSAGE_PREFIX);
+                    sp_io::storage::clear_prefix(gear_common::STORAGE_PROGRAM_PREFIX);
+                    sp_io::storage::clear_prefix(gear_common::STORAGE_WAITLIST_PREFIX);
                     gear_core::storage::Storage {
                         message_queue: rti::ext::ExtMessageQueue::default(),
                         program_storage: rti::ext::ExtProgramStorage,


### PR DESCRIPTION
Required for correct testing of (#80)

Allows to test allocation page count and compare exact allocated page indexes.

@shamilsan
