### PR TITLE
Add minimum Rust compiler version to gear-node

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0"
 build = "build.rs"
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
+rust-version = "1.56"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
- Add the minimum required Rust compiler version: 1.56 at the moment.
