### PR TITLE
Ability to initialize ProgramId with number/name/ss58

### DIFF
--- a/gtest/src/address.rs
+++ b/gtest/src/address.rs
@@ -1,0 +1,75 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use gear_core::program::ProgramId;
+use serde::{Deserialize, Deserializer, Serialize};
+use std::str::FromStr;
+
+use sp_core::{crypto::Ss58Codec, hexdisplay::AsBytesRef, sr25519::Public};
+use sp_keyring::sr25519::Keyring;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "kind", content = "value")]
+pub enum Address {
+    #[serde(rename = "account")]
+    Account(String),
+    #[serde(rename = "id")]
+    ProgramId(u64),
+    #[serde(rename = "ss58")]
+    SS58(String),
+}
+
+impl Default for Address {
+    fn default() -> Self {
+        Self::Account("alice".to_string())
+    }
+}
+
+impl Address {
+    pub fn into_program_id(self) -> ProgramId {
+        match self {
+            Self::Account(s) => {
+                ProgramId::from_slice(Keyring::from_str(&s).unwrap().to_h256_public().as_bytes())
+            }
+            Self::ProgramId(id) => ProgramId::from(id),
+            Self::SS58(s) => {
+                ProgramId::from_slice(Public::from_ss58check(&s).unwrap().as_bytes_ref())
+            }
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum UntaggedAddress {
+    Integer(u64),
+    Address(Address),
+}
+
+impl From<UntaggedAddress> for Address {
+    fn from(a: UntaggedAddress) -> Self {
+        match a {
+            UntaggedAddress::Address(s) => s,
+            UntaggedAddress::Integer(n) => Address::ProgramId(n),
+        }
+    }
+}
+
+pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Address, D::Error> {
+    UntaggedAddress::deserialize(deserializer).map(|a| a.into())
+}

--- a/gtest/src/check.rs
+++ b/gtest/src/check.rs
@@ -202,7 +202,7 @@ fn check_messages(
                 }
 
                 match_or_else(
-                    Some(ProgramId::from(exp.destination)),
+                    Some(exp.destination.clone().into_program_id()),
                     msg.dest,
                     |expected, actual| {
                         errors.push(MessagesError::destination(position, expected, actual))
@@ -383,7 +383,7 @@ where
         let progs_n_paths: Vec<(&str, ProgramId)> = test
             .programs
             .iter()
-            .map(|prog| (prog.path.as_ref(), ProgramId::from(prog.id)))
+            .map(|prog| (prog.path.as_ref(), prog.id.clone().into_program_id()))
             .collect();
 
         for fixture_no in 0..test.fixtures.len() {

--- a/gtest/src/lib.rs
+++ b/gtest/src/lib.rs
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+pub mod address;
 pub mod check;
 pub mod js;
 pub mod runner;

--- a/gtest/src/main.rs
+++ b/gtest/src/main.rs
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+mod address;
 mod check;
 mod js;
 mod runner;

--- a/gtest/src/runner.rs
+++ b/gtest/src/runner.rs
@@ -171,7 +171,7 @@ pub fn init_fixture<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList>(
             init_source = source.clone().into_program_id();
         }
         runner.init_program(InitializeProgramInfo {
-            new_program_id: program.id.into(),
+            new_program_id: program.id.clone().into_program_id(),
             source_id: init_source,
             code,
             message: ExtMessage {
@@ -226,7 +226,7 @@ pub fn init_fixture<MQ: MessageQueue, PS: ProgramStorage, WL: WaitList>(
         }
         runner.queue_message(MessageDispatch {
             source_id: message_source,
-            destination_id: message.destination.into(),
+            destination_id: message.destination.clone().into_program_id(),
             data: ExtMessage {
                 id: nonce.into(),
                 payload,


### PR DESCRIPTION
Resolves #417 .

One will be able to write the following:
```yaml

  - id:
      kind: ss58
      value: 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
    path: target/wasm32-unknown-unknown/release/test_bob.
# ...
    expected:
      - step: 1
        messages:
          - destination:
              kind: ss58
              value: 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
            payload:
              kind: bytes
              
```

and use user's AccountId/ProgramId as destination of messages. This feature eases to implement bots.

@gear-tech/dev 
