### PR TITLE
Store program pages in storage

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -24,8 +24,7 @@ pub mod storage_queue;
 
 use codec::{Decode, Encode};
 use sp_core::{crypto::UncheckedFrom, H256};
-use sp_std::collections::btree_map::BTreeMap;
-use sp_std::collections::btree_set::BTreeSet;
+use sp_std::collections::{btree_map::BTreeMap, btree_set::BTreeSet};
 use sp_std::prelude::*;
 
 use storage_queue::StorageQueue;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -228,7 +228,7 @@ pub fn remove_program(id: H256) {
     if let Some(program) = get_program(id) {
         release_code(program.code_hash);
     }
-    sp_io::storage::clear(&program_key(id))
+    sp_io::storage::clear_prefix(&program_key(id))
 }
 
 pub fn program_exists(id: H256) -> bool {

--- a/common/src/native.rs
+++ b/common/src/native.rs
@@ -74,9 +74,10 @@ pub fn dequeue_message() -> Option<CoreMessage> {
 }
 
 pub fn get_program(id: ProgramId) -> Option<Program> {
-    crate::get_program(H256::from_slice(id.as_slice())).map(|prog| {
+    let id_h256 = H256::from_slice(id.as_slice());
+    crate::get_program(id_h256).map(|prog| {
         let persistent_pages =
-            crate::get_program_pages(H256::from_slice(id.as_slice()), prog.persistent_pages);
+            crate::get_program_pages(id_h256, prog.persistent_pages);
         if let Some(code) = crate::get_code(prog.code_hash) {
             let mut program = Program::new(id, code, persistent_pages).unwrap();
             program.set_message_nonce(prog.nonce);

--- a/common/src/native.rs
+++ b/common/src/native.rs
@@ -76,8 +76,7 @@ pub fn dequeue_message() -> Option<CoreMessage> {
 pub fn get_program(id: ProgramId) -> Option<Program> {
     let id_h256 = H256::from_slice(id.as_slice());
     crate::get_program(id_h256).map(|prog| {
-        let persistent_pages =
-            crate::get_program_pages(id_h256, prog.persistent_pages);
+        let persistent_pages = crate::get_program_pages(id_h256, prog.persistent_pages);
         if let Some(code) = crate::get_code(prog.code_hash) {
             let mut program = Program::new(id, code, persistent_pages).unwrap();
             program.set_message_nonce(prog.nonce);

--- a/common/src/native.rs
+++ b/common/src/native.rs
@@ -119,18 +119,6 @@ pub fn program_exists(id: ProgramId) -> bool {
     crate::program_exists(H256::from_slice(id.as_slice()))
 }
 
-pub fn page_info(page: u32) -> Option<ProgramId> {
-    crate::page_info(page).map(|pid| ProgramId::from_slice(&pid[..]))
-}
-
-pub fn alloc(page: u32, pid: ProgramId) {
-    crate::alloc(page, H256::from_slice(pid.as_slice()));
-}
-
-pub fn dealloc(page: u32) {
-    crate::dealloc(page);
-}
-
 pub fn insert_waiting_message(id: MessageId, message: CoreMessage) {
     crate::insert_waiting_message(H256::from_slice(id.as_slice()), message.into());
 }

--- a/node-rti/src/ext.rs
+++ b/node-rti/src/ext.rs
@@ -123,10 +123,7 @@ impl From<ExtWaitList> for MessageMap {
 mod tests {
     use super::*;
 
-    use gear_common::{
-        STORAGE_ALLOCATION_PREFIX, STORAGE_CODE_PREFIX, STORAGE_MESSAGE_PREFIX,
-        STORAGE_WAITLIST_PREFIX,
-    };
+    use gear_common::{STORAGE_CODE_PREFIX, STORAGE_MESSAGE_PREFIX, STORAGE_WAITLIST_PREFIX};
     use gear_core::message::Payload;
 
     fn new_test_ext() -> sp_io::TestExternalities {
@@ -139,7 +136,6 @@ mod tests {
     fn new_test_storage(
     ) -> gear_core::storage::Storage<ExtMessageQueue, ExtProgramStorage, ExtWaitList> {
         sp_io::storage::clear_prefix(STORAGE_CODE_PREFIX);
-        sp_io::storage::clear_prefix(STORAGE_ALLOCATION_PREFIX);
         sp_io::storage::clear_prefix(STORAGE_MESSAGE_PREFIX);
         sp_io::storage::clear_prefix(STORAGE_PROGRAM_PREFIX);
         sp_io::storage::clear_prefix(STORAGE_WAITLIST_PREFIX);

--- a/rpc-tests/index.js
+++ b/rpc-tests/index.js
@@ -140,7 +140,13 @@ async function checkMemory(api, exp, programs) {
     const bytes = Uint8Array.from(Buffer.from(mem.bytes.slice(2), 'hex'));
     const atPage = Math.floor(at / 65536);
     at -= atPage * 65536;
-    let pages = gearProgram.persistent_pages;
+
+    let pages = [];
+
+    for (let page in gearProgram.persistent_pages.keys()) {
+      const buf = await api.rpc.state.getStorage(`0x${Buffer.from('g::prog::').toString('hex')}${programs[mem.program_id].slice(2)}::mem::${page.toHex()}`);
+      pages.push([page, buf]);
+    }
 
     for (let [pageNumber, buf] of pages) {
       if (pageNumber == atPage) {
@@ -261,6 +267,8 @@ async function processExpected(api, sudoPair, fixture, programs) {
           errors.push(`MEMORY ERR: ${res}`);
         }
       }
+    } else {
+
     }
     // TODO: FIX IF NO STEPS
   }
@@ -385,7 +393,7 @@ async function main() {
     types: {
       "Program": {
         'static_pages': 'u32',
-        'persistent_pages': 'BTreeMap<u32, Vec<u8>>',
+        'persistent_pages': 'BTreeSet<u32>',
         'code_hash': 'H256',
         'nonce': 'u64',
       },

--- a/rpc-tests/index.js
+++ b/rpc-tests/index.js
@@ -267,7 +267,6 @@ async function processExpected(api, sudoPair, fixture, programs) {
           errors.push(`MEMORY ERR: ${res}`);
         }
       }
-    } else {
 
     }
     // TODO: FIX IF NO STEPS

--- a/utils/gear-test-cli/src/command.rs
+++ b/utils/gear-test-cli/src/command.rs
@@ -37,7 +37,6 @@ impl GearTestCmd {
             .execute_with(|| {
                 gear_test::check::check_main(self.input.to_vec(), true, false, false, || {
                     sp_io::storage::clear_prefix(gear_common::STORAGE_CODE_PREFIX);
-                    sp_io::storage::clear_prefix(gear_common::STORAGE_ALLOCATION_PREFIX);
                     sp_io::storage::clear_prefix(gear_common::STORAGE_MESSAGE_PREFIX);
                     sp_io::storage::clear_prefix(gear_common::STORAGE_PROGRAM_PREFIX);
                     sp_io::storage::clear_prefix(gear_common::STORAGE_WAITLIST_PREFIX);


### PR DESCRIPTION

- `Program.persistent_pages: BTreeSet<u32>` instead of `BTreeMap<u32, Vec<u8>>`
- each page is stored with prefix `g::prog::<program_id>::pages::<page_num>`

@gear-tech/dev 
