### PR TITLE
Add mem::forget for returned strings

### DIFF
--- a/gstd/src/macros/export.rs
+++ b/gstd/src/macros/export.rs
@@ -24,7 +24,7 @@ macro_rules! export {
         #[no_mangle]
         pub unsafe extern "C" fn $f() -> *mut [i32; 2] {
             let result = gstd::macros::util::to_wasm_ptr($val);
-            core::mem::forget(result);
+            core::mem::forget($val);
             result
         }
     };

--- a/gstd/src/macros/export.rs
+++ b/gstd/src/macros/export.rs
@@ -23,8 +23,9 @@ macro_rules! export {
     ($f:ident -> $val:expr) => {
         #[no_mangle]
         pub unsafe extern "C" fn $f() -> *mut [i32; 2] {
-            let result = gstd::macros::util::to_wasm_ptr($val);
-            core::mem::forget($val);
+            let buffer = $val.to_string();
+            let result = gstd::macros::util::to_wasm_ptr(buffer.as_bytes());
+            core::mem::forget(buffer);
             result
         }
     };

--- a/gstd/src/macros/export.rs
+++ b/gstd/src/macros/export.rs
@@ -23,7 +23,9 @@ macro_rules! export {
     ($f:ident -> $val:expr) => {
         #[no_mangle]
         pub unsafe extern "C" fn $f() -> *mut [i32; 2] {
-            gstd::macros::util::to_wasm_ptr($val)
+            let result = gstd::macros::util::to_wasm_ptr($val);
+            core::mem::forget(result);
+            result
         }
     };
 }


### PR DESCRIPTION
Otherwise allocator will corrupt memory which was returned