### PR TITLE
Add docs to program initialization related code

### DIFF
--- a/core-runner/src/runner.rs
+++ b/core-runner/src/runner.rs
@@ -733,8 +733,8 @@ pub struct RunResult {
 /// The function is needed to abstract common procedures of different program function calls.
 ///
 /// Actual function run is performed in the virtual machine (VM). Programs, which are run in the VM, import functions from some environment
-/// that Gear provides. These functions (so called sys-calls), are provided by sandbox backend or wasmtime backend (see core-backend crates)
-/// which implements trait [Environment](../../gear_backend_common/trait.Environment.html).
+/// that Gear provides. These functions (so called sys-calls), are provided by sandbox or wasmtime backends (see core-backend crates),
+/// which implement [Environment](../../gear_backend_common/trait.Environment.html) trait.
 /// This trait provides us an ability to setup all the needed settings for the run and actually run the desired function, providing program (wasm module) with
 /// sys-calls.
 /// A crucial dependency for the actual run in the VM is `Ext`, which is created in the function's body.

--- a/core-runner/src/runner.rs
+++ b/core-runner/src/runner.rs
@@ -517,7 +517,9 @@ impl<SC: StorageCarrier, E: Environment<Ext>> Runner<SC, E> {
         RunningContext::new(&self.config, allocations)
     }
 
-    /// Initialize a new program. This includes putting this program in the storage and dispatching
+    /// Initialize a new program.
+    ///
+    /// This includes putting this program in the storage and dispatching
     /// initialization message for it.
     ///
     /// Initialization process looks as following:
@@ -797,8 +799,6 @@ fn run<E: Environment<Ext>>(
     if let Some(max_page) = max_page {
         let max_page_num = *max_page.0;
         let mem_size = memory.size();
-        // If we charge for `max_page_num == memsize`, then we perform a double charge,
-        // because gas was charged previously. todo - check that by running tests
         if max_page_num >= mem_size {
             let amount =
                 context.config.mem_grow_cost * ((max_page_num - mem_size).raw() as u64 + 1);

--- a/core-runner/src/runner.rs
+++ b/core-runner/src/runner.rs
@@ -533,7 +533,7 @@ impl<SC: StorageCarrier, E: Environment<Ext>> Runner<SC, E> {
     ///
     /// # Errors
     /// Function returns an error in several situations:
-    /// 1. Creating, setting and resetting a [Program](todo-ref) ended up with an error.
+    /// 1. Creating, setting and resetting a [Program](../..gear_core/program/struct.Program.html) ended up with an error.
     /// 2. If needed static pages amount is more then the maximum set in the runner config, function returns with an error.
     /// 3. If code instrumentation with gas instructions ended up with an error.
     pub fn init_program(
@@ -733,15 +733,16 @@ pub struct RunResult {
 /// The function is needed to abstract common procedures of different program function calls.
 ///
 /// Actual function run is performed in the virtual machine (VM). Programs, which are run in the VM, import functions from some environment
-/// that Gear provides. These functions (so called sys-calls), are provided by the [backend](todo-ref-sandbox) which implements trait [Environment](todo-ref).
+/// that Gear provides. These functions (so called sys-calls), are provided by sandbox backend or wasmtime backend (see core-backend crates)
+/// which implements trait [Environment](../../gear_backend_common/trait.Environment.html).
 /// This trait provides us an ability to setup all the needed settings for the run and actually run the desired function, providing program (wasm module) with
 /// sys-calls.
-/// A crucial dependency for the actual run in the VM is [Ext](todo-ref), which is created in the function's body.
+/// A crucial dependency for the actual run in the VM is `Ext`, which is created in the function's body.
 ///
 /// By the end of the run all the side effects (changes in memory, newly generated messages) are handled.
 ///
-/// The function doesn't return an error, although the run can end up with a [Trap](todo-ref). However,
-/// in the [outcome](todo-ref) field we state, that the trap occurred. So the trap occurres in several situations:
+/// The function doesn't return an error, although the run can end up with a trap. However,
+/// in the `RunResult.outcome` field we state, that the trap occurred. So the trap occurs in several situations:
 /// 1. Gas charge for initial or loaded pages failed;
 /// 2. There weren't enough gas for future memory grow;
 /// 3. Program function execution ended up with an error.

--- a/core-runner/src/runner.rs
+++ b/core-runner/src/runner.rs
@@ -517,7 +517,7 @@ impl<SC: StorageCarrier, E: Environment<Ext>> Runner<SC, E> {
         RunningContext::new(&self.config, allocations)
     }
 
-    /// Initialize new program This includes putting this program in the storage and dispatching
+    /// Initialize a new program. This includes putting this program in the storage and dispatching
     /// initialization message for it.
     ///
     /// Initialization process looks as following:

--- a/gtest/src/check.rs
+++ b/gtest/src/check.rs
@@ -149,10 +149,10 @@ fn check_messages(
                     .as_mut()
                     .map(|payload| match payload {
                         PayloadVariant::Custom(_) => {
-                            if let Some(v) =
-                                progs_n_paths.iter().find(|v| source_n_dest.contains(&v.1))
+                            if let Some(&(path, prog_id)) =
+                                progs_n_paths.iter().find(|(_, prog_id)| source_n_dest.contains(prog_id))
                             {
-                                let is_outgoing = v.1 == source_n_dest[0];
+                                let is_outgoing = prog_id == source_n_dest[0];
 
                                 let meta_type = match (is_init, is_outgoing) {
                                     (true, true) => MetaType::InitOutput,
@@ -161,7 +161,7 @@ fn check_messages(
                                     (false, false) => MetaType::HandleInput,
                                 };
 
-                                let path: String = v.0.replace(".wasm", ".meta.wasm");
+                                let path: String = path.replace(".wasm", ".meta.wasm");
 
                                 let json =
                                     MetaData::Json(String::from_utf8(payload.to_bytes()).unwrap());
@@ -352,6 +352,11 @@ fn read_test_from_file<P: AsRef<std::path::Path>>(path: P) -> anyhow::Result<Tes
     Ok(u)
 }
 
+/// Runs tests defined in `files`.
+///
+/// To understand how tests are structured see [sample](todo-ref-module) module.
+/// For each fixture in the test file from `files` the function setups (initializes) it and then performs all the checks
+/// by first running messages defined in the fixture section and then checking (if required) message state, allocations and memory.
 pub fn check_main<SC, F>(
     files: Vec<std::path::PathBuf>,
     skip_messages: bool,

--- a/gtest/src/check.rs
+++ b/gtest/src/check.rs
@@ -149,8 +149,9 @@ fn check_messages(
                     .as_mut()
                     .map(|payload| match payload {
                         PayloadVariant::Custom(_) => {
-                            if let Some(&(path, prog_id)) =
-                                progs_n_paths.iter().find(|(_, prog_id)| source_n_dest.contains(prog_id))
+                            if let Some(&(path, prog_id)) = progs_n_paths
+                                .iter()
+                                .find(|(_, prog_id)| source_n_dest.contains(prog_id))
                             {
                                 let is_outgoing = prog_id == source_n_dest[0];
 
@@ -354,7 +355,7 @@ fn read_test_from_file<P: AsRef<std::path::Path>>(path: P) -> anyhow::Result<Tes
 
 /// Runs tests defined in `files`.
 ///
-/// To understand how tests are structured see [sample](todo-ref-module) module.
+/// To understand how tests are structured see [sample](../sample/index.html) module.
 /// For each fixture in the test file from `files` the function setups (initializes) it and then performs all the checks
 /// by first running messages defined in the fixture section and then checking (if required) message state, allocations and memory.
 pub fn check_main<SC, F>(

--- a/gtest/src/js/mod.rs
+++ b/gtest/src/js/mod.rs
@@ -16,8 +16,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+//! JS module.
+//!
 //! Module contains all the needed types and functionality for an easy inference of structures of messages sent to or
-//! received from *init* and *handle* functions..
+//! received from *init* and *handle* functions.
 //!
 //! Information about message structure makes it easier for an [idea](https://idea.gear-tech.io/) user to send
 //! messages to smart contracts. This modules provides an internal functionality for deducting what fields

--- a/gtest/src/js/mod.rs
+++ b/gtest/src/js/mod.rs
@@ -87,8 +87,8 @@ pub fn call_node(script_path: PathBuf, args: Vec<&str>) -> Vec<u8> {
 /// Helper type which is used as a store for payload in two different formats, which are
 /// JSON format and in SCALE codec format.
 ///
-/// [CodecBytes](todo-ref) is a variant which stores encoded message payload.
-/// [Json](todo-ref) stores decoded message payload as a JSON string.
+/// [CodecBytes](enum.MetaData.html#variant.CodecBytes) is a variant which stores encoded message payload.
+/// [Json](enum.MetaData.html#variant.Json) stores decoded message payload as a JSON string.
 #[derive(Clone)]
 pub enum MetaData {
     CodecBytes(Vec<u8>),
@@ -114,8 +114,8 @@ impl MetaData {
 
     /// Encodes or decodes metadata.
     ///
-    /// If `Self` stores decoded data, then the function will encode that data to SCALE codec bytes, returning [CodecBytes](todo-ref).
-    /// If `Self` stores encoded data, then the function will decode that data to JSON string, returning [Json](todo-ref).
+    /// If `Self` stores decoded data, then the function will encode that data to SCALE codec bytes, returning [CodecBytes](enum.MetaData.html#variant.CodecBytes).
+    /// If `Self` stores encoded data, then the function will decode that data to JSON string, returning [Json](enum.MetaData.html#variant.Json).
     pub fn convert(self, meta_wasm: &str, meta_type: &MetaType) -> Result<Self, String> {
         let mut gear_path = std::env::current_dir().expect("Unable to get current dir");
         while !gear_path.ends_with("gear") {

--- a/gtest/src/lib.rs
+++ b/gtest/src/lib.rs
@@ -16,6 +16,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+//! Crate defines functionality to test wasm programs.
+//!
+//! In [gear](todo-ref) you have several ways to test smart contracts. This crate provides developers with an opportunity
+//! to define test strategies in some *test.yaml* file. Crate's test runner will run all the tests and return found errors in case they
+//! occurred. One of the main usages of the current crate is done by [gear node](todo-ref): when running node executable you can define run
+//! options and one of them is to run tests. One of the main features of such run is that node's key-value storage will be used.
+
 pub mod address;
 pub mod check;
 pub mod js;

--- a/gtest/src/lib.rs
+++ b/gtest/src/lib.rs
@@ -18,9 +18,9 @@
 
 //! Crate defines functionality to test wasm programs.
 //!
-//! In [gear](todo-ref) you have several ways to test smart contracts. This crate provides developers with an opportunity
+//! You have several ways to test smart contracts. This crate provides developers with an opportunity
 //! to define test strategies in some *test.yaml* file. Crate's test runner will run all the tests and return found errors in case they
-//! occurred. One of the main usages of the current crate is done by [gear node](todo-ref): when running node executable you can define run
+//! occurred. One of the main usages of the current crate is done by gear [node](../gear_node/index.html): when running node executable you can define run
 //! options and one of them is to run tests. One of the main features of such run is that node's key-value storage will be used.
 
 pub mod address;

--- a/gtest/src/runner.rs
+++ b/gtest/src/runner.rs
@@ -119,8 +119,8 @@ impl CollectState for ExtStorage {
 
 /// Initializes programs defined in `test.programs` and queues all the messages from `test.fixtures[fixture_no]`.
 ///
-/// Program initialization and queueing messages is performed by [Runner](todo-ref), which uses `storage` as a storage
-/// manager. This storage is actually returned to the function caller to be later used to run queued messages.
+/// Program initialization and queueing messages is performed by [Runner](../../gear_core_runner/runner/struct.Runner.html),
+/// which uses `storage` as a storage manager. This storage is actually returned to the function caller to be later used to run queued messages.
 pub fn init_fixture<SC: StorageCarrier>(
     storage: Storage<SC::MQ, SC::PS>,
     test: &Test,

--- a/gtest/src/sample.rs
+++ b/gtest/src/sample.rs
@@ -50,7 +50,7 @@ fn de_bytes<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Er
 /// In test nested structure *program* is one the highest fields. The other one is *fixture*.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Program {
-    /// Path to programs wasm blob.
+    /// Path to program's wasm blob.
     pub path: String,
     /// Program's id.
     #[serde(deserialize_with = "address::deserialize")]
@@ -69,13 +69,23 @@ pub struct Program {
     pub init_value: Option<u128>,
 }
 
+/// Expected data after running messages, defined in the fixture.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Expectation {
+    /// Step number.
+    ///
+    /// By defining the field we control how many messaged does the test runner actually process.
+    /// So, we can perform test checks after different processing steps and look into interim state.
     pub step: Option<usize>,
+    /// Expected messages in the message queue.
     pub messages: Option<Vec<Message>>,
+    /// Expected allocations after program run.
     pub allocations: Option<Vec<Allocations>>,
+    /// Expected data to be in the memory.
     pub memory: Option<Vec<BytesAt>>,
+    /// Expected messages in the log.
     pub log: Option<Vec<Message>>,
+    /// Flag, which points that errors are allowed. Could be used to check traps.
     #[serde(rename = "allowError")]
     pub allow_error: Option<bool>,
 }
@@ -195,7 +205,6 @@ pub struct Message {
 /// Main model describing test structure
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Test {
-    pub title: String, // todo[sab] tmp - remove
     /// Programs and related data used for tests
     pub programs: Vec<Program>,
     /// A set of messages and expected results of running them in the context of defined [programs](todo-field-ref).


### PR DESCRIPTION
In order to close #347, some research on how program initialization works was done. For the purpose of research `gtest` and underlying crates were discovered and (partly) documented in the context of program initialization. I didn't intend to document everything, but do that just in some bounded scope while understanding program submit process.

No issues were resolved here, actually.
Please merge asap.
