### PR TITLE
Implement syscall `exit`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4292,6 +4292,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "tests-distributor",
+ "tests-exit-init",
  "tests-init-wait",
  "wabt",
 ]
@@ -7573,6 +7574,14 @@ dependencies = [
  "parity-scale-codec",
  "substrate-wasm-builder",
  "tests-common",
+]
+
+[[package]]
+name = "tests-exit-init"
+version = "0.1.0"
+dependencies = [
+ "gstd",
+ "substrate-wasm-builder",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4292,6 +4292,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "tests-distributor",
+ "tests-exit-handle",
  "tests-exit-init",
  "tests-init-wait",
  "wabt",
@@ -7574,6 +7575,14 @@ dependencies = [
  "parity-scale-codec",
  "substrate-wasm-builder",
  "tests-common",
+]
+
+[[package]]
+name = "tests-exit-handle"
+version = "0.1.0"
+dependencies = [
+ "gstd",
+ "substrate-wasm-builder",
 ]
 
 [[package]]

--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{LEAVE_TRAP_STR, WAIT_TRAP_STR};
+use crate::{EXIT_TRAP_STR, LEAVE_TRAP_STR, WAIT_TRAP_STR};
 use alloc::{string::String, vec, vec::Vec};
 use gear_core::{
     env::{Ext, LaterExt},
@@ -94,6 +94,18 @@ pub fn gas<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static str>
 
 pub fn gas_available<E: Ext>(ext: LaterExt<E>) -> impl Fn() -> i64 {
     move || ext.with(|ext: &mut E| ext.gas_available()).unwrap_or(0) as i64
+}
+
+pub fn exit<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static str> {
+    move |program_id_ptr: i32| {
+        let _ = ext.with(|ext: &mut E| -> Result<(), &'static str> {
+            let dest: ProgramId = get_id(ext, program_id_ptr as u32 as _).into();
+            ext.exit(dest)
+        })?;
+
+        // Intentionally return an error to break the execution
+        Err(EXIT_TRAP_STR)
+    }
 }
 
 pub fn msg_id<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static str> {

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -30,20 +30,22 @@ use gear_core::{
     gas::GasAmount,
     memory::{Memory, PageBuf, PageNumber},
     message::{MessageId, OutgoingMessage, ReplyMessage},
+    program::ProgramId,
 };
 
+pub const EXIT_TRAP_STR: &str = "exit";
 pub const LEAVE_TRAP_STR: &str = "leave";
 pub const WAIT_TRAP_STR: &str = "wait";
 
 pub enum TerminationReason<'a> {
+    Exit(ProgramId),
+    Leave,
     Success,
     Trap {
         explanation: Option<&'static str>,
         description: Option<Cow<'a, str>>,
     },
-    Manual {
-        wait: bool,
-    },
+    Wait,
 }
 
 pub struct ExtInfo {
@@ -55,6 +57,8 @@ pub struct ExtInfo {
     pub nonce: u64,
 
     pub trap_explanation: Option<&'static str>,
+
+    pub exit_argument: Option<ProgramId>,
 }
 
 pub struct BackendReport<'a> {

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -22,7 +22,7 @@ use core::{
     convert::{TryFrom, TryInto},
     slice::Iter,
 };
-use gear_backend_common::{funcs, ExtInfo, LEAVE_TRAP_STR, WAIT_TRAP_STR};
+use gear_backend_common::{funcs, ExtInfo, EXIT_TRAP_STR, LEAVE_TRAP_STR, WAIT_TRAP_STR};
 use gear_core::{
     env::Ext,
     message::{MessageId, OutgoingPacket, ReplyPacket},
@@ -172,6 +172,25 @@ pub fn size<E: Ext + Into<ExtInfo>>(ctx: &mut Runtime<E>, _args: &[Value]) -> Sy
         .with(|ext| ext.msg().len())
         .map(return_i32)
         .unwrap_or_else(|_| return_i32(0))
+}
+
+pub fn exit<E: Ext + Into<ExtInfo>>(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
+    let value_to_ptr = pop_i32(&mut args.iter())?;
+
+    let _: Result<ReturnValue, HostError> = ctx
+        .ext
+        .with(|ext: &mut E| {
+            let value_to: ProgramId = funcs::get_id(ext, value_to_ptr).into();
+            ext.exit(value_to)
+        })
+        .map(|_| Ok(ReturnValue::Unit))
+        .map_err(|err| {
+            ctx.trap = Some(err);
+            HostError
+        })?;
+
+    ctx.trap = Some(EXIT_TRAP_STR);
+    Err(HostError)
 }
 
 pub fn exit_code<E: Ext + Into<ExtInfo>>(ctx: &mut Runtime<E>, _args: &[Value]) -> SyscallOutput {

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -72,6 +72,8 @@ pub enum DispatchResultKind {
     Trap(Option<&'static str>),
     /// Wait dispatch.
     Wait,
+    /// Exit dispatch.
+    Exit(ProgramId),
 }
 
 /// Result of the specific dispatch.
@@ -163,6 +165,14 @@ pub enum JournalNote {
         /// Amount of gas burned.
         amount: u64,
     },
+    /// Exit the program.
+    ExitDispatch {
+        /// Id of the program called `exit`.
+        id_exited: ProgramId,
+        /// Address where all remaining value of the program should
+        /// be transferred to.
+        value_destination: ProgramId,
+    },
     /// Message was handled and no longer exists.
     ///
     /// This should be the last update involving this message id.
@@ -213,6 +223,8 @@ pub trait JournalHandler {
     fn message_dispatched(&mut self, outcome: DispatchOutcome);
     /// Process gas burned.
     fn gas_burned(&mut self, message_id: MessageId, origin: ProgramId, amount: u64);
+    /// Process exit dispatch.
+    fn exit_dispatch(&mut self, id_exited: ProgramId, value_destination: ProgramId);
     /// Process message consumed.
     fn message_consumed(&mut self, message_id: MessageId);
     /// Process send message.

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -152,6 +152,7 @@ pub fn execute_wasm<E: Environment<Ext>>(
         block_info: settings.block_info,
         config: settings.config,
         error_explanation: None,
+        exit_argument: None,
     };
 
     // Running backend.
@@ -174,10 +175,8 @@ pub fn execute_wasm<E: Environment<Ext>>(
 
     // Parsing outcome.
     let kind = match termination {
-        TerminationReason::Success | TerminationReason::Manual { wait: false } => {
-            DispatchResultKind::Success
-        }
-        TerminationReason::Manual { wait: true } => DispatchResultKind::Wait,
+        TerminationReason::Exit(value_dest) => DispatchResultKind::Exit(value_dest),
+        TerminationReason::Leave | TerminationReason::Success => DispatchResultKind::Success,
         TerminationReason::Trap {
             explanation,
             description,
@@ -191,6 +190,7 @@ pub fn execute_wasm<E: Environment<Ext>>(
 
             DispatchResultKind::Trap(explanation)
         }
+        TerminationReason::Wait => DispatchResultKind::Wait,
     };
 
     // Updating program memory

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -44,6 +44,8 @@ pub struct Ext {
     pub config: AllocationsConfig,
     /// Any guest code panic explanation, if available.
     pub error_explanation: Option<&'static str>,
+    /// Contains argument to the `exit` if it was called.
+    pub exit_argument: Option<ProgramId>,
 }
 
 impl From<Ext> for ExtInfo {
@@ -76,6 +78,7 @@ impl From<Ext> for ExtInfo {
             awakening,
             nonce,
             trap_explanation,
+            exit_argument: ext.exit_argument,
         }
     }
 }
@@ -205,6 +208,15 @@ impl EnvExt for Ext {
 
     fn source(&mut self) -> ProgramId {
         self.message_context.current().source()
+    }
+
+    fn exit(&mut self, address: ProgramId) -> Result<(), &'static str> {
+        if self.exit_argument.is_some() {
+            Err("Cannot call `exit' twice")
+        } else {
+            self.exit_argument = Some(address);
+            Ok(())
+        }
     }
 
     fn message_id(&mut self) -> MessageId {

--- a/core-processor/src/handler.rs
+++ b/core-processor/src/handler.rs
@@ -17,7 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::common::{JournalHandler, JournalNote};
-use alloc::collections::BTreeMap;
+use alloc::{collections::BTreeMap, vec};
 
 /// Handle some journal records passing them to the journal handler.
 pub fn handle_journal(
@@ -26,6 +26,7 @@ pub fn handle_journal(
 ) {
     let mut page_updates = BTreeMap::new();
     let mut nonces = BTreeMap::new();
+    let mut exit_list = vec![];
 
     for note in journal.into_iter() {
         match note {
@@ -35,6 +36,10 @@ pub fn handle_journal(
                 origin,
                 amount,
             } => handler.gas_burned(message_id, origin, amount),
+            JournalNote::ExitDispatch {
+                id_exited,
+                value_destination,
+            } => exit_list.push((id_exited, value_destination)),
             JournalNote::MessageConsumed(message_id) => handler.message_consumed(message_id),
             JournalNote::SendMessage {
                 message_id,
@@ -68,5 +73,9 @@ pub fn handle_journal(
         for (page_number, data) in pages {
             handler.update_page(program_id, page_number, data);
         }
+    }
+
+    for (id_exited, value_destination) in exit_list {
+        handler.exit_dispatch(id_exited, value_destination);
     }
 }

--- a/core-processor/src/processor.rs
+++ b/core-processor/src/processor.rs
@@ -210,6 +210,12 @@ fn process_success(res: DispatchResult) -> Vec<JournalNote> {
     }
 
     match res.kind {
+        DispatchResultKind::Exit(value_destination) => {
+            journal.push(JournalNote::ExitDispatch {
+                id_exited: program_id,
+                value_destination,
+            });
+        }
         DispatchResultKind::Wait => {
             let mut dispatch = res.dispatch;
             dispatch.message.gas_limit = res.gas_amount.left();

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -88,6 +88,9 @@ pub trait Ext {
     /// Get the source of the message currently being handled.
     fn source(&mut self) -> ProgramId;
 
+    /// Terminate the program and transfer all available value to the address.
+    fn exit(&mut self, address: ProgramId) -> Result<(), &'static str>;
+
     /// Get the id of the message currently being handled.
     fn message_id(&mut self) -> MessageId;
 
@@ -237,6 +240,9 @@ mod tests {
         }
         fn source(&mut self) -> ProgramId {
             ProgramId::from(0)
+        }
+        fn exit(&mut self, _address: ProgramId) -> Result<(), &'static str> {
+            Ok(())
         }
         fn message_id(&mut self) -> MessageId {
             0.into()

--- a/gcore/src/exec.rs
+++ b/gcore/src/exec.rs
@@ -27,6 +27,7 @@ mod sys {
     extern "C" {
         pub fn gr_block_height() -> u32;
         pub fn gr_block_timestamp() -> u64;
+        pub fn gr_exit(program_id_ptr: *const u8) -> !;
         pub fn gr_gas_available() -> u64;
         pub fn gr_program_id(val: *mut u8);
         pub fn gr_leave() -> !;
@@ -79,6 +80,26 @@ pub fn block_height() -> u32 {
 /// ```
 pub fn block_timestamp() -> u64 {
     unsafe { sys::gr_block_timestamp() }
+}
+
+/// Terminate the execution of a program. The program and all corresponding data
+/// are removed from the storage. This is similiar to
+/// `std::process::exit`. `value_destination` specifies the address where all
+/// available to the program value should be transferred to.
+/// Maybe called in `init` method as well.
+///
+/// # Examples
+///
+/// ```
+/// use gcore::{exec, msg};
+///
+/// pub unsafe extern "C" fn handle() {
+///     // ...
+///     exec::exit(msg::source());
+/// }
+/// ```
+pub fn exit(value_destination: ActorId) -> ! {
+    unsafe { sys::gr_exit(value_destination.as_slice().as_ptr()) }
 }
 
 /// Get the current value of the gas available for execution.

--- a/gear-test/src/manager.rs
+++ b/gear-test/src/manager.rs
@@ -94,6 +94,11 @@ impl JournalHandler for InMemoryExtManager {
         };
     }
     fn gas_burned(&mut self, _message_id: MessageId, _origin: ProgramId, _amount: u64) {}
+
+    fn exit_dispatch(&mut self, id_exited: ProgramId, _value_destination: ProgramId) {
+        self.programs.borrow_mut().remove(&id_exited);
+    }
+
     fn message_consumed(&mut self, message_id: MessageId) {
         if let Some(index) = self
             .message_queue

--- a/gstd/src/exec.rs
+++ b/gstd/src/exec.rs
@@ -74,6 +74,26 @@
 use crate::{ActorId, MessageId};
 pub use gcore::exec::{block_height, block_timestamp, gas_available};
 
+/// Terminate the execution of a program. The program and all corresponding data
+/// are removed from the storage. This is similiar to
+/// `std::process::exit`. `value_destination` specifies the address where all
+/// available to the program value should be transferred to.
+/// Maybe called in `init` method as well.
+///
+/// # Examples
+///
+/// ```
+/// use gstd::{exec, msg};
+///
+/// pub unsafe extern "C" fn handle() {
+///     // ...
+///     exec::exit(msg::source());
+/// }
+/// ```
+pub fn exit(value_destination: ActorId) -> ! {
+    gcore::exec::exit(value_destination.into())
+}
+
 /// Terminate the current message handling.
 ///
 /// For cases when the message handling needs to be terminated with state

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -299,6 +299,11 @@ impl JournalHandler for ExtManager {
         }
     }
     fn gas_burned(&mut self, _message_id: MessageId, _origin: ProgramId, _amount: u64) {}
+
+    fn exit_dispatch(&mut self, id_exited: ProgramId, _value_destination: ProgramId) {
+        self.programs.remove(&id_exited);
+    }
+
     fn message_consumed(&mut self, message_id: MessageId) {
         if let Some(index) = self
             .message_queue

--- a/pallets/gear/Cargo.toml
+++ b/pallets/gear/Cargo.toml
@@ -47,6 +47,7 @@ gear-core = { path = "../../core" }
 hex-literal = "0.3.4"
 tests-distributor = { path = "../../tests/distributor" }
 tests-init-wait = { path = "../../tests/init-wait" }
+tests-exit-init = { path = "../../tests/exit-init" }
 
 [features]
 default = ['std']

--- a/pallets/gear/Cargo.toml
+++ b/pallets/gear/Cargo.toml
@@ -48,6 +48,7 @@ hex-literal = "0.3.4"
 tests-distributor = { path = "../../tests/distributor" }
 tests-init-wait = { path = "../../tests/init-wait" }
 tests-exit-init = { path = "../../tests/exit-init" }
+tests-exit-handle = { path = "../../tests/exit-handle" }
 
 [features]
 default = ['std']

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -1369,12 +1369,58 @@ fn wake_messages_after_program_inited() {
     })
 }
 
+#[test]
+fn exit_init() {
+    use tests_exit_init::WASM_BINARY_BLOATY;
+
+    init_logger();
+    new_test_ext().execute_with(|| {
+        System::reset_events();
+
+        assert_ok!(GearPallet::<Test>::submit_program(
+            Origin::signed(USER_1).into(),
+            WASM_BINARY_BLOATY.expect("Wasm binary missing!").to_vec(),
+            vec![],
+            Vec::new(),
+            10_000_000u64,
+            0u128
+        ));
+
+        let program_id = utils::get_last_program_id();
+
+        run_to_block(2, None);
+
+        assert!(!Gear::is_failed(program_id));
+        assert!(!Gear::is_initialized(program_id));
+
+        let actual_n = Gear::mailbox(USER_1)
+            .map(|t| {
+                t.into_values().fold(0usize, |i, _| {
+                    i + 1
+                })
+            })
+            .unwrap_or(0);
+
+        assert_eq!(actual_n, 0);
+
+        // Program is removed and can be submitted again
+        assert_ok!(GearPallet::<Test>::submit_program(
+            Origin::signed(USER_1).into(),
+            WASM_BINARY_BLOATY.expect("Wasm binary missing!").to_vec(),
+            vec![],
+            Vec::new(),
+            10_000_000u64,
+            0u128
+        ));
+    })
+}
+
 mod utils {
     use codec::Encode;
     use frame_support::dispatch::{DispatchErrorWithPostInfo, DispatchResultWithPostInfo};
     use sp_core::H256;
 
-    use super::{assert_ok, pallet, run_to_block, GearPallet, Mailbox, Origin, Test};
+    use super::{assert_ok, pallet, run_to_block, GearPallet, SystemPallet, Mailbox, Origin, Test, Event, MockEvent, MessageInfo};
 
     pub(super) const DEFAULT_GAS_LIMIT: u64 = 10_000;
     pub(super) const DEFAULT_SALT: &'static [u8; 4] = b"salt";
@@ -1493,6 +1539,23 @@ mod utils {
         let mut id = program_id.to_vec();
         id.extend_from_slice(&program_nonce.to_le_bytes());
         sp_io::hashing::blake2_256(&id).into()
+    }
+
+    pub(super) fn get_last_program_id() -> H256 {
+        let event = match SystemPallet::<Test>::events()
+            .last()
+            .map(|r| r.event.clone())
+        {
+            Some(MockEvent::Gear(e)) => e,
+            _ => unreachable!("Should be one Gear event"),
+        };
+
+        let MessageInfo { program_id, .. } = match event {
+            Event::InitMessageEnqueued(info) => info,
+            _ => unreachable!("expect Event::InitMessageEnqueued"),
+        };
+
+        program_id
     }
 
     #[derive(Debug, Copy, Clone)]

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -1395,11 +1395,7 @@ fn exit_init() {
         assert!(!Gear::is_initialized(program_id));
 
         let actual_n = Gear::mailbox(USER_1)
-            .map(|t| {
-                t.into_values().fold(0usize, |i, _| {
-                    i + 1
-                })
-            })
+            .map(|t| t.into_values().fold(0usize, |i, _| i + 1))
             .unwrap_or(0);
 
         assert_eq!(actual_n, 0);
@@ -1453,11 +1449,7 @@ fn exit_handle() {
         assert!(!Gear::is_failed(program_id));
 
         let actual_n = Gear::mailbox(USER_1)
-            .map(|t| {
-                t.into_values().fold(0usize, |i, _| {
-                    i + 1
-                })
-            })
+            .map(|t| t.into_values().fold(0usize, |i, _| i + 1))
             .unwrap_or(0);
 
         assert_eq!(actual_n, 0);
@@ -1482,7 +1474,10 @@ mod utils {
     use frame_support::dispatch::{DispatchErrorWithPostInfo, DispatchResultWithPostInfo};
     use sp_core::H256;
 
-    use super::{assert_ok, pallet, run_to_block, GearPallet, SystemPallet, Mailbox, Origin, Test, Event, MockEvent, MessageInfo};
+    use super::{
+        assert_ok, pallet, run_to_block, Event, GearPallet, Mailbox, MessageInfo, MockEvent,
+        Origin, SystemPallet, Test,
+    };
 
     pub(super) const DEFAULT_GAS_LIMIT: u64 = 10_000;
     pub(super) const DEFAULT_SALT: &'static [u8; 4] = b"salt";

--- a/tests/common/src/lib.rs
+++ b/tests/common/src/lib.rs
@@ -288,6 +288,10 @@ impl<'a> JournalHandler for Journal<'a> {
         self.context.gas_spent.insert(message_id, amount);
     }
 
+    fn exit_dispatch(&mut self, id_exited: ProgramId, _value_destination: ProgramId) {
+        self.context.programs.remove(&id_exited);
+    }
+
     fn message_consumed(&mut self, _message_id: MessageId) {}
 
     fn send_message(&mut self, _origin: MessageId, message: Message) {

--- a/tests/exit-handle/Cargo.toml
+++ b/tests/exit-handle/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tests-exit-handle"
+version = "0.1.0"
+authors = ["Gear Technologies"]
+edition = "2018"
+license = "GPL-3.0"
+
+[dependencies]
+gstd = { path = "../../gstd", features = ["debug"] }
+
+[build-dependencies]
+substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+
+[lib]
+
+[features]
+std = []
+default = ["std"]

--- a/tests/exit-handle/build.rs
+++ b/tests/exit-handle/build.rs
@@ -1,0 +1,8 @@
+use substrate_wasm_builder::WasmBuilder;
+
+fn main() {
+    WasmBuilder::new()
+        .with_current_project()
+        .import_memory()
+        .build();
+}

--- a/tests/exit-handle/src/lib.rs
+++ b/tests/exit-handle/src/lib.rs
@@ -21,6 +21,5 @@ mod wasm {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn init() {
-    }
+    pub unsafe extern "C" fn init() {}
 }

--- a/tests/exit-handle/src/lib.rs
+++ b/tests/exit-handle/src/lib.rs
@@ -1,0 +1,26 @@
+#![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "std")]
+mod native {
+    include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+}
+
+#[cfg(feature = "std")]
+pub use native::{WASM_BINARY, WASM_BINARY_BLOATY};
+
+#[cfg(not(feature = "std"))]
+mod wasm {
+    use gstd::{exec, msg};
+
+    #[no_mangle]
+    pub unsafe extern "C" fn handle() {
+        exec::exit(msg::source());
+        // should not be executed
+        msg::reply(b"reply", exec::gas_available(), 0);
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn init() {
+    }
+}

--- a/tests/exit-init/Cargo.toml
+++ b/tests/exit-init/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tests-exit-init"
+version = "0.1.0"
+authors = ["Gear Technologies"]
+edition = "2018"
+license = "GPL-3.0"
+
+[dependencies]
+gstd = { path = "../../gstd", features = ["debug"] }
+
+[build-dependencies]
+substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+
+[lib]
+
+[features]
+std = []
+default = ["std"]

--- a/tests/exit-init/build.rs
+++ b/tests/exit-init/build.rs
@@ -1,0 +1,8 @@
+use substrate_wasm_builder::WasmBuilder;
+
+fn main() {
+    WasmBuilder::new()
+        .with_current_project()
+        .import_memory()
+        .build();
+}

--- a/tests/exit-init/src/lib.rs
+++ b/tests/exit-init/src/lib.rs
@@ -1,0 +1,27 @@
+#![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
+#![cfg_attr(not(feature = "std"), feature(const_btree_new))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "std")]
+mod native {
+    include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+}
+
+#[cfg(feature = "std")]
+pub use native::{WASM_BINARY, WASM_BINARY_BLOATY};
+
+#[cfg(not(feature = "std"))]
+mod wasm {
+    use gstd::{exec, msg};
+
+    #[no_mangle]
+    pub unsafe extern "C" fn handle() {
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn init() {
+        exec::exit(msg::source());
+        // should not be executed
+        msg::reply(b"reply", exec::gas_available(), 0);
+    }
+}

--- a/tests/exit-init/src/lib.rs
+++ b/tests/exit-init/src/lib.rs
@@ -15,8 +15,7 @@ mod wasm {
     use gstd::{exec, msg};
 
     #[no_mangle]
-    pub unsafe extern "C" fn handle() {
-    }
+    pub unsafe extern "C" fn handle() {}
 
     #[no_mangle]
     pub unsafe extern "C" fn init() {

--- a/utils/gear-test-cli/src/manager.rs
+++ b/utils/gear-test-cli/src/manager.rs
@@ -109,6 +109,11 @@ where
     fn gas_burned(&mut self, message_id: MessageId, origin: ProgramId, amount: u64) {
         self.inner.gas_burned(message_id, origin, amount)
     }
+
+    fn exit_dispatch(&mut self, id_exited: ProgramId, value_destination: ProgramId) {
+        self.inner.exit_dispatch(id_exited, value_destination);
+    }
+
     fn message_consumed(&mut self, message_id: MessageId) {
         self.inner.message_consumed(message_id)
     }


### PR DESCRIPTION
Resolves #453

@gear-tech/dev 


**Release notes**: add new syscall `exit`. It allows to preemptively stop the execution of a program and remove the program from the storage. All available to program value is transferred to the address specified in `exit` argument.
