### PR TITLE
Add messaging negative tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7426,6 +7426,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tests-messages"
+version = "0.1.0"
+dependencies = [
+ "gear-core",
+ "gear-core-runner",
+ "gstd",
+ "parity-scale-codec",
+ "substrate-wasm-builder",
+ "tests-common",
+]
+
+[[package]]
 name = "tests-node"
 version = "0.1.0"
 dependencies = [

--- a/gcore/src/general.rs
+++ b/gcore/src/general.rs
@@ -48,8 +48,8 @@
 ///     let msg_handle = msg::send_init();
 /// }
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct MessageHandle(pub u32);
+#[derive(Debug, PartialEq, Eq)]
+pub struct MessageHandle(pub(crate) u32);
 
 /// Message identifier.
 ///

--- a/gstd/src/msg.rs
+++ b/gstd/src/msg.rs
@@ -23,7 +23,7 @@ use codec::{Decode, Encode, Output};
 use galloc::prelude::*;
 pub use gcore::msg::{exit_code, id, reply_to, source, value};
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct MessageHandle(gcore::MessageHandle);
 
 impl MessageHandle {

--- a/tests/btree/src/lib.rs
+++ b/tests/btree/src/lib.rs
@@ -51,7 +51,7 @@ mod wasm {
 
     use alloc::collections::BTreeMap;
     use codec::{Decode, Encode};
-    use gstd::{ext, msg, prelude::*};
+    use gstd::{debug, ext, msg, prelude::*};
 
     use super::{Reply, Request};
 
@@ -62,7 +62,7 @@ mod wasm {
         let reply = match msg::load() {
             Ok(request) => process(request),
             Err(e) => {
-                ext::debug(&format!("Error processing request: {:?}", e));
+                debug!("Error processing request: {:?}", e);
                 Reply::Error
             }
         };

--- a/tests/distributor/src/lib.rs
+++ b/tests/distributor/src/lib.rs
@@ -50,7 +50,7 @@ mod wasm {
     use alloc::collections::BTreeSet;
     use codec::{Decode, Encode};
     use core::future::Future;
-    use gstd::{exec, ext, msg, prelude::*, ProgramId};
+    use gstd::{debug, exec, ext, msg, prelude::*, ProgramId};
     use gstd_async::mutex::Mutex;
 
     use super::{Reply, Request};
@@ -134,7 +134,7 @@ mod wasm {
                     Request::Report => Self::handle_report().await,
                 },
                 Err(e) => {
-                    ext::debug(&format!("Error processing request: {:?}", e));
+                    debug!("Error processing request: {:?}", e);
                     Reply::Failure
                 }
             };

--- a/tests/gas_limit/src/lib.rs
+++ b/tests/gas_limit/src/lib.rs
@@ -32,7 +32,7 @@ mod wasm {
     extern crate alloc;
 
     use codec::{Decode, Encode};
-    use gstd::{ext, msg, prelude::*, MessageId, ProgramId};
+    use gstd::{debug, ext, msg, prelude::*, MessageId, ProgramId};
 
     use super::{Reply, Request};
 
@@ -77,7 +77,7 @@ mod wasm {
         let reply = msg::load::<Request>()
             .map(process_request)
             .unwrap_or_else(|e| {
-                ext::debug(&format!("Error processing request: {:?}", e));
+                debug!("Error processing request: {:?}", e);
                 Reply::Error
             });
 

--- a/tests/messages/Cargo.toml
+++ b/tests/messages/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "tests-messages"
+version = "0.1.0"
+authors = ["Gear Technologies"]
+edition = "2018"
+license = "GPL-3.0"
+
+[dependencies]
+gstd = { path = "../../gstd", features = ["debug"] }
+gear-core-runner = { path = "../../core-runner", optional = true }
+gear-core = { path = "../../core", optional = true }
+codec = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
+common = { package = "tests-common", path = "../common", optional = true }
+
+[build-dependencies]
+substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+
+[lib]
+
+[features]
+std = ["gear-core-runner", "gear-core", "codec/std", "common"]
+default = ["std"]

--- a/tests/messages/build.rs
+++ b/tests/messages/build.rs
@@ -1,0 +1,9 @@
+use substrate_wasm_builder::WasmBuilder;
+
+fn main() {
+    // regular build
+    WasmBuilder::new()
+        .with_current_project()
+        .import_memory()
+        .build();
+}

--- a/tests/messages/src/lib.rs
+++ b/tests/messages/src/lib.rs
@@ -32,7 +32,7 @@ mod wasm {
     extern crate alloc;
 
     use codec::{Decode, Encode};
-    use gstd::{ext, msg, prelude::*, MessageId, ProgramId};
+    use gstd::{debug, ext, msg, prelude::*, MessageId, ProgramId};
 
     use super::{Reply, Request};
 
@@ -97,7 +97,7 @@ mod wasm {
         msg::load::<Request>()
             .map(process_request)
             .unwrap_or_else(|e| {
-                ext::debug(&format!("Error processing request: {:?}", e));
+                debug!("Error processing request: {:?}", e);
             });
     }
 }

--- a/tests/messages/src/lib.rs
+++ b/tests/messages/src/lib.rs
@@ -1,0 +1,209 @@
+#![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::{Decode, Encode};
+#[cfg(not(feature = "std"))]
+use gstd::{prelude::*, *};
+
+#[cfg(feature = "std")]
+#[cfg(test)]
+mod native {
+    include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+}
+
+#[derive(Encode, Debug, Decode, PartialEq)]
+pub enum Request {
+    SendOnce,
+    SendInf,
+    SendPushAfterCommit,
+    ReplyOnce,
+    ReplyTwice,
+    ReplyPushAfterReply,
+}
+
+#[derive(Encode, Debug, Decode, PartialEq)]
+pub enum Reply {
+    Empty,
+    Error,
+}
+
+#[cfg(not(feature = "std"))]
+mod wasm {
+    extern crate alloc;
+
+    use codec::{Decode, Encode};
+    use gstd::{ext, msg, prelude::*, MessageId, ProgramId};
+
+    use super::{Reply, Request};
+
+    mod gear_sys {
+        extern "C" {
+            pub fn gr_send_init() -> u32;
+            pub fn gr_send_push(handle: u32, data_ptr: *const u8, data_len: u32);
+            pub fn gr_send_commit(
+                handle: u32,
+                message_id_ptr: *mut u8,
+                program: *const u8,
+                gas_limit: u64,
+                value_ptr: *const u8,
+            );
+        }
+    }
+
+    static mut BUFFER: Vec<u8> = Vec::new();
+
+    fn process_request(request: Request) {
+        match request {
+            Request::SendOnce => {
+                msg::send(ProgramId::from(0), "SendOnce", 0, 0);
+            }
+            Request::SendInf => loop {
+                msg::send(ProgramId::from(0), "SendInf", 0, 0);
+            },
+            Request::SendPushAfterCommit => unsafe {
+                let handle = gear_sys::gr_send_init();
+                let mut message_id = [0u8; 32];
+                gear_sys::gr_send_commit(
+                    handle,
+                    message_id.as_mut_ptr(),
+                    ProgramId::from(0).as_slice().as_ptr(),
+                    0,
+                    0u128.to_le_bytes().as_ptr(),
+                );
+                let data = "bytes";
+                gear_sys::gr_send_push(handle, data.as_ptr(), data.len() as u32);
+            },
+            Request::ReplyOnce => {
+                msg::reply("ReplyOnce", 0, 0);
+            }
+            Request::ReplyTwice => {
+                msg::reply("ReplyTwice1", 0, 0);
+                msg::reply("ReplyTwice2", 0, 0);
+            }
+            Request::ReplyPushAfterReply => {
+                msg::reply("ReplyPushAfterReply1", 0, 0);
+                msg::reply_push("ReplyPushAfterReply2");
+            }
+        }
+    }
+
+    #[no_mangle]
+    pub extern "C" fn init() {
+        msg::reply((), 0, 0);
+    }
+
+    #[no_mangle]
+    pub extern "C" fn handle() {
+        msg::load::<Request>()
+            .map(process_request)
+            .unwrap_or_else(|e| {
+                ext::debug(&format!("Error processing request: {:?}", e));
+            });
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "std")]
+mod tests {
+    use super::{native, Request};
+
+    use codec::Encode;
+    use common::{Error::Panic, RunResult, RunnerContext};
+
+    #[test]
+    fn binary_available() {
+        assert!(native::WASM_BINARY.is_some());
+        assert!(native::WASM_BINARY_BLOATY.is_some());
+    }
+
+    fn wasm_code() -> &'static [u8] {
+        native::WASM_BINARY_BLOATY.expect("wasm binary exists")
+    }
+
+    #[test]
+    fn program_can_be_initialized() {
+        let mut runner = RunnerContext::default();
+
+        // Assertions are performed when decoding reply
+        let _reply: () = runner.init_program_with_reply(wasm_code());
+    }
+
+    #[test]
+    fn send_normal() {
+        let mut runner = RunnerContext::default();
+        runner.init_program(wasm_code());
+
+        let report = runner.request_report::<_, ()>(Request::SendOnce);
+        assert_eq!(report.result, RunResult::Normal);
+
+        let expected_payload = "SendOnce".encode();
+        assert!(runner
+            .storage()
+            .log
+            .get()
+            .iter()
+            .any(|log| log.payload.as_ref() == &expected_payload))
+    }
+
+    #[test]
+    fn send_message_limit() {
+        let mut runner = RunnerContext::default();
+        runner.init_program(wasm_code());
+
+        let report = runner.request_report::<_, ()>(Request::SendInf);
+        assert_eq!(
+            report.result,
+            RunResult::Trap(String::from("Message init error"))
+        );
+        // TODO: Should log be checked for messages?
+        // assert_eq!(runner.storage().log.get().len(), 130)
+    }
+
+    #[test]
+    fn send_push_after_commit() {
+        let mut runner = RunnerContext::default();
+        runner.init_program(wasm_code());
+
+        let report = runner.request_report::<_, ()>(Request::SendPushAfterCommit);
+        assert_eq!(
+            report.result,
+            RunResult::Trap(String::from("Payload push error"))
+        );
+    }
+
+    #[test]
+    fn reply_normal() {
+        let mut runner = RunnerContext::default();
+        runner.init_program(wasm_code());
+
+        let report = runner.request_report::<_, String>(Request::ReplyOnce);
+        assert_eq!(report.result, RunResult::Normal);
+        assert_eq!(report.response, Some(Ok(String::from("ReplyOnce"))));
+    }
+
+    #[test]
+    fn reply_twice() {
+        let mut runner = RunnerContext::default();
+        runner.init_program(wasm_code());
+
+        let report = runner.request_report::<_, String>(Request::ReplyTwice);
+        assert_eq!(
+            report.result,
+            RunResult::Trap(String::from("Reply commit error"))
+        );
+        assert_eq!(report.response, Some(Err(Panic)));
+    }
+
+    #[test]
+    fn reply_push_after_reply() {
+        let mut runner = RunnerContext::default();
+        runner.init_program(wasm_code());
+
+        let report = runner.request_report::<_, String>(Request::ReplyPushAfterReply);
+        assert_eq!(
+            report.result,
+            RunResult::Trap(String::from("Reply payload push error"))
+        );
+        assert_eq!(report.response, Some(Err(Panic)));
+    }
+}

--- a/tests/node/src/lib.rs
+++ b/tests/node/src/lib.rs
@@ -20,8 +20,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};
-#[cfg(not(feature = "std"))]
-use gstd::{prelude::*, *};
 
 #[cfg(feature = "std")]
 #[cfg(test)]
@@ -62,7 +60,7 @@ mod wasm {
 
     use alloc::collections::{BTreeMap, BTreeSet};
     use codec::{Decode, Encode};
-    use gstd::{exec, ext, msg, prelude::*, MessageId, ProgramId};
+    use gstd::{debug, exec, ext, msg, prelude::*, MessageId, ProgramId};
 
     use super::{Initialization, Operation, Reply, Request};
 
@@ -97,7 +95,7 @@ mod wasm {
         let reply = match msg::load() {
             Ok(request) => process(request),
             Err(e) => {
-                ext::debug(&format!("Error processing request: {:?}", e));
+                debug!("Error processing request: {:?}", e);
                 Reply::Failure
             }
         };


### PR DESCRIPTION
Fixes messaging tests #141.

Breaks `gcore` API compatibility to prevent invalid operations on message handle.