### PR TITLE
Add converter to leaking pointer to `gstd`

### DIFF
--- a/examples/meta/src/lib.rs
+++ b/examples/meta/src/lib.rs
@@ -164,9 +164,5 @@ pub unsafe extern "C" fn meta_state() -> *mut [i32; 2] {
             .collect::<Vec<Wallet>>()
             .encode(),
     };
-
-    let result = gstd::macros::util::to_wasm_ptr(&encoded[..]);
-    core::mem::forget(encoded);
-
-    result
+    gstd::macros::util::to_leak_ptr(encoded)
 }

--- a/gstd/src/macros/mod.rs
+++ b/gstd/src/macros/mod.rs
@@ -44,4 +44,11 @@ pub mod util {
             bytes.as_ref().len() as _,
         ]))
     }
+
+    pub fn to_leak_ptr(bytes: impl Into<Vec<u8>>) -> *mut [i32; 2] {
+        let bytes = bytes.into();
+        let ptr = Box::into_raw(Box::new([bytes.as_ptr() as _, bytes.len() as _]));
+        core::mem::forget(bytes);
+        ptr
+    }
 }


### PR DESCRIPTION
Resolves #593.

- Add `gstd::macros::util::to_leak_ptr()` function.
- Update the `demo-meta` example.

@gear-tech/dev 
