### PR TITLE
Move meta data to send_commit

### DIFF
--- a/core-backend/src/funcs.rs
+++ b/core-backend/src/funcs.rs
@@ -169,10 +169,19 @@ pub(crate) fn send<E: Ext>(
 
 pub(crate) fn send_commit<E: Ext>(
     ext: LaterExt<E>,
-) -> impl Fn(i32, i32) -> Result<(), &'static str> {
-    move |handle_ptr: i32, message_id_ptr: i32| {
+) -> impl Fn(i32, i32, i32, i64, i32) -> Result<(), &'static str> {
+    move |handle_ptr: i32,
+          message_id_ptr: i32,
+          program_id_ptr: i32,
+          gas_limit: i64,
+          value_ptr: i32| {
         ext.with(|ext: &mut E| -> Result<(), &'static str> {
-            let message_id = ext.send_commit(handle_ptr as _)?;
+            let dest: ProgramId = get_id(ext, program_id_ptr).into();
+            let value = get_u128(ext, value_ptr);
+            let message_id = ext.send_commit(
+                handle_ptr as _,
+                OutgoingPacket::new(dest, vec![].into(), gas_limit as _, value),
+            )?;
             ext.set_mem(message_id_ptr as isize as _, message_id.as_slice());
             Ok(())
         })?
@@ -180,25 +189,9 @@ pub(crate) fn send_commit<E: Ext>(
     }
 }
 
-pub(crate) fn send_init<E: Ext>(
-    ext: LaterExt<E>,
-) -> impl Fn(i32, i32, i32, i64, i32) -> Result<i32, &'static str> {
-    move |program_id_ptr: i32,
-          payload_ptr: i32,
-          payload_len: i32,
-          gas_limit: i64,
-          value_ptr: i32| {
-        let result = ext.with(|ext: &mut E| {
-            let dest: ProgramId = get_id(ext, program_id_ptr).into();
-            let payload = get_vec(ext, payload_ptr, payload_len);
-            let value = get_u128(ext, value_ptr);
-            ext.send_init(OutgoingPacket::new(
-                dest,
-                payload.into(),
-                gas_limit as _,
-                value,
-            ))
-        })?;
+pub(crate) fn send_init<E: Ext>(ext: LaterExt<E>) -> impl Fn() -> Result<i32, &'static str> {
+    move || {
+        let result = ext.with(|ext: &mut E| ext.send_init())?;
         result
             .map_err(|_| "Trapping: unable to init message")
             .map(|handle| handle as _)

--- a/core-backend/src/wasmi/env.rs
+++ b/core-backend/src/wasmi/env.rs
@@ -145,10 +145,10 @@ impl<E: Ext + 'static> Externals for Runtime<E> {
 
             Some(FuncIndex::SendCommit) => funcs::send_commit(self.ext.clone())(
                 args.nth(0),
-                args.nth(0),
-                args.nth(0),
-                args.nth(0),
-                args.nth(0),
+                args.nth(1),
+                args.nth(2),
+                args.nth(3),
+                args.nth(4),
             )
             .map(|_| None)
             .map_err(|_| Trap::new(TrapKind::UnexpectedSignature)),

--- a/core-backend/src/wasmi/env.rs
+++ b/core-backend/src/wasmi/env.rs
@@ -143,21 +143,19 @@ impl<E: Ext + 'static> Externals for Runtime<E> {
             .map(|_| None)
             .map_err(|_| Trap::new(TrapKind::UnexpectedSignature)),
 
-            Some(FuncIndex::SendCommit) => {
-                funcs::send_commit(self.ext.clone())(args.nth(0), args.nth(0))
-                    .map(|_| None)
-                    .map_err(|_| Trap::new(TrapKind::UnexpectedSignature))
-            }
-
-            Some(FuncIndex::SendInit) => funcs::send_init(self.ext.clone())(
+            Some(FuncIndex::SendCommit) => funcs::send_commit(self.ext.clone())(
                 args.nth(0),
-                args.nth(1),
-                args.nth(2),
-                args.nth(3),
-                args.nth(4),
+                args.nth(0),
+                args.nth(0),
+                args.nth(0),
+                args.nth(0),
             )
             .map(|_| None)
             .map_err(|_| Trap::new(TrapKind::UnexpectedSignature)),
+
+            Some(FuncIndex::SendInit) => funcs::send_init(self.ext.clone())()
+                .map(|_| None)
+                .map_err(|_| Trap::new(TrapKind::UnexpectedSignature)),
 
             Some(FuncIndex::SendPush) => {
                 funcs::send_push(self.ext.clone())(args.nth(0), args.nth(1), args.nth(2))

--- a/core-backend/src/wasmtime/env.rs
+++ b/core-backend/src/wasmtime/env.rs
@@ -53,7 +53,7 @@ impl<E: Ext + 'static> Environment<E> {
         result.add_func_i32_to_u32("alloc", funcs::alloc);
         result.add_func_i32("free", funcs::free);
         result.add_func_i32("gas", funcs::gas);
-        result.add_func_to_i64("gr_gas_available", funcs::gas_available);
+        result.add_func_into_i64("gr_gas_available", funcs::gas_available);
         result.add_func_i64("gr_charge", funcs::charge);
         result.add_func_i32_i32("gr_debug", funcs::debug);
         result.add_func_i32("gr_msg_id", funcs::msg_id);
@@ -62,10 +62,10 @@ impl<E: Ext + 'static> Environment<E> {
         result.add_func_i32_i32("gr_reply_push", funcs::reply_push);
         result.add_func_i32("gr_reply_to", funcs::reply_to);
         result.add_func_i32_i32_i32_i64_i32_i32("gr_send", funcs::send);
-        result.add_func_i32_i32("gr_send_commit", funcs::send_commit);
-        result.add_func_i32_i32_i32_i64_i32_to_i32("gr_send_init", funcs::send_init);
+        result.add_func_i32_i32_i32_i64_i32("gr_send_commit", funcs::send_commit);
+        result.add_func_to_i32("gr_send_init", funcs::send_init);
         result.add_func_i32_i32_i32("gr_send_push", funcs::send_push);
-        result.add_func_to_i32("gr_size", funcs::size);
+        result.add_func_into_i32("gr_size", funcs::size);
         result.add_func_i32("gr_source", funcs::source);
         result.add_func_i32("gr_value", funcs::value);
         result.add_func("gr_wait", funcs::wait);
@@ -225,12 +225,9 @@ impl<E: Ext + 'static> Environment<E> {
         );
     }
 
-    fn add_func_i32_i32_i32_i64_i32_to_i32<F>(
-        &mut self,
-        key: &'static str,
-        func: fn(LaterExt<E>) -> F,
-    ) where
-        F: 'static + Fn(i32, i32, i32, i64, i32) -> Result<i32, &'static str>,
+    fn add_func_i32_i32_i32_i64_i32<F>(&mut self, key: &'static str, func: fn(LaterExt<E>) -> F)
+    where
+        F: 'static + Fn(i32, i32, i32, i64, i32) -> Result<(), &'static str>,
     {
         self.funcs.insert(
             key,
@@ -278,7 +275,7 @@ impl<E: Ext + 'static> Environment<E> {
         );
     }
 
-    fn add_func_to_i32<F>(&mut self, key: &'static str, func: fn(LaterExt<E>) -> F)
+    fn add_func_into_i32<F>(&mut self, key: &'static str, func: fn(LaterExt<E>) -> F)
     where
         F: 'static + Fn() -> i32,
     {
@@ -286,7 +283,17 @@ impl<E: Ext + 'static> Environment<E> {
             .insert(key, Func::wrap(&self.store, func(self.ext.clone())));
     }
 
-    fn add_func_to_i64<F>(&mut self, key: &'static str, func: fn(LaterExt<E>) -> F)
+    fn add_func_to_i32<F>(&mut self, key: &'static str, func: fn(LaterExt<E>) -> F)
+    where
+        F: 'static + Fn() -> Result<i32, &'static str>,
+    {
+        self.funcs.insert(
+            key,
+            Func::wrap(&self.store, Self::wrap0(func(self.ext.clone()))),
+        );
+    }
+
+    fn add_func_into_i64<F>(&mut self, key: &'static str, func: fn(LaterExt<E>) -> F)
     where
         F: 'static + Fn() -> i64,
     {

--- a/core-runner/src/runner.rs
+++ b/core-runner/src/runner.rs
@@ -688,11 +688,8 @@ impl EnvExt for Ext {
         self.return_with_tracing(result)
     }
 
-    fn send_init(&mut self, msg: OutgoingPacket) -> Result<usize, &'static str> {
-        let result = self
-            .messages
-            .send_init(msg)
-            .map_err(|_e| "Message init error");
+    fn send_init(&mut self) -> Result<usize, &'static str> {
+        let result = self.messages.send_init().map_err(|_e| "Message init error");
 
         self.return_with_tracing(result)
     }
@@ -715,7 +712,11 @@ impl EnvExt for Ext {
         self.return_with_tracing(result)
     }
 
-    fn send_commit(&mut self, handle: usize) -> Result<MessageId, &'static str> {
+    fn send_commit(
+        &mut self,
+        handle: usize,
+        msg: OutgoingPacket,
+    ) -> Result<MessageId, &'static str> {
         {
             let gas_limit = match self
                 .messages
@@ -736,7 +737,7 @@ impl EnvExt for Ext {
 
         let result = self
             .messages
-            .send_commit(handle)
+            .send_commit(handle, msg)
             .map_err(|_e| "Message commit error");
 
         self.return_with_tracing(result)

--- a/core-runner/src/runner.rs
+++ b/core-runner/src/runner.rs
@@ -670,6 +670,7 @@ impl Ext {
 impl EnvExt for Ext {
     fn alloc(&mut self, pages: PageNumber) -> Result<PageNumber, &'static str> {
         self.gas(pages.raw() * self.alloc_cost as u32)?;
+
         let result = self
             .memory_context
             .alloc(pages)
@@ -683,6 +684,7 @@ impl EnvExt for Ext {
             return self
                 .return_with_tracing(Err("Gas limit exceeded while trying to send message"));
         }
+
         let result = self.messages.send(msg).map_err(|_e| "Message send error");
 
         self.return_with_tracing(result)
@@ -717,23 +719,10 @@ impl EnvExt for Ext {
         handle: usize,
         msg: OutgoingPacket,
     ) -> Result<MessageId, &'static str> {
-        {
-            let gas_limit = match self
-                .messages
-                .get_gas_limit(handle)
-                .map_err(|_e| "Message commit error")
-            {
-                Ok(gas) => gas,
-                Err(_e) => {
-                    return self.return_with_tracing(Err("No message to commit"));
-                }
-            };
-
-            if self.gas_counter.charge(gas_limit) != ChargeResult::Enough {
-                return self
-                    .return_with_tracing(Err("Gas limit exceeded while trying to send message"));
-            }
-        }
+        if self.gas_counter.charge(msg.gas_limit()) != ChargeResult::Enough {
+            return self
+                .return_with_tracing(Err("Gas limit exceeded while trying to send message"));
+        };
 
         let result = self
             .messages
@@ -763,11 +752,13 @@ impl EnvExt for Ext {
 
     fn free(&mut self, ptr: PageNumber) -> Result<(), &'static str> {
         let result = self.memory_context.free(ptr).map_err(|_e| "Free error");
+
         self.return_with_tracing(result)
     }
 
     fn debug(&mut self, data: &str) -> Result<(), &'static str> {
         log::debug!("DEBUG: {}", data);
+
         Ok(())
     }
 

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -53,7 +53,7 @@ pub trait Ext {
     fn send(&mut self, msg: OutgoingPacket) -> Result<MessageId, &'static str>;
 
     /// Initialize a new incomplete message for another program and return its handle.
-    fn send_init(&mut self, msg: OutgoingPacket) -> Result<usize, &'static str>;
+    fn send_init(&mut self) -> Result<usize, &'static str>;
 
     /// Push an extra buffer into message payload by handle.
     fn send_push(&mut self, handle: usize, buffer: &[u8]) -> Result<(), &'static str>;
@@ -62,7 +62,11 @@ pub trait Ext {
     fn reply_push(&mut self, buffer: &[u8]) -> Result<(), &'static str>;
 
     /// Complete message and send it to another program.
-    fn send_commit(&mut self, handle: usize) -> Result<MessageId, &'static str>;
+    fn send_commit(
+        &mut self,
+        handle: usize,
+        msg: OutgoingPacket,
+    ) -> Result<MessageId, &'static str>;
 
     /// Produce reply to the current message.
     fn reply(&mut self, msg: ReplyPacket) -> Result<(), &'static str>;
@@ -181,7 +185,7 @@ mod tests {
         fn send(&mut self, _msg: OutgoingPacket) -> Result<MessageId, &'static str> {
             Ok(MessageId::default())
         }
-        fn send_init(&mut self, _msg: OutgoingPacket) -> Result<usize, &'static str> {
+        fn send_init(&mut self) -> Result<usize, &'static str> {
             Ok(0)
         }
         fn send_push(&mut self, _handle: usize, _buffer: &[u8]) -> Result<(), &'static str> {
@@ -190,7 +194,11 @@ mod tests {
         fn reply_push(&mut self, _buffer: &[u8]) -> Result<(), &'static str> {
             Ok(())
         }
-        fn send_commit(&mut self, _handle: usize) -> Result<MessageId, &'static str> {
+        fn send_commit(
+            &mut self,
+            _handle: usize,
+            _msg: OutgoingPacket,
+        ) -> Result<MessageId, &'static str> {
             Ok(MessageId::default())
         }
         fn reply(&mut self, _msg: ReplyPacket) -> Result<(), &'static str> {

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -728,21 +728,6 @@ impl<IG: MessageIdGenerator + 'static> MessageContext<IG> {
         self.id_generator.borrow().current()
     }
 
-    /// Return gas_limit of the message by handle.
-    pub fn get_gas_limit(&self, handle: usize) -> Result<u64, Error> {
-        let state = self.state.borrow();
-
-        if handle >= state.outgoing.len() {
-            return Err(Error::OutOfBounds);
-        }
-
-        if let (None, Some(msg)) = &state.outgoing[handle] {
-            Ok(msg.gas_limit())
-        } else {
-            Err(Error::OutOfBounds)
-        }
-    }
-
     /// Drop this context.
     ///
     /// Do it to return all outgoing messages and optional reply generated using this context.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "mem",
     "meta",
     "minimal",
+    "multiping",
     "panicker",
     "ping",
     "sum",

--- a/examples/multiping/Cargo.toml
+++ b/examples/multiping/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "demo-multiping"
+version = "0.1.0"
+authors = ["Gear Technologies"]
+edition = "2018"
+license = "GPL-3.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+gstd = { path = "../../gstd", features = ["debug"] }

--- a/examples/multiping/src/lib.rs
+++ b/examples/multiping/src/lib.rs
@@ -1,0 +1,32 @@
+#![no_std]
+#![feature(default_alloc_error_handler)]
+
+use gstd::{msg, prelude::*};
+
+#[no_mangle]
+pub unsafe extern "C" fn handle() {
+    let new_msg = String::from_utf8(msg::load()).expect("Invalid message: should be utf-8");
+
+    if new_msg == "PING" {
+        msg::reply(b"PO", 10_000_000, 0);
+        msg::reply_push(b"NG");
+    }
+
+    if new_msg == "PING PING PING" {
+        let handle = msg::send_init();
+        msg::send_push(handle, b"PONG1");
+        msg::send_push(handle, b"PONG2");
+        msg::send_push(handle, b"PONG3");
+        msg::send_commit(handle, msg::source(), 1844674407370955161, 0);
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn init() {}
+
+#[panic_handler]
+fn panic(_info: &panic::PanicInfo) -> ! {
+    unsafe {
+        core::arch::wasm32::unreachable();
+    }
+}

--- a/examples/multiping/src/lib.rs
+++ b/examples/multiping/src/lib.rs
@@ -17,7 +17,7 @@ pub unsafe extern "C" fn handle() {
         msg::send_push(handle, b"PONG1");
         msg::send_push(handle, b"PONG2");
         msg::send_push(handle, b"PONG3");
-        msg::send_commit(handle, msg::source(), 1844674407370955161, 0);
+        msg::send_commit(handle, msg::source(), 10_000_000, 0);
     }
 }
 

--- a/gstd/src/general.rs
+++ b/gstd/src/general.rs
@@ -16,6 +16,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MessageHandle(pub(crate) u32);
+
 #[derive(Clone, Copy, Debug, Default, Hash, Ord, PartialEq, PartialOrd, Eq)]
 pub struct MessageId(pub [u8; 32]);
 

--- a/gstd/src/msg.rs
+++ b/gstd/src/msg.rs
@@ -17,10 +17,8 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::prelude::Vec;
+use crate::MessageHandle;
 use crate::{MessageId, ProgramId};
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct MessageHandle(u32);
 
 mod sys {
     extern "C" {

--- a/gtest/spec/test_multiping.yaml
+++ b/gtest/spec/test_multiping.yaml
@@ -1,0 +1,36 @@
+title: Multiping
+
+programs:
+  - id: 1
+    path: examples/target/wasm32-unknown-unknown/release/demo_multiping.wasm
+
+fixtures:
+  - title: multiping
+
+    messages:
+      - destination: 1
+        payload:
+          kind: utf-8
+          value: PING
+      - destination: 1
+        payload:
+          kind: utf-8
+          value: PING PING PING
+
+    expected:
+      - step: 1
+        log:
+          - destination: 0
+            payload:
+              kind: utf-8
+              value: PONG
+      - step: 2
+        log:
+          - destination: 0
+            payload:
+              kind: utf-8
+              value: PONG
+          - destination: 0
+            payload:
+              kind: utf-8
+              value: PONG1PONG2PONG3


### PR DESCRIPTION
- Message meta data about destination, gas limit and value moved to `send_commit` from `send_init`
- `MessageId` now generates only when message are sent or committed
- Removed `FormationStatus` flag: now `MessageState`'s `outgoing` has type `Vec<(Option<Payload>, Option<OutgoingMessage>)>`. When `Option<Payload>` is `None` it means that `OutgoingMessage` was formed

- API updated
- Tests updated

@gear-tech/dev