### PR TITLE
Provide `program_id()` syscall

### DIFF
--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -248,16 +248,16 @@ pub fn source<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static s
     move |source_ptr: i32| {
         ext.with(|ext: &mut E| {
             let source = ext.source();
-            ext.set_mem(source_ptr as isize as _, source.as_slice());
+            ext.set_mem(source_ptr as _, source.as_slice());
         })
     }
 }
 
-pub fn actor_id<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static str> {
+pub fn program_id<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static str> {
     move |source_ptr: i32| {
         ext.with(|ext: &mut E| {
             let actor_id = ext.program_id();
-            ext.set_mem(source_ptr as isize as _, actor_id.as_slice());
+            ext.set_mem(source_ptr as _, actor_id.as_slice());
         })
     }
 }

--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -253,6 +253,15 @@ pub fn source<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static s
     }
 }
 
+pub fn actor_id<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static str> {
+    move |source_ptr: i32| {
+        ext.with(|ext: &mut E| {
+            let actor_id = ext.program_id();
+            ext.set_mem(source_ptr as isize as _, actor_id.as_slice());
+        })
+    }
+}
+
 pub fn value<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static str> {
     move |value_ptr: i32| ext.with(|ext: &mut E| set_u128(ext, value_ptr, ext.value()))
 }

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -505,25 +505,7 @@ impl<E: Ext + 'static> SandboxEnvironment<E> {
                 })
         }
 
-        fn source<E: Ext>(ctx: &mut Runtime<E>, args: &[Value]) -> Result<ReturnValue, HostError> {
-            let source_ptr: i32 = match args[0] {
-                Value::I32(val) => val,
-                _ => return Err(HostError),
-            };
-            ctx.ext
-                .with(|ext: &mut E| {
-                    let source = ext.source();
-                    ext.set_mem(source_ptr as isize as _, source.as_slice());
-                    Ok(())
-                })
-                .and_then(|res| res.map(|_| ReturnValue::Unit))
-                .map_err(|err| {
-                    ctx.trap_reason = Some(err);
-                    HostError
-                })
-        }
-
-        fn actor_id<E: Ext>(
+        fn program_id<E: Ext>(
             ctx: &mut Runtime<E>,
             args: &[Value],
         ) -> Result<ReturnValue, HostError> {
@@ -534,7 +516,25 @@ impl<E: Ext + 'static> SandboxEnvironment<E> {
             ctx.ext
                 .with(|ext: &mut E| {
                     let source = ext.program_id();
-                    ext.set_mem(source_ptr as isize as _, source.as_slice());
+                    ext.set_mem(source_ptr as _, source.as_slice());
+                    Ok(())
+                })
+                .and_then(|res| res.map(|_| ReturnValue::Unit))
+                .map_err(|err| {
+                    ctx.trap_reason = Some(err);
+                    HostError
+                })
+        }
+
+        fn source<E: Ext>(ctx: &mut Runtime<E>, args: &[Value]) -> Result<ReturnValue, HostError> {
+            let source_ptr: i32 = match args[0] {
+                Value::I32(val) => val,
+                _ => return Err(HostError),
+            };
+            ctx.ext
+                .with(|ext: &mut E| {
+                    let source = ext.source();
+                    ext.set_mem(source_ptr as _, source.as_slice());
                     Ok(())
                 })
                 .and_then(|res| res.map(|_| ReturnValue::Unit))
@@ -612,7 +612,7 @@ impl<E: Ext + 'static> SandboxEnvironment<E> {
         env_builder.add_host_func("env", "gr_read", read);
         env_builder.add_host_func("env", "gr_size", size);
         env_builder.add_host_func("env", "gr_source", source);
-        env_builder.add_host_func("env", "gr_actor_id", actor_id);
+        env_builder.add_host_func("env", "gr_program_id", program_id);
         env_builder.add_host_func("env", "gr_value", value);
         env_builder.add_host_func("env", "gr_reply", reply);
         env_builder.add_host_func("env", "gr_reply_commit", reply_commit);

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -70,6 +70,7 @@ impl<E: Ext + 'static> WasmtimeEnvironment<E> {
         result.add_func_i32_i32_i32("gr_send_push", funcs::send_push);
         result.add_func_into_i32("gr_size", funcs::size);
         result.add_func_i32("gr_source", funcs::source);
+        result.add_func_i32("gr_actor_id", funcs::actor_id);
         result.add_func_i32("gr_value", funcs::value);
         result.add_func("gr_wait", funcs::wait);
         result.add_func_i32("gr_wake", funcs::wake);

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -59,6 +59,7 @@ impl<E: Ext + 'static> WasmtimeEnvironment<E> {
         result.add_func_into_i64("gr_gas_available", funcs::gas_available);
         result.add_func_i32_i32("gr_debug", funcs::debug);
         result.add_func_i32("gr_msg_id", funcs::msg_id);
+        result.add_func_i32("gr_program_id", funcs::program_id);
         result.add_func_i32_i32_i32("gr_read", funcs::read);
         result.add_func_i32_i32_i64_i32_i32("gr_reply", funcs::reply);
         result.add_func_i32_i64_i32("gr_reply_commit", funcs::reply_commit);
@@ -70,7 +71,6 @@ impl<E: Ext + 'static> WasmtimeEnvironment<E> {
         result.add_func_i32_i32_i32("gr_send_push", funcs::send_push);
         result.add_func_into_i32("gr_size", funcs::size);
         result.add_func_i32("gr_source", funcs::source);
-        result.add_func_i32("gr_actor_id", funcs::actor_id);
         result.add_func_i32("gr_value", funcs::value);
         result.add_func("gr_wait", funcs::wait);
         result.add_func_i32("gr_wake", funcs::wake);

--- a/core-runner/src/ext.rs
+++ b/core-runner/src/ext.rs
@@ -184,6 +184,10 @@ impl EnvExt for Ext {
         self.messages.current().id()
     }
 
+    fn program_id(&mut self) -> ProgramId {
+        self.memory_context.program_id()
+    }
+
     fn free(&mut self, ptr: PageNumber) -> Result<(), &'static str> {
         let result = self.memory_context.free(ptr).map_err(|_e| "Free error");
 

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -91,6 +91,9 @@ pub trait Ext {
     /// Get the id of the message currently being handled.
     fn message_id(&mut self) -> MessageId;
 
+    /// Get the id of program itself
+    fn program_id(&mut self) -> ProgramId;
+
     /// Free specific memory page.
     ///
     /// Unlike traditional allocator, if multiple pages allocated via `alloc`, all pages
@@ -233,6 +236,9 @@ mod tests {
             ProgramId::from(0)
         }
         fn message_id(&mut self) -> MessageId {
+            0.into()
+        }
+        fn program_id(&mut self) -> ProgramId {
             0.into()
         }
         fn free(&mut self, _ptr: PageNumber) -> Result<(), &'static str> {

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -362,6 +362,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "demo-program-id"
+version = "0.1.0"
+dependencies = [
+ "gstd",
+]
+
+[[package]]
 name = "demo-rwlock"
 version = "0.1.0"
 dependencies = [

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "mutex",
     "panicker",
     "ping",
+    "program-id",
     "rwlock",
     "rwlock_write",
     "sum",

--- a/examples/program-id/Cargo.toml
+++ b/examples/program-id/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "demo-program-id"
+version = "0.1.0"
+authors = ["Gear Technologies"]
+edition = "2018"
+license = "GPL-3.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+gstd = { path = "../../gstd", features = ["debug"] }

--- a/examples/program-id/src/lib.rs
+++ b/examples/program-id/src/lib.rs
@@ -1,13 +1,12 @@
 #![no_std]
 
-// for panic/oom handlers
-use gstd::{exec, msg};
+use gstd::{debug, exec, msg};
 
 #[no_mangle]
 pub unsafe extern "C" fn handle() {
-    gstd::debug!("Starting program id");
-    let program_id = exec::actor_id();
-    gstd::debug!("My program id {:?}", program_id);
+    debug!("Starting program id");
+    let program_id = exec::program_id();
+    debug!("My program id: {:?}", program_id);
     msg::reply(b"program_id", 0, 0);
 }
 

--- a/examples/program-id/src/lib.rs
+++ b/examples/program-id/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+
+// for panic/oom handlers
+use gstd::{exec, msg};
+
+#[no_mangle]
+pub unsafe extern "C" fn handle() {
+    gstd::debug!("Starting program id");
+    let program_id = exec::actor_id();
+    gstd::debug!("My program id {:?}", program_id);
+    msg::reply(b"program_id", 0, 0);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn init() {}

--- a/gcore/src/exec.rs
+++ b/gcore/src/exec.rs
@@ -20,6 +20,7 @@
 //!
 //! Provides API for low-level async implementation.
 
+use crate::ActorId;
 use crate::MessageId;
 
 mod sys {
@@ -29,6 +30,7 @@ mod sys {
         pub fn gr_gas_available() -> u64;
         pub fn gr_wait() -> !;
         pub fn gr_wake(waker_id_ptr: *const u8);
+        pub fn gr_actor_id(val: *mut u8);
     }
 }
 
@@ -146,4 +148,22 @@ pub fn wake(waker_id: MessageId) {
     unsafe {
         sys::gr_wake(waker_id.as_slice().as_ptr());
     }
+}
+
+/// Return program id of the program.
+///
+/// # Examples
+///
+/// ```
+/// use gcore::{exec, ActorId};
+///
+/// pub unsafe extern "C" fn handle() {
+///     // ...
+///     exec::actor_id();
+/// }
+/// ```
+pub fn actor_id() -> ActorId {
+    let mut actor_id = ActorId::default();
+    unsafe { sys::gr_actor_id(actor_id.as_mut_slice().as_mut_ptr()) }
+    actor_id
 }

--- a/gcore/src/exec.rs
+++ b/gcore/src/exec.rs
@@ -28,9 +28,9 @@ mod sys {
         pub fn gr_block_height() -> u32;
         pub fn gr_block_timestamp() -> u64;
         pub fn gr_gas_available() -> u64;
+        pub fn gr_program_id(val: *mut u8);
         pub fn gr_wait() -> !;
         pub fn gr_wake(waker_id_ptr: *const u8);
-        pub fn gr_actor_id(val: *mut u8);
     }
 }
 
@@ -150,7 +150,7 @@ pub fn wake(waker_id: MessageId) {
     }
 }
 
-/// Return program id of the program.
+/// Return ID of the current program.
 ///
 /// # Examples
 ///
@@ -159,11 +159,11 @@ pub fn wake(waker_id: MessageId) {
 ///
 /// pub unsafe extern "C" fn handle() {
 ///     // ...
-///     exec::actor_id();
+///     let me = exec::program_id();
 /// }
 /// ```
-pub fn actor_id() -> ActorId {
+pub fn program_id() -> ActorId {
     let mut actor_id = ActorId::default();
-    unsafe { sys::gr_actor_id(actor_id.as_mut_slice().as_mut_ptr()) }
+    unsafe { sys::gr_program_id(actor_id.as_mut_slice().as_mut_ptr()) }
     actor_id
 }

--- a/gstd/src/exec.rs
+++ b/gstd/src/exec.rs
@@ -18,7 +18,7 @@
 
 //! Program execution regulation module.
 
-use crate::MessageId;
+use crate::{ActorId, MessageId};
 pub use gcore::exec::{block_height, block_timestamp, gas_available};
 
 pub fn wait() -> ! {
@@ -27,4 +27,8 @@ pub fn wait() -> ! {
 
 pub fn wake(waker_id: MessageId) {
     gcore::exec::wake(waker_id.into())
+}
+
+pub fn actor_id() -> ActorId {
+    gcore::exec::actor_id().into()
 }

--- a/gstd/src/exec.rs
+++ b/gstd/src/exec.rs
@@ -29,6 +29,6 @@ pub fn wake(waker_id: MessageId) {
     gcore::exec::wake(waker_id.into())
 }
 
-pub fn actor_id() -> ActorId {
-    gcore::exec::actor_id().into()
+pub fn program_id() -> ActorId {
+    gcore::exec::program_id().into()
 }

--- a/gtest/spec/test_program_id.yaml
+++ b/gtest/spec/test_program_id.yaml
@@ -1,0 +1,18 @@
+title: Program_id test
+
+programs:
+  - id: 1
+    path: target/wasm32-unknown-unknown/release/demo_program_id.wasm
+
+fixtures:
+  - title: program_id
+    messages:
+      - destination: 1
+        payload:
+          kind: utf-8
+          value: empty here
+    expected:
+      - step: 1
+        log:
+          - destination: 1000001
+            exitCode: 0


### PR DESCRIPTION
**Release Notes:** `program_id()` function is added to `gstd` which returns program_id of the program in execution. This can be used where the program wants to store funds like fungible-tokens to for itself. 