### PR TITLE
Roll back changes in state if extrinsic throws

### DIFF
--- a/pallets/gear/src/mock.rs
+++ b/pallets/gear/src/mock.rs
@@ -123,7 +123,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
         .unwrap();
 
     pallet_balances::GenesisConfig::<Test> {
-        balances: vec![(1, 100_000_000_u128), (2, 1_u128), (BLOCK_AUTHOR, 1_u128)],
+        balances: vec![(1, 100_000_000_u128), (2, 2_u128), (BLOCK_AUTHOR, 1_u128)],
     }
     .assimilate_storage(&mut t)
     .unwrap();


### PR DESCRIPTION
Newly added tests revealed that `send_message` and `send_reply` extrinsics, having failed, can in some cases still modify the state.
The suggested fix wraps the two calls in the `transactional` macro thereby forcing all changes to be rolled back if anything but `Ok(())` has been returned.