### PR TITLE
Refactor syscalls wrappers by removing repeating pieces

### DIFF
--- a/core-backend/src/funcs.rs
+++ b/core-backend/src/funcs.rs
@@ -17,6 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use alloc::string::String;
+use alloc::vec::Vec;
 use gear_core::env::{Ext, LaterExt};
 use gear_core::message::{OutgoingPacket, ReplyPacket};
 use gear_core::program::ProgramId;
@@ -32,7 +33,7 @@ pub(crate) fn alloc<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<u32, &'s
                 log::debug!("ALLOC: {} pages at {}", pages, ptr);
                 ptr
             })
-            .unwrap_or(0u32);
+            .unwrap_or_default();
 
         Ok(ptr)
     }
@@ -52,11 +53,8 @@ pub(crate) fn free<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'sta
 
 pub(crate) fn charge<E: Ext>(ext: LaterExt<E>) -> impl Fn(i64) -> Result<(), &'static str> {
     move |gas: i64| {
-        if ext.with(|ext: &mut E| ext.charge(gas as u64))?.is_err() {
-            Err("Trapping: unable to charge gas for reserve")
-        } else {
-            Ok(())
-        }
+        ext.with(|ext: &mut E| ext.charge(gas as u64))?
+            .map_err(|_| "Trapping: unable to charge gas for reserve")
     }
 }
 
@@ -69,18 +67,14 @@ pub(crate) fn debug<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32, i32) -> Result<(),
             ext.get_mem(str_ptr, &mut data);
             let debug_str = unsafe { String::from_utf8_unchecked(data) };
             log::debug!("DEBUG: {}", debug_str);
-        })?;
-        Ok(())
+        })
     }
 }
 
 pub(crate) fn gas<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static str> {
     move |val: i32| {
-        if ext.with(|ext: &mut E| ext.gas(val as _))?.is_err() {
-            Err("Trapping: unable to report about gas used")
-        } else {
-            Ok(())
-        }
+        ext.with(|ext: &mut E| ext.gas(val as _))?
+            .map_err(|_| "Trapping: unable to report about gas used")
     }
 }
 
@@ -89,8 +83,7 @@ pub(crate) fn msg_id<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'s
         ext.with(|ext: &mut E| {
             let message_id = ext.message_id();
             ext.set_mem(msg_id_ptr as isize as _, message_id.as_slice());
-        })?;
-        Ok(())
+        })
     }
 }
 
@@ -98,63 +91,35 @@ pub(crate) fn read<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32, i32, i32) -> Result
     move |at: i32, len: i32, dest: i32| {
         let at = at as u32 as usize;
         let len = len as u32 as usize;
-        let dest = dest as u32 as usize;
         ext.with(|ext: &mut E| {
             let msg = ext.msg().to_vec();
-            ext.set_mem(dest, &msg[at..at + len]);
-        })?;
-        Ok(())
+            ext.set_mem(dest as _, &msg[at..(at + len)]);
+        })
     }
 }
 
 pub(crate) fn reply<E: Ext>(
     ext: LaterExt<E>,
 ) -> impl Fn(i32, i32, i64, i32) -> Result<(), &'static str> {
-    move |message_ptr: i32, message_len: i32, gas_limit: i64, value_ptr: i32| {
-        let message_ptr = message_ptr as u32 as usize;
-        let message_len = message_len as u32 as usize;
+    move |payload_ptr: i32, payload_len: i32, gas_limit: i64, value_ptr: i32| {
         let result = ext.with(|ext: &mut E| {
-            let mut data = vec![0u8; message_len];
-            ext.get_mem(message_ptr, &mut data);
-
-            let mut value_le = [0u8; 16];
-            ext.get_mem(value_ptr as isize as _, &mut value_le);
-
-            ext.reply(ReplyPacket::new(
-                0,
-                data.into(),
-                gas_limit as _,
-                u128::from_le_bytes(value_le),
-            ))
+            let payload = get_vec(ext, payload_ptr, payload_len);
+            let value = get_u128(ext, value_ptr);
+            ext.reply(ReplyPacket::new(0, payload.into(), gas_limit as _, value))
         })?;
-
-        if result.is_err() {
-            return Err("Trapping: unable to send message");
-        }
-
-        Ok(())
+        result.map_err(|_| "Trapping: unable to send message")
     }
 }
 
 pub(crate) fn reply_push<E: Ext>(
     ext: LaterExt<E>,
 ) -> impl Fn(i32, i32) -> Result<(), &'static str> {
-    move |message_ptr: i32, message_len: i32| {
-        let message_ptr = message_ptr as u32 as usize;
-        let message_len = message_len as u32 as usize;
-
-        let result = ext.with(|ext: &mut E| {
-            let mut data = vec![0u8; message_len];
-            ext.get_mem(message_ptr, &mut data);
-
-            ext.reply_push(&data)
-        })?;
-
-        if result.is_err() {
-            return Err("Trapping: unable to push payload into reply");
-        }
-
-        Ok(())
+    move |payload_ptr: i32, payload_len: i32| {
+        ext.with(|ext: &mut E| {
+            let payload = get_vec(ext, payload_ptr, payload_len);
+            ext.reply_push(&payload)
+        })?
+        .map_err(|_| "Trapping: unable to push payload into reply")
     }
 }
 
@@ -177,48 +142,29 @@ pub(crate) fn send<E: Ext>(
     ext: LaterExt<E>,
 ) -> impl Fn(i32, i32, i32, i64, i32) -> Result<(), &'static str> {
     move |program_id_ptr: i32,
-          message_ptr: i32,
-          message_len: i32,
+          payload_ptr: i32,
+          payload_len: i32,
           gas_limit: i64,
           value_ptr: i32| {
-        let message_ptr = message_ptr as u32 as usize;
-        let message_len = message_len as u32 as usize;
         let result = ext.with(|ext: &mut E| {
-            let mut data = vec![0u8; message_len];
-            ext.get_mem(message_ptr, &mut data);
-            let mut program_id = [0u8; 32];
-            ext.get_mem(program_id_ptr as isize as _, &mut program_id);
-            let program_id = ProgramId::from_slice(&program_id);
-
-            let mut value_le = [0u8; 16];
-            ext.get_mem(value_ptr as isize as _, &mut value_le);
-
+            let dest: ProgramId = get_id(ext, program_id_ptr).into();
+            let payload = get_vec(ext, payload_ptr, payload_len);
+            let value = get_u128(ext, value_ptr);
             ext.send(OutgoingPacket::new(
-                program_id,
-                data.into(),
+                dest,
+                payload.into(),
                 gas_limit as _,
-                u128::from_le_bytes(value_le),
+                value,
             ))
-        });
-
-        if result.is_err() {
-            return Err("Trapping: unable to send message");
-        }
-
-        Ok(())
+        })?;
+        result.map_err(|_| "Trapping: unable to send message")
     }
 }
 
 pub(crate) fn send_commit<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static str> {
     move |handle_ptr: i32| {
-        let handle_ptr = handle_ptr as u32 as usize;
-
-        let result = ext.with(|ext: &mut E| ext.send_commit(handle_ptr))?;
-        if result.is_err() {
-            return Err("Trapping: unable to commit and send message");
-        }
-
-        Ok(())
+        ext.with(|ext: &mut E| ext.send_commit(handle_ptr as _))?
+            .map_err(|_| "Trapping: unable to commit and send message")
     }
 }
 
@@ -226,66 +172,41 @@ pub(crate) fn send_init<E: Ext>(
     ext: LaterExt<E>,
 ) -> impl Fn(i32, i32, i32, i64, i32) -> Result<i32, &'static str> {
     move |program_id_ptr: i32,
-          message_ptr: i32,
-          message_len: i32,
+          payload_ptr: i32,
+          payload_len: i32,
           gas_limit: i64,
           value_ptr: i32| {
-        let message_ptr = message_ptr as u32 as usize;
-        let message_len = message_len as u32 as usize;
         let result = ext.with(|ext: &mut E| {
-            let mut data = vec![0u8; message_len];
-            ext.get_mem(message_ptr, &mut data);
-            let mut program_id = [0u8; 32];
-            ext.get_mem(program_id_ptr as isize as _, &mut program_id);
-            let program_id = ProgramId::from_slice(&program_id);
-
-            let mut value_le = [0u8; 16];
-            ext.get_mem(value_ptr as isize as _, &mut value_le);
-
+            let dest: ProgramId = get_id(ext, program_id_ptr).into();
+            let payload = get_vec(ext, payload_ptr, payload_len);
+            let value = get_u128(ext, value_ptr);
             ext.send_init(OutgoingPacket::new(
-                program_id,
-                data.into(),
+                dest,
+                payload.into(),
                 gas_limit as _,
-                u128::from_le_bytes(value_le),
+                value,
             ))
         })?;
-
-        if result.is_err() {
-            return Err("Trapping: unable to init message");
-        };
-
-        Ok(result.unwrap() as isize as i32)
+        result
+            .map_err(|_| "Trapping: unable to init message")
+            .map(|handle| handle as _)
     }
 }
 
 pub(crate) fn send_push<E: Ext>(
     ext: LaterExt<E>,
 ) -> impl Fn(i32, i32, i32) -> Result<(), &'static str> {
-    move |handle_ptr: i32, message_ptr: i32, message_len: i32| {
-        let handle_ptr = handle_ptr as u32 as usize;
-        let message_ptr = message_ptr as u32 as usize;
-        let message_len = message_len as u32 as usize;
-
-        let result = ext.with(|ext: &mut E| {
-            let mut data = vec![0u8; message_len];
-            ext.get_mem(message_ptr, &mut data);
-
-            ext.send_push(handle_ptr, &data)
-        })?;
-
-        if result.is_err() {
-            return Err("Trapping: unable to push payload into message");
-        }
-
-        Ok(())
+    move |handle_ptr: i32, payload_ptr: i32, payload_len: i32| {
+        ext.with(|ext: &mut E| {
+            let payload = get_vec(ext, payload_ptr, payload_len);
+            ext.send_push(handle_ptr as _, &payload)
+        })?
+        .map_err(|_| "Trapping: unable to push payload into message")
     }
 }
 
 pub(crate) fn size<E: Ext>(ext: LaterExt<E>) -> impl Fn() -> i32 {
-    move || {
-        ext.with(|ext: &mut E| ext.msg().len() as isize as i32)
-            .unwrap_or(0)
-    }
+    move || ext.with(|ext: &mut E| ext.msg().len() as _).unwrap_or(0)
 }
 
 pub(crate) fn source<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static str> {
@@ -293,19 +214,12 @@ pub(crate) fn source<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'s
         ext.with(|ext: &mut E| {
             let source = ext.source();
             ext.set_mem(source_ptr as isize as _, source.as_slice());
-        })?;
-        Ok(())
+        })
     }
 }
 
 pub(crate) fn value<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static str> {
-    move |value_ptr: i32| {
-        ext.with(|ext: &mut E| {
-            let source = ext.value();
-            ext.set_mem(value_ptr as isize as _, &source.to_le_bytes()[..]);
-        })?;
-        Ok(())
-    }
+    move |value_ptr: i32| ext.with(|ext: &mut E| set_u128(ext, value_ptr, ext.value()))
 }
 
 pub(crate) fn wait<E: Ext>(ext: LaterExt<E>) -> impl Fn() -> Result<(), &'static str> {
@@ -314,4 +228,27 @@ pub(crate) fn wait<E: Ext>(ext: LaterExt<E>) -> impl Fn() -> Result<(), &'static
         // Intentionally return an error to break the execution
         Err("wait")
     }
+}
+
+// Helper functions
+fn get_id<E: Ext>(ext: &E, ptr: i32) -> [u8; 32] {
+    let mut id = [0u8; 32];
+    ext.get_mem(ptr as _, &mut id);
+    id
+}
+
+fn get_u128<E: Ext>(ext: &E, ptr: i32) -> u128 {
+    let mut u128_le = [0u8; 16];
+    ext.get_mem(ptr as _, &mut u128_le);
+    u128::from_le_bytes(u128_le)
+}
+
+fn get_vec<E: Ext>(ext: &E, ptr: i32, len: i32) -> Vec<u8> {
+    let mut vec = vec![0u8; len as _];
+    ext.get_mem(ptr as _, &mut vec);
+    vec
+}
+
+fn set_u128<E: Ext>(ext: &mut E, ptr: i32, val: u128) {
+    ext.set_mem(ptr as _, &val.to_le_bytes());
 }

--- a/core-runner/src/runner.rs
+++ b/core-runner/src/runner.rs
@@ -722,7 +722,7 @@ impl EnvExt for Ext {
             .expect("Memory out of bounds.");
     }
 
-    fn get_mem(&mut self, ptr: usize, buffer: &mut [u8]) {
+    fn get_mem(&self, ptr: usize, buffer: &mut [u8]) {
         self.memory_context.memory().read(ptr, buffer);
     }
 
@@ -747,7 +747,7 @@ impl EnvExt for Ext {
         }
     }
 
-    fn value(&mut self) -> u128 {
+    fn value(&self) -> u128 {
         self.messages.current().value()
     }
 

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -91,7 +91,7 @@ pub trait Ext {
     fn set_mem(&mut self, ptr: usize, val: &[u8]);
 
     /// Reads memory contents at the given offset into a buffer.
-    fn get_mem(&mut self, ptr: usize, buffer: &mut [u8]);
+    fn get_mem(&self, ptr: usize, buffer: &mut [u8]);
 
     /// Access currently handled message payload.
     fn msg(&mut self) -> &[u8];
@@ -103,7 +103,7 @@ pub trait Ext {
     fn charge(&mut self, gas: u64) -> Result<(), &'static str>;
 
     /// Value associated with message.
-    fn value(&mut self) -> u128;
+    fn value(&self) -> u128;
 
     /// Interrupt the program and reschedule execution.
     fn wait(&mut self) -> Result<(), &'static str>;
@@ -206,14 +206,14 @@ mod tests {
             Ok(())
         }
         fn set_mem(&mut self, _ptr: usize, _val: &[u8]) {}
-        fn get_mem(&mut self, _ptr: usize, _buffer: &mut [u8]) {}
+        fn get_mem(&self, _ptr: usize, _buffer: &mut [u8]) {}
         fn msg(&mut self) -> &[u8] {
             &[]
         }
         fn gas(&mut self, _amount: u32) -> Result<(), &'static str> {
             Ok(())
         }
-        fn value(&mut self) -> u128 {
+        fn value(&self) -> u128 {
             0
         }
         fn charge(&mut self, _gas: u64) -> Result<(), &'static str> {


### PR DESCRIPTION
I got tired of solving conflicts. So I push this small change separately.

- Tune refs vs. mut refs.
- Use `Result` in a more functional way.
- Don't Repeat Yourself (DRY).

@gear-tech/dev 
