### PR TITLE
Add example program that calls `wait` in `init`

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -305,7 +305,6 @@ dependencies = [
 name = "demo-init-wait"
 version = "0.1.0"
 dependencies = [
- "gcore",
  "gstd",
 ]
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -302,6 +302,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "demo-init-wait"
+version = "0.1.0"
+dependencies = [
+ "gcore",
+ "gstd",
+]
+
+[[package]]
 name = "demo-mem"
 version = "0.1.0"
 dependencies = [

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "fib",
     "fungible-token",
     "futures-unordered",
+    "init-wait",
     "mem",
     "guestbook",
     "gui-test",

--- a/examples/init-wait/Cargo.toml
+++ b/examples/init-wait/Cargo.toml
@@ -9,5 +9,4 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-gcore = { path = "../../gcore", features = ["debug"] }
 gstd = { path = "../../gstd", features = ["debug"] }

--- a/examples/init-wait/Cargo.toml
+++ b/examples/init-wait/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "demo-init-wait"
+version = "0.1.0"
+authors = ["Gear Technologies"]
+edition = "2018"
+license = "GPL-3.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+gcore = { path = "../../gcore", features = ["debug"] }
+gstd = { path = "../../gstd", features = ["debug"] }

--- a/examples/init-wait/src/lib.rs
+++ b/examples/init-wait/src/lib.rs
@@ -1,0 +1,50 @@
+#![no_std]
+
+use gstd::{exec, msg, MessageId};
+
+#[derive(PartialEq, Debug)]
+enum State {
+    NotInited,
+    WaitForReply,
+    Inited,
+}
+
+static mut STATE: State = State::NotInited;
+static mut INIT_MESSAGE: MessageId = MessageId::new([0; 32]);
+
+#[no_mangle]
+pub unsafe extern "C" fn handle() {
+    if STATE != State::Inited {
+        panic!("not initialized");
+    }
+
+    msg::reply(b"Hello world!", 0, 0);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn init() {
+    match STATE {
+        State::NotInited => {
+            INIT_MESSAGE = msg::id();
+            msg::send(
+                msg::source(),
+                b"PING",
+                exec::gas_available() - 100_000_000,
+                0,
+            );
+            STATE = State::WaitForReply;
+            exec::wait();
+        }
+        State::WaitForReply => {
+            STATE = State::Inited;
+        }
+        _ => panic!("unreachable!"),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn handle_reply() {
+    if STATE == State::WaitForReply {
+        exec::wake(INIT_MESSAGE);
+    }
+}


### PR DESCRIPTION
Resolves #489.

Currently without test_spec.yaml since there is no support in node/gtest at the moment.

@gear-tech/dev 
