### PR TITLE
Remove rpc tests from CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -74,10 +74,10 @@ jobs:
       - name: Run testsuite
         run: ./target/release/gear-node runtests ./gtest/spec/*.yaml
 
-      - name: Run rpc-test
-        run: |
-          ./target/release/gear-node --dev -l 2 & sleep 5
-          node rpc-tests/index.js ./gtest/spec/*.yaml
+      # - name: Run rpc-test
+      #   run: |
+      #     ./target/release/gear-node --dev -l 2 & sleep 5
+      #     node rpc-tests/index.js ./gtest/spec/*.yaml
 
       - name: Run metadata test
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -74,10 +74,6 @@ jobs:
       - name: Run testsuite
         run: ./target/release/gear-node runtests ./gtest/spec/*.yaml
 
-      # - name: Run rpc-test
-      #   run: |
-      #     ./target/release/gear-node --dev -l 2 & sleep 5
-      #     node rpc-tests/index.js ./gtest/spec/*.yaml
 
       - name: Run metadata test
         run: |


### PR DESCRIPTION
At the moment RPC tests works randomly and cannot act as a good test yet.

They might be fixed later, so there is no need to delete it now, just comment it in CI check.

@gear-tech/dev