### PR TITLE
Make wait-list scoped to corresponding program (#129)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7387,6 +7387,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tests-wait-wake"
+version = "0.1.0"
+dependencies = [
+ "gear-core",
+ "gear-core-runner",
+ "gstd",
+ "parity-scale-codec",
+ "substrate-wasm-builder",
+ "tests-common",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,7 @@ members = [
     "node-runner",
     "pallets/*",
     "runtime",
-    "tests/btree",
-    "tests/common",
-    "tests/distributor",
-    "tests/gas_limit/",
-    "tests/node",
+    "tests/*",
     "utils/gear-test-cli",
     "utils/wasm-proc",
 ]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -147,10 +147,12 @@ fn page_key(id: H256, page: u32) -> Vec<u8> {
     key
 }
 
-fn wait_key(id: H256) -> Vec<u8> {
+fn wait_key(prog_id: H256, msg_id: H256) -> Vec<u8> {
     let mut key = Vec::new();
     key.extend(STORAGE_WAITLIST_PREFIX);
-    id.encode_to(&mut key);
+    prog_id.encode_to(&mut key);
+    key.extend(b"::");
+    msg_id.encode_to(&mut key);
     key
 }
 
@@ -283,19 +285,19 @@ pub fn caller_nonce_fetch_inc(caller_id: H256) -> u64 {
     original_nonce
 }
 
-pub(crate) fn insert_waiting_message(id: H256, message: Message) {
-    sp_io::storage::set(&wait_key(id), &message.encode());
+pub(crate) fn insert_waiting_message(prog_id: H256, msg_id: H256, message: Message) {
+    sp_io::storage::set(&wait_key(prog_id, msg_id), &message.encode());
 }
 
-pub(crate) fn get_waiting_message(id: H256) -> Option<Message> {
-    sp_io::storage::get(&wait_key(id))
+pub(crate) fn get_waiting_message(prog_id: H256, msg_id: H256) -> Option<Message> {
+    sp_io::storage::get(&wait_key(prog_id, msg_id))
         .as_ref()
         .map(|val| Message::decode(&mut &val[..]).ok())
         .flatten()
 }
 
-pub(crate) fn remove_waiting_message(id: H256) -> Option<Message> {
-    let id = wait_key(id);
+pub(crate) fn remove_waiting_message(prog_id: H256, msg_id: H256) -> Option<Message> {
+    let id = wait_key(prog_id, msg_id);
     let msg: Option<Message> = sp_io::storage::get(&id)
         .map(|val| Message::decode(&mut &val[..]).expect("message encoded correctly"));
 

--- a/common/src/native.rs
+++ b/common/src/native.rs
@@ -119,14 +119,26 @@ pub fn program_exists(id: ProgramId) -> bool {
     crate::program_exists(H256::from_slice(id.as_slice()))
 }
 
-pub fn insert_waiting_message(id: MessageId, message: CoreMessage) {
-    crate::insert_waiting_message(H256::from_slice(id.as_slice()), message.into());
+pub fn insert_waiting_message(prog_id: ProgramId, msg_id: MessageId, message: CoreMessage) {
+    crate::insert_waiting_message(
+        H256::from_slice(prog_id.as_slice()),
+        H256::from_slice(msg_id.as_slice()),
+        message.into(),
+    );
 }
 
-pub fn get_waiting_message(id: MessageId) -> Option<CoreMessage> {
-    crate::get_waiting_message(H256::from_slice(id.as_slice())).map(|msg| msg.into())
+pub fn get_waiting_message(prog_id: ProgramId, msg_id: MessageId) -> Option<CoreMessage> {
+    crate::get_waiting_message(
+        H256::from_slice(prog_id.as_slice()),
+        H256::from_slice(msg_id.as_slice()),
+    )
+    .map(|msg| msg.into())
 }
 
-pub fn remove_waiting_message(id: MessageId) -> Option<CoreMessage> {
-    crate::remove_waiting_message(H256::from_slice(id.as_slice())).map(|msg| msg.into())
+pub fn remove_waiting_message(prog_id: ProgramId, msg_id: MessageId) -> Option<CoreMessage> {
+    crate::remove_waiting_message(
+        H256::from_slice(prog_id.as_slice()),
+        H256::from_slice(msg_id.as_slice()),
+    )
+    .map(|msg| msg.into())
 }

--- a/core-runner/src/runner.rs
+++ b/core-runner/src/runner.rs
@@ -364,11 +364,12 @@ impl<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList> Runner<MQ, PS, WL> {
         }
 
         if let Some(waiting_msg) = run_result.waiting.take() {
-            self.wait_list.insert(waiting_msg.id, waiting_msg);
+            self.wait_list
+                .insert(program.id(), waiting_msg.id, waiting_msg);
         }
 
         for (waker_id, gas) in &run_result.awakening {
-            if let Some(mut msg) = self.wait_list.remove(*waker_id) {
+            if let Some(mut msg) = self.wait_list.remove(program.id(), *waker_id) {
                 // Increase gas available to the message
                 if u64::max_value() - gas < msg.gas_limit() {
                     // TODO: issue #323
@@ -1122,8 +1123,8 @@ mod tests {
         } = runner.complete();
         let mut wait_list: MessageMap = wait_list.into();
 
-        assert!(wait_list.contains_key(&msg_id));
-        let msg = wait_list.remove(&msg_id).unwrap();
+        assert!(wait_list.contains_key(&(dest_id.into(), msg_id)));
+        let msg = wait_list.remove(&(dest_id.into(), msg_id)).unwrap();
 
         assert_eq!(msg.source, source_id.into());
         assert_eq!(msg.dest, dest_id.into());

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -143,15 +143,15 @@ impl From<InMemoryMessageQueue> for Vec<Message> {
 }
 
 /// Message map with id as a key.
-pub type MessageMap = BTreeMap<MessageId, Message>;
+pub type MessageMap = BTreeMap<(ProgramId, MessageId), Message>;
 
 /// Wait list for suspended messages.
 pub trait WaitList: Default {
     /// Insert a message to the wait list.
-    fn insert(&mut self, id: MessageId, message: Message);
+    fn insert(&mut self, program_id: ProgramId, msg_id: MessageId, message: Message);
 
     /// Remove the message from the wait list and return it if any.
-    fn remove(&mut self, id: MessageId) -> Option<Message>;
+    fn remove(&mut self, program_id: ProgramId, id: MessageId) -> Option<Message>;
 }
 
 /// In-memory wait list (for tests).
@@ -168,12 +168,12 @@ impl InMemoryWaitList {
 }
 
 impl WaitList for InMemoryWaitList {
-    fn insert(&mut self, id: MessageId, message: Message) {
-        self.inner.insert(id, message);
+    fn insert(&mut self, program_id: ProgramId, id: MessageId, message: Message) {
+        self.inner.insert((program_id, id), message);
     }
 
-    fn remove(&mut self, id: MessageId) -> Option<Message> {
-        self.inner.remove(&id)
+    fn remove(&mut self, program_id: ProgramId, id: MessageId) -> Option<Message> {
+        self.inner.remove(&(program_id, id))
     }
 }
 

--- a/tests/wait_wake/Cargo.toml
+++ b/tests/wait_wake/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "tests-wait-wake"
+version = "0.1.0"
+authors = ["Gear Technologies"]
+edition = "2018"
+license = "GPL-3.0"
+
+[dependencies]
+gstd = { path = "../../gstd", features = ["debug"] }
+gear-core-runner = { path = "../../core-runner", optional = true }
+gear-core = { path = "../../core", optional = true }
+codec = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
+common = { package = "tests-common", path = "../common", optional = true }
+
+[build-dependencies]
+substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+
+[lib]
+
+[features]
+std = ["gear-core-runner", "gear-core", "codec/std", "common"]
+default = ["std"]

--- a/tests/wait_wake/build.rs
+++ b/tests/wait_wake/build.rs
@@ -1,0 +1,9 @@
+use substrate_wasm_builder::WasmBuilder;
+
+fn main() {
+    // regular build
+    WasmBuilder::new()
+        .with_current_project()
+        .import_memory()
+        .build();
+}

--- a/tests/wait_wake/src/lib.rs
+++ b/tests/wait_wake/src/lib.rs
@@ -1,0 +1,232 @@
+#![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
+#![cfg_attr(not(feature = "std"), feature(const_btree_new))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::{Decode, Encode};
+
+#[cfg(feature = "std")]
+#[cfg(test)]
+mod native {
+    include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+}
+
+#[derive(Encode, Debug, Decode, PartialEq)]
+pub enum Request {
+    EchoWait(u32),
+    Wake([u8; 32]),
+}
+
+#[cfg(not(feature = "std"))]
+mod wasm {
+
+    extern crate alloc;
+
+    use codec::{Decode, Encode};
+    use gstd::{exec, ext, msg, prelude::*, MessageId, ProgramId};
+
+    use super::Request;
+
+    static mut ECHOES: BTreeMap<MessageId, u32> = BTreeMap::new();
+
+    fn process_request(request: Request) {
+        match request {
+            Request::EchoWait(n) => {
+                unsafe { ECHOES.insert(msg::id(), n) };
+                exec::wait();
+            }
+            Request::Wake(id) => exec::wake(MessageId(id), exec::gas_available() - 100_000),
+        }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn init() {
+        msg::reply((), 0, 0);
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn handle() {
+        if let Some(reply) = unsafe { ECHOES.remove(&msg::id()) } {
+            msg::reply(reply, 0, 0);
+        } else {
+            msg::load::<Request>().map(process_request);
+        }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn handle_reply() {}
+}
+
+#[cfg(test)]
+#[cfg(feature = "std")]
+mod tests {
+    use super::{native, Request};
+    use common::*;
+    use gear_core::message::MessageId;
+    use std::convert::TryInto;
+
+    #[test]
+    fn binary_available() {
+        assert!(native::WASM_BINARY.is_some());
+        assert!(native::WASM_BINARY_BLOATY.is_some());
+    }
+
+    fn wasm_code() -> &'static [u8] {
+        native::WASM_BINARY_BLOATY.expect("wasm binary exists")
+    }
+
+    #[test]
+    fn program_can_be_initialized() {
+        let mut runner = RunnerContext::default();
+
+        // Assertions are performed when decoding reply
+        let _reply: () = runner.init_program_with_reply(InitProgram::from(wasm_code()));
+    }
+
+    #[test]
+    fn wake_self() {
+        let prog_id_1 = 1;
+
+        let mut runner = RunnerContext::default();
+        runner.init_program(InitProgram::from(wasm_code()).id(prog_id_1));
+
+        let msg_id_1 = MessageId::from(10);
+        let msg_id_2 = MessageId::from(20);
+
+        let reply = runner.try_request::<_, ()>(
+            MessageBuilder::from(Request::EchoWait(100))
+                .id(msg_id_1)
+                .destination(prog_id_1),
+        );
+        assert_eq!(reply, None);
+
+        let reply = runner.try_request::<_, ()>(
+            MessageBuilder::from(Request::EchoWait(200))
+                .id(msg_id_2)
+                .destination(prog_id_1),
+        );
+        assert_eq!(reply, None);
+
+        let reply = runner.try_request::<_, ()>(
+            MessageBuilder::from(Request::Wake(
+                msg_id_1
+                    .as_slice()
+                    .try_into()
+                    .expect("MessageId inner array size is 32"),
+            ))
+            .destination(prog_id_1),
+        );
+        assert_eq!(reply, None);
+
+        let reply = runner.try_request::<_, ()>(
+            MessageBuilder::from(Request::Wake(
+                msg_id_2
+                    .as_slice()
+                    .try_into()
+                    .expect("MessageId inner array size is 32"),
+            ))
+            .destination(prog_id_1),
+        );
+        assert_eq!(reply, None);
+
+        let reply: u32 = runner
+            .get_response_to(msg_id_1)
+            .expect("No response to original message")
+            .expect("Unable to parse response to original message");
+        assert_eq!(reply, 100);
+
+        let reply: u32 = runner
+            .get_response_to(msg_id_2)
+            .expect("No response to original message")
+            .expect("Unable to parse response to original message");
+        assert_eq!(reply, 200);
+    }
+
+    #[test]
+    fn wake_other() {
+        let prog_id_1 = 1;
+        let prog_id_2 = 2;
+
+        let mut runner = RunnerContext::default();
+        runner.init_program(InitProgram::from(wasm_code()).id(prog_id_1));
+        runner.init_program(InitProgram::from(wasm_code()).id(prog_id_2));
+
+        let msg_id_1 = MessageId::from(10);
+        let msg_id_2 = MessageId::from(20);
+
+        let reply = runner.try_request::<_, ()>(
+            MessageBuilder::from(Request::EchoWait(100))
+                .id(msg_id_1)
+                .destination(prog_id_1),
+        );
+        assert_eq!(reply, None);
+
+        let reply = runner.try_request::<_, ()>(
+            MessageBuilder::from(Request::EchoWait(200))
+                .id(msg_id_2)
+                .destination(prog_id_2),
+        );
+        assert_eq!(reply, None);
+
+        let reply = runner.try_request::<_, ()>(
+            MessageBuilder::from(Request::Wake(
+                msg_id_1
+                    .as_slice()
+                    .try_into()
+                    .expect("MessageId inner array size is 32"),
+            ))
+            .destination(prog_id_2),
+        );
+        assert_eq!(reply, None);
+
+        let reply = runner.try_request::<_, ()>(
+            MessageBuilder::from(Request::Wake(
+                msg_id_2
+                    .as_slice()
+                    .try_into()
+                    .expect("MessageId inner array size is 32"),
+            ))
+            .destination(prog_id_1),
+        );
+        assert_eq!(reply, None);
+
+        let reply = runner.get_response_to::<_, u32>(msg_id_1);
+        assert_eq!(reply, None);
+
+        let reply = runner.get_response_to::<_, u32>(msg_id_2);
+        assert_eq!(reply, None);
+
+        let reply = runner.try_request::<_, ()>(
+            MessageBuilder::from(Request::Wake(
+                msg_id_2
+                    .as_slice()
+                    .try_into()
+                    .expect("MessageId inner array size is 32"),
+            ))
+            .destination(prog_id_2),
+        );
+        assert_eq!(reply, None);
+
+        let reply = runner
+            .get_response_to::<_, u32>(msg_id_2)
+            .expect("No response to original message")
+            .expect("Unable to parse response to original message");
+        assert_eq!(reply, 200);
+
+        let reply = runner.try_request::<_, ()>(
+            MessageBuilder::from(Request::Wake(
+                msg_id_1
+                    .as_slice()
+                    .try_into()
+                    .expect("MessageId inner array size is 32"),
+            ))
+            .destination(prog_id_1),
+        );
+        assert_eq!(reply, None);
+
+        let reply = runner
+            .get_response_to::<_, u32>(msg_id_1)
+            .expect("No response to original message")
+            .expect("Unable to parse response to original message");
+        assert_eq!(reply, 100);
+    }
+}


### PR DESCRIPTION
Fixes #129.

- wait-list cache now has `(ProgramId, MessageId)` tuple as a key;
- wait-list is stored with prefix `g::wait::<ProgramId>::<MessageId>`;
- Acessing wait-list message now also requires ProgramId. Current ProgramId is used, so program can only access own wait-list messages;
- wait-list standalone tests were added.

@NikVolf @shamilsan 