### PR TITLE
`gtest`: add verbose mode

### DIFF
--- a/gtest/src/check.rs
+++ b/gtest/src/check.rs
@@ -510,11 +510,13 @@ where
 /// To understand how tests are structured see [sample](../sample/index.html) module.
 /// For each fixture in the test file from `files` the function setups (initializes) it and then performs all the checks
 /// by first running messages defined in the fixture section and then checking (if required) message state, allocations and memory.
+#[allow(clippy::too_many_arguments)]
 pub fn check_main<SC, F>(
     files: Vec<std::path::PathBuf>,
     skip_messages: bool,
     skip_allocations: bool,
     skip_memory: bool,
+    print_logs: bool,
     storage_factory: F,
     ext: Option<Box<dyn Fn() -> sp_io::TestExternalities + Send + Sync + 'static>>,
 ) -> anyhow::Result<()>
@@ -585,11 +587,6 @@ where
                         skip_memory,
                     )
                 };
-                println!(
-                    "Fixture {}: {}",
-                    test.fixtures[fixture_no].title.bold(),
-                    output
-                );
                 if output != "Ok".bright_green() {
                     map.read()
                         .unwrap()
@@ -599,7 +596,21 @@ where
                         .for_each(|line| {
                             eprintln!("{}", line.bright_red());
                         });
+                } else if print_logs {
+                    map.read()
+                        .unwrap()
+                        .get(&thread::current().id())
+                        .unwrap()
+                        .iter()
+                        .for_each(|line| {
+                            println!("{}", line);
+                        });
                 }
+                println!(
+                    "Fixture {}: {}",
+                    test.fixtures[fixture_no].title.bold(),
+                    output
+                );
             });
     });
 

--- a/gtest/src/main.rs
+++ b/gtest/src/main.rs
@@ -38,15 +38,20 @@ struct Opts {
     pub skip_memory: bool,
     /// JSON sample file(s) or dir
     pub input: Vec<std::path::PathBuf>,
+    /// A level of verbosity
+    #[clap(short, long, parse(from_occurrences))]
+    verbose: i32,
 }
 
 pub fn main() -> anyhow::Result<()> {
     let opts: Opts = Opts::parse();
+    let print_logs = !matches!(opts.verbose, 0);
     check::check_main::<InMemoryStorage, _>(
         opts.input.to_vec(),
         opts.skip_messages,
         opts.skip_allocations,
         opts.skip_memory,
+        print_logs,
         InMemoryStorage::default,
         None,
     )

--- a/utils/gear-test-cli/src/command.rs
+++ b/utils/gear-test-cli/src/command.rs
@@ -40,6 +40,7 @@ impl GearTestCmd {
                     false,
                     false,
                     false,
+                    false,
                     || {
                         sp_io::storage::clear_prefix(gear_common::STORAGE_CODE_PREFIX, None);
                         sp_io::storage::clear_prefix(gear_common::STORAGE_MESSAGE_PREFIX, None);


### PR DESCRIPTION
`-v` to print logs from fixture runs.

@gear-tech/dev 
