### PR TITLE
Fix standalone tests after upgrading rustc to v1.55

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -16,13 +16,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install nightly tools
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          components: rustfmt, clippy
-          override: true
-
       - name: Check fmt
         run: |
           cargo fmt --all -- --check
@@ -39,6 +32,7 @@ jobs:
           cargo clippy --package gstd --all-features -- -D warnings
           cargo clippy --package gstd-async --all-features -- -D warnings
           echo cargo clippy --package pallet-gear --all-features -- -D warnings # TODO: Fix
+
   build:
     needs: check
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,6 +658,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
+name = "camino"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d74260d9bf6944e2208aa46841b4b8f0d7ffc0849a06837b2f510337f86b2b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +681,20 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714a157da7991e23d90686b9524b9e12e0407a108647f52e9328f4b3d51ac7f"
 dependencies = [
+ "cargo-platform",
+ "semver 0.11.0",
+ "semver-parser 0.10.2",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "081e3f0755c1f380c2d010481b6fa2e02973586d5f2b24eebb7a2a1d98b143d8"
+dependencies = [
+ "camino",
  "cargo-platform",
  "semver 0.11.0",
  "semver-parser 0.10.2",
@@ -2083,7 +2106,7 @@ dependencies = [
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
- "substrate-wasm-builder",
+ "substrate-wasm-builder 4.0.0",
  "wabt",
 ]
 
@@ -5686,7 +5709,7 @@ dependencies = [
  "pwasm-utils",
  "sc-allocator",
  "sp-core",
- "sp-maybe-compressed-blob",
+ "sp-maybe-compressed-blob 4.0.0-dev (git+https://github.com/paritytech/substrate.git)",
  "sp-serializer",
  "sp-wasm-interface",
  "thiserror",
@@ -6846,7 +6869,7 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-keystore",
- "sp-maybe-compressed-blob",
+ "sp-maybe-compressed-blob 4.0.0-dev (git+https://github.com/paritytech/substrate.git)",
  "sp-runtime-interface",
  "sp-state-machine",
  "sp-std",
@@ -6883,6 +6906,14 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-externalities",
+]
+
+[[package]]
+name = "sp-maybe-compressed-blob"
+version = "4.0.0-dev"
+source = "git+https://github.com/gear-tech/substrate.git?rev=ccf9bee#ccf9bee6f75c44bf1ce4b926d5a3c0e1b1b55501"
+dependencies = [
+ "zstd",
 ]
 
 [[package]]
@@ -7332,7 +7363,22 @@ dependencies = [
  "ansi_term 0.12.1",
  "atty",
  "build-helper",
- "cargo_metadata",
+ "cargo_metadata 0.12.3",
+ "tempfile",
+ "toml",
+ "walkdir",
+ "wasm-gc-api",
+]
+
+[[package]]
+name = "substrate-wasm-builder"
+version = "5.0.0-dev"
+source = "git+https://github.com/gear-tech/substrate.git?rev=ccf9bee#ccf9bee6f75c44bf1ce4b926d5a3c0e1b1b55501"
+dependencies = [
+ "ansi_term 0.12.1",
+ "build-helper",
+ "cargo_metadata 0.13.1",
+ "sp-maybe-compressed-blob 4.0.0-dev (git+https://github.com/gear-tech/substrate.git?rev=ccf9bee)",
  "tempfile",
  "toml",
  "walkdir",
@@ -7429,7 +7475,7 @@ dependencies = [
  "gear-core-runner",
  "gstd",
  "parity-scale-codec",
- "substrate-wasm-builder",
+ "substrate-wasm-builder 5.0.0-dev",
  "tests-common",
 ]
 
@@ -7441,7 +7487,7 @@ dependencies = [
  "gear-core-runner",
  "gstd",
  "parity-scale-codec",
- "substrate-wasm-builder",
+ "substrate-wasm-builder 4.0.0",
 ]
 
 [[package]]
@@ -7454,7 +7500,7 @@ dependencies = [
  "gstd",
  "gstd-async",
  "parity-scale-codec",
- "substrate-wasm-builder",
+ "substrate-wasm-builder 4.0.0",
  "tests-common",
 ]
 
@@ -7467,7 +7513,7 @@ dependencies = [
  "gear-core-runner",
  "gstd",
  "parity-scale-codec",
- "substrate-wasm-builder",
+ "substrate-wasm-builder 4.0.0",
  "tests-common",
 ]
 
@@ -8024,9 +8070,9 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
  "winapi 0.3.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7487,7 +7487,6 @@ dependencies = [
  "gear-core-runner",
  "gstd",
  "parity-scale-codec",
- "substrate-wasm-builder 4.0.0",
 ]
 
 [[package]]
@@ -7500,7 +7499,7 @@ dependencies = [
  "gstd",
  "gstd-async",
  "parity-scale-codec",
- "substrate-wasm-builder 4.0.0",
+ "substrate-wasm-builder 5.0.0-dev",
  "tests-common",
 ]
 
@@ -7513,7 +7512,7 @@ dependencies = [
  "gear-core-runner",
  "gstd",
  "parity-scale-codec",
- "substrate-wasm-builder 4.0.0",
+ "substrate-wasm-builder 5.0.0-dev",
  "tests-common",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ init:
 
 .PHONY: fmt
 fmt:
-	@cargo +nightly fmt --all
-	@cargo +nightly fmt --all --manifest-path examples/Cargo.toml -- --config=license_template_path=""
+	@cargo fmt --all
+	@cargo fmt --all --manifest-path examples/Cargo.toml -- --config=license_template_path=""
 
 .PHONY: node
 node:

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -893,11 +893,9 @@ mod tests {
         );
 
         // And checking that it is not formed
-        assert!(
-            context.state.borrow_mut().outgoing[expected_handle]
-                .0
-                .is_some()
-        );
+        assert!(context.state.borrow_mut().outgoing[expected_handle]
+            .0
+            .is_some());
 
         // Checking that we are able to push payload for the
         // message that we have not commited yet
@@ -920,11 +918,9 @@ mod tests {
         assert!(context.send_push(0, &[5, 7]).is_err());
         assert!(context.send_push(expected_handle, &[5, 7]).is_err());
         assert!(context.send_commit(0, OutgoingPacket::default()).is_err());
-        assert!(
-            context
-                .send_commit(expected_handle, OutgoingPacket::default())
-                .is_err()
-        );
+        assert!(context
+            .send_commit(expected_handle, OutgoingPacket::default())
+            .is_err());
 
         // Checking that we also get an error when trying
         // to commit or send a non-existent message

--- a/gstd-meta/tests/json.rs
+++ b/gstd-meta/tests/json.rs
@@ -63,9 +63,7 @@ fn check(types: Vec<MetaType>, expectation: &'static str) {
 #[test]
 fn primitives_json() {
     check(
-        types!(
-            bool, char, str, String, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128
-        ),
+        types!(bool, char, str, String, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128),
         "{}",
     );
 }

--- a/node-rti/src/ext.rs
+++ b/node-rti/src/ext.rs
@@ -133,8 +133,8 @@ mod tests {
             .into()
     }
 
-    fn new_test_storage()
-    -> gear_core::storage::Storage<ExtMessageQueue, ExtProgramStorage, ExtWaitList> {
+    fn new_test_storage(
+    ) -> gear_core::storage::Storage<ExtMessageQueue, ExtProgramStorage, ExtWaitList> {
         sp_io::storage::clear_prefix(STORAGE_CODE_PREFIX, None);
         sp_io::storage::clear_prefix(STORAGE_MESSAGE_PREFIX, None);
         sp_io::storage::clear_prefix(STORAGE_PROGRAM_PREFIX, None);

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,0 @@
-condense_wildcard_suffixes = true
-format_code_in_doc_comments = true
-license_template_path = "HEADER-GPL3"
-version = "Two"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -4,8 +4,8 @@ set -e
 cd "$(dirname "$0")/.."
 
 echo "*** Run fmt"
-cargo +nightly fmt --all
-cargo +nightly fmt --all --manifest-path examples/Cargo.toml -- --config=license_template_path=""
+cargo fmt --all
+cargo fmt --all --manifest-path examples/Cargo.toml -- --config=license_template_path=""
 
 echo "*** Run clippy"
 # TODO: Spread clippy to `--workspace`

--- a/tests/btree/Cargo.toml
+++ b/tests/btree/Cargo.toml
@@ -13,7 +13,7 @@ codec = { package = "parity-scale-codec", version = "2", default-features = fals
 common = { package = "tests-common", path = "../common", optional = true }
 
 [build-dependencies]
-substrate-wasm-builder = "4.0.0"
+substrate-wasm-builder = { git = "https://github.com/gear-tech/substrate.git", rev = "ccf9bee" }
 
 [lib]
 

--- a/tests/btree/src/lib.rs
+++ b/tests/btree/src/lib.rs
@@ -120,7 +120,7 @@ mod tests {
     }
 
     fn wasm_code() -> &'static [u8] {
-        native::WASM_BINARY.expect("wasm binary exists")
+        native::WASM_BINARY_BLOATY.expect("wasm binary exists")
     }
 
     #[test]

--- a/tests/common/Cargo.toml
+++ b/tests/common/Cargo.toml
@@ -10,10 +10,3 @@ gstd = { path = "../../gstd", features = ["debug"] }
 gear-core-runner = { path = "../../core-runner" }
 gear-core = { path = "../../core" }
 codec = { package = "parity-scale-codec", version = "2", default-features = false }
-
-[build-dependencies]
-substrate-wasm-builder = "4.0.0"
-
-[lib]
-
-[features]

--- a/tests/distributor/Cargo.toml
+++ b/tests/distributor/Cargo.toml
@@ -14,7 +14,7 @@ codec = { package = "parity-scale-codec", version = "2", default-features = fals
 common = { package = "tests-common", path = "../common", optional = true }
 
 [build-dependencies]
-substrate-wasm-builder = "4.0.0"
+substrate-wasm-builder = { git = "https://github.com/gear-tech/substrate.git", rev = "ccf9bee" }
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/tests/distributor/src/lib.rs
+++ b/tests/distributor/src/lib.rs
@@ -238,7 +238,7 @@ mod tests {
     }
 
     fn wasm_code() -> &'static [u8] {
-        native::WASM_BINARY.expect("wasm binary exists")
+        native::WASM_BINARY_BLOATY.expect("wasm binary exists")
     }
 
     #[test]

--- a/tests/node/Cargo.toml
+++ b/tests/node/Cargo.toml
@@ -13,7 +13,7 @@ codec = { package = "parity-scale-codec", version = "2", default-features = fals
 common = { package = "tests-common", path = "../common", optional = true }
 
 [build-dependencies]
-substrate-wasm-builder = "4.0.0"
+substrate-wasm-builder = { git = "https://github.com/gear-tech/substrate.git", rev = "ccf9bee" }
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/tests/node/src/lib.rs
+++ b/tests/node/src/lib.rs
@@ -321,7 +321,7 @@ mod tests {
     }
 
     fn wasm_code() -> &'static [u8] {
-        native::WASM_BINARY.expect("wasm binary exists")
+        native::WASM_BINARY_BLOATY.expect("wasm binary exists")
     }
 
     #[test]


### PR DESCRIPTION
Fixes #258.

- Move to the local fork of `substrate-wasm-builder`.
- Fix the rustic flags applying in `substrate-wasm-builder`.
- Replace `WASM_BINARY` with `WASM_BINARY_BLOATY`
