### PR TITLE
Keep all gas in parent's tree when sending message to mailbox

### DIFF
--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -127,39 +127,26 @@ fn send_message_works() {
             DEFAULT_GAS_LIMIT,
             mail_value,
         ));
-        let mail_reserves = GasConverter::gas_to_fee(DEFAULT_GAS_LIMIT);
 
-        // Transfer of `mail_value` has completed and gas reserved
+        // Transfer of `mail_value` completed.
+        // Gas limit is ignored for messages headed to a mailbox - no funds have been reserved.
         assert_eq!(
             BalancesPallet::<Test>::free_balance(USER_1),
-            user1_initial_balance - (mail_value + mail_reserves)
+            user1_initial_balance - mail_value
         );
-        // However, only `value` has been transferred to the recipient yet
+        // The recipient has already received the funds
         assert_eq!(
             BalancesPallet::<Test>::free_balance(USER_2),
             user2_initial_balance + mail_value
         );
 
-        // The `gas_limit` part will be released to the sender upon message queue processing
+        // Ensure the message didn't burn any gas (i.e. never went through processing pipeline)
         let remaining_weight = 100_000;
         run_to_block(3, Some(remaining_weight));
 
         // Messages were sent by user 1 only
-        let user1_actual_msgs_spends =
-            GasConverter::gas_to_fee(remaining_weight - GasAllowance::<Test>::get());
-
-        // Balance of user 2 is the same
-        assert_eq!(
-            BalancesPallet::<Test>::free_balance(USER_2),
-            user2_initial_balance + mail_value
-        );
-
-        // Since gas_limit is ignored for mailboxed messages, all gas except what was actually
-        // spent (nothing in this case) should have been returned to the sender (i.e. USER_1)
-        assert_eq!(
-            BalancesPallet::<Test>::free_balance(USER_1),
-            user1_initial_balance - (mail_value + user1_actual_msgs_spends)
-        );
+        let actual_gas_burned = remaining_weight - GasAllowance::<Test>::get();
+        assert_eq!(actual_gas_burned, 0);
     });
 }
 
@@ -760,13 +747,25 @@ fn send_reply_works() {
 }
 
 #[test]
-fn send_reply_insufficient_program_balance() {
+fn send_reply_failure_to_claim_from_mailbox() {
     init_logger();
     new_test_ext().execute_with(|| {
+        // Expecting error as long as the user doesn't have messages in mailbox
+        assert_noop!(
+            GearPallet::<Test>::send_reply(
+                Origin::signed(USER_1).into(),
+                5.into_origin(), // non existent `reply_to_id`
+                EMPTY_PAYLOAD.to_vec(),
+                DEFAULT_GAS_LIMIT,
+                0
+            ),
+            Error::<Test>::NoMessageInMailbox
+        );
+
         // caution: runs to block 2
         let reply_to_id = setup_mailbox_test_state(USER_1);
 
-        // Program doesn't have enough balance - error expected
+        // Program doesn't have enough balance: 1000 units of currency is claimed by `USER_1` first
         assert_noop!(
             GearPallet::<Test>::send_reply(
                 Origin::signed(USER_1).into(),
@@ -781,119 +780,7 @@ fn send_reply_insufficient_program_balance() {
 }
 
 #[test]
-fn send_reply_expected_failure() {
-    let wat = r#"
-    (module
-        (import "env" "gr_send" (func $send (param i32 i32 i32 i64 i32 i32)))
-        (import "env" "gr_source" (func $gr_source (param i32)))
-        (import "env" "memory" (memory 1))
-        (export "handle" (func $handle))
-        (export "init" (func $init))
-        (export "handle_reply" (func $handle_reply))
-        (func $handle
-            i32.const 16384
-            call $gr_source
-            i32.const 16384
-            i32.const 0
-            i32.const 32
-            i64.const 1000000
-            i32.const 1024
-            i32.const 40000
-            call $send
-        )
-        (func $handle_reply)
-        (func $init)
-    )"#;
-
-    init_logger();
-    new_test_ext().execute_with(|| {
-        // Expecting error as long as the user doesn't have messages in mailbox
-        assert_noop!(
-            GearPallet::<Test>::send_reply(
-                Origin::signed(LOW_BALANCE_USER).into(),
-                5.into_origin(), // non existent `reply_to_id`
-                EMPTY_PAYLOAD.to_vec(),
-                DEFAULT_GAS_LIMIT,
-                0
-            ),
-            Error::<Test>::NoMessageInMailbox
-        );
-
-        // Submitting program and sending it message to invoke a message, that will be added to LOW_BALANCE_USER's mailbox
-        let prog_id = {
-            let res = submit_program_default(USER_1, ProgramCodeKind::Custom(wat));
-            assert_ok!(res);
-            res.expect("submit result was asserted")
-        };
-
-        run_to_block(2, None);
-
-        // increase LOW_BALANCE_USER balance a bit to allow him send message
-        let reply_gas_spent = GearPallet::<Test>::get_gas_spent(prog_id, EMPTY_PAYLOAD.to_vec())
-            .expect("program exists and not faulty");
-
-        assert_ok!(BalancesPallet::<Test>::transfer(
-            Origin::signed(USER_1).into(),
-            LOW_BALANCE_USER,
-            GasConverter::gas_to_fee(reply_gas_spent),
-        ));
-
-        assert_ok!(GearPallet::<Test>::send_message(
-            Origin::signed(LOW_BALANCE_USER).into(),
-            prog_id,
-            EMPTY_PAYLOAD.to_vec(),
-            reply_gas_spent,
-            0,
-        ));
-
-        let prog = common::get_program(prog_id).expect("Created above");
-        let reply_to_id = compute_program_message_id(prog_id.as_bytes(), prog.nonce);
-
-        run_to_block(3, None);
-
-        assert_noop!(
-            GearPallet::<Test>::send_reply(
-                Origin::signed(LOW_BALANCE_USER).into(),
-                reply_to_id,
-                EMPTY_PAYLOAD.to_vec(),
-                10_000_000, // Too big gas limit value
-                1000
-            ),
-            Error::<Test>::NotEnoughBalanceForReserve
-        );
-
-        let value_balance = BalancesPallet::<Test>::free_balance(LOW_BALANCE_USER);
-        let gas_limit = 1;
-
-        // Value transfer is attempted if `value` field is greater than 0
-        assert_noop!(
-            GearPallet::<Test>::send_reply(
-                Origin::signed(LOW_BALANCE_USER).into(),
-                reply_to_id,
-                EMPTY_PAYLOAD.to_vec(),
-                gas_limit, // Must be greater than incoming gas_limit to have changed the state during reserve()
-                value_balance - 1 + 1,
-            ),
-            pallet_balances::Error::<Test>::InsufficientBalance
-        );
-
-        // Gas limit too high
-        let block_gas_limit = <Test as pallet::Config>::BlockGasLimit::get();
-        assert_noop!(
-            GearPallet::<Test>::send_reply(
-                Origin::signed(USER_1).into(),
-                reply_to_id,
-                EMPTY_PAYLOAD.to_vec(),
-                block_gas_limit + 1,
-                1000
-            ),
-            Error::<Test>::GasLimitTooHigh
-        );
-    })
-}
-
-#[test]
-fn send_reply_value_offset_works() {
+fn send_reply_value_claiming_works() {
     init_logger();
     new_test_ext().execute_with(|| {
         let prog_id = {
@@ -926,8 +813,7 @@ fn send_reply_value_offset_works() {
             program_nonce += 1;
             next_block += 1;
 
-            let user_balance = BalancesPallet::<Test>::free_balance(USER_1);
-
+            // Top up program's account so it could send value in message
             let send_to_program_amount = locked_value * 2;
             assert_ok!(
                 <BalancesPallet::<Test> as frame_support::traits::Currency<_>>::transfer(
@@ -937,10 +823,8 @@ fn send_reply_value_offset_works() {
                     frame_support::traits::ExistenceRequirement::AllowDeath
                 )
             );
-            assert_eq!(
-                BalancesPallet::<Test>::free_balance(USER_1),
-                user_balance - send_to_program_amount
-            );
+
+            let user_balance = BalancesPallet::<Test>::free_balance(USER_1);
             assert_eq!(BalancesPallet::<Test>::reserved_balance(USER_1), 0);
 
             assert_ok!(GearPallet::<Test>::send_reply(
@@ -951,11 +835,9 @@ fn send_reply_value_offset_works() {
                 value_to_reply,
             ));
 
-            let user_expected_balance = user_balance
-                - send_to_program_amount
-                - value_to_reply
-                - GasConverter::gas_to_fee(gas_limit_to_reply)
-                + locked_value;
+            let user_expected_balance =
+                user_balance - value_to_reply - GasConverter::gas_to_fee(gas_limit_to_reply)
+                    + locked_value;
             assert_eq!(
                 BalancesPallet::<Test>::free_balance(USER_1),
                 user_expected_balance
@@ -1536,7 +1418,7 @@ mod utils {
                     .expect("program must exist")
                     .code_hash,
                 sp_io::hashing::blake2_256(&expected_code).into(),
-                "can invokle send to mailbox only from `ProgramCodeKind::OutgoingWithValueInHandle` program"
+                "can invoke send to mailbox only from `ProgramCodeKind::OutgoingWithValueInHandle` program"
             );
         }
 


### PR DESCRIPTION
Resolves #556.

This change creates a distinction between messages in queue or those being processed and messages in some user's mailbox: getting into a mailbox is the end of a message life cycle, where no further processing can take place. Therefore, messages in the mailbox should not bring along any gas: no new node should be `split_off` from the gas tree associated with the parent message - all gas must remain in the parent tree.

This allows to unblock gas tree consumption if the only unconsumed message in a chain is that ended up in someone's mailbox.

If a reply follows, the author of the reply message must create a separate gas tree and pay for it by reserving their currency.
This allows to avoid a potentially buggy situation with offsetting gas/value of a mailboxed message against that of a reply message: now a `send_reply` call would simply claim the value from the mailbox first (`gas_limit` must be zero based on what is discussed here above) and then send a usual message.