### PR TITLE
Add a syscall to get the block timestamp in programs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4172,6 +4172,7 @@ dependencies = [
  "log",
  "pallet-authorship",
  "pallet-balances",
+ "pallet-timestamp",
  "parity-scale-codec",
  "parity-wasm 0.42.2",
  "primitive-types",

--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -39,6 +39,10 @@ pub fn block_height<E: Ext>(ext: LaterExt<E>) -> impl Fn() -> i32 {
     move || ext.with(|ext: &mut E| ext.block_height()).unwrap_or(0) as i32
 }
 
+pub fn block_timestamp<E: Ext>(ext: LaterExt<E>) -> impl Fn() -> i64 {
+    move || ext.with(|ext: &mut E| ext.block_timestamp()).unwrap_or(0) as i64
+}
+
 pub fn exit_code<E: Ext>(ext: LaterExt<E>) -> impl Fn() -> Result<i32, &'static str> {
     move || {
         let reply_tuple = ext.with(|ext: &mut E| ext.reply_to())?;

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -320,6 +320,17 @@ impl<E: Ext + 'static> SandboxEnvironment<E> {
             Ok(ReturnValue::Value(Value::I32(block_height as i32)))
         }
 
+        fn block_timestamp<E: Ext>(
+            ctx: &mut Runtime<E>,
+            _args: &[Value],
+        ) -> Result<ReturnValue, HostError> {
+            let block_timestamp = ctx
+                .ext
+                .with(|ext: &mut E| ext.block_timestamp())
+                .unwrap_or(0);
+            Ok(ReturnValue::Value(Value::I32(block_timestamp as i32)))
+        }
+
         fn reply<E: Ext>(ctx: &mut Runtime<E>, args: &[Value]) -> Result<ReturnValue, HostError> {
             let payload_ptr: i32 = match args[0] {
                 Value::I32(val) => val,
@@ -575,6 +586,7 @@ impl<E: Ext + 'static> SandboxEnvironment<E> {
         env_builder.add_host_func("env", "alloc", alloc);
         env_builder.add_host_func("env", "free", free);
         env_builder.add_host_func("env", "gr_block_height", block_height);
+        env_builder.add_host_func("env", "gr_block_timestamp", block_timestamp);
         env_builder.add_host_func("env", "gr_exit_code", exit_code);
         env_builder.add_host_func("env", "gr_send", send);
         env_builder.add_host_func("env", "gr_send_commit", send_commit);

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -54,6 +54,7 @@ impl<E: Ext + 'static> WasmtimeEnvironment<E> {
         result.add_func_i32("free", funcs::free);
         result.add_func_i32("gas", funcs::gas);
         result.add_func_into_i32("gr_block_height", funcs::block_height);
+        result.add_func_into_i64("gr_block_timestamp", funcs::block_timestamp);
         result.add_func_to_i32("gr_exit_code", funcs::exit_code);
         result.add_func_into_i64("gr_gas_available", funcs::gas_available);
         result.add_func_i32_i32("gr_debug", funcs::debug);

--- a/core-runner/src/builder.rs
+++ b/core-runner/src/builder.rs
@@ -17,7 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::runner::{Config, ExtMessage, InitializeProgramInfo, Runner};
-use crate::ext::Ext;
+use crate::ext::{BlockInfo, Ext};
 use alloc::vec::*;
 use gear_backend_common::Environment;
 use gear_core::storage::{MessageQueue, ProgramStorage, Storage, WaitList};
@@ -31,7 +31,7 @@ pub struct RunnerBuilder<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList, E: 
     config: Config,
     programs: Vec<InitializeProgramInfo>,
     storage: Storage<MQ, PS, WL>,
-    block_height: u32,
+    block_info: BlockInfo,
     env: core::marker::PhantomData<E>,
 }
 
@@ -48,9 +48,9 @@ impl<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList, E: Environment<Ext>>
         Default::default()
     }
 
-    /// Set block height.
-    pub fn block_height(mut self, value: u32) -> Self {
-        self.block_height = value;
+    /// Set the block info.
+    pub fn block_info(mut self, value: BlockInfo) -> Self {
+        self.block_info = value;
         self
     }
 
@@ -110,7 +110,7 @@ impl<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList, E: Environment<Ext>>
 
     /// Initialize all programs and return [`Runner`].
     pub fn build(self) -> Runner<MQ, PS, WL, E> {
-        let mut runner = Runner::new(&self.config, self.storage, self.block_height, E::default());
+        let mut runner = Runner::new(&self.config, self.storage, self.block_info, E::default());
         for program in self.programs {
             runner
                 .init_program(program)

--- a/core-runner/src/ext.rs
+++ b/core-runner/src/ext.rs
@@ -26,6 +26,15 @@ use gear_core::{
 
 use crate::util::BlakeMessageIdGenerator;
 
+/// Structure with the info about the current block.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct BlockInfo {
+    /// Current block height.
+    pub height: u32,
+    /// Current block timestamp in msecs since tne Unix epoch.
+    pub timestamp: u64,
+}
+
 /// Structure providing externalities for running host functions.
 pub struct Ext {
     /// Memory context.
@@ -40,8 +49,8 @@ pub struct Ext {
     pub mem_grow_cost: u64,
     /// Any guest code panic explanation, if available.
     pub last_error_returned: Option<&'static str>,
-    /// Current block height.
-    pub block_height: u32,
+    /// Current block info.
+    pub block_info: BlockInfo,
 }
 
 impl Ext {
@@ -99,7 +108,11 @@ impl EnvExt for Ext {
     }
 
     fn block_height(&self) -> u32 {
-        self.block_height
+        self.block_info.height
+    }
+
+    fn block_timestamp(&self) -> u64 {
+        self.block_info.timestamp
     }
 
     fn send_init(&mut self) -> Result<usize, &'static str> {

--- a/core-runner/src/lib.rs
+++ b/core-runner/src/lib.rs
@@ -29,5 +29,5 @@ mod builder;
 mod ext;
 pub mod runner;
 mod util;
-pub use ext::Ext;
+pub use ext::{BlockInfo, Ext};
 pub use runner::*;

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -49,6 +49,9 @@ pub trait Ext {
     /// Get the current block height.
     fn block_height(&self) -> u32;
 
+    /// Get the current block timestamp.
+    fn block_timestamp(&self) -> u64;
+
     /// Initialize a new incomplete message for another program and return its handle.
     fn send_init(&mut self) -> Result<usize, &'static str>;
 
@@ -199,6 +202,9 @@ mod tests {
             Err("")
         }
         fn block_height(&self) -> u32 {
+            0
+        }
+        fn block_timestamp(&self) -> u64 {
             0
         }
         fn send_init(&mut self) -> Result<usize, &'static str> {

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -217,7 +217,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "demo-block-height"
+name = "demo-block-info"
 version = "0.1.0"
 dependencies = [
  "gstd",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -6,7 +6,7 @@ members = [
     "async-sign",
     "async-sign/signed_message",
     "async-sign/test_bob",
-    "block-height",
+    "block-info",
     "chat",
     "chat/bot",
     "chat/room",

--- a/examples/block-info/Cargo.toml
+++ b/examples/block-info/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "demo-block-height"
+name = "demo-block-info"
 version = "0.1.0"
 authors = ["Gear Technologies"]
 edition = "2018"

--- a/examples/block-info/src/lib.rs
+++ b/examples/block-info/src/lib.rs
@@ -1,10 +1,15 @@
 #![no_std]
 
-use gstd::{exec, msg, prelude::*};
+use core::time::Duration;
+use gstd::{debug, exec, msg, prelude::*};
 
 #[no_mangle]
 pub unsafe extern "C" fn handle() {
     let payload = String::from_utf8(msg::load_bytes()).expect("Invalid message");
+
+    let bt = Duration::from_millis(exec::block_timestamp());
+    debug!("Timestamp: {:?}", bt);
+
     let bh = exec::block_height();
     msg::reply_bytes(format!("{}_{}", payload, bh), 10_000_000, 0);
 }

--- a/examples/block-info/test_block_info.yaml
+++ b/examples/block-info/test_block_info.yaml
@@ -1,14 +1,14 @@
-title: Block height
+title: Block info
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_block_height.wasm
+    path: target/wasm32-unknown-unknown/release/demo_block_info.wasm
     source:
       kind: account
       value: alice
 
 fixtures:
-  - title: block-height
+  - title: block-info
 
     messages:
       - destination: 1

--- a/gcore/src/exec.rs
+++ b/gcore/src/exec.rs
@@ -25,6 +25,7 @@ use crate::MessageId;
 mod sys {
     extern "C" {
         pub fn gr_block_height() -> u32;
+        pub fn gr_block_timestamp() -> u64;
         pub fn gr_gas_available() -> u64;
         pub fn gr_wait() -> !;
         pub fn gr_wake(waker_id_ptr: *const u8, gas_limit: u64);
@@ -51,6 +52,30 @@ mod sys {
 /// ```
 pub fn block_height() -> u32 {
     unsafe { sys::gr_block_height() }
+}
+
+/// Get the current block timestamp.
+///
+/// The timestamp is the number of milliseconds elapsed since the Unix epoch.
+///
+/// # Examples
+///
+/// ```
+/// use gcore::{exec, msg};
+///
+/// // Send a reply after the block timestamp reaches the February 22, 2022
+/// pub unsafe extern "C" fn handle() {
+///     if exec::block_timestamp() >= 1645488000000 {
+///         msg::reply(
+///             b"The current block is generated after February 22, 2022",
+///             1_000_000,
+///             0,
+///         );
+///     }
+/// }
+/// ```
+pub fn block_timestamp() -> u64 {
+    unsafe { sys::gr_block_timestamp() }
 }
 
 /// Get the current value of the gas available for execution.

--- a/gtest/src/runner.rs
+++ b/gtest/src/runner.rs
@@ -36,6 +36,7 @@ use sp_core::{crypto::Ss58Codec, hexdisplay::AsBytesRef, sr25519::Public};
 use sp_keyring::sr25519::Keyring;
 use std::fmt::Write;
 use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use regex::Regex;
 
@@ -130,7 +131,7 @@ pub fn init_fixture<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList>(
     let mut runner = Runner::new(
         &Config::default(),
         storage,
-        0,
+        Default::default(),
         gear_backend_wasmtime::WasmtimeEnvironment::<Ext>::default(),
     );
     let mut nonce = 0;
@@ -258,6 +259,11 @@ where
     if let Some(steps) = steps {
         for step_no in 0..steps {
             runner.set_block_height(step_no as _);
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_millis())
+                .unwrap_or(0);
+            runner.set_block_timestamp(timestamp as _);
             let run_result = runner.run_next(u64::MAX);
 
             log::info!("step: {}", step_no + 1);

--- a/node-runner/src/lib.rs
+++ b/node-runner/src/lib.rs
@@ -26,7 +26,7 @@ use sp_core::H256;
 use gear_core::{message::MessageId, program::ProgramId, storage::Storage};
 
 use gear_backend_common::Environment;
-pub use gear_core_runner::Ext;
+pub use gear_core_runner::{BlockInfo, Ext};
 use gear_core_runner::{
     ExecutionOutcome, ExtMessage, InitializeProgramInfo, MessageDispatch, RunNextResult, Runner,
 };
@@ -99,9 +99,9 @@ impl ExecutionReport {
 
 pub fn process<E: Environment<Ext>>(
     max_gas_limit: u64,
-    block_height: u32,
+    block_info: BlockInfo,
 ) -> Result<ExecutionReport, Error> {
-    let mut runner = ExtRunner::<E>::builder().block_height(block_height).build();
+    let mut runner = ExtRunner::<E>::builder().block_info(block_info).build();
     let result = runner.run_next(max_gas_limit);
 
     let Storage {
@@ -124,9 +124,9 @@ pub fn init_program<E: Environment<Ext>>(
     init_payload: Vec<u8>,
     gas_limit: u64,
     value: u128,
-    block_height: u32,
+    block_info: BlockInfo,
 ) -> Result<ExecutionReport, Error> {
-    let mut runner = ExtRunner::<E>::builder().block_height(block_height).build();
+    let mut runner = ExtRunner::<E>::builder().block_info(block_info).build();
 
     let init_message_id = MessageId::from_slice(&init_message_id[..]);
     let run_result = runner

--- a/pallets/gear/Cargo.toml
+++ b/pallets/gear/Cargo.toml
@@ -35,6 +35,7 @@ sp-io = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.g
 sp-runtime = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false }
 pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 pallet-authorship = { version = "4.0.0-dev", default-features = false, git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 
 [dev-dependencies]
 serde = "1.0.101"

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -641,7 +641,7 @@ pub mod pallet {
         /// Emits the following events:
         /// - `InitMessageEnqueued(MessageInfo)` when init message is placed in the queue.
         #[pallet::weight(
-            <T as pallet::Config>::WeightInfo::submit_program(code.len() as u32, init_payload.len() as u32)
+            <T as Config>::WeightInfo::submit_program(code.len() as u32, init_payload.len() as u32)
         )]
         pub fn submit_program(
             origin: OriginFor<T>,
@@ -715,7 +715,7 @@ pub mod pallet {
         /// Emits the following events:
         /// - `DispatchMessageEnqueued(MessageInfo)` when dispatch message is placed in the queue.
         #[frame_support::transactional]
-        #[pallet::weight(<T as pallet::Config>::WeightInfo::send_message(payload.len() as u32))]
+        #[pallet::weight(<T as Config>::WeightInfo::send_message(payload.len() as u32))]
         pub fn send_message(
             origin: OriginFor<T>,
             destination: H256,
@@ -783,7 +783,7 @@ pub mod pallet {
         ///
         /// - `DispatchMessageEnqueued(H256)` when dispatch message is placed in the queue.
         #[frame_support::transactional]
-        #[pallet::weight(<T as pallet::Config>::WeightInfo::send_reply(payload.len() as u32))]
+        #[pallet::weight(<T as Config>::WeightInfo::send_reply(payload.len() as u32))]
         pub fn send_reply(
             origin: OriginFor<T>,
             reply_to_id: H256,
@@ -880,7 +880,7 @@ pub mod pallet {
         ///
         /// Emits the following events:
         /// - `ProgramRemoved(id)` when succesful.
-        #[pallet::weight(<T as pallet::Config>::WeightInfo::remove_stale_program())]
+        #[pallet::weight(<T as Config>::WeightInfo::remove_stale_program())]
         pub fn remove_stale_program(
             origin: OriginFor<T>,
             program_id: H256,

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -44,12 +44,15 @@ pub mod pallet {
     };
     use frame_system::pallet_prelude::*;
     use primitive_types::H256;
+    use runner::BlockInfo;
     use scale_info::TypeInfo;
     use sp_runtime::traits::{Saturating, UniqueSaturatedInto};
     use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 
     #[pallet::config]
-    pub trait Config: frame_system::Config + pallet_authorship::Config {
+    pub trait Config:
+        frame_system::Config + pallet_authorship::Config + pallet_timestamp::Config
+    {
         /// Because this pallet emits events, it depends on the runtime's definition of an event.
         type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 
@@ -287,7 +290,10 @@ pub mod pallet {
 
             let mut weight = Self::gas_allowance() as Weight;
             let mut total_handled = 0u32;
-            let block_height = <frame_system::Pallet<T>>::block_number().unique_saturated_into();
+            let block_info = BlockInfo {
+                height: <frame_system::Pallet<T>>::block_number().unique_saturated_into(),
+                timestamp: <pallet_timestamp::Pallet<T>>::get().unique_saturated_into(),
+            };
 
             for message in messages {
                 match message {
@@ -323,7 +329,7 @@ pub mod pallet {
                             payload.to_vec(),
                             gas_limit,
                             value,
-                            block_height,
+                            block_info,
                         ) {
                             Err(_) => {
                                 // `init_program` in Runner can only return Err(_) in two cases:
@@ -470,7 +476,7 @@ pub mod pallet {
             loop {
                 match runner::process::<gear_backend_sandbox::SandboxEnvironment<runner::Ext>>(
                     GasAllowance::<T>::get(),
-                    block_height,
+                    block_info,
                 ) {
                     Ok(execution_report) => {
                         if execution_report.handled == 0 {
@@ -635,7 +641,7 @@ pub mod pallet {
         /// Emits the following events:
         /// - `InitMessageEnqueued(MessageInfo)` when init message is placed in the queue.
         #[pallet::weight(
-            T::WeightInfo::submit_program(code.len() as u32, init_payload.len() as u32)
+            <T as pallet::Config>::WeightInfo::submit_program(code.len() as u32, init_payload.len() as u32)
         )]
         pub fn submit_program(
             origin: OriginFor<T>,
@@ -709,7 +715,7 @@ pub mod pallet {
         /// Emits the following events:
         /// - `DispatchMessageEnqueued(MessageInfo)` when dispatch message is placed in the queue.
         #[frame_support::transactional]
-        #[pallet::weight(T::WeightInfo::send_message(payload.len() as u32))]
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::send_message(payload.len() as u32))]
         pub fn send_message(
             origin: OriginFor<T>,
             destination: H256,
@@ -777,7 +783,7 @@ pub mod pallet {
         ///
         /// - `DispatchMessageEnqueued(H256)` when dispatch message is placed in the queue.
         #[frame_support::transactional]
-        #[pallet::weight(T::WeightInfo::send_reply(payload.len() as u32))]
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::send_reply(payload.len() as u32))]
         pub fn send_reply(
             origin: OriginFor<T>,
             reply_to_id: H256,
@@ -874,7 +880,7 @@ pub mod pallet {
         ///
         /// Emits the following events:
         /// - `ProgramRemoved(id)` when succesful.
-        #[pallet::weight(T::WeightInfo::remove_stale_program())]
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::remove_stale_program())]
         pub fn remove_stale_program(
             origin: OriginFor<T>,
             program_id: H256,

--- a/pallets/gear/src/mock.rs
+++ b/pallets/gear/src/mock.rs
@@ -40,6 +40,7 @@ construct_runtime!(
         Gear: pallet_gear::{Pallet, Call, Storage, Event<T>},
         Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
         Authorship: pallet_authorship::{Pallet, Storage},
+        Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
     }
 );
 
@@ -114,6 +115,17 @@ impl pallet_authorship::Config for Test {
     type UncleGenerations = ();
     type FilterUncle = ();
     type EventHandler = ();
+}
+
+parameter_types! {
+    pub const MinimumPeriod: u64 = 500;
+}
+
+impl pallet_timestamp::Config for Test {
+    type Moment = u64;
+    type OnTimestampSet = ();
+    type MinimumPeriod = MinimumPeriod;
+    type WeightInfo = ();
 }
 
 // Build genesis storage according to the mock runtime.

--- a/tests/common/src/lib.rs
+++ b/tests/common/src/lib.rs
@@ -236,7 +236,7 @@ impl RunnerContext {
         Self::new(Runner::new(
             config,
             Default::default(),
-            0,
+            Default::default(),
             WasmtimeEnvironment::default(),
         ))
     }
@@ -484,7 +484,7 @@ impl RunnerState {
                 Self::Storage(storage, config) => Self::Runner(Runner::new(
                     &config,
                     storage,
-                    0,
+                    Default::default(),
                     WasmtimeEnvironment::default(),
                 )),
                 _ => Self::Runner(Runner::default()),


### PR DESCRIPTION
Fixes #301.

- Add `gr_block_timestamp` syscall that returns `u64` timestamp in milliseconds since the Unix epoch.
- Rename `blolck-height` example to `block-info`.

@gear-tech/dev 
