### PR TITLE
Normalize missing entry case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,6 +1970,7 @@ dependencies = [
  "gear-common",
  "gear-core",
  "log",
+ "parity-wasm 0.42.2",
  "sp-io",
  "sp-sandbox",
 ]

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -90,7 +90,7 @@ pub trait Environment<E: Ext + Into<ExtInfo> + 'static>: Default + Sized {
     ) -> Result<(), BackendError<'static>>;
 
     /// Run setuped instance starting at `entry_point` - wasm export function name.
-    /// NOTE: expternal environment must be setuped.
+    /// NOTE: external environment must be setuped.
     fn execute(&mut self, entry_point: &str) -> Result<BackendReport, BackendError>;
 
     /// Create internal representation of wasm memory with size `total_pages`

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -90,7 +90,7 @@ pub trait Environment<E: Ext + Into<ExtInfo> + 'static>: Default + Sized {
     ) -> Result<(), BackendError<'static>>;
 
     /// Run setuped instance starting at `entry_point` - wasm export function name.
-    /// NOTE: external environment must be setuped.
+    /// NOTE: external environment must be set up.
     fn execute(&mut self, entry_point: &str) -> Result<BackendReport, BackendError>;
 
     /// Create internal representation of wasm memory with size `total_pages`

--- a/core-backend/sandbox/Cargo.toml
+++ b/core-backend/sandbox/Cargo.toml
@@ -9,12 +9,12 @@ license = "GPL-3.0"
 gear-core = { path = "../../core" }
 gear-backend-common = { path = "../common" }
 common = { package = "gear-common", path = "../../common", default-features = false }
-sp-io = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false }
 
+parity-wasm = { version = "0.42.2", default-features = false }
+sp-io = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false }
 sp-sandbox = { version = "0.10.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false }
 log = { version = "0.4.14", default-features = false }
 
 [features]
 default = ["std"]
 std = ["sp-sandbox/std", "log/std"]
-

--- a/examples/block-info/src/lib.rs
+++ b/examples/block-info/src/lib.rs
@@ -13,6 +13,3 @@ pub unsafe extern "C" fn handle() {
     let bh = exec::block_height();
     msg::reply_bytes(format!("{}_{}", payload, bh), 10_000_000, 0);
 }
-
-#[no_mangle]
-pub unsafe extern "C" fn init() {}

--- a/examples/bot/src/lib.rs
+++ b/examples/bot/src/lib.rs
@@ -171,9 +171,6 @@ pub unsafe extern "C" fn handle() {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn handle_reply() {}
-
-#[no_mangle]
 pub unsafe extern "C" fn init() {
     let maybe_handlers: Result<Vec<Handler>, _> = msg::load();
 

--- a/examples/collector/src/lib.rs
+++ b/examples/collector/src/lib.rs
@@ -30,6 +30,3 @@ pub unsafe extern "C" fn handle() {
         MY_COLLECTION.insert(COUNTER, new_msg);
     }
 }
-
-#[no_mangle]
-pub unsafe extern "C" fn init() {}

--- a/examples/decoder/src/lib.rs
+++ b/examples/decoder/src/lib.rs
@@ -51,6 +51,3 @@ pub unsafe extern "C" fn handle() {
 
     handle.commit(msg::source(), 10_000_000, 0);
 }
-
-#[no_mangle]
-pub unsafe extern "C" fn init() {}

--- a/examples/exit-code/src/lib.rs
+++ b/examples/exit-code/src/lib.rs
@@ -5,12 +5,6 @@ use gstd::{msg, prelude::ToString, ActorId};
 static mut HOST: ActorId = ActorId::new([0u8; 32]);
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {}
-
-#[no_mangle]
-pub unsafe extern "C" fn handle() {}
-
-#[no_mangle]
 pub unsafe extern "C" fn handle_reply() {
     msg::send_bytes(HOST, msg::exit_code().to_string(), 0, 0);
 }

--- a/examples/fib/src/lib.rs
+++ b/examples/fib/src/lib.rs
@@ -36,6 +36,3 @@ pub unsafe extern "C" fn handle() {
         debug!(log);
     }
 }
-
-#[no_mangle]
-pub unsafe extern "C" fn init() {}

--- a/examples/guestbook/src/lib.rs
+++ b/examples/guestbook/src/lib.rs
@@ -38,6 +38,3 @@ pub unsafe extern "C" fn handle() {
         }
     }
 }
-
-#[no_mangle]
-pub unsafe extern "C" fn init() {}

--- a/examples/mem/src/lib.rs
+++ b/examples/mem/src/lib.rs
@@ -9,6 +9,3 @@ pub unsafe extern "C" fn handle() {
     msg::reply(&data, 0, 0);
     panic!()
 }
-
-#[no_mangle]
-pub unsafe extern "C" fn init() {}

--- a/examples/minimal/src/lib.rs
+++ b/examples/minimal/src/lib.rs
@@ -6,6 +6,3 @@ use gstd::msg;
 pub unsafe extern "C" fn handle() {
     msg::reply(b"Hello world!", 0, 0);
 }
-
-#[no_mangle]
-pub unsafe extern "C" fn init() {}

--- a/examples/multiping/src/lib.rs
+++ b/examples/multiping/src/lib.rs
@@ -22,6 +22,3 @@ pub unsafe extern "C" fn handle() {
         msg::send_commit(handle, msg::source(), 10_000_000, 0);
     }
 }
-
-#[no_mangle]
-pub unsafe extern "C" fn init() {}

--- a/examples/panicker/src/lib.rs
+++ b/examples/panicker/src/lib.rs
@@ -1,13 +1,9 @@
 #![no_std]
 
-// for panic/oom handlers
-extern crate gstd;
+use gstd::debug;
 
 #[no_mangle]
 pub unsafe extern "C" fn handle() {
-    gstd::debug!("Starting panicker handle");
+    debug!("Starting panicker handle");
     panic!("I just panic every time")
 }
-
-#[no_mangle]
-pub unsafe extern "C" fn init() {}

--- a/examples/ping/src/lib.rs
+++ b/examples/ping/src/lib.rs
@@ -22,8 +22,3 @@ pub unsafe extern "C" fn handle() {
         debug!(log);
     }
 }
-
-#[no_mangle]
-pub unsafe extern "C" fn init() {
-    debug!("Hello from ping init");
-}

--- a/examples/program-id/src/lib.rs
+++ b/examples/program-id/src/lib.rs
@@ -9,6 +9,3 @@ pub unsafe extern "C" fn handle() {
     debug!("My program id: {:?}", program_id);
     msg::reply(b"program_id", 0, 0);
 }
-
-#[no_mangle]
-pub unsafe extern "C" fn init() {}

--- a/examples/state_rollback/src/lib.rs
+++ b/examples/state_rollback/src/lib.rs
@@ -28,6 +28,3 @@ pub unsafe extern "C" fn handle() {
         }
     }
 }
-
-#[no_mangle]
-pub unsafe extern "C" fn init() {}

--- a/examples/sync_duplicate/src/lib.rs
+++ b/examples/sync_duplicate/src/lib.rs
@@ -4,34 +4,16 @@ use gstd::{msg, prelude::*};
 
 static mut COUNTER: usize = 0;
 
-fn increase() {
-    unsafe {
-        COUNTER += 1;
-    }
-}
-
-fn get() -> i32 {
-    (unsafe { COUNTER }) as i32
-}
-
-fn clear() {
-    unsafe {
-        COUNTER = 0;
-    }
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn init() {}
-
 #[gstd::async_main]
 async fn main() {
     let msg = String::from_utf8(msg::load_bytes()).expect("Invalid message: should be utf-8");
     if &msg == "async" {
-        increase();
+        COUNTER += 1;
         let _ = msg::send_bytes_and_wait_for_reply(2.into(), b"PING", 100_000_000, 0)
             .await
             .expect("Error in async message processing");
-        msg::reply(get(), 100_000_000, 0);
-        clear();
+        msg::reply(COUNTER as i32, 100_000_000, 0);
+
+        COUNTER = 0;
     };
 }

--- a/examples/vec/src/lib.rs
+++ b/examples/vec/src/lib.rs
@@ -27,6 +27,3 @@ pub unsafe extern "C" fn handle() {
         debug!(log);
     }
 }
-
-#[no_mangle]
-pub unsafe extern "C" fn init() {}

--- a/examples/wait/src/lib.rs
+++ b/examples/wait/src/lib.rs
@@ -33,6 +33,3 @@ pub unsafe extern "C" fn handle() {
         }
     }
 }
-
-#[no_mangle]
-pub unsafe extern "C" fn init() {}


### PR DESCRIPTION
Resolves #640.

@gear-tech/dev 

**Release Notes**: If some of entry point (`init`, `handle` or `handle_reply`) isn't provided, it means now that this function is an empty function.

This code ⬇️ 
```rust
#![no_std]

use gstd::msg;

#[no_mangle]
pub unsafe extern "C" fn handle() {
    msg::reply_bytes("Handle", 0, 0);
}
```
now equals this one ⬇️ 
```rust
#![no_std]

use gstd::msg;

#[no_mangle]
pub unsafe extern "C" fn init() { }

#[no_mangle]
pub unsafe extern "C" fn handle() {
    msg::reply_bytes("Handle", 0, 0);
}

#[no_mangle]
pub unsafe extern "C" fn handle_reply() { }
```

It used to cause panic.