### PR TITLE
Remove message processed thing also

### DIFF
--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -143,10 +143,6 @@ pub mod pallet {
     #[pallet::getter(fn message_queue)]
     pub type MessageQueue<T> = StorageValue<_, Vec<IntermediateMessage>>;
 
-    #[pallet::storage]
-    #[pallet::getter(fn messages_processed)]
-    pub type MessagesProcessed<T> = StorageValue<_, u32, ValueQuery>;
-
     #[pallet::type_value]
     pub fn DefaultForGasLimit<T: Config>() -> u64 {
         T::BlockGasLimit::get()
@@ -251,7 +247,6 @@ pub mod pallet {
         pub fn process_queue() -> Weight {
             // At the beginning of a new block, we process all queued messages
             let messages = <MessageQueue<T>>::take().unwrap_or_default();
-            let messages_processed = <MessagesProcessed<T>>::get();
 
             let mut weight = Self::gas_allowance() as Weight;
             let mut total_handled = 0u32;
@@ -431,12 +426,6 @@ pub mod pallet {
                         }
 
                         total_handled += execution_report.handled;
-
-                        <MessagesProcessed<T>>::mutate(|messages_processed| {
-                            *messages_processed =
-                                messages_processed.saturating_add(execution_report.handled)
-                        });
-                        let messages_processed = <MessagesProcessed<T>>::get();
 
                         for (destination, gas_left) in execution_report.gas_refunds {
                             let refund = Self::gas_to_fee(gas_left);

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -349,9 +349,6 @@ fn messages_processing_works() {
         crate::Pallet::<Test>::process_queue();
         System::assert_last_event(crate::Event::MessagesDequeued(2).into());
 
-        // `InitProgram` doesn't increase the counter, but the reply message does; hence 1.
-        assert_eq!(Gear::messages_processed(), 1);
-
         // First message is sent to a non-existing program - and should get into log.
         // Second message still gets processed thereby adding 1 to the total processed messages counter.
         MessageQueue::<Test>::put(vec![
@@ -376,7 +373,6 @@ fn messages_processing_works() {
         ]);
         crate::Pallet::<Test>::process_queue();
         System::assert_last_event(crate::Event::MessagesDequeued(2).into());
-        assert_eq!(Gear::messages_processed(), 3); // Counter not reset, 1 added
     })
 }
 


### PR DESCRIPTION
Since it was required for rpc-tests that are now being redesigned