### PR TITLE
Validate `Registry` for each `.meta.wasm`

### DIFF
--- a/utils/wasm-proc/metadata-js/test.js
+++ b/utils/wasm-proc/metadata-js/test.js
@@ -5,9 +5,27 @@ const path = require("path");
 const wasmMetadata = require(".");
 const { TypeRegistry } = require('@polkadot/types')
 
-let wasmBytes = fs.readFileSync(
-    path.join(__dirname, "../../../target/wasm32-unknown-unknown/release/demo_meta.meta.wasm")
-);
+function hexIsValid(str) {
+    let re = /0x[0-9a-f]+/;
+    return re.test(str);
+}
+
+const targetDir = path.join(__dirname, "../../../target/wasm32-unknown-unknown/release/");
+const files = fs.readdirSync(targetDir);
+
+for (const file of files) {
+    if (file.endsWith(".meta.wasm")) {
+        let wasmBytes = fs.readFileSync(path.join(targetDir, file));
+        wasmMetadata.getWasmMetadata(wasmBytes).then(metadata => {
+            if (metadata.registry !== null && !hexIsValid(metadata.registry)) {
+                console.log(`Demo ${file} has invalid hex in registry: ${metadata.registry}`);
+                process.exit(1)
+            }
+        });
+    }
+}
+
+let wasmBytes = fs.readFileSync(path.join(targetDir, "demo_meta.meta.wasm"));
 
 wasmMetadata.getWasmMetadata(wasmBytes).then(metadata => {
     const reg = new TypeRegistry();
@@ -32,10 +50,7 @@ wasmMetadata.getWasmMetadata(wasmBytes).then(metadata => {
     )
 });
 
-// async
-wasmBytes = fs.readFileSync(
-    path.join(__dirname, "../../../target/wasm32-unknown-unknown/release/demo_async.meta.wasm")
-);
+wasmBytes = fs.readFileSync(path.join(targetDir, "demo_async.meta.wasm"));
 
 wasmMetadata.getWasmMetadata(wasmBytes).then(metadata => {
     const reg = new TypeRegistry();


### PR DESCRIPTION
Resolves #500.

- Make calling functions exports optional: if provided in wasm.
- For each binary, which contains `meta_registry` function, check if it's valid hex.

@gear-tech/dev