### PR TITLE
[skip ci] Fix link to chain spec in README

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -99,7 +99,7 @@ RUST_LOG=debug RUST_BACKTRACE=1 ./target/release/gear-node -lruntime=debug --dev
 At the MVP stage, multinode testnet is also supported!
 
 To see the multi-node consensus algorithm in action, run a local testnet with two validator nodes,
-Alice and Bob, that have been [configured](./node/src/chain_spec.rs) as the initial
+Alice and Bob, that have been [configured](./src/chain_spec.rs) as the initial
 authorities of the `local` testnet chain and endowed with testnet units.
 
 Note: this will require two terminal sessions (one for each node).


### PR DESCRIPTION
Rendered: https://github.com/gear-tech/gear/blob/sy-fix-link/node/README.md
