### PR TITLE
Refactor gas charges when accounting further messages

### DIFF
--- a/core-backend/src/funcs.rs
+++ b/core-backend/src/funcs.rs
@@ -50,13 +50,6 @@ pub(crate) fn free<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'sta
     }
 }
 
-pub(crate) fn charge<E: Ext>(ext: LaterExt<E>) -> impl Fn(i64) -> Result<(), &'static str> {
-    move |gas: i64| {
-        ext.with(|ext: &mut E| ext.charge(gas as u64))?
-            .map_err(|_| "Trapping: unable to charge gas for reserve")
-    }
-}
-
 pub(crate) fn debug<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32, i32) -> Result<(), &'static str> {
     move |str_ptr: i32, str_len: i32| {
         let str_ptr = str_ptr as u32 as usize;

--- a/core-backend/src/wasmi/env.rs
+++ b/core-backend/src/wasmi/env.rs
@@ -86,10 +86,6 @@ impl<E: Ext + 'static> Externals for Runtime<E> {
                 .map(|v| Some(RuntimeValue::I32(v as i32)))
                 .map_err(|_| Trap::new(TrapKind::UnexpectedSignature)),
 
-            Some(FuncIndex::Charge) => funcs::charge(self.ext.clone())(args.nth(0))
-                .map(|_| None)
-                .map_err(|_| Trap::new(TrapKind::InvalidConversionToInt)),
-
             Some(FuncIndex::Debug) => funcs::debug(self.ext.clone())(args.nth(0), args.nth(1))
                 .map(|_| None)
                 .map_err(|_| Trap::new(TrapKind::UnexpectedSignature)),
@@ -204,7 +200,6 @@ impl<E: Ext + 'static> ModuleImportResolver for Environment<E> {
             "free" => func_instance!(Free, ValueType::I32 => None),
             "gas" => func_instance!(Gas, ValueType::I32 => None),
             "gr_gas_available" => func_instance!(GasAvailable, => Some(ValueType::I64)),
-            "gr_charge" => func_instance!(Charge, ValueType::I64 => None),
             "gr_debug" => func_instance!(Debug, ValueType::I32, ValueType::I32 => None),
             "gr_msg_id" => func_instance!(MsgId, ValueType::I32 => None),
             "gr_read" => {

--- a/core-backend/src/wasmtime/env.rs
+++ b/core-backend/src/wasmtime/env.rs
@@ -54,7 +54,6 @@ impl<E: Ext + 'static> Environment<E> {
         result.add_func_i32("free", funcs::free);
         result.add_func_i32("gas", funcs::gas);
         result.add_func_to_i64("gr_gas_available", funcs::gas_available);
-        result.add_func_i64("gr_charge", funcs::charge);
         result.add_func_i32_i32("gr_debug", funcs::debug);
         result.add_func_i32("gr_msg_id", funcs::msg_id);
         result.add_func_i32_i32_i32("gr_read", funcs::read);
@@ -261,16 +260,6 @@ impl<E: Ext + 'static> Environment<E> {
     fn add_func_i32_to_u32<F>(&mut self, key: &'static str, func: fn(LaterExt<E>) -> F)
     where
         F: 'static + Fn(i32) -> Result<u32, &'static str>,
-    {
-        self.funcs.insert(
-            key,
-            Func::wrap(&self.store, Self::wrap1(func(self.ext.clone()))),
-        );
-    }
-
-    fn add_func_i64<F>(&mut self, key: &'static str, func: fn(LaterExt<E>) -> F)
-    where
-        F: 'static + Fn(i64) -> Result<(), &'static str>,
     {
         self.funcs.insert(
             key,

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -102,9 +102,6 @@ pub trait Ext {
     /// Tell how much gas is left in running context.
     fn gas_available(&mut self) -> u64;
 
-    /// Transfer gas to program from the caller side.
-    fn charge(&mut self, gas: u64) -> Result<(), &'static str>;
-
     /// Value associated with message.
     fn value(&self) -> u128;
 
@@ -224,9 +221,6 @@ mod tests {
         }
         fn value(&self) -> u128 {
             0
-        }
-        fn charge(&mut self, _gas: u64) -> Result<(), &'static str> {
-            Ok(())
         }
         fn wait(&mut self) -> Result<(), &'static str> {
             Ok(())

--- a/gstd/src/msg.rs
+++ b/gstd/src/msg.rs
@@ -25,7 +25,6 @@ pub struct MessageHandle(u32);
 mod sys {
     extern "C" {
         pub fn gr_gas_available() -> u64;
-        pub fn gr_charge(gas: u64);
         pub fn gr_msg_id(val: *mut u8);
         pub fn gr_read(at: u32, len: u32, dest: *mut u8);
         pub fn gr_reply(data_ptr: *const u8, data_len: u32, gas_limit: u64, value_ptr: *const u8);
@@ -53,12 +52,6 @@ mod sys {
         pub fn gr_value(val: *mut u8);
         pub fn gr_wait() -> !;
         pub fn gr_wake(waker_id_ptr: *const u8);
-    }
-}
-
-pub fn charge(gas: u64) {
-    unsafe {
-        sys::gr_charge(gas);
     }
 }
 

--- a/gstd/tests/smoke.rs
+++ b/gstd/tests/smoke.rs
@@ -105,18 +105,6 @@ fn messages() {
     assert_eq!(msg_load, b"HELLO");
 }
 
-#[test]
-fn transfer_gas() {
-    msg::charge(1000);
-    unsafe {
-        assert_eq!(GAS, 1000);
-    }
-    msg::charge(2000);
-    unsafe {
-        assert_eq!(GAS, 3000);
-    }
-}
-
 #[cfg(feature = "debug")]
 #[test]
 fn debug() {

--- a/node-rti/src/lib.rs
+++ b/node-rti/src/lib.rs
@@ -49,7 +49,6 @@ pub struct ExecutionReport {
     pub log: Vec<gear_common::Message>,
     pub gas_refunds: Vec<(H256, u64)>,
     pub gas_charges: Vec<(H256, u64)>,
-    pub gas_transfers: Vec<(H256, H256, u64)>,
     pub outcomes: Vec<(H256, Result<(), Vec<u8>>)>,
 }
 
@@ -60,7 +59,6 @@ impl ExecutionReport {
             handled,
             gas_left,
             gas_spent,
-            gas_requests,
             outcomes,
             ..
         } = result;
@@ -81,16 +79,6 @@ impl ExecutionReport {
             gas_charges: gas_spent
                 .into_iter()
                 .map(|(program_id, gas_left)| (H256::from_slice(program_id.as_slice()), gas_left))
-                .collect(),
-            gas_transfers: gas_requests
-                .into_iter()
-                .map(|(source_id, dest_id, gas_requested)| {
-                    (
-                        H256::from_slice(source_id.as_slice()),
-                        H256::from_slice(dest_id.as_slice()),
-                        gas_requested,
-                    )
-                })
                 .collect(),
             outcomes: outcomes
                 .into_iter()
@@ -155,7 +143,6 @@ pub trait GearExecutor {
         let result = RunNextResult::from_single(
             init_message_id,
             ProgramId::from_slice(&caller_id[..]),
-            ProgramId::from_slice(&program_id[..]),
             run_result,
         );
 

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -586,17 +586,6 @@ pub mod pallet {
                                     }
                                 }
 
-                                for (source, dest, gas_transfer) in execution_report.gas_transfers {
-                                    let transfer_fee = Self::gas_to_fee(gas_transfer);
-
-                                    let _ = T::Currency::repatriate_reserved(
-                                        &<T::AccountId as Origin>::from_origin(source),
-                                        &<T::AccountId as Origin>::from_origin(dest),
-                                        transfer_fee,
-                                        BalanceStatus::Free,
-                                    );
-                                }
-
                                 for message in execution_report.log {
                                     Self::deposit_event(Event::Log(message));
                                 }
@@ -713,17 +702,6 @@ pub mod pallet {
 
                             // Decrease block gas allowance
                             GasAllowance::<T>::mutate(|x| *x = x.saturating_sub(gas_charge));
-                        }
-
-                        for (source, dest, gas_transfer) in execution_report.gas_transfers {
-                            let transfer_fee = Self::gas_to_fee(gas_transfer);
-
-                            let _ = T::Currency::repatriate_reserved(
-                                &<T::AccountId as Origin>::from_origin(source),
-                                &<T::AccountId as Origin>::from_origin(dest),
-                                transfer_fee,
-                                BalanceStatus::Free,
-                            );
                         }
 
                         for message in execution_report.log {

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -218,6 +218,7 @@ fn send_message_works() {
         assert_eq!(msg_id, id);
 
         // Sending message to a non-program address works as a simple value transfer
+        // Gas limit is not transfered and returned back to sender (since operation is no-op).
         assert_eq!(Balances::free_balance(1), 99990000);
         assert_eq!(Balances::free_balance(2), 1);
         assert_ok!(Pallet::<Test>::send_message(
@@ -233,7 +234,10 @@ fn send_message_works() {
         assert_eq!(Balances::free_balance(2), 20_001);
         // The `gas_limit` part will be released to the recepient in the next block
         run_to_block(2, Some(100_000));
-        assert_eq!(Balances::free_balance(2), 30_001);
+        assert_eq!(Balances::free_balance(2), 20_001);
+
+        // original sender gets back whatever gas_limit he used to send a message.
+        assert_eq!(Balances::free_balance(1), 99_970_000);
     })
 }
 


### PR DESCRIPTION
1. Gas is not counted as burned and validator does not claim it (yet) when one message creates another message
2. Gas reservation is removed because now you can just send message to yourself to do basically the same