### PR TITLE
Skip vector destruction in vec example, so that two pages stay allocated

### DIFF
--- a/examples/vec/src/lib.rs
+++ b/examples/vec/src/lib.rs
@@ -19,6 +19,10 @@ pub unsafe extern "C" fn handle() {
     msg::send(msg::source(), v.len() as i32, 10_000_000, 0);
     debug!("{:?} total message(s) stored: ", MESSAGE_LOG.len());
 
+    // Test idea is to allocate two wasm pages and check this allocation,
+    // so we must skip @v disctruction.
+    core::mem::forget(v);
+
     for log in MESSAGE_LOG.iter() {
         debug!(log);
     }

--- a/examples/vec/src/lib.rs
+++ b/examples/vec/src/lib.rs
@@ -19,8 +19,8 @@ pub unsafe extern "C" fn handle() {
     msg::send(msg::source(), v.len() as i32, 10_000_000, 0);
     debug!("{:?} total message(s) stored: ", MESSAGE_LOG.len());
 
-    // Test idea is to allocate two wasm pages and check this allocation,
-    // so we must skip @v disctruction.
+    // The test idea is to allocate two wasm pages and check this allocation,
+    // so we must skip `v` destruction.
     core::mem::forget(v);
 
     for log in MESSAGE_LOG.iter() {

--- a/gtest/spec/test_vec.yaml
+++ b/gtest/spec/test_vec.yaml
@@ -30,5 +30,5 @@ fixtures:
             exact_pages: [17]
           - program_id: 2
             filter: dynamic
-            exact_pages: [17]
+            exact_pages: [17,18]
 


### PR DESCRIPTION
Fixes #358.
