### PR TITLE
Rework gstd-async to be based on wait/wake

### DIFF
--- a/core-backend/src/funcs.rs
+++ b/core-backend/src/funcs.rs
@@ -58,7 +58,7 @@ pub(crate) fn debug<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32, i32) -> Result<(),
             let mut data = vec![0u8; str_len];
             ext.get_mem(str_ptr, &mut data);
             let debug_str = unsafe { String::from_utf8_unchecked(data) };
-            log::debug!("DEBUG: {}", debug_str);
+            log::debug!(target: "gwasm_debug", "DEBUG: {}", debug_str);
         })
     }
 }

--- a/gstd-async/src/msg.rs
+++ b/gstd-async/src/msg.rs
@@ -16,42 +16,79 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll};
 use gstd::{msg, MessageId, ProgramId};
 
-// Persistent state (must be stored between blocks)
-static mut MESSAGE_STATE: MessageState = MessageState::Idle;
+static mut WAITING_MESSAGES: Option<BTreeMap<MessageId, MessageId>> = None;
+static mut FUTURES: Option<BTreeMap<MessageId, MessageFutures>> = None;
 
-#[derive(PartialEq)]
-enum MessageState {
-    Idle,
-    Sent,
-    WaitForReply,
+#[derive(Clone, Default)]
+pub struct MessageFuture {
+    reply: Option<Vec<u8>>,
 }
 
-pub struct MessageFuture;
+impl MessageFuture {
+    pub fn new() -> Self {
+        Self { reply: None }
+    }
+
+    pub fn set_reply(&mut self, payload: Vec<u8>) {
+        self.reply = Some(payload);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.reply.is_none()
+    }
+}
 
 impl Future for MessageFuture {
     type Output = Vec<u8>;
 
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match *state() {
-            MessageState::Idle => Poll::Pending, // TODO: Unreachable, consider adding an assert here
-            MessageState::Sent => {
-                set_state(MessageState::WaitForReply);
-                Poll::Pending
-            }
-            MessageState::WaitForReply => {
-                if let Some(reply) = get_reply() {
-                    Poll::Ready(reply)
-                } else {
-                    Poll::Pending
-                }
-            }
+    fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let fut = &mut *self;
+        if fut.reply.is_some() {
+            Poll::Ready(fut.reply.take().unwrap())
+        } else {
+            Poll::Pending
         }
+    }
+}
+
+pub(crate) struct MessageFutures {
+    current: usize,
+    futures: Vec<MessageFuture>,
+}
+
+impl MessageFutures {
+    pub fn new() -> Self {
+        Self {
+            current: 0,
+            futures: Vec::new(),
+        }
+    }
+
+    pub fn reset_current(&mut self) {
+        self.current = 0;
+    }
+
+    pub fn clear(&mut self) {
+        self.futures.clear();
+    }
+
+    pub fn current_future_mut(&mut self) -> &mut MessageFuture {
+        while self.current >= self.futures.len() {
+            self.futures.push(MessageFuture::new());
+        }
+        self.futures.get_mut(self.current).unwrap()
+    }
+
+    pub fn next_future(&mut self) -> &MessageFuture {
+        self.current += 1;
+        self.current_future_mut()
     }
 }
 
@@ -62,29 +99,35 @@ pub fn send_and_wait_for_reply(
     gas_limit: u64,
     value: u128,
 ) -> MessageFuture {
-    if *state() == MessageState::Idle {
-        msg::send_with_value(program, payload, gas_limit, value);
-        set_state(MessageState::Sent);
+    let key_id = msg::id();
+    let fut = futures(key_id).next_future();
+    if fut.is_empty() {
+        // New message
+        let sent_msg_id = msg::send_with_value(program, payload, gas_limit, value);
+        waiting_messages().insert(sent_msg_id, key_id);
+        msg::wait();
     }
-    MessageFuture
+
+    fut.clone()
 }
 
-fn get_reply() -> Option<Vec<u8>> {
-    if msg::reply_to() != MessageId::default() {
-        set_state(MessageState::Idle);
-        return Some(msg::load());
-    }
-    None
-}
-
-#[inline]
-fn state() -> &'static MessageState {
-    unsafe { &MESSAGE_STATE }
-}
-
-#[inline]
-fn set_state(state: MessageState) {
+pub(crate) fn waiting_messages() -> &'static mut BTreeMap<MessageId, MessageId> {
     unsafe {
-        MESSAGE_STATE = state;
+        if WAITING_MESSAGES.is_none() {
+            WAITING_MESSAGES = Some(BTreeMap::new());
+        }
+        WAITING_MESSAGES.as_mut().unwrap()
+    }
+}
+
+pub(crate) fn futures(id: MessageId) -> &'static mut MessageFutures {
+    unsafe {
+        if FUTURES.is_none() {
+            FUTURES = Some(BTreeMap::new());
+        }
+        let map = FUTURES
+            .as_mut()
+            .expect("Cannot be none as it is set above; qed");
+        map.entry(id).or_insert_with(MessageFutures::new)
     }
 }

--- a/gtest/spec/test_async.yaml
+++ b/gtest/spec/test_async.yaml
@@ -5,9 +5,15 @@ programs:
     path: examples/target/wasm32-unknown-unknown/release/demo_async.wasm
     init_message:
       kind: utf-8
-      value: "{2}"
+      value: "{2},{3},{4}"
 
   - id: 2
+    path: examples/target/wasm32-unknown-unknown/release/demo_ping.wasm
+
+  - id: 3
+    path: examples/target/wasm32-unknown-unknown/release/demo_ping.wasm
+
+  - id: 4
     path: examples/target/wasm32-unknown-unknown/release/demo_ping.wasm
 
 fixtures:
@@ -15,18 +21,12 @@ fixtures:
 
     messages:
       - destination: 1
-        payload:
+        payload: &start
           kind: utf-8
           value: START
 
     expected:
       - step: 1
-        log:
-          - destination: 0
-            payload:
-              kind: utf-8
-              value: LOG
-
         messages:
           - destination: 2
             payload: &ping
@@ -42,10 +42,42 @@ fixtures:
 
       - step: 3
         messages:
-          - destination: 2
-            payload: *ping
+          - destination: 1
+            payload: *start
 
       - step: 4
         messages:
+          - destination: 3
+            payload: *ping
+
+      - step: 5
+        messages:
           - destination: 1
             payload: *pong
+
+      - step: 6
+        messages:
+          - destination: 1
+            payload: *start
+
+      - step: 7
+        messages:
+          - destination: 4
+            payload: *ping
+
+      - step: 8
+        messages:
+          - destination: 1
+            payload: *pong
+
+      - step: 9
+        messages:
+          - destination: 1
+            payload: *start
+
+      - step: 10
+        log:
+          - destination: 0
+            payload:
+              kind: utf-8
+              value: SUCCESS

--- a/gtest/src/main.rs
+++ b/gtest/src/main.rs
@@ -20,9 +20,9 @@ mod check;
 mod runner;
 mod sample;
 
-use gear_core::storage::InMemoryStorage;
-
 use clap::{AppSettings, Clap};
+use gear_core::storage::InMemoryStorage;
+use std::io::Write;
 
 #[derive(Clap)]
 #[clap(setting = AppSettings::ColoredHelp)]
@@ -47,8 +47,9 @@ pub fn main() -> anyhow::Result<()> {
     let opts: Opts = Opts::parse();
     match opts.verbose {
         0 => env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(
-            "gtest=warn,gear_core=warn,gear_core_backend=warn,gear_core_runner=warn",
+            "gtest=warn,gear_core=warn,gear_core_backend=warn,gear_core_runner=warn,gwasm_debug=debug",
         ))
+        .format(|buf, record| writeln!(buf, "{}", record.args()))
         .init(),
         1 => env_logger::Builder::from_env(
             env_logger::Env::default().default_filter_or("gtest=info"),

--- a/gtest/src/runner.rs
+++ b/gtest/src/runner.rs
@@ -92,13 +92,12 @@ pub fn init_fixture<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList>(
             init_message = match init_msg {
                 PayloadVariant::Utf8(s) => {
                     // Insert ProgramId
-                    if let Some(caps) = program_id_regex.captures(s) {
+                    let mut s = s.clone();
+                    while let Some(caps) = program_id_regex.captures(&s) {
                         let id = caps["id"].parse::<u64>().unwrap();
-                        let s = s.replace(&caps[0], &encode_hex(ProgramId::from(id).as_slice()));
-                        s.into_bytes()
-                    } else {
-                        init_msg.clone().into_raw()
+                        s = s.replace(&caps[0], &encode_hex(ProgramId::from(id).as_slice()));
                     }
+                    s.into_bytes()
                 }
                 _ => init_msg.clone().into_raw(),
             }


### PR DESCRIPTION
Another step to deal with #11.

- Use `wait`/`wake` functions.
- The solution is quite ugly and not optimal at the moment, need to find a better one.

TODO:

- [x] Pass multiple addresses via curly braces in YAML spec.
