### PR TITLE
Move on back to rustfmt v1

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -16,13 +16,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install nightly tools
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          components: rustfmt, clippy
-          override: true
-
       - name: Check fmt
         run: |
           cargo fmt --all -- --check
@@ -39,6 +32,7 @@ jobs:
           cargo clippy --package gstd --all-features -- -D warnings
           cargo clippy --package gstd-async --all-features -- -D warnings
           echo cargo clippy --package pallet-gear --all-features -- -D warnings # TODO: Fix
+
   build:
     needs: check
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ init:
 
 .PHONY: fmt
 fmt:
-	@cargo +nightly fmt --all
-	@cargo +nightly fmt --all --manifest-path examples/Cargo.toml -- --config=license_template_path=""
+	@cargo fmt --all
+	@cargo fmt --all --manifest-path examples/Cargo.toml -- --config=license_template_path=""
 
 .PHONY: node
 node:

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -893,11 +893,9 @@ mod tests {
         );
 
         // And checking that it is not formed
-        assert!(
-            context.state.borrow_mut().outgoing[expected_handle]
-                .0
-                .is_some()
-        );
+        assert!(context.state.borrow_mut().outgoing[expected_handle]
+            .0
+            .is_some());
 
         // Checking that we are able to push payload for the
         // message that we have not commited yet
@@ -920,11 +918,9 @@ mod tests {
         assert!(context.send_push(0, &[5, 7]).is_err());
         assert!(context.send_push(expected_handle, &[5, 7]).is_err());
         assert!(context.send_commit(0, OutgoingPacket::default()).is_err());
-        assert!(
-            context
-                .send_commit(expected_handle, OutgoingPacket::default())
-                .is_err()
-        );
+        assert!(context
+            .send_commit(expected_handle, OutgoingPacket::default())
+            .is_err());
 
         // Checking that we also get an error when trying
         // to commit or send a non-existent message

--- a/gstd-meta/tests/json.rs
+++ b/gstd-meta/tests/json.rs
@@ -63,9 +63,7 @@ fn check(types: Vec<MetaType>, expectation: &'static str) {
 #[test]
 fn primitives_json() {
     check(
-        types!(
-            bool, char, str, String, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128
-        ),
+        types!(bool, char, str, String, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128),
         "{}",
     );
 }

--- a/node-rti/src/ext.rs
+++ b/node-rti/src/ext.rs
@@ -133,8 +133,8 @@ mod tests {
             .into()
     }
 
-    fn new_test_storage()
-    -> gear_core::storage::Storage<ExtMessageQueue, ExtProgramStorage, ExtWaitList> {
+    fn new_test_storage(
+    ) -> gear_core::storage::Storage<ExtMessageQueue, ExtProgramStorage, ExtWaitList> {
         sp_io::storage::clear_prefix(STORAGE_CODE_PREFIX, None);
         sp_io::storage::clear_prefix(STORAGE_MESSAGE_PREFIX, None);
         sp_io::storage::clear_prefix(STORAGE_PROGRAM_PREFIX, None);

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,0 @@
-condense_wildcard_suffixes = true
-format_code_in_doc_comments = true
-license_template_path = "HEADER-GPL3"
-version = "Two"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -4,8 +4,8 @@ set -e
 cd "$(dirname "$0")/.."
 
 echo "*** Run fmt"
-cargo +nightly fmt --all
-cargo +nightly fmt --all --manifest-path examples/Cargo.toml -- --config=license_template_path=""
+cargo fmt --all
+cargo fmt --all --manifest-path examples/Cargo.toml -- --config=license_template_path=""
 
 echo "*** Run clippy"
 # TODO: Spread clippy to `--workspace`


### PR DESCRIPTION
- Revert `rustfmt` back to v1.
- Now we can use cargo fmt with the stable compiler as earlier.