### PR TITLE
Refactor `Runner` to depend on a single Storage trait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 target/
 .vscode
 .DS_Store
+.idea

--- a/core-runner/src/builder.rs
+++ b/core-runner/src/builder.rs
@@ -16,33 +16,31 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use super::runner::{Config, ExtMessage, InitializeProgramInfo, Runner};
-use crate::ext::{BlockInfo, Ext};
 use alloc::vec::*;
-use gear_backend_common::Environment;
-use gear_core::storage::{MessageQueue, ProgramStorage, Storage, WaitList};
 
-#[cfg(test)]
-use gear_core::storage::{InMemoryMessageQueue, InMemoryProgramStorage, InMemoryWaitList};
+use gear_backend_common::Environment;
+use gear_core::storage::{Storage, StorageCarrier};
+
+use super::{
+    ext::{BlockInfo, Ext},
+    runner::{Config, ExtMessage, InitializeProgramInfo, Runner},
+};
 
 /// Builder for [`Runner`].
 #[derive(Default)]
-pub struct RunnerBuilder<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList, E: Environment<Ext>> {
+pub struct RunnerBuilder<SC: StorageCarrier, E: Environment<Ext>> {
     config: Config,
     programs: Vec<InitializeProgramInfo>,
-    storage: Storage<MQ, PS, WL>,
+    storage: Storage<SC::MQ, SC::PS, SC::WL>,
     block_info: BlockInfo,
     env: core::marker::PhantomData<E>,
 }
 
 #[cfg(test)]
 /// Fully in-memory runner builder (for tests).
-pub type InMemoryRunnerBuilder<E> =
-    RunnerBuilder<InMemoryMessageQueue, InMemoryProgramStorage, InMemoryWaitList, E>;
+pub type InMemoryRunnerBuilder<E> = RunnerBuilder<gear_core::storage::InMemoryStorage, E>;
 
-impl<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList, E: Environment<Ext>>
-    RunnerBuilder<MQ, PS, WL, E>
-{
+impl<SC: StorageCarrier, E: Environment<Ext>> RunnerBuilder<SC, E> {
     /// Create an empty `RunnerBuilder` for default [`Runner`].
     pub fn new() -> Self {
         Default::default()
@@ -109,7 +107,7 @@ impl<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList, E: Environment<Ext>>
     }
 
     /// Initialize all programs and return [`Runner`].
-    pub fn build(self) -> Runner<MQ, PS, WL, E> {
+    pub fn build(self) -> Runner<SC, E> {
         let mut runner = Runner::new(&self.config, self.storage, self.block_info, E::default());
         for program in self.programs {
             runner

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -27,6 +27,19 @@ use crate::{
     program::{Program, ProgramId},
 };
 
+/// General trait, which informs what exact storage types are used by a storage manager ("carrier").
+///
+/// Mainly used for readability in order to keep readable signatures of the types that
+/// manage different storage domains (for example, the [Storage](enum.Storage.html)).
+pub trait StorageCarrier: Default {
+    /// Message queue type used by storage manager
+    type MQ: MessageQueue;
+    /// Program storage type used by storage manager
+    type PS: ProgramStorage;
+    /// Wait list type used by storage manager
+    type WL: WaitList;
+}
+
 /// Abstraction over program storage.
 pub trait ProgramStorage: Default {
     /// Get the program from the storage.
@@ -218,6 +231,12 @@ pub struct Storage<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList> {
     pub wait_list: WL,
     /// Log.
     pub log: Log,
+}
+
+impl<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList> StorageCarrier for Storage<MQ, PS, WL> {
+    type MQ = MQ;
+    type PS = PS;
+    type WL = WL;
 }
 
 impl<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList> Storage<MQ, PS, WL> {

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -29,7 +29,7 @@ use crate::{
 
 /// General trait, which informs what exact storage types are used by a storage manager ("carrier").
 ///
-/// Mainly used for readability in order to keep readable signatures of the types that
+/// Mainly used for readability in order to keep readable definitions of types that
 /// manage different storage domains (for example, the [Storage](enum.Storage.html)).
 pub trait StorageCarrier: Default {
     /// Message queue type used by storage manager

--- a/gtest/src/check.rs
+++ b/gtest/src/check.rs
@@ -352,15 +352,17 @@ fn read_test_from_file<P: AsRef<std::path::Path>>(path: P) -> anyhow::Result<Tes
     Ok(u)
 }
 
-pub fn check_main<MQ: storage::MessageQueue, PS: storage::ProgramStorage, WL: storage::WaitList>(
+pub fn check_main<SC, F>(
     files: Vec<std::path::PathBuf>,
     skip_messages: bool,
     skip_allocations: bool,
     skip_memory: bool,
-    storage_factory: impl Fn() -> storage::Storage<MQ, PS, WL>,
+    storage_factory: F,
 ) -> anyhow::Result<()>
 where
-    storage::Storage<MQ, PS, WL>: CollectState,
+    SC: storage::StorageCarrier,
+    F: Fn() -> storage::Storage<SC::MQ, SC::PS, SC::WL>,
+    storage::Storage<SC::MQ, SC::PS, SC::WL>: CollectState,
 {
     let mut tests = Vec::new();
 
@@ -388,7 +390,8 @@ where
 
         for fixture_no in 0..test.fixtures.len() {
             for exp in &test.fixtures[fixture_no].expected {
-                let output = match runner::init_fixture(storage_factory(), &test, fixture_no) {
+                let output = match runner::init_fixture::<SC>(storage_factory(), &test, fixture_no)
+                {
                     Ok(initialized_fixture) => {
                         let (mut final_state, _result) = runner::run(initialized_fixture, exp.step);
 

--- a/gtest/src/main.rs
+++ b/gtest/src/main.rs
@@ -64,7 +64,7 @@ pub fn main() -> anyhow::Result<()> {
             .init(),
     }
 
-    check::check_main(
+    check::check_main::<InMemoryStorage, _>(
         opts.input.to_vec(),
         opts.skip_messages,
         opts.skip_allocations,

--- a/node-runner/src/lib.rs
+++ b/node-runner/src/lib.rs
@@ -26,7 +26,6 @@ use sp_core::H256;
 use gear_core::{message::MessageId, program::ProgramId, storage::Storage};
 
 use gear_backend_common::Environment;
-// todo [sab] remove re-export (gtest)
 pub use gear_core_runner::{BlockInfo, Ext};
 use gear_core_runner::{
     ExecutionOutcome, ExtMessage, InitializeProgramInfo, MessageDispatch, RunNextResult, Runner,

--- a/node-runner/src/lib.rs
+++ b/node-runner/src/lib.rs
@@ -26,6 +26,7 @@ use sp_core::H256;
 use gear_core::{message::MessageId, program::ProgramId, storage::Storage};
 
 use gear_backend_common::Environment;
+// todo [sab] remove re-export (gtest)
 pub use gear_core_runner::{BlockInfo, Ext};
 use gear_core_runner::{
     ExecutionOutcome, ExtMessage, InitializeProgramInfo, MessageDispatch, RunNextResult, Runner,
@@ -34,7 +35,9 @@ use sp_std::prelude::*;
 
 use crate::ext::*;
 
-pub type ExtRunner<E> = Runner<ExtMessageQueue, ExtProgramStorage, ExtWaitList, E>;
+type ExtRunner<E> = Runner<ExtStorage, E>;
+/// Storage used for running node
+pub type ExtStorage = Storage<ExtMessageQueue, ExtProgramStorage, ExtWaitList>;
 
 #[derive(Debug, Encode, Decode)]
 pub enum Error {

--- a/tests/common/src/lib.rs
+++ b/tests/common/src/lib.rs
@@ -21,7 +21,8 @@ use gear_backend_wasmtime::WasmtimeEnvironment;
 use gear_core::storage::InMemoryStorage;
 use gear_core::{message::MessageId, program::ProgramId};
 use gear_core_runner::{
-    Config, ExecutionOutcome, Ext, ExtMessage, InitializeProgramInfo, MessageDispatch, InMemoryRunner,
+    Config, ExecutionOutcome, Ext, ExtMessage, InMemoryRunner, InitializeProgramInfo,
+    MessageDispatch,
 };
 use std::collections::HashSet;
 

--- a/tests/common/src/lib.rs
+++ b/tests/common/src/lib.rs
@@ -18,21 +18,14 @@
 
 use codec::{Decode, Encode, Error as CodecError};
 use gear_backend_wasmtime::WasmtimeEnvironment;
-use gear_core::storage::{
-    InMemoryMessageQueue, InMemoryProgramStorage, InMemoryStorage, InMemoryWaitList,
-};
+use gear_core::storage::InMemoryStorage;
 use gear_core::{message::MessageId, program::ProgramId};
 use gear_core_runner::{
-    Config, ExecutionOutcome, Ext, ExtMessage, InitializeProgramInfo, MessageDispatch, Runner,
+    Config, ExecutionOutcome, Ext, ExtMessage, InitializeProgramInfo, MessageDispatch, InMemoryRunner,
 };
 use std::collections::HashSet;
 
-pub type MemoryRunner = Runner<
-    InMemoryMessageQueue,
-    InMemoryProgramStorage,
-    InMemoryWaitList,
-    WasmtimeEnvironment<Ext>,
->;
+pub type InMemoryWasmRunner = InMemoryRunner<WasmtimeEnvironment<Ext>>;
 
 pub struct InitProgram {
     pub program_id: Option<ProgramId>,
@@ -222,7 +215,7 @@ pub struct RunnerContext {
 }
 
 impl RunnerContext {
-    pub fn new(runner: MemoryRunner) -> Self {
+    pub fn new(runner: InMemoryWasmRunner) -> Self {
         Self {
             runner_state: RunnerState::Runner(runner),
             program_id: 1,
@@ -233,7 +226,7 @@ impl RunnerContext {
     }
 
     pub fn with_config(config: &Config) -> Self {
-        Self::new(Runner::new(
+        Self::new(InMemoryWasmRunner::new(
             config,
             Default::default(),
             Default::default(),
@@ -426,7 +419,7 @@ impl RunnerContext {
         self.runner_state.convert_to_storage()
     }
 
-    fn runner(&mut self) -> &mut MemoryRunner {
+    fn runner(&mut self) -> &mut InMemoryWasmRunner {
         self.runner_state.convert_to_runner()
     }
 
@@ -470,24 +463,24 @@ impl Default for RunnerContext {
 }
 
 enum RunnerState {
-    Runner(MemoryRunner),
+    Runner(InMemoryWasmRunner),
     Storage(InMemoryStorage, Config),
     Uninitialzied,
 }
 
 impl RunnerState {
-    fn convert_to_runner(&mut self) -> &mut MemoryRunner {
+    fn convert_to_runner(&mut self) -> &mut InMemoryWasmRunner {
         if let Self::Runner(runner) = self {
             runner
         } else {
             *self = match std::mem::take(self) {
-                Self::Storage(storage, config) => Self::Runner(Runner::new(
+                Self::Storage(storage, config) => Self::Runner(InMemoryWasmRunner::new(
                     &config,
                     storage,
                     Default::default(),
                     WasmtimeEnvironment::default(),
                 )),
-                _ => Self::Runner(Runner::default()),
+                _ => Self::Runner(InMemoryWasmRunner::default()),
             };
 
             self.convert_to_runner()

--- a/utils/gear-test-cli/src/command.rs
+++ b/utils/gear-test-cli/src/command.rs
@@ -35,7 +35,7 @@ impl GearTestCmd {
     pub fn run(&self, _config: Configuration) -> sc_cli::Result<()> {
         new_test_ext()
             .execute_with(|| {
-                gear_test::check::check_main(self.input.to_vec(), false, false, false, || {
+                gear_test::check::check_main::<runner::ExtStorage, _>(self.input.to_vec(), false, false, false, || {
                     sp_io::storage::clear_prefix(gear_common::STORAGE_CODE_PREFIX, None);
                     sp_io::storage::clear_prefix(gear_common::STORAGE_MESSAGE_PREFIX, None);
                     sp_io::storage::clear_prefix(gear_common::STORAGE_PROGRAM_PREFIX, None);

--- a/utils/gear-test-cli/src/command.rs
+++ b/utils/gear-test-cli/src/command.rs
@@ -35,18 +35,24 @@ impl GearTestCmd {
     pub fn run(&self, _config: Configuration) -> sc_cli::Result<()> {
         new_test_ext()
             .execute_with(|| {
-                gear_test::check::check_main::<runner::ExtStorage, _>(self.input.to_vec(), false, false, false, || {
-                    sp_io::storage::clear_prefix(gear_common::STORAGE_CODE_PREFIX, None);
-                    sp_io::storage::clear_prefix(gear_common::STORAGE_MESSAGE_PREFIX, None);
-                    sp_io::storage::clear_prefix(gear_common::STORAGE_PROGRAM_PREFIX, None);
-                    sp_io::storage::clear_prefix(gear_common::STORAGE_WAITLIST_PREFIX, None);
-                    gear_core::storage::Storage {
-                        message_queue: runner::ext::ExtMessageQueue::default(),
-                        program_storage: runner::ext::ExtProgramStorage,
-                        wait_list: Default::default(),
-                        log: Default::default(),
-                    }
-                })
+                gear_test::check::check_main::<runner::ExtStorage, _>(
+                    self.input.to_vec(),
+                    false,
+                    false,
+                    false,
+                    || {
+                        sp_io::storage::clear_prefix(gear_common::STORAGE_CODE_PREFIX, None);
+                        sp_io::storage::clear_prefix(gear_common::STORAGE_MESSAGE_PREFIX, None);
+                        sp_io::storage::clear_prefix(gear_common::STORAGE_PROGRAM_PREFIX, None);
+                        sp_io::storage::clear_prefix(gear_common::STORAGE_WAITLIST_PREFIX, None);
+                        gear_core::storage::Storage {
+                            message_queue: runner::ext::ExtMessageQueue::default(),
+                            program_storage: runner::ext::ExtProgramStorage,
+                            wait_list: Default::default(),
+                            log: Default::default(),
+                        }
+                    },
+                )
             })
             .map_err(|e| sc_cli::Error::Application(e.into()))
     }


### PR DESCRIPTION
Close #386 .

- Make `core_runner::Runner` and other types definitions more readable with covering `storage::{MessageQueue, ProgramState, WaitList}` traits unders one trait (i.e., `StorageCarrier`).

@gear-tech/dev 
