### PR TITLE
Runner builder

### DIFF
--- a/core-runner/src/builder.rs
+++ b/core-runner/src/builder.rs
@@ -22,33 +22,14 @@ impl RunnerBuilder {
     }
 
     /// Set [`Config`].
-    pub fn config(self, config: Config) -> RunnerBuilder {
-        RunnerBuilder {
-            config: config,
-            programs: self.programs,
-            storage: self.storage,
-        }
+    pub fn config(mut self, config: Config) -> RunnerBuilder {
+        self.config = config;
+        self
     }
 
     /// Set [`Program`] to be initialized on build.
-    pub fn program(
-        mut self,
-        source_id: u64,
-        new_program_id: u64,
-        code: Vec<u8>,
-        message: ExtMessage,
-    ) -> RunnerBuilder {
-        self.programs.push(InitializeProgramInfo {
-            source_id: source_id.into(),
-            new_program_id: new_program_id.into(),
-            message,
-            code,
-        });
-        RunnerBuilder {
-            config: self.config,
-            programs: self.programs,
-            storage: self.storage,
-        }
+    pub fn program(self, code: Vec<u8>) -> ProgramBuilder {
+        ProgramBuilder::new(self, code)
     }
 
     /// Initialize all programs and return [`Runner`].
@@ -60,5 +41,57 @@ impl RunnerBuilder {
                 .expect("failed to init program");
         }
         runner
+    }
+}
+
+pub struct ProgramBuilder {
+    runner_builder: RunnerBuilder,
+    code: Vec<u8>,
+    source_id: u64,
+    new_program_id: u64,
+    message: ExtMessage,
+}
+
+impl ProgramBuilder {
+    pub fn new(runner_builder: RunnerBuilder, code: Vec<u8>) -> ProgramBuilder {
+        ProgramBuilder {
+            runner_builder,
+            code,
+            source_id: 1001,
+            new_program_id: 1,
+            message: ExtMessage {
+                id: 1000001.into(),
+                payload: vec![],
+                gas_limit: u64::MAX,
+                value: 0,
+            },
+        }
+    }
+
+    pub fn build(self) -> RunnerBuilder {
+        let mut runner = self.runner_builder;
+
+        runner.programs.push(InitializeProgramInfo {
+            source_id: self.source_id.into(),
+            new_program_id: self.new_program_id.into(),
+            code: self.code,
+            message: self.message,
+        });
+        runner
+    }
+
+    pub fn source(mut self, id: u64) -> ProgramBuilder {
+        self.source_id = id;
+        self
+    }
+
+    pub fn program_id(mut self, id: u64) -> ProgramBuilder {
+        self.new_program_id = id;
+        self
+    }
+
+    pub fn message(mut self, message: ExtMessage) -> ProgramBuilder {
+        self.message = message;
+        self
     }
 }

--- a/core-runner/src/builder.rs
+++ b/core-runner/src/builder.rs
@@ -90,7 +90,7 @@ impl ProgramBuilder {
         self
     }
 
-    pub fn message(mut self, message: ExtMessage) -> ProgramBuilder {
+    pub fn init_message(mut self, message: ExtMessage) -> ProgramBuilder {
         self.message = message;
         self
     }

--- a/core-runner/src/builder.rs
+++ b/core-runner/src/builder.rs
@@ -13,8 +13,8 @@ pub struct RunnerBuilder {
 
 impl RunnerBuilder {
     /// Default [`Runner`].
-    pub fn new() -> RunnerBuilder {
-        RunnerBuilder {
+    pub fn new() -> Self {
+        Self {
             config: Config::default(),
             programs: vec![],
             storage: InMemoryStorage::default(),
@@ -22,7 +22,7 @@ impl RunnerBuilder {
     }
 
     /// Set [`Config`].
-    pub fn config(mut self, config: Config) -> RunnerBuilder {
+    pub fn config(mut self, config: Config) -> Self {
         self.config = config;
         self
     }
@@ -53,14 +53,15 @@ pub struct ProgramBuilder {
 }
 
 impl ProgramBuilder {
-    pub fn new(runner_builder: RunnerBuilder, code: Vec<u8>) -> ProgramBuilder {
+    pub fn new(runner_builder: RunnerBuilder, code: Vec<u8>) -> Self {
+        let counter = runner_builder.programs.len() as u64;
         ProgramBuilder {
             runner_builder,
             code,
             source_id: 1001,
-            new_program_id: 1,
+            new_program_id: 1 + counter,
             message: ExtMessage {
-                id: 1000001.into(),
+                id: (1000000 + counter).into(),
                 payload: vec![],
                 gas_limit: u64::MAX,
                 value: 0,
@@ -80,17 +81,17 @@ impl ProgramBuilder {
         runner
     }
 
-    pub fn source(mut self, id: u64) -> ProgramBuilder {
+    pub fn source(mut self, id: u64) -> Self {
         self.source_id = id;
         self
     }
 
-    pub fn program_id(mut self, id: u64) -> ProgramBuilder {
+    pub fn id(mut self, id: u64) -> Self {
         self.new_program_id = id;
         self
     }
 
-    pub fn init_message(mut self, message: ExtMessage) -> ProgramBuilder {
+    pub fn init_message(mut self, message: ExtMessage) -> Self {
         self.message = message;
         self
     }

--- a/core-runner/src/builder.rs
+++ b/core-runner/src/builder.rs
@@ -1,0 +1,64 @@
+use super::runner::{Config, ExtMessage, InitializeProgramInfo, Runner};
+use alloc::vec::*;
+use gear_core::storage::{
+    InMemoryMessageQueue, InMemoryProgramStorage, InMemoryStorage, InMemoryWaitList,
+};
+
+/// Builder for [`Runner`].
+pub struct RunnerBuilder {
+    config: Config,
+    programs: Vec<InitializeProgramInfo>,
+    storage: InMemoryStorage,
+}
+
+impl RunnerBuilder {
+    /// Default [`Runner`].
+    pub fn new() -> RunnerBuilder {
+        RunnerBuilder {
+            config: Config::default(),
+            programs: vec![],
+            storage: InMemoryStorage::default(),
+        }
+    }
+
+    /// Set [`Config`].
+    pub fn config(self, config: Config) -> RunnerBuilder {
+        RunnerBuilder {
+            config: config,
+            programs: self.programs,
+            storage: self.storage,
+        }
+    }
+
+    /// Set [`Program`] to be initialized on build.
+    pub fn program(
+        mut self,
+        source_id: u64,
+        new_program_id: u64,
+        code: Vec<u8>,
+        message: ExtMessage,
+    ) -> RunnerBuilder {
+        self.programs.push(InitializeProgramInfo {
+            source_id: source_id.into(),
+            new_program_id: new_program_id.into(),
+            message,
+            code,
+        });
+        RunnerBuilder {
+            config: self.config,
+            programs: self.programs,
+            storage: self.storage,
+        }
+    }
+
+    /// Initialize all programs and return [`Runner`].
+    pub fn build(self) -> Runner<InMemoryMessageQueue, InMemoryProgramStorage, InMemoryWaitList> {
+        let mut runner = Runner::new(&self.config, self.storage);
+        for program in self.programs {
+            runner
+                .init_program(program)
+                .expect("failed to init program");
+        }
+        runner
+    }
+}

--- a/core-runner/src/lib.rs
+++ b/core-runner/src/lib.rs
@@ -24,6 +24,7 @@
 #[macro_use]
 extern crate alloc;
 
+#[allow(dead_code)]
+mod builder;
 pub mod runner;
-
 pub use runner::*;

--- a/core-runner/src/runner.rs
+++ b/core-runner/src/runner.rs
@@ -1128,7 +1128,7 @@ mod tests {
 
         let mut runner = RunnerBuilder::new()
             .program(parse_wat(wat))
-            .message(ExtMessage {
+            .init_message(ExtMessage {
                 id: 1000001.into(),
                 payload: "init".as_bytes().to_vec(),
                 gas_limit: u64::MAX,
@@ -1280,7 +1280,7 @@ mod tests {
 
         let mut runner = RunnerBuilder::new()
             .program(parse_wat(wat))
-            .message(ExtMessage {
+            .init_message(ExtMessage {
                 id: 1000001.into(),
                 payload: "init".as_bytes().to_vec(),
                 gas_limit: u64::MAX,
@@ -1340,7 +1340,7 @@ mod tests {
             .program(parse_wat(wat))
             .source(source_id)
             .program_id(dest_id)
-            .message(ExtMessage {
+            .init_message(ExtMessage {
                 id: 1000001.into(),
                 payload: "init".as_bytes().to_vec(),
                 gas_limit: u64::MAX,
@@ -1408,7 +1408,7 @@ mod tests {
 
         let mut runner = RunnerBuilder::new()
             .program(parse_wat(wat))
-            .message(ExtMessage {
+            .init_message(ExtMessage {
                 id: 1000001.into(),
                 payload: "init".as_bytes().to_vec(),
                 gas_limit: u64::MAX,

--- a/core-runner/src/runner.rs
+++ b/core-runner/src/runner.rs
@@ -189,74 +189,6 @@ pub struct Runner<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList> {
     env: Environment<Ext>,
 }
 
-/// Builder for [`Runner`].
-pub struct RunnerBuilder<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList> {
-    config: Config,
-    programs: Vec<InitializeProgramInfo>,
-    storage: Storage<MQ, PS, WL>,
-}
-
-impl<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList> RunnerBuilder<MQ, PS, WL> {
-    /// Default [`Runner`].
-    pub fn new() -> RunnerBuilder<MQ, PS, WL> {
-        RunnerBuilder {
-            config: Config::default(),
-            programs: vec![],
-            storage: Storage::default(),
-        }
-    }
-
-    /// Set [`Config`].
-    pub fn config(self, config: Config) -> RunnerBuilder<MQ, PS, WL> {
-        RunnerBuilder {
-            config: config,
-            programs: self.programs,
-            storage: self.storage,
-        }
-    }
-
-    /// Set [`Storage`].
-    pub fn storage(self, storage: Storage<MQ, PS, WL>) -> RunnerBuilder<MQ, PS, WL> {
-        RunnerBuilder {
-            config: self.config,
-            programs: self.programs,
-            storage: storage,
-        }
-    }
-
-    /// Set [`Program`] to be initialized on build.
-    pub fn program(
-        mut self,
-        source_id: u64,
-        new_program_id: u64,
-        code: Vec<u8>,
-        message: ExtMessage,
-    ) -> RunnerBuilder<MQ, PS, WL> {
-        self.programs.push(InitializeProgramInfo {
-            source_id: source_id.into(),
-            new_program_id: new_program_id.into(),
-            message,
-            code,
-        });
-        RunnerBuilder {
-            config: self.config,
-            programs: self.programs,
-            storage: self.storage,
-        }
-    }
-
-    /// Initialize all programs and return [`Runner`].
-    pub fn build(self) -> Runner<MQ, PS, WL> {
-        let mut runner = Runner::new(&self.config, self.storage);
-        for program in self.programs {
-            runner
-                .init_program(program)
-                .expect("failed to init program");
-        }
-        runner
-    }
-}
-
 /// Message payload with pre-generated identifier and economic data.
 pub struct ExtMessage {
     /// Id of the message.
@@ -1050,6 +982,7 @@ mod tests {
     extern crate wabt;
 
     use super::*;
+    use crate::builder::RunnerBuilder;
     use env_logger::Env;
     use gear_core::storage::{
         InMemoryMessageQueue, InMemoryProgramStorage, InMemoryStorage, InMemoryWaitList, MessageMap,

--- a/core-runner/src/runner.rs
+++ b/core-runner/src/runner.rs
@@ -1023,19 +1023,7 @@ mod tests {
                 (func $init)
             )"#;
 
-        let mut runner = RunnerBuilder::new()
-            .program(
-                1001,
-                1,
-                parse_wat(wat),
-                ExtMessage {
-                    id: 1000001.into(),
-                    payload: vec![],
-                    gas_limit: u64::MAX,
-                    value: 0,
-                },
-            )
-            .build();
+        let mut runner = RunnerBuilder::new().program(parse_wat(wat)).build().build();
 
         runner.queue_message(MessageDispatch {
             source_id: 1001.into(),
@@ -1139,17 +1127,14 @@ mod tests {
           )"#;
 
         let mut runner = RunnerBuilder::new()
-            .program(
-                1001,
-                1,
-                parse_wat(wat),
-                ExtMessage {
-                    id: 1000001.into(),
-                    payload: "init".as_bytes().to_vec(),
-                    gas_limit: u64::MAX,
-                    value: 0,
-                },
-            )
+            .program(parse_wat(wat))
+            .message(ExtMessage {
+                id: 1000001.into(),
+                payload: "init".as_bytes().to_vec(),
+                gas_limit: u64::MAX,
+                value: 0,
+            })
+            .build()
             .build();
 
         runner.run_next(u64::MAX);
@@ -1238,19 +1223,7 @@ mod tests {
             )
           )"#;
 
-        let mut runner = RunnerBuilder::new()
-            .program(
-                1001,
-                1,
-                parse_wat(wat),
-                ExtMessage {
-                    id: 1000001.into(),
-                    payload: vec![],
-                    gas_limit: u64::MAX,
-                    value: 0,
-                },
-            )
-            .build();
+        let mut runner = RunnerBuilder::new().program(parse_wat(wat)).build().build();
 
         runner.run_next(u64::MAX);
 
@@ -1306,17 +1279,14 @@ mod tests {
         let program_id = 1.into();
 
         let mut runner = RunnerBuilder::new()
-            .program(
-                1001,
-                1,
-                parse_wat(wat),
-                ExtMessage {
-                    id: 1000001.into(),
-                    payload: "init".as_bytes().to_vec(),
-                    gas_limit: u64::MAX,
-                    value: 0,
-                },
-            )
+            .program(parse_wat(wat))
+            .message(ExtMessage {
+                id: 1000001.into(),
+                payload: "init".as_bytes().to_vec(),
+                gas_limit: u64::MAX,
+                value: 0,
+            })
+            .build()
             .build();
 
         runner.queue_message(MessageDispatch {
@@ -1367,17 +1337,16 @@ mod tests {
         let msg_id: MessageId = 1000001.into();
 
         let mut runner = RunnerBuilder::new()
-            .program(
-                source_id,
-                dest_id,
-                parse_wat(wat),
-                ExtMessage {
-                    id: 1000001.into(),
-                    payload: "init".as_bytes().to_vec(),
-                    gas_limit: u64::MAX,
-                    value: 0,
-                },
-            )
+            .program(parse_wat(wat))
+            .source(source_id)
+            .program_id(dest_id)
+            .message(ExtMessage {
+                id: 1000001.into(),
+                payload: "init".as_bytes().to_vec(),
+                gas_limit: u64::MAX,
+                value: 0,
+            })
+            .build()
             .build();
 
         let payload = b"Test Wait";
@@ -1438,17 +1407,14 @@ mod tests {
         )"#;
 
         let mut runner = RunnerBuilder::new()
-            .program(
-                1001,
-                1,
-                parse_wat(wat),
-                ExtMessage {
-                    id: 1000001.into(),
-                    payload: "init".as_bytes().to_vec(),
-                    gas_limit: u64::MAX,
-                    value: 0,
-                },
-            )
+            .program(parse_wat(wat))
+            .message(ExtMessage {
+                id: 1000001.into(),
+                payload: "init".as_bytes().to_vec(),
+                gas_limit: u64::MAX,
+                value: 0,
+            })
+            .build()
             .build();
 
         let gas_limit = 1000_000;

--- a/core-runner/src/runner.rs
+++ b/core-runner/src/runner.rs
@@ -1339,7 +1339,7 @@ mod tests {
         let mut runner = RunnerBuilder::new()
             .program(parse_wat(wat))
             .source(source_id)
-            .program_id(dest_id)
+            .id(dest_id)
             .init_message(ExtMessage {
                 id: 1000001.into(),
                 payload: "init".as_bytes().to_vec(),

--- a/core-runner/src/runner.rs
+++ b/core-runner/src/runner.rs
@@ -984,9 +984,7 @@ mod tests {
     use super::*;
     use crate::builder::RunnerBuilder;
     use env_logger::Env;
-    use gear_core::storage::{
-        InMemoryMessageQueue, InMemoryProgramStorage, InMemoryStorage, InMemoryWaitList, MessageMap,
-    };
+    use gear_core::storage::{InMemoryStorage, MessageMap};
 
     fn parse_wat(source: &str) -> Vec<u8> {
         let module_bytes = wabt::Wat2Wasm::new()
@@ -1140,20 +1138,19 @@ mod tests {
               )
           )"#;
 
-        let mut runner: Runner<InMemoryMessageQueue, InMemoryProgramStorage, InMemoryWaitList> =
-            RunnerBuilder::new()
-                .program(
-                    1001,
-                    1,
-                    parse_wat(wat),
-                    ExtMessage {
-                        id: 1000001.into(),
-                        payload: "init".as_bytes().to_vec(),
-                        gas_limit: u64::MAX,
-                        value: 0,
-                    },
-                )
-                .build();
+        let mut runner = RunnerBuilder::new()
+            .program(
+                1001,
+                1,
+                parse_wat(wat),
+                ExtMessage {
+                    id: 1000001.into(),
+                    payload: "init".as_bytes().to_vec(),
+                    gas_limit: u64::MAX,
+                    value: 0,
+                },
+            )
+            .build();
 
         runner.run_next(u64::MAX);
 
@@ -1241,20 +1238,19 @@ mod tests {
             )
           )"#;
 
-        let mut runner: Runner<InMemoryMessageQueue, InMemoryProgramStorage, InMemoryWaitList> =
-            RunnerBuilder::new()
-                .program(
-                    1001,
-                    1,
-                    parse_wat(wat),
-                    ExtMessage {
-                        id: 1000001.into(),
-                        payload: vec![],
-                        gas_limit: u64::MAX,
-                        value: 0,
-                    },
-                )
-                .build();
+        let mut runner = RunnerBuilder::new()
+            .program(
+                1001,
+                1,
+                parse_wat(wat),
+                ExtMessage {
+                    id: 1000001.into(),
+                    payload: vec![],
+                    gas_limit: u64::MAX,
+                    value: 0,
+                },
+            )
+            .build();
 
         runner.run_next(u64::MAX);
 
@@ -1309,20 +1305,19 @@ mod tests {
         let caller_id = 0.into();
         let program_id = 1.into();
 
-        let mut runner: Runner<InMemoryMessageQueue, InMemoryProgramStorage, InMemoryWaitList> =
-            RunnerBuilder::new()
-                .program(
-                    1001,
-                    1,
-                    parse_wat(wat),
-                    ExtMessage {
-                        id: 1000001.into(),
-                        payload: "init".as_bytes().to_vec(),
-                        gas_limit: u64::MAX,
-                        value: 0,
-                    },
-                )
-                .build();
+        let mut runner = RunnerBuilder::new()
+            .program(
+                1001,
+                1,
+                parse_wat(wat),
+                ExtMessage {
+                    id: 1000001.into(),
+                    payload: "init".as_bytes().to_vec(),
+                    gas_limit: u64::MAX,
+                    value: 0,
+                },
+            )
+            .build();
 
         runner.queue_message(MessageDispatch {
             source_id: caller_id,
@@ -1371,20 +1366,19 @@ mod tests {
         let gas_limit = 1_000_000;
         let msg_id: MessageId = 1000001.into();
 
-        let mut runner: Runner<InMemoryMessageQueue, InMemoryProgramStorage, InMemoryWaitList> =
-            RunnerBuilder::new()
-                .program(
-                    source_id,
-                    dest_id,
-                    parse_wat(wat),
-                    ExtMessage {
-                        id: 1000001.into(),
-                        payload: "init".as_bytes().to_vec(),
-                        gas_limit: u64::MAX,
-                        value: 0,
-                    },
-                )
-                .build();
+        let mut runner = RunnerBuilder::new()
+            .program(
+                source_id,
+                dest_id,
+                parse_wat(wat),
+                ExtMessage {
+                    id: 1000001.into(),
+                    payload: "init".as_bytes().to_vec(),
+                    gas_limit: u64::MAX,
+                    value: 0,
+                },
+            )
+            .build();
 
         let payload = b"Test Wait";
 
@@ -1443,20 +1437,19 @@ mod tests {
             (func $init)
         )"#;
 
-        let mut runner: Runner<InMemoryMessageQueue, InMemoryProgramStorage, InMemoryWaitList> =
-            RunnerBuilder::new()
-                .program(
-                    1001,
-                    1,
-                    parse_wat(wat),
-                    ExtMessage {
-                        id: 1000001.into(),
-                        payload: "init".as_bytes().to_vec(),
-                        gas_limit: u64::MAX,
-                        value: 0,
-                    },
-                )
-                .build();
+        let mut runner = RunnerBuilder::new()
+            .program(
+                1001,
+                1,
+                parse_wat(wat),
+                ExtMessage {
+                    id: 1000001.into(),
+                    payload: "init".as_bytes().to_vec(),
+                    gas_limit: u64::MAX,
+                    value: 0,
+                },
+            )
+            .build();
 
         let gas_limit = 1000_000;
         let caller_id = 1001.into();


### PR DESCRIPTION
Fixes #128.

```rust
let mut runner = RunnerBuilder::new()
            .program(parse_wat(wat))
            .init_message(ExtMessage {
                id: 1000001.into(),
                payload: "init".as_bytes().to_vec(),
                gas_limit: u64::MAX,
                value: 0,
            })
            .build()
            .program(parse_wat(wat))
            .build()
            .build();
```

@gear-tech/dev 
