### PR TITLE
Bump parity-db from 0.3.1 to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,9 +4331,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241f9c5d25063080f2c02846221f13e1d0e5e18fa00c32c234aad585b744ee55"
+checksum = "91b679c6acc14fac74382942e2b73bea441686a33430b951ea03b5aeb6a7f254"
 dependencies = [
  "blake2-rfc",
  "crc32fast",


### PR DESCRIPTION
- Need to build gear-node against Windows.
