### PR TITLE
Rename `condensator` example to `capacitor`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,7 +5,7 @@ members = [
     "chat/bot",
     "chat/room",
     "collector",
-    "condensator",
+    "capacitor",
     "decoder",
     "fib",
     "mem",

--- a/examples/capacitor/Cargo.toml
+++ b/examples/capacitor/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "demo-condensator"
+name = "demo-capacitor"
 version = "0.1.0"
 authors = ["Gear Technologies"]
 edition = "2018"

--- a/examples/capacitor/src/lib.rs
+++ b/examples/capacitor/src/lib.rs
@@ -19,7 +19,7 @@ pub unsafe extern "C" fn handle() {
     CHARGE += to_add;
 
     ext::debug(&format!(
-        "Charge condensator with {}, new charge {}",
+        "Charge capacitor with {}, new charge {}",
         to_add, CHARGE,
     ));
 
@@ -45,7 +45,7 @@ pub unsafe extern "C" fn init() {
     LIMIT = limit;
 
     ext::debug(&format!(
-        "Init condensator with limit capacity {}, {}",
+        "Init capacitor with limit capacity {}, {}",
         LIMIT, initstr,
     ));
 }

--- a/gtest/spec/test_capacitor.yaml
+++ b/gtest/spec/test_capacitor.yaml
@@ -1,14 +1,14 @@
-title: basic condensator check
+title: Basic capacitor check
 
 programs:
   - id: 1
-    path: examples/target/wasm32-unknown-unknown/release/demo_condensator.wasm
+    path: examples/target/wasm32-unknown-unknown/release/demo_capacitor.wasm
     init_message:
       kind: utf-8
       value: "200"
 
 fixtures:
-  - title: test charging/discharging
+  - title: Test charging/discharging
     messages:
       - payload:
           kind: utf-8


### PR DESCRIPTION
According to changes in the whitepaper: https://github.com/gear-tech/gear-wp/blob/main/TECHNICAL.md
