### PR TITLE
switch to allocator with disabled static buffer allocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ dependencies = [
 [[package]]
 name = "dlmalloc"
 version = "0.1.4"
-source = "git+https://github.com/gear-tech/dlmalloc-rust.git?rev=a981bb84ed1e6edcceb4db6f93450551353c31dc#a981bb84ed1e6edcceb4db6f93450551353c31dc"
+source = "git+https://github.com/gear-tech/dlmalloc-rust.git?rev=1674c2c0d027e057ef85ce27e9b452363207266f#1674c2c0d027e057ef85ce27e9b452363207266f"
 dependencies = [
  "libc",
  "libc_print",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "dlmalloc"
 version = "0.1.4"
-source = "git+https://github.com/gear-tech/dlmalloc-rust.git?rev=a981bb84ed1e6edcceb4db6f93450551353c31dc#a981bb84ed1e6edcceb4db6f93450551353c31dc"
+source = "git+https://github.com/gear-tech/dlmalloc-rust.git?rev=1674c2c0d027e057ef85ce27e9b452363207266f#1674c2c0d027e057ef85ce27e9b452363207266f"
 dependencies = [
  "libc",
  "libc_print",

--- a/examples/async/src/lib.rs
+++ b/examples/async/src/lib.rs
@@ -7,7 +7,7 @@ static mut DEST_0: ActorId = ActorId::new([0u8; 32]);
 static mut DEST_1: ActorId = ActorId::new([0u8; 32]);
 static mut DEST_2: ActorId = ActorId::new([0u8; 32]);
 
-const GAS_LIMIT: u64 = 50_000_000;
+const GAS_LIMIT: u64 = 60_000_000;
 
 gstd::metadata! {
     title: "demo async",

--- a/examples/mutex/src/lib.rs
+++ b/examples/mutex/src/lib.rs
@@ -7,7 +7,7 @@ use gstd::{exec, msg, prelude::*, ActorId};
 static mut PING_DEST: ActorId = ActorId::new([0u8; 32]);
 static MUTEX: Mutex<u32> = Mutex::new(0);
 
-const GAS_LIMIT: u64 = 60_000_000;
+const GAS_LIMIT: u64 = 70_000_000;
 
 #[no_mangle]
 pub unsafe extern "C" fn init() {

--- a/examples/rwlock_write/src/lib.rs
+++ b/examples/rwlock_write/src/lib.rs
@@ -7,7 +7,7 @@ use gstd::{exec, msg, prelude::*, ActorId};
 static mut PING_DEST: ActorId = ActorId::new([0u8; 32]);
 static RWLOCK: RwLock<u32> = RwLock::new(0);
 
-const GAS_LIMIT: u64 = 60_000_000;
+const GAS_LIMIT: u64 = 70_000_000;
 
 #[no_mangle]
 pub unsafe extern "C" fn init() {

--- a/galloc/Cargo.toml
+++ b/galloc/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
-dlmalloc = { git = "https://github.com/gear-tech/dlmalloc-rust.git", rev = "a981bb84ed1e6edcceb4db6f93450551353c31dc" }
+dlmalloc = { git = "https://github.com/gear-tech/dlmalloc-rust.git", rev = "1674c2c0d027e057ef85ce27e9b452363207266f" }
 
 [features]
 debug = ["dlmalloc/debug"]

--- a/gtest/spec/test_vec.yaml
+++ b/gtest/spec/test_vec.yaml
@@ -27,7 +27,7 @@ fixtures:
         allocations:
           - program_id: 1
             filter: dynamic
-            exact_pages: []
+            exact_pages: [17]
           - program_id: 2
             filter: dynamic
             exact_pages: [17,18]


### PR DESCRIPTION
switch to allocator with disabled static buffer allocation,
fix gas because without static allocation allocator use more gas.

FYI: there is some problems with allocation in static buffer and js WebAssebly module. currently investigate this problems, and I will enable static allocation in future when this problem will be solved.