### PR TITLE
Fix demo gas and switch to new version allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,6 +1276,7 @@ dependencies = [
 [[package]]
 name = "dlmalloc"
 version = "0.1.4"
+source = "git+https://github.com/gear-tech/dlmalloc-rust.git?rev=a981bb84ed1e6edcceb4db6f93450551353c31dc#a981bb84ed1e6edcceb4db6f93450551353c31dc"
 dependencies = [
  "libc",
  "libc_print",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,6 @@ dependencies = [
 [[package]]
 name = "dlmalloc"
 version = "0.1.4"
-source = "git+https://github.com/gear-tech/dlmalloc-rust.git?rev=324d4c94de64e5e104b49938a3471331d9ad9c2b#324d4c94de64e5e104b49938a3471331d9ad9c2b"
 dependencies = [
  "libc",
  "libc_print",
@@ -1933,9 +1932,6 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 [[package]]
 name = "gcore"
 version = "0.1.0"
-dependencies = [
- "dlmalloc",
-]
 
 [[package]]
 name = "gear-backend-common"

--- a/core-runner/src/runner.rs
+++ b/core-runner/src/runner.rs
@@ -731,6 +731,8 @@ fn run<E: Environment<Ext>>(
         nonce: program.message_nonce(),
     };
 
+    let (left_before, burned_before) = (gas_counter.left(), gas_counter.burned());
+
     // Charge gas for initial or loaded pages.
     match entry_point {
         EntryPoint::Init => {
@@ -865,6 +867,16 @@ fn run<E: Environment<Ext>>(
         gas_left -= gas_to_transfer;
         *gas_limit = gas_to_transfer;
     });
+
+    let (left_after, burned_after) = (ext.gas_counter.left(), ext.gas_counter.burned());
+    assert!(left_before >= left_after);
+    assert!(burned_after >= burned_before);
+    log::debug!(
+        "({}) Gas burned: {}; Gas used {}",
+        program.id(),
+        burned_after - burned_before,
+        left_before - left_after
+    );
 
     RunResult {
         messages,

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -441,6 +441,7 @@ dependencies = [
 [[package]]
 name = "dlmalloc"
 version = "0.1.4"
+source = "git+https://github.com/gear-tech/dlmalloc-rust.git?rev=a981bb84ed1e6edcceb4db6f93450551353c31dc#a981bb84ed1e6edcceb4db6f93450551353c31dc"
 dependencies = [
  "libc",
  "libc_print",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -441,7 +441,6 @@ dependencies = [
 [[package]]
 name = "dlmalloc"
 version = "0.1.4"
-source = "git+https://github.com/gear-tech/dlmalloc-rust.git?rev=324d4c94de64e5e104b49938a3471331d9ad9c2b#324d4c94de64e5e104b49938a3471331d9ad9c2b"
 dependencies = [
  "libc",
  "libc_print",
@@ -585,9 +584,6 @@ dependencies = [
 [[package]]
 name = "gcore"
 version = "0.1.0"
-dependencies = [
- "dlmalloc",
-]
 
 [[package]]
 name = "generic-array"

--- a/examples/async/src/lib.rs
+++ b/examples/async/src/lib.rs
@@ -7,7 +7,7 @@ static mut DEST_0: ActorId = ActorId::new([0u8; 32]);
 static mut DEST_1: ActorId = ActorId::new([0u8; 32]);
 static mut DEST_2: ActorId = ActorId::new([0u8; 32]);
 
-const GAS_LIMIT: u64 = 5_000_000_000;
+const GAS_LIMIT: u64 = 50_000_000;
 
 gstd::metadata! {
     title: "demo async",

--- a/examples/chat/bot/src/lib.rs
+++ b/examples/chat/bot/src/lib.rs
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn init() {
                 RoomMessage::Join {
                     under_name: name.to_string().into_bytes(),
                 },
-                1_000_000_000,
+                100_000_000,
                 0,
             );
         }

--- a/examples/chat/room/src/lib.rs
+++ b/examples/chat/room/src/lib.rs
@@ -63,7 +63,7 @@ unsafe fn room(room_msg: RoomMessage) {
                             )
                             .into_bytes(),
                         ),
-                        200_000_000,
+                        50_000_000,
                         0,
                     );
                 }

--- a/examples/fungible-token/Cargo.toml
+++ b/examples/fungible-token/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 gstd = {path = "../../gstd", features = ["debug"] }
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive", "full"] }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 primitive-types = { version = "0.10.1", default-features = false, features = ["scale-info"]}

--- a/examples/incomplete_async_payloads/src/lib.rs
+++ b/examples/incomplete_async_payloads/src/lib.rs
@@ -2,7 +2,7 @@
 
 use gstd::{debug, msg, prelude::*};
 
-const GAS_LIMIT: u64 = 50_000_000;
+const GAS_LIMIT: u64 = 10_000_000;
 
 #[gstd::async_main]
 async fn main() {

--- a/examples/mutex/src/lib.rs
+++ b/examples/mutex/src/lib.rs
@@ -7,7 +7,7 @@ use gstd::{exec, msg, prelude::*, ActorId};
 static mut PING_DEST: ActorId = ActorId::new([0u8; 32]);
 static MUTEX: Mutex<u32> = Mutex::new(0);
 
-const GAS_LIMIT: u64 = 500_000_000;
+const GAS_LIMIT: u64 = 60_000_000;
 
 #[no_mangle]
 pub unsafe extern "C" fn init() {

--- a/examples/ping/src/lib.rs
+++ b/examples/ping/src/lib.rs
@@ -9,7 +9,7 @@ pub unsafe extern "C" fn handle() {
     let new_msg = String::from_utf8(msg::load_bytes()).expect("Invalid message");
 
     if new_msg == "PING" {
-        msg::reply_bytes("PONG", 10_000_000, 0);
+        msg::reply_bytes("PONG", 12_000_000, 0);
     }
 
     MESSAGE_LOG.push(new_msg);

--- a/examples/ping/src/lib.rs
+++ b/examples/ping/src/lib.rs
@@ -9,7 +9,7 @@ pub unsafe extern "C" fn handle() {
     let new_msg = String::from_utf8(msg::load_bytes()).expect("Invalid message");
 
     if new_msg == "PING" {
-        msg::reply_bytes("PONG", 100_000_000, 0);
+        msg::reply_bytes("PONG", 10_000_000, 0);
     }
 
     MESSAGE_LOG.push(new_msg);
@@ -19,11 +19,6 @@ pub unsafe extern "C" fn handle() {
     for log in MESSAGE_LOG.iter() {
         debug!(log);
     }
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn handle_reply() {
-    msg::reply("PONG", 20_000_000, 0);
 }
 
 #[no_mangle]

--- a/examples/rwlock_write/src/lib.rs
+++ b/examples/rwlock_write/src/lib.rs
@@ -7,7 +7,7 @@ use gstd::{exec, msg, prelude::*, ActorId};
 static mut PING_DEST: ActorId = ActorId::new([0u8; 32]);
 static RWLOCK: RwLock<u32> = RwLock::new(0);
 
-const GAS_LIMIT: u64 = 500_000_000;
+const GAS_LIMIT: u64 = 60_000_000;
 
 #[no_mangle]
 pub unsafe extern "C" fn init() {

--- a/examples/sync_duplicate/src/lib.rs
+++ b/examples/sync_duplicate/src/lib.rs
@@ -25,10 +25,10 @@ async fn main() {
     let msg = String::from_utf8(msg::load_bytes()).expect("Invalid message: should be utf-8");
     if &msg == "async" {
         increase();
-        let _ = msg::send_bytes_and_wait_for_reply(2.into(), b"PING", 500_000_000, 0)
+        let _ = msg::send_bytes_and_wait_for_reply(2.into(), b"PING", 100_000_000, 0)
             .await
             .expect("Error in async message processing");
-        msg::reply(get(), 500_000_000, 0);
+        msg::reply(get(), 100_000_000, 0);
         clear();
     };
 }

--- a/examples/token-vendor/Cargo.toml
+++ b/examples/token-vendor/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 gstd = { path = "../../gstd", features = ["debug"] }
 
 bs58 = { version = "0.4.0", default-features = false, features = ["alloc"] }
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive", "full"] }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
 primitive-types = { version = "0.10.1", default-features = false, features = ["scale-info"]}

--- a/examples/token-vendor/Cargo.toml
+++ b/examples/token-vendor/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 gstd = { path = "../../gstd", features = ["debug"] }
 
 bs58 = { version = "0.4.0", default-features = false, features = ["alloc"] }
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive","full"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
 primitive-types = { version = "0.10.1", default-features = false, features = ["scale-info"]}

--- a/examples/token-vendor/src/lib.rs
+++ b/examples/token-vendor/src/lib.rs
@@ -10,7 +10,7 @@ use codec::{Decode, Encode};
 use primitive_types::H256;
 use scale_info::TypeInfo;
 
-const GAS_RESERVE: u64 = 500_000_000;
+const GAS_RESERVE: u64 = 50_000_000;
 
 struct State {
     owner_id: Option<ActorId>,

--- a/examples/token-vendor/workshop-example/Cargo.toml
+++ b/examples/token-vendor/workshop-example/Cargo.toml
@@ -10,6 +10,6 @@ crate-type = ["cdylib"]
 [dependencies]
 gstd = { path = "../../../gstd", features = ["debug"] }
 
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive", "full"] }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }

--- a/examples/token-vendor/workshop-example/Cargo.toml
+++ b/examples/token-vendor/workshop-example/Cargo.toml
@@ -10,6 +10,6 @@ crate-type = ["cdylib"]
 [dependencies]
 gstd = { path = "../../../gstd", features = ["debug"] }
 
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive","full"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }

--- a/examples/token-vendor/workshop-example/src/lib.rs
+++ b/examples/token-vendor/workshop-example/src/lib.rs
@@ -28,7 +28,7 @@ impl State {
 }
 
 static mut STATE: State = State { user_id: None };
-const GAS_RESERVE: u64 = 100_000_000;
+const GAS_RESERVE: u64 = 20_000_000;
 
 #[no_mangle]
 pub unsafe extern "C" fn init() {

--- a/galloc/Cargo.toml
+++ b/galloc/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
-# dlmalloc = { git = "https://github.com/gear-tech/dlmalloc-rust.git", rev = "a981bb84ed1e6edcceb4db6f93450551353c31dc" }
+dlmalloc = { git = "https://github.com/gear-tech/dlmalloc-rust.git", rev = "a981bb84ed1e6edcceb4db6f93450551353c31dc" }
 
 [features]
 debug = ["dlmalloc/debug"]

--- a/galloc/Cargo.toml
+++ b/galloc/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
-dlmalloc = { git = "https://github.com/gear-tech/dlmalloc-rust.git", rev = "324d4c94de64e5e104b49938a3471331d9ad9c2b" }
+# dlmalloc = { git = "https://github.com/gear-tech/dlmalloc-rust.git", rev = "a981bb84ed1e6edcceb4db6f93450551353c31dc" }
 
 [features]
 debug = ["dlmalloc/debug"]

--- a/gcore/Cargo.toml
+++ b/gcore/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
-dlmalloc = { git = "https://github.com/gear-tech/dlmalloc-rust.git", rev = "324d4c94de64e5e104b49938a3471331d9ad9c2b" }
-
 [features]
-debug = ["dlmalloc/debug"]
+debug=[]
+

--- a/gstd/Cargo.toml
+++ b/gstd/Cargo.toml
@@ -11,7 +11,7 @@ gcore = { path = "../gcore" }
 gstd-codegen = { path = "codegen" }
 
 bs58 = { version = "0.4.0", default-features = false, features = ["alloc"] }
-codec = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive", "full"]}
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive","full"]}
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 primitive-types = { version = "0.10.1", default-features = false, features = ["scale-info"]}
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }

--- a/gtest/spec/test_capacitor.yaml
+++ b/gtest/spec/test_capacitor.yaml
@@ -49,4 +49,4 @@ fixtures:
             destination: 0
         allocations:
           - program_id: 1
-            contains_pages: [17]
+            contains_pages: []

--- a/gtest/spec/test_chat.yaml
+++ b/gtest/spec/test_chat.yaml
@@ -39,12 +39,5 @@ fixtures:
               kind: bytes
               value: "0x012c746573743a2068656c6c6f"
             destination: 3
-        memory:
-          - program_id: 1
-            at: "0x110008"
-            bytes: "0x74657374"
       - messages: []
-        memory:
-          - program_id: 1
-            at: "0x110100"
-            bytes: "0x68656c6c6f"
+

--- a/gtest/spec/test_vec.yaml
+++ b/gtest/spec/test_vec.yaml
@@ -27,7 +27,7 @@ fixtures:
         allocations:
           - program_id: 1
             filter: dynamic
-            exact_pages: [17]
+            exact_pages: []
           - program_id: 2
             filter: dynamic
             exact_pages: [17,18]

--- a/gtest/src/js/package-lock.json
+++ b/gtest/src/js/package-lock.json
@@ -5,7 +5,7 @@
     "packages": {
         "": {
             "dependencies": {
-                "@gear-js/api": "^0.8.10",
+                "@gear-js/api": "^0.8.11",
                 "yargs": "17.1.1"
             }
         },
@@ -22,9 +22,9 @@
             }
         },
         "node_modules/@gear-js/api": {
-            "version": "0.8.10",
-            "resolved": "https://registry.npmjs.org/@gear-js/api/-/api-0.8.10.tgz",
-            "integrity": "sha512-TqWQKP5QOCHqIAULQed2QMTmlO5aWyjyxDt2cD06zdgx1Lx2NHZOz4LcN8FhsDLKJipp1Y6M5QAIV3KM9L4m1A==",
+            "version": "0.8.11",
+            "resolved": "https://registry.npmjs.org/@gear-js/api/-/api-0.8.11.tgz",
+            "integrity": "sha512-rHhZquGS3yHVwhjyWfn/kudx0C1Wmyf99AarGdQXY17Lf6ygSBOc1oYTRXFuacASUNzhKplNeNHQiy3GW2my4Q==",
             "peerDependencies": {
                 "@polkadot/api": "^6.9.2",
                 "rxjs": "^7.3.0"
@@ -1086,9 +1086,9 @@
             }
         },
         "@gear-js/api": {
-            "version": "0.8.10",
-            "resolved": "https://registry.npmjs.org/@gear-js/api/-/api-0.8.10.tgz",
-            "integrity": "sha512-TqWQKP5QOCHqIAULQed2QMTmlO5aWyjyxDt2cD06zdgx1Lx2NHZOz4LcN8FhsDLKJipp1Y6M5QAIV3KM9L4m1A==",
+            "version": "0.8.11",
+            "resolved": "https://registry.npmjs.org/@gear-js/api/-/api-0.8.11.tgz",
+            "integrity": "sha512-rHhZquGS3yHVwhjyWfn/kudx0C1Wmyf99AarGdQXY17Lf6ygSBOc1oYTRXFuacASUNzhKplNeNHQiy3GW2my4Q==",
             "requires": {}
         },
         "@polkadot/api": {

--- a/gtest/src/js/package.json
+++ b/gtest/src/js/package.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "@gear-js/api": "^0.8.10",
+        "@gear-js/api": "^0.8.11",
         "yargs": "17.1.1"
     }
 }

--- a/tests/distributor/src/lib.rs
+++ b/tests/distributor/src/lib.rs
@@ -94,7 +94,7 @@ mod wasm {
                 let reply_bytes = msg::send_bytes_and_wait_for_reply(
                     program_handle,
                     &encoded_request[..],
-                    exec::gas_available() - 50_000_000,
+                    exec::gas_available() - 60_000_000,
                     0,
                 )
                 .await
@@ -140,7 +140,7 @@ mod wasm {
             };
 
             debug!("Handle request finished");
-            msg::reply(reply, exec::gas_available() - 50_000_000, 0);
+            msg::reply(reply, exec::gas_available() - 60_000_000, 0);
         }
 
         async fn handle_receive(amount: u64) -> Reply {
@@ -305,7 +305,7 @@ mod tests {
         assert_eq!(reply, Reply::Amount(11));
     }
 
-    // This test show how RefCell will prevent to do conficting changes (prevent multi-aliasing of the program state)
+    // This test show how RefCell will prevent to do conflicting changes (prevent multi-aliasing of the program state)
     #[test]
     fn conflicting_nodes() {
         env_logger::Builder::from_env(env_logger::Env::default()).init();


### PR DESCRIPTION
Issues #432 
- Fix gas in demos - reduce gas_limit values.
- Change allocator version to new, where implemented:
   - Static buffer allocation for small requests
   - Fix problem with small chunks which restrict to free page sometimes
   - Add free in realloc and sys_alloc
   - Optimize allocator algorithms
   
**Release notes**: Improves our user-space custom allocator
