### PR TITLE
Build examples separately to prevent feature join

### DIFF
--- a/examples/fib/src/lib.rs
+++ b/examples/fib/src/lib.rs
@@ -37,3 +37,10 @@ pub unsafe extern "C" fn handle() {
 
 #[no_mangle]
 pub unsafe extern "C" fn init() {}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe {
+        core::arch::wasm32::unreachable();
+    }
+}

--- a/examples/panicker/Cargo.toml
+++ b/examples/panicker/Cargo.toml
@@ -9,4 +9,4 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-gstd = { path = "../../gstd", features = ["debug"] }
+gcore = { path = "../../gcore", features = ["debug"] }

--- a/examples/panicker/src/lib.rs
+++ b/examples/panicker/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![feature(default_alloc_error_handler)]
 
-use gstd::prelude::*;
+use gcore::prelude::*;
 
 #[no_mangle]
 pub unsafe extern "C" fn handle() {
@@ -10,3 +10,10 @@ pub unsafe extern "C" fn handle() {
 
 #[no_mangle]
 pub unsafe extern "C" fn init() {}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe {
+        core::arch::wasm32::unreachable();
+    }
+}

--- a/examples/sum/src/lib.rs
+++ b/examples/sum/src/lib.rs
@@ -59,3 +59,10 @@ pub unsafe extern "C" fn init() {
     );
     STATE.set_send_to(send_to);
 }
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe {
+        core::arch::wasm32::unreachable();
+    }
+}

--- a/examples/vec/src/lib.rs
+++ b/examples/vec/src/lib.rs
@@ -30,3 +30,10 @@ pub unsafe extern "C" fn handle() {
 
 #[no_mangle]
 pub unsafe extern "C" fn init() {}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe {
+        core::arch::wasm32::unreachable();
+    }
+}

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env sh
 
 set -e
-cd "$(dirname "$0")/../examples"
 
-cargo +nightly build --workspace --release
+ROOT_DIR="$(cd "$(dirname "$0")"/../examples && pwd)"
+
+# Get newline-separated list of all workspace members in `$1/Cargo.toml`
+function get_members() {
+  tr -d "\n" < "$1/Cargo.toml" |
+    sed -n -e 's/.*members[[:space:]]*=[[:space:]]*\[\([^]]*\)\].*/\1/p' |
+    sed -n -e 's/,/\n/gp' |
+    sed -n -e 's/[[:space:]]*"\(.*\)"/\1/p'
+}
+
+# For each entry in Cargo.toml workspace members:
+for entry in $(get_members $ROOT_DIR); do
+  # Quotes around `$entry` are not used intentionally to support globs in entry syntax, e.g. "member/*"
+  for member in "$ROOT_DIR"/$entry; do
+    cd "$member"
+    cargo +nightly build --release
+  done
+done

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -5,7 +5,7 @@ set -e
 ROOT_DIR="$(cd "$(dirname "$0")"/../examples && pwd)"
 
 # Get newline-separated list of all workspace members in `$1/Cargo.toml`
-function get_members() {
+get_members() {
   tr -d "\n" < "$1/Cargo.toml" |
     sed -n -e 's/.*members[[:space:]]*=[[:space:]]*\[\([^]]*\)\].*/\1/p' |
     sed -n -e 's/,/\n/gp' |


### PR DESCRIPTION
- Rewrite build-tests script to build each example separately
- Fix dependency features in examples

Unfortunately, the only way to separate dependency feature flags for workspace members is to build them separately

@NikVolf @shamilsan 
