### PR TITLE
[skip ci] Fix error in documentation and command example

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -6,7 +6,7 @@
 
 The compiled runtime code as well as the genesis block configuration (the initial network state) should be placed in a "chain spec" JSON file that would later be supplied as a command line argumnet to the ```gear-node``` command:
 ```bash
-./target/release/gear-test \
+./target/release/gear-node \
   --base-path /tmp/data \
   --chain=chain_spec.json \
   ...

--- a/ansible/tasks/docker/docker-compose.yaml.j2
+++ b/ansible/tasks/docker/docker-compose.yaml.j2
@@ -10,7 +10,7 @@ services:
     image: schernovgear/gear:nightly
     volumes:
       - "/home/ec2-user/gear-data/:/gear/"
-    command: gear-node --base-path /gear/  --prometheus-external --offchain-worker=Never {% if rpc is not defined %} --validator {% endif %} {% if rpc is defined %} --unsafe-ws-external --unsafe-rpc-external --rpc-methods Unsafe --rpc-cors all {% endif %} {% if bootnodeId is defined %} --bootnodes /ip4/{{ bootnode }}/tcp/30333/p2p/{{ bootnodeId }} {% endif %}
+    command: gear-node --base-path /gear/  --prometheus-external {% if rpc is not defined %} --validator {% endif %} {% if rpc is defined %} --unsafe-ws-external --unsafe-rpc-external --rpc-methods Unsafe --rpc-cors all {% endif %} {% if bootnodeId is defined %} --bootnodes /ip4/{{ bootnode }}/tcp/30333/p2p/{{ bootnodeId }} {% endif %}
 
 volumes:
   gear-data:


### PR DESCRIPTION
Rectify documentation and the command that runs the node in the old template file which is still useful as an example of how to run a validator.