### PR TITLE
Configure rustfmt to be more useful

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -16,8 +16,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Install nightly tools
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: rustfmt, clippy
+          override: true
+
       - name: Check fmt
-        run: cargo fmt --all -- --check
+        run: |
+          cargo fmt --all -- --check
+          cargo fmt --all --manifest-path examples/Cargo.toml -- --config=license_template_path="" --check
 
       - name: Run clippy
         run: | # TODO: Expand clippy to be workspace-wide

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ init:
 
 .PHONY: fmt
 fmt:
-	@cargo fmt --all
+	@cargo +nightly fmt --all
+	@cargo +nightly fmt --all --manifest-path examples/Cargo.toml -- --config=license_template_path=""
 
 .PHONY: node
 node:

--- a/core-runner/src/builder.rs
+++ b/core-runner/src/builder.rs
@@ -1,3 +1,21 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use super::runner::{Config, ExtMessage, InitializeProgramInfo, Runner};
 use alloc::vec::*;
 use gear_core::storage::{

--- a/core-runner/src/ext.rs
+++ b/core-runner/src/ext.rs
@@ -1,3 +1,21 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use gear_core::{
     env::Ext as EnvExt,
     gas::{ChargeResult, GasCounter},

--- a/core-runner/src/runner.rs
+++ b/core-runner/src/runner.rs
@@ -1149,7 +1149,7 @@ mod tests {
         assert_eq!(result.gas_left[0].0, caller_id);
         assert!(result.gas_left[0].1 < gas_limit);
 
-        let (gas_available, _, _) = runner
+        let (gas_available, ..) = runner
             .log
             .get()
             .first()

--- a/core-runner/src/util.rs
+++ b/core-runner/src/util.rs
@@ -1,3 +1,21 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use gear_core::message::MessageId;
 use gear_core::program::ProgramId;
 

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -893,9 +893,11 @@ mod tests {
         );
 
         // And checking that it is not formed
-        assert!(context.state.borrow_mut().outgoing[expected_handle]
-            .0
-            .is_some());
+        assert!(
+            context.state.borrow_mut().outgoing[expected_handle]
+                .0
+                .is_some()
+        );
 
         // Checking that we are able to push payload for the
         // message that we have not commited yet
@@ -918,9 +920,11 @@ mod tests {
         assert!(context.send_push(0, &[5, 7]).is_err());
         assert!(context.send_push(expected_handle, &[5, 7]).is_err());
         assert!(context.send_commit(0, OutgoingPacket::default()).is_err());
-        assert!(context
-            .send_commit(expected_handle, OutgoingPacket::default())
-            .is_err());
+        assert!(
+            context
+                .send_commit(expected_handle, OutgoingPacket::default())
+                .is_err()
+        );
 
         // Checking that we also get an error when trying
         // to commit or send a non-existent message

--- a/examples/capacitor/src/lib.rs
+++ b/examples/capacitor/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 #![feature(default_alloc_error_handler)]
 
+use gcore::{ext, msg};
 use gstd::prelude::*;
-use gcore::{msg, ext};
 
 // Begin of demo
 static mut CHARGE: u32 = 0;
@@ -13,7 +13,8 @@ static mut DISCHARGE_HISTORY: Vec<u32> = Vec::new();
 
 #[no_mangle]
 pub unsafe extern "C" fn handle() {
-    let new_msg = String::from_utf8(gstd::msg::load_bytes()).expect("Invalid message: should be utf-8");
+    let new_msg =
+        String::from_utf8(gstd::msg::load_bytes()).expect("Invalid message: should be utf-8");
 
     let to_add = u32::from_str(new_msg.as_ref()).expect("Invalid number");
 
@@ -40,7 +41,8 @@ pub unsafe extern "C" fn handle() {
 
 #[no_mangle]
 pub unsafe extern "C" fn init() {
-    let initstr = String::from_utf8(gstd::msg::load_bytes()).expect("Invalid message: should be utf-8");
+    let initstr =
+        String::from_utf8(gstd::msg::load_bytes()).expect("Invalid message: should be utf-8");
     let limit = u32::from_str(initstr.as_ref()).expect("Invalid number");
 
     LIMIT = limit;

--- a/examples/collector/src/lib.rs
+++ b/examples/collector/src/lib.rs
@@ -4,8 +4,8 @@
 extern crate alloc;
 
 use alloc::collections::BTreeMap;
-use gstd::prelude::*;
 use gcore::msg;
+use gstd::prelude::*;
 
 static mut MY_COLLECTION: BTreeMap<usize, String> = BTreeMap::new();
 
@@ -13,7 +13,8 @@ static mut COUNTER: usize = 0;
 
 #[no_mangle]
 pub unsafe extern "C" fn handle() {
-    let new_msg = String::from_utf8(gstd::msg::load_bytes()).expect("Invalid message: should be utf-8");
+    let new_msg =
+        String::from_utf8(gstd::msg::load_bytes()).expect("Invalid message: should be utf-8");
     if new_msg == "log" {
         let collapsed = mem::replace(&mut MY_COLLECTION, BTreeMap::new())
             .into_iter()

--- a/examples/decoder/src/lib.rs
+++ b/examples/decoder/src/lib.rs
@@ -6,7 +6,8 @@ use gstd::prelude::*;
 
 #[no_mangle]
 pub unsafe extern "C" fn handle() {
-    let new_msg = String::from_utf8(gstd::msg::load_bytes()).expect("Invalid message: should be utf-8");
+    let new_msg =
+        String::from_utf8(gstd::msg::load_bytes()).expect("Invalid message: should be utf-8");
 
     let code: Vec<usize> = new_msg
         .split_whitespace()

--- a/examples/multiping/src/lib.rs
+++ b/examples/multiping/src/lib.rs
@@ -6,7 +6,8 @@ use gstd::prelude::*;
 
 #[no_mangle]
 pub unsafe extern "C" fn handle() {
-    let new_msg = String::from_utf8(gstd::msg::load_bytes()).expect("Invalid message: should be utf-8");
+    let new_msg =
+        String::from_utf8(gstd::msg::load_bytes()).expect("Invalid message: should be utf-8");
 
     if new_msg == "PING" {
         msg::reply(b"PO", 10_000_000, 0);

--- a/examples/ping/src/lib.rs
+++ b/examples/ping/src/lib.rs
@@ -8,7 +8,8 @@ static mut MESSAGE_LOG: Vec<String> = vec![];
 
 #[no_mangle]
 pub unsafe extern "C" fn handle() {
-    let new_msg = String::from_utf8(gstd::msg::load_bytes()).expect("Invalid message: should be utf-8");
+    let new_msg =
+        String::from_utf8(gstd::msg::load_bytes()).expect("Invalid message: should be utf-8");
 
     if new_msg == "PING" {
         msg::reply(b"PONG", 10_000_000, 0);

--- a/node-rti/src/ext.rs
+++ b/node-rti/src/ext.rs
@@ -133,8 +133,8 @@ mod tests {
             .into()
     }
 
-    fn new_test_storage(
-    ) -> gear_core::storage::Storage<ExtMessageQueue, ExtProgramStorage, ExtWaitList> {
+    fn new_test_storage()
+    -> gear_core::storage::Storage<ExtMessageQueue, ExtProgramStorage, ExtWaitList> {
         sp_io::storage::clear_prefix(STORAGE_CODE_PREFIX, None);
         sp_io::storage::clear_prefix(STORAGE_MESSAGE_PREFIX, None);
         sp_io::storage::clear_prefix(STORAGE_PROGRAM_PREFIX, None);

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -189,7 +189,7 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
                 return Err(ServiceError::Other(format!(
                     "Error hooking up remote keystore for {}: {}",
                     url, e
-                )))
+                )));
             }
         };
     }

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -270,7 +270,6 @@ pub mod pallet {
         ///
         /// Emits the following events:
         /// - `InitMessageEnqueued(MessageInfo)` when init message is placed in the queue.
-        ///
         #[pallet::weight(
             T::WeightInfo::submit_program(code.len() as u32, init_payload.len() as u32)
         )]
@@ -343,7 +342,6 @@ pub mod pallet {
         ///
         /// Emits the following events:
         /// - `DispatchMessageEnqueued(H256)` when dispatch message is placed in the queue.
-        ///
         #[pallet::weight(T::WeightInfo::send_message(payload.len() as u32))]
         pub fn send_message(
             origin: OriginFor<T>,
@@ -407,7 +405,6 @@ pub mod pallet {
         /// - `value`: balance to be transferred to the program once it's been created.
         ///
         /// - `DispatchMessageEnqueued(H256)` when dispatch message is placed in the queue.
-        ///
         #[pallet::weight(T::WeightInfo::send_reply(payload.len() as u32))]
         pub fn send_reply(
             origin: OriginFor<T>,
@@ -463,7 +460,6 @@ pub mod pallet {
         /// - `InitFailure(MessageInfo, Reason)` when initialization message fails;
         /// - `Log(Message)` when a dispatched message spawns other messages (including replies);
         /// - `MessageDispatched(H256)` when a dispatch message has been processed with some outcome.
-        ///
         #[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
         pub fn process_queue(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
             ensure_none(origin)?;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+condense_wildcard_suffixes = true
+format_code_in_doc_comments = true
+license_template_path = "HEADER-GPL3"
+version = "Two"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -4,8 +4,8 @@ set -e
 cd "$(dirname "$0")/.."
 
 echo "*** Run fmt"
-cargo fmt --all
-cd examples && cargo fmt --all && cd ..
+cargo +nightly fmt --all
+cargo +nightly fmt --all --manifest-path examples/Cargo.toml -- --config=license_template_path=""
 
 echo "*** Run clippy"
 # TODO: Spread clippy to `--workspace`

--- a/tests/btree/build.rs
+++ b/tests/btree/build.rs
@@ -1,3 +1,21 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use substrate_wasm_builder::WasmBuilder;
 
 fn main() {

--- a/tests/btree/src/lib.rs
+++ b/tests/btree/src/lib.rs
@@ -1,3 +1,21 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/tests/common/src/lib.rs
+++ b/tests/common/src/lib.rs
@@ -1,3 +1,21 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use codec::{Decode, Encode};
 
 use gear_core::storage::{

--- a/tests/distributor/build.rs
+++ b/tests/distributor/build.rs
@@ -1,3 +1,21 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use substrate_wasm_builder::WasmBuilder;
 
 fn main() {

--- a/tests/distributor/src/lib.rs
+++ b/tests/distributor/src/lib.rs
@@ -1,3 +1,21 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/tests/node/build.rs
+++ b/tests/node/build.rs
@@ -1,3 +1,21 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use substrate_wasm_builder::WasmBuilder;
 
 fn main() {

--- a/tests/node/src/lib.rs
+++ b/tests/node/src/lib.rs
@@ -1,3 +1,21 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
 #![cfg_attr(not(feature = "std"), no_std)]
 


### PR DESCRIPTION
- Add `rustfmt.toml` with specific settings.
- Use rustfmt v2.
- Add some useful settings.
- Update CI to conform.
