### PR TITLE
Remove `Runner::message_queue` field 

### DIFF
--- a/core-runner/src/builder.rs
+++ b/core-runner/src/builder.rs
@@ -23,7 +23,7 @@ use gear_core::storage::{Storage, StorageCarrier};
 
 use super::{
     ext::{BlockInfo, Ext},
-    runner::{Config, ExtMessage, InitializeProgramInfo, Runner},
+    runner::{Config, ExtMessage, InitializeProgramInfo, RunResult, Runner},
 };
 
 /// Builder for [`Runner`].
@@ -107,13 +107,12 @@ impl<SC: StorageCarrier, E: Environment<Ext>> RunnerBuilder<SC, E> {
     }
 
     /// Initialize all programs and return [`Runner`].
-    pub fn build(self) -> Runner<SC, E> {
+    pub fn build(self) -> (Runner<SC, E>, Vec<anyhow::Result<RunResult>>) {
         let mut runner = Runner::new(&self.config, self.storage, self.block_info, E::default());
+        let mut result = Vec::with_capacity(self.programs.len());
         for program in self.programs {
-            runner
-                .init_program(program)
-                .expect("failed to init program");
+            result.push(runner.init_program(program));
         }
-        runner
+        (runner, result)
     }
 }

--- a/core-runner/src/runner.rs
+++ b/core-runner/src/runner.rs
@@ -897,7 +897,9 @@ mod tests {
                 (func $init)
             )"#;
 
-        let mut runner: TestRunner = new_test_builder().program(parse_wat(wat)).build();
+        let (mut runner, results): (TestRunner, _) =
+            new_test_builder().program(parse_wat(wat)).build();
+        assert!(results.iter().all(|r| r.is_ok()));
 
         let message = Message {
             id: 1000002.into(),
@@ -996,7 +998,7 @@ mod tests {
               )
           )"#;
 
-        let mut runner = new_test_builder()
+        let (mut runner, mut results) = new_test_builder()
             .program(parse_wat(wat))
             .with_init_message(ExtMessage {
                 id: 1000001.into(),
@@ -1007,11 +1009,15 @@ mod tests {
             .build();
 
         assert_eq!(
-            runner
-                .message_queue
+            results
                 .pop()
-                .map(|m| (m.payload().to_vec(), m.source(), m.dest())),
-            Some((b"ok".to_vec(), 1.into(), 1.into()))
+                .and_then(|r| r.ok())
+                .and_then(|mut r| r.messages.pop())
+                .map(|m| {
+                    let m = m.into_message(1.into());
+                    (m.payload().to_vec(), m.dest())
+                }),
+            Some((b"ok".to_vec(), 1.into()))
         );
 
         let message = Message {
@@ -1089,14 +1095,18 @@ mod tests {
             )
           )"#;
 
-        let mut runner = new_test_builder().program(parse_wat(wat)).build();
+        let (mut runner, mut results) = new_test_builder().program(parse_wat(wat)).build();
 
         assert_eq!(
-            runner
-                .message_queue
+            results
                 .pop()
-                .map(|m| (m.payload().to_vec(), m.source(), m.dest())),
-            Some((b"ok".to_vec(), 1.into(), 1.into()))
+                .and_then(|r| r.ok())
+                .and_then(|mut r| r.messages.pop())
+                .map(|m| {
+                    let m = m.into_message(1.into());
+                    (m.payload().to_vec(), m.dest())
+                }),
+            Some((b"ok".to_vec(), 1.into()))
         );
 
         // send page num to be freed
@@ -1142,7 +1152,7 @@ mod tests {
         let gas_limit = 1_000_000;
         let msg_id: MessageId = 1000001.into();
 
-        let mut runner = new_test_builder()
+        let (mut runner, results) = new_test_builder()
             .program(parse_wat(wat))
             .with_source_id(source_id)
             .with_program_id(dest_id)
@@ -1153,6 +1163,7 @@ mod tests {
                 value: 0,
             })
             .build();
+        assert!(results.iter().all(|r| r.is_ok()));
 
         let payload = b"Test Wait";
 
@@ -1206,7 +1217,7 @@ mod tests {
             (func $init)
         )"#;
 
-        let mut runner = new_test_builder()
+        let (mut runner, results) = new_test_builder()
             .program(parse_wat(wat))
             .with_init_message(ExtMessage {
                 id: 1000001.into(),
@@ -1215,6 +1226,7 @@ mod tests {
                 value: 0,
             })
             .build();
+        assert!(results.iter().all(|r| r.is_ok()));
 
         let gas_limit = 1000_000;
         let caller_id = 1001.into();
@@ -1323,7 +1335,7 @@ mod tests {
                 (func $init)
             )"#;
 
-        let mut runner: TestRunner = new_test_builder()
+        let (mut runner, results): (TestRunner, _) = new_test_builder()
             .program(parse_wat(wat))
             .with_source_id(1001)
             .with_program_id(1)
@@ -1334,6 +1346,7 @@ mod tests {
                 value: 0,
             })
             .build();
+        assert!(results.iter().all(|r| r.is_ok()));
 
         let message = Message {
             id: 1000001.into(),

--- a/gtest/spec/test_chat.yaml
+++ b/gtest/spec/test_chat.yaml
@@ -29,7 +29,7 @@ fixtures:
           value: "0x002c707269766174655f6d7367"
         destination: 2
     expected:
-      - step: 6
+      - step: 4
         messages:
           - payload:
               kind: bytes

--- a/node-runner/src/lib.rs
+++ b/node-runner/src/lib.rs
@@ -119,7 +119,10 @@ pub fn process<E: Environment<Ext>>(
     message: gear_common::Message,
     block_info: BlockInfo,
 ) -> Result<ExecutionReport, Error> {
-    let mut runner = ExtRunner::<E>::builder().block_info(block_info).build();
+    // TODO: it's not required to process possible errors since
+    // builder doesn't contain any program here. Check `program` method
+    // for details
+    let (mut runner, _) = ExtRunner::<E>::builder().block_info(block_info).build();
 
     Ok(runner.run_next(message.into()).into())
 }
@@ -135,7 +138,10 @@ pub fn init_program<E: Environment<Ext>>(
     value: u128,
     block_info: BlockInfo,
 ) -> Result<ExecutionReport, Error> {
-    let mut runner = ExtRunner::<E>::builder().block_info(block_info).build();
+    // TODO: it's not required to process possible errors since
+    // builder doesn't contain any program here. Check `program` method
+    // for details
+    let (mut runner, _) = ExtRunner::<E>::builder().block_info(block_info).build();
 
     let init_message_id = MessageId::from_slice(&init_message_id[..]);
     let program_id = ProgramId::from_slice(&program_id[..]);


### PR DESCRIPTION
Resolves #464 .

`Runner::message_queue` removed so messages don't get duplicated after `init`. Code is adjusted to the change

@gear-tech/dev 
