### PR TITLE
Add staging testnet chain spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,6 +2084,7 @@ dependencies = [
  "gear-node-rti",
  "gear-runtime",
  "gear-test-cli",
+ "hex-literal",
  "jsonrpc-core",
  "pallet-gear-rpc",
  "pallet-transaction-payment-rpc",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -17,6 +17,7 @@ name = "gear-node"
 
 [dependencies]
 structopt = "0.3.8"
+hex-literal = "0.3.1"
 
 sc-cli = { version = "0.9.0", git = "https://github.com/paritytech/substrate.git", features = ["wasmtime"] }
 sp-core = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git" }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -20,9 +20,10 @@ use gear_runtime::{
     AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, Signature, SudoConfig,
     SystemConfig, WASM_BINARY,
 };
+use hex_literal::hex;
 use sc_service::ChainType;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_core::{sr25519, Pair, Public};
+use sp_core::{crypto::UncheckedInto, sr25519, Pair, Public};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
@@ -133,6 +134,78 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
         // Bootnodes
         vec![],
         // Telemetry
+        None,
+        // Protocol ID
+        None,
+        // Properties
+        None,
+        // Extensions
+        None,
+    ))
+}
+
+/// Staging testnet config.
+pub fn staging_testnet_config() -> Result<ChainSpec, String> {
+    let wasm_binary =
+        WASM_BINARY.ok_or_else(|| "Staging testnet wasm not available".to_string())?;
+
+    Ok(ChainSpec::from_genesis(
+        "Staging Testnet",
+        "staging_testnet",
+        ChainType::Live,
+        move || {
+            testnet_genesis(
+                wasm_binary,
+                // Initial PoA authorities
+                vec![
+                    (
+                        // 5Gc7RXDUqWR7yupYFv6KMaak3fMbxYV1z6gEEGhQxeD4TBj9
+                        hex!["c8e4df7eac6b52dc5281659f1f393903932ee4b1f69f311c3cb123bc40f9267a"]
+                            .unchecked_into(),
+                        // 5HJh75wf2Y8EY8nbfMkVZNU8UhXFtAvZnQ4v5pmmWQctuNun
+                        hex!["e7d812ca5322f9b735e6cef4953cb706ce349752d7c737ef7aac817ebb840de1"]
+                            .unchecked_into(),
+                    ),
+                    (
+                        // 5DRmQFTuJaMDuU6JMJgUhsCqrdURito3pUpTnDcFKRswdGXz
+                        hex!["3c4c519e3d7149c93181e8e3762562db6f580c27502e9a6ab2f7464d6185241b"]
+                            .unchecked_into(),
+                        // 5EHVLwinhXcguU6AzyD3bRipHSDzc4nBLveP4uk4Xui2oW1b
+                        hex!["6238894f19edef4a4a638b3fab9b42909336912bd6ccdf835e9ecc24a64a8713"]
+                            .unchecked_into(),
+                    ),
+                    (
+                        // 5E4jfoWJHckHB7WyDGebTwD6yEg2pyjxbHwJvCGc9fVGZ3GN
+                        hex!["587e919f8149e31f7d4e99e8fbdf30ff119593376f066e20dacda9054892b478"]
+                            .unchecked_into(),
+                        // 5GVFRgURF6fz8giQSnrPwt156GHecRSLcRYvKaxKsanDroFS
+                        hex!["c3a91848c88b9481405fb29d07cc221c400763ce3ed3c8735c64a86c026bb5ee"]
+                            .unchecked_into(),
+                    ),
+                    (
+                        // 5HZJiwwz2sqoPMw8eGLD1d3fiWgZzTQwR5j8EnHBtjqTAUqq
+                        hex!["f2fd6936b8ddad025d329ff2d6b5577e6381cb25333f6f17f592494b0b61ef55"]
+                            .unchecked_into(),
+                        // 5DzyLcBcyWzNFbLv1UgxUEyyi7mVgwrrpjPK6E47EF5TNDMJ
+                        hex!["559f99f172dcfef6c6894cfe53312b3f11d67c3ac0c29ead872d3ec37f7fcffa"]
+                            .unchecked_into(),
+                    ),
+                ],
+                // Sudo account
+                // 5CtLwzLdsTZnyA3TN7FUV58FV4NZ1tUuTDM9yjwRuvt6ac1i
+                hex!["2455655ad2a1f9fbe510699026fc810a2b3cb91d432c141db54a9968da944955"].into(),
+                // Pre-funded accounts
+                vec![
+                    // root_key
+                    hex!["2455655ad2a1f9fbe510699026fc810a2b3cb91d432c141db54a9968da944955"].into(),
+                ],
+                true,
+            )
+        },
+        // Bootnodes
+        vec![],
+        // Telemetry
+        // TODO: define telemetry endpoints
         None,
         // Protocol ID
         None,

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -51,6 +51,7 @@ impl SubstrateCli for Cli {
         Ok(match id {
             "dev" => Box::new(chain_spec::development_config()?),
             "" | "local" => Box::new(chain_spec::local_testnet_config()?),
+            "staging" => Box::new(chain_spec::staging_testnet_config()?),
             path => Box::new(chain_spec::ChainSpec::from_json_file(
                 std::path::PathBuf::from(path),
             )?),


### PR DESCRIPTION
Fixes #163 .

- Staging testnet configuration has 4 initial authority accounts and a root_key account who would hold the whole initial token supply.