### PR TITLE
Add CI config for documentation deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+name: Docs
+
+on:
+  push:
+    branches: [master]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Build Docs
+        run: |
+          cargo doc -p gear-core -p gstd -p gstd-async --no-deps
+          echo "<html><head><meta http-equiv=\"refresh\" content=\"0; url=/gear_core/index.html\" /></head><body></body></html>" > ./target/doc/index.html
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc
+          cname: docs.gear.rs
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/gstd-async/src/lib.rs
+++ b/gstd-async/src/lib.rs
@@ -18,6 +18,7 @@
 
 #![no_std]
 #![cfg_attr(feature = "strict", deny(warnings))]
+#![doc(html_logo_url = "https://gear-tech.io/images/logo-black.svg")]
 
 extern crate alloc;
 

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -18,6 +18,7 @@
 
 #![no_std]
 #![cfg_attr(feature = "strict", deny(warnings))]
+#![doc(html_logo_url = "https://gear-tech.io/images/logo-black.svg")]
 
 extern crate galloc;
 


### PR DESCRIPTION
- Revert CI config that generates docs for gear-core.
- Add docs generation for `gstd` and `gstd-async`.
- Deploy docs to `gh-pages` branch.
- GH Pages will be configured after merge.