### PR TITLE
add `AccountId` field to `get_gas_spent` rpc call

### DIFF
--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -47,7 +47,7 @@ where
     C: Send + Sync + 'static,
     C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
     C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
-    C::Api: pallet_gear_rpc::GearRuntimeApi<Block, ProgramId>,
+    C::Api: pallet_gear_rpc::GearRuntimeApi<Block, AccountId, ProgramId>,
     C::Api: BlockBuilder<Block>,
     P: TransactionPool + 'static,
 {

--- a/pallets/gear/rpc/runtime-api/src/lib.rs
+++ b/pallets/gear/rpc/runtime-api/src/lib.rs
@@ -22,8 +22,11 @@ use codec::Codec;
 use sp_std::vec::Vec;
 
 sp_api::decl_runtime_apis! {
-    pub trait GearApi<ProgramId>
-    where ProgramId: Codec {
-        fn get_gas_spent(program_id: ProgramId, payload: Vec<u8>) -> Option<u64>;
+    pub trait GearApi<AccountId, ProgramId>
+    where
+    AccountId: Codec,
+    ProgramId: Codec,
+    {
+        fn get_gas_spent(account_id: AccountId, program_id: ProgramId, payload: Vec<u8>) -> Option<u64>;
     }
 }

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -302,7 +302,7 @@ pub mod pallet {
             Ok(message)
         }
 
-        pub fn get_gas_spent(dest: H256, payload: Vec<u8>) -> Option<u64> {
+        pub fn get_gas_spent(source: H256, dest: H256, payload: Vec<u8>) -> Option<u64> {
             let mut ext_manager = ExtManager::<T>::default();
 
             let block_info = BlockInfo {
@@ -312,7 +312,7 @@ pub mod pallet {
 
             let mut messages: VecDeque<Message> = VecDeque::from([Message {
                 id: common::next_message_id(&payload),
-                source: 100001.into_origin(),
+                source,
                 dest,
                 gas_limit: u64::MAX,
                 payload,

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -350,10 +350,10 @@ fn block_gas_limit_works() {
 
         // Count gas needed to process programs with default payload
         let expected_gas_msg_to_pid1 =
-            GearPallet::<Test>::get_gas_spent(pid1, EMPTY_PAYLOAD.to_vec())
+            GearPallet::<Test>::get_gas_spent(USER_1.into_origin(), pid1, EMPTY_PAYLOAD.to_vec())
                 .expect("internal error: get gas spent (pid1) failed");
         let expected_gas_msg_to_pid2 =
-            GearPallet::<Test>::get_gas_spent(pid2, EMPTY_PAYLOAD.to_vec())
+            GearPallet::<Test>::get_gas_spent(USER_1.into_origin(), pid2, EMPTY_PAYLOAD.to_vec())
                 .expect("internal error: get gas spent (pid2) failed");
 
         // TrapInHandle code kind is used because processing default payload in its
@@ -874,8 +874,12 @@ fn claim_value_from_mailbox_works() {
             populate_mailbox_from_program(prog_id, USER_2, USER_1, 2, 0, gas_sent, value_sent);
 
         let gas_burned = GasConverter::gas_to_fee(
-            GearPallet::<Test>::get_gas_spent(prog_id, EMPTY_PAYLOAD.to_vec())
-                .expect("program exists and not faulty"),
+            GearPallet::<Test>::get_gas_spent(
+                USER_1.into_origin(),
+                prog_id,
+                EMPTY_PAYLOAD.to_vec(),
+            )
+            .expect("program exists and not faulty"),
         );
 
         run_to_block(3, None);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -42,6 +42,7 @@ use sp_std::prelude::*;
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
+use gear_common::Origin as GearOrigin;
 pub use pallet_gear::manager::ExtManager;
 
 // A few exports that help ease life for downstream crates.
@@ -600,12 +601,13 @@ impl_runtime_apis! {
     }
 
     // Here we implement our custom runtime API.
-    impl pallet_gear_rpc_runtime_api::GearApi<Block, ProgramId> for Runtime {
+    impl pallet_gear_rpc_runtime_api::GearApi<Block, AccountId, ProgramId> for Runtime {
         fn get_gas_spent(
+            account_id: AccountId,
             program_id: ProgramId,
             payload: Vec<u8>,
         ) -> Option<u64> {
-            Gear::get_gas_spent(program_id, payload)
+            Gear::get_gas_spent(account_id.into_origin(), program_id, payload)
         }
     }
 


### PR DESCRIPTION
Since message processing can depend on the source, specifying it will allow to more accurately calculate the cost.

```bash
curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d   '{
     "jsonrpc":"2.0",
      "id":1,
      "method":"gear_getGasSpent",
      "params": ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
        "0x91f004f8ebf242f97d52c76d92e9a6776b7f1d341491c7d1dfd1f88b072631f3",
        "0x50494e47"]
    }'
```
@gear-tech/dev 