### PR TITLE
Add workaround to rpc-tests

### DIFF
--- a/rpc-tests/src/index.ts
+++ b/rpc-tests/src/index.ts
@@ -448,10 +448,10 @@ async function processTest(testData: ITestData, api: GearApi, debugMode: DebugMo
       Frankly speaking for any programs that may emit messages in their `init` method.
 
       Before new messages may be appended to the queue programs should be inited and
-      outgoing messages should be queued if any. So here we just wait for 2-3 blocks
+      outgoing messages should be queued if any. So here we just wait for several blocks
       before enqueuing new messages.
     */
-    const countLimit = 2;
+    const countLimit = 5;
     let count = 0;
     const unsubscribe = await api.rpc.chain.subscribeNewHeads((_header) => {
       if (++count === countLimit) {

--- a/rpc-tests/src/index.ts
+++ b/rpc-tests/src/index.ts
@@ -444,6 +444,25 @@ async function processTest(testData: ITestData, api: GearApi, debugMode: DebugMo
 
     await api.tx.utility.batch(txs).signAndSend(sudoPair, { nonce: -1 });
 
+    /* This is a workaround for chat demo program.
+      Frankly speaking for any programs that may emit messages in their `init` method.
+
+      Before new messages may be appended to the queue programs should be inited and
+      outgoing messages should be queued if any. So here we just wait for 2-3 blocks
+      before enqueuing new messages.
+    */
+    const countLimit = 2;
+    let count = 0;
+    const unsubscribe = await api.rpc.chain.subscribeNewHeads((_header) => {
+      if (++count === countLimit) {
+        unsubscribe();
+      }
+    });
+
+    while (count < countLimit) {
+      await sleep(100);
+    }
+
     const out = await processFixture(api, debugMode, sudoPair, fixture);
     if (out.length > 0) {
       console.log(`Fixture ${fixture.title}: Ok`);


### PR DESCRIPTION
Wait for 2-3 blocks before sending new messages. This fixes failures looking like this:
```
Fixture rwlock-write
MSG ERR: Message not found (expected: {
  "destination": 6,
  "payload": {
    "kind": "utf-8",
    "value": "START"
  }
})
Encountered an error: broken pipe
Enable a logger to see more information.
Error: Process completed with exit code 1.
```

for example: https://github.com/gear-tech/gear/runs/4671100387?check_suite_focus=true
https://github.com/gear-tech/gear/runs/4719226629?check_suite_focus=true
