### PR TITLE
Enable runtime 'debug' mode

### DIFF
--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -91,7 +91,7 @@ pub mod pallet {
         /// Debug mode has been turned on or off
         DebugMode(bool),
         /// A snapshot of the program storage ('debug mode' only)
-        ProgramStorageDump(Vec<Program>),
+        ProgramStorageDump(Vec<ProgramDetails>),
         /// A snapshot of the message queue ('debug mode' only)
         MessageQueueDump(Vec<Message>),
     }
@@ -147,8 +147,8 @@ pub mod pallet {
         pub origin: H256,
     }
 
-    #[derive(Debug, Encode, Decode, Clone, PartialEq)]
-    pub struct Program {
+    #[derive(Debug, Encode, Decode, Clone, PartialEq, TypeInfo)]
+    pub struct ProgramDetails {
         pub id: H256,
         pub static_pages: u32,
         pub persistent_pages: BTreeMap<u32, Vec<u8>>,
@@ -546,14 +546,14 @@ pub mod pallet {
         }
 
         fn dump_programs_storage() {
-            let programs: Vec<Program> = PrefixIterator::new(
+            let programs = PrefixIterator::<ProgramDetails>::new(
                 common::STORAGE_PROGRAM_PREFIX.to_vec(),
                 common::STORAGE_PROGRAM_PREFIX.to_vec(),
                 |key, mut value| {
                     assert_eq!(key.len(), 32);
                     let program_id = H256::from_slice(key);
                     let program = common::Program::decode(&mut value)?;
-                    Ok(Program {
+                    Ok(ProgramDetails {
                         id: program_id,
                         static_pages: program.static_pages,
                         persistent_pages: common::get_program_pages(

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -24,7 +24,6 @@ use frame_support::{assert_noop, assert_ok};
 use gear_core::program::{Program, ProgramId};
 use hex_literal::hex;
 use sp_core::H256;
-use sp_std::collections::btree_map::BTreeMap;
 
 pub(crate) fn init_logger() {
     let _ = env_logger::Builder::from_default_env()
@@ -1422,23 +1421,19 @@ fn debug_mode_works() {
 
         // The log should have many occurrences of the programs storage contents dump
         // After init messages processing
-        let mut empty_pages_16 = BTreeMap::new();
-        for i in 0u32..16 {
-            empty_pages_16.insert(i, vec![0; 65536]);
-        }
         System::assert_has_event(
             crate::Event::ProgramStorageDump(vec![
-                crate::Program {
+                crate::ProgramDetails {
                     id: programs[0],
                     static_pages: 16,
-                    persistent_pages: empty_pages_16.clone(),
+                    persistent_pages: (0..16).map(|i| (i, vec![0; 65536])).collect(),
                     code_hash: H256::from(sp_io::hashing::blake2_256(&code_1)),
                     nonce: 0u64,
                 },
-                crate::Program {
+                crate::ProgramDetails {
                     id: programs[1],
                     static_pages: 16,
-                    persistent_pages: empty_pages_16.clone(),
+                    persistent_pages: (0..16).map(|i| (i, vec![0; 65536])).collect(),
                     code_hash: H256::from(sp_io::hashing::blake2_256(&code_2)),
                     nonce: 0u64,
                 },
@@ -1446,23 +1441,19 @@ fn debug_mode_works() {
             .into(),
         );
         // After message queue processing
-        let mut empty_pages_20 = BTreeMap::new();
-        for i in 0u32..20 {
-            empty_pages_20.insert(i, vec![0; 65536]);
-        }
         System::assert_has_event(
             crate::Event::ProgramStorageDump(vec![
-                crate::Program {
+                crate::ProgramDetails {
                     id: programs[0],
                     static_pages: 16,
-                    persistent_pages: empty_pages_16.clone(),
+                    persistent_pages: (0..16).map(|i| (i, vec![0; 65536])).collect(),
                     code_hash: H256::from(sp_io::hashing::blake2_256(&code_1)),
                     nonce: 0u64,
                 },
-                crate::Program {
+                crate::ProgramDetails {
                     id: programs[1],
                     static_pages: 16,
-                    persistent_pages: empty_pages_20.clone(),
+                    persistent_pages: (0..20).map(|i| (i, vec![0; 65536])).collect(),
                     code_hash: H256::from(sp_io::hashing::blake2_256(&code_2)),
                     nonce: 0u64,
                 },


### PR DESCRIPTION
Fixes #246.

- added a storage value that holds the flag indicating whether the runtime "debug" mode is on;
- added an extrinsic callable by the root origin that can modify this storage value thus switching the debug mode on and off in runtime (without a need for restarting a node or storage migration);
- the message queue and programs storage contents are wrapped as runtime events.

The following information is currently being logged:

- [x] full state of the message queue
- [x] programs storage
- [x] programs memory