### PR TITLE
Add a new `send_and_wait` syscall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ rpc-test:
 .PHONY: test
 test:
 	@cargo test --workspace
+	@cargo test -p gear-core-backend --no-default-features --features wasmi_backend
 
 .PHONY: test-release
 test-release:

--- a/core-backend/src/funcs.rs
+++ b/core-backend/src/funcs.rs
@@ -265,6 +265,7 @@ pub(crate) fn wake<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'sta
 }
 
 // Helper functions
+#[cfg(feature = "wasmtime_backend")]
 pub(crate) fn is_exit_trap(trap: &str) -> bool {
     trap.starts_with(EXIT_TRAP_STR)
 }

--- a/core-backend/src/wasmi/env.rs
+++ b/core-backend/src/wasmi/env.rs
@@ -140,7 +140,7 @@ impl<E: Ext + 'static> Externals for Runtime<E> {
             .map(|_| None)
             .map_err(|_| Trap::new(TrapKind::UnexpectedSignature)),
 
-            Some(FuncIndex::SendAndWait) => funcs::send(self.ext.clone())(
+            Some(FuncIndex::SendAndWait) => funcs::send_and_wait(self.ext.clone())(
                 args.nth(0),
                 args.nth(1),
                 args.nth(2),

--- a/core-backend/src/wasmi/env.rs
+++ b/core-backend/src/wasmi/env.rs
@@ -45,19 +45,20 @@ struct Runtime<E: Ext + 'static> {
 enum FuncIndex {
     Alloc = 1,
     Charge,
-    SendCommit,
     Debug,
     Free,
     Gas,
     GasAvailable,
     MsgId,
-    SendInit,
-    SendPush,
-    ReplyPush,
     Read,
     Reply,
+    ReplyPush,
     ReplyTo,
     Send,
+    SendAndWait,
+    SendCommit,
+    SendInit,
+    SendPush,
     Size,
     Source,
     Value,
@@ -135,6 +136,16 @@ impl<E: Ext + 'static> Externals for Runtime<E> {
                 args.nth(3),
                 args.nth(4),
                 args.nth(5),
+            )
+            .map(|_| None)
+            .map_err(|_| Trap::new(TrapKind::UnexpectedSignature)),
+
+            Some(FuncIndex::SendAndWait) => funcs::send(self.ext.clone())(
+                args.nth(0),
+                args.nth(1),
+                args.nth(2),
+                args.nth(3),
+                args.nth(4),
             )
             .map(|_| None)
             .map_err(|_| Trap::new(TrapKind::UnexpectedSignature)),
@@ -217,6 +228,11 @@ impl<E: Ext + 'static> ModuleImportResolver for Environment<E> {
                 ValueType::I64,
                 ValueType::I32,
                 ValueType::I32 => None),
+            "gr_send_and_wait" => func_instance!(SendAndWait, ValueType::I32,
+                    ValueType::I32,
+                    ValueType::I32,
+                    ValueType::I32,
+                    ValueType::I32 => None),
             "gr_send_commit" => func_instance!(SendCommit, ValueType::I32, ValueType::I32 => None),
             "gr_send_init" => func_instance!(SendInit, ValueType::I32,
                 ValueType::I32,

--- a/core-backend/src/wasmtime/env.rs
+++ b/core-backend/src/wasmtime/env.rs
@@ -61,6 +61,7 @@ impl<E: Ext + 'static> Environment<E> {
         result.add_func_i32_i32("gr_reply_push", funcs::reply_push);
         result.add_func_i32("gr_reply_to", funcs::reply_to);
         result.add_func_i32_i32_i32_i64_i32_i32("gr_send", funcs::send);
+        result.add_func_i32_i32_i32_i32_i32("gr_send_and_wait", funcs::send_and_wait);
         result.add_func_i32_i32_i32_i64_i32("gr_send_commit", funcs::send_commit);
         result.add_func_to_i32("gr_send_init", funcs::send_init);
         result.add_func_i32_i32_i32("gr_send_push", funcs::send_push);
@@ -221,6 +222,16 @@ impl<E: Ext + 'static> Environment<E> {
         self.funcs.insert(
             key,
             Func::wrap(&self.store, Self::wrap3(func(self.ext.clone()))),
+        );
+    }
+
+    fn add_func_i32_i32_i32_i32_i32<F>(&mut self, key: &'static str, func: fn(LaterExt<E>) -> F)
+    where
+        F: 'static + Fn(i32, i32, i32, i32, i32) -> Result<(), &'static str>,
+    {
+        self.funcs.insert(
+            key,
+            Func::wrap(&self.store, Self::wrap5(func(self.ext.clone()))),
         );
     }
 

--- a/gcore/src/msg.rs
+++ b/gcore/src/msg.rs
@@ -35,6 +35,13 @@ mod sys {
             value_ptr: *const u8,
             message_id_ptr: *mut u8,
         );
+        pub fn gr_send_and_wait(
+            program: *const u8,
+            data_ptr: *const u8,
+            data_len: u32,
+            value_ptr: *const u8,
+            message_id_ptr: *mut u8,
+        ) -> !;
         pub fn gr_send_commit(
             handle: u32,
             message_id_ptr: *mut u8,
@@ -97,6 +104,23 @@ pub fn reply_to() -> MessageId {
 
 pub fn send(program: ProgramId, payload: &[u8], gas_limit: u64) -> MessageId {
     send_with_value(program, payload, gas_limit, 0u128)
+}
+
+pub fn send_and_wait(
+    program: ProgramId,
+    payload: &[u8],
+    value: u128,
+    message_id: &mut MessageId,
+) -> ! {
+    unsafe {
+        sys::gr_send_and_wait(
+            program.as_slice().as_ptr(),
+            payload.as_ptr(),
+            payload.len() as _,
+            value.to_le_bytes().as_ptr(),
+            message_id.as_mut_slice().as_mut_ptr(),
+        )
+    }
 }
 
 pub fn send_commit(


### PR DESCRIPTION
Fixes #140.

- Add a new `send_and_wait` function to `gcore`.

TODO: 
- [ ] Some test?
- [ ] Do we need update `gstd-asyc` to the new function?
