### PR TITLE
gear-wasm-builder: Always build WASM in release mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2228,7 +2228,7 @@ dependencies = [
 
 [[package]]
 name = "gear-wasm-builder"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/utils/wasm-builder/Cargo.toml
+++ b/utils/wasm-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gear-wasm-builder"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 description = "Utility for building Gear programs"

--- a/utils/wasm-builder/README.md
+++ b/utils/wasm-builder/README.md
@@ -7,10 +7,12 @@ This is a helper crate that can be used in build scripts for building Gear progr
 1. Add the `gear-wasm-buider` crate as a build dependency to the `Cargo.toml`:
 
 ```toml
-...
+# ...
+
 [build-dependencies]
-gear-wasm-builder = "0.1.0"
-...
+gear-wasm-builder = "0.1.1"
+
+# ...
 ```
 
 2. Create a `build.rs` file and place it at the directory with `Cargo.toml`:

--- a/utils/wasm-builder/src/cargo_command.rs
+++ b/utils/wasm-builder/src/cargo_command.rs
@@ -61,8 +61,7 @@ impl CargoCommand {
             .args(&self.args)
             .arg("--color=always")
             .arg(format!("--manifest-path={}", self.manifest_path.display()))
-            .arg("--profile")
-            .arg(&self.profile)
+            .arg("--release")
             .arg("--")
             .args(&self.rustc_flags)
             .env(self.skip_build_env(), ""); // Don't build the original crate recursively

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -99,16 +99,12 @@ impl WasmProject {
         lib.insert("name".into(), crate_info.snake_case_name.into());
         lib.insert("crate-type".into(), vec!["cdylib".to_string()].into());
 
-        let mut dev_profile = Table::new();
-        dev_profile.insert("panic".into(), "abort".into());
-
         let mut release_profile = Table::new();
         release_profile.insert("lto".into(), true.into());
         release_profile.insert("opt-level".into(), "s".into());
-        release_profile.insert("panic".into(), "abort".into());
 
         let mut profile = Table::new();
-        profile.insert("dev".into(), dev_profile.into());
+        profile.insert("dev".into(), release_profile.clone().into());
         profile.insert("release".into(), release_profile.into());
 
         let mut crate_package = Table::new();
@@ -176,11 +172,11 @@ impl WasmProject {
         fs::write(
             &wasm_binary_rs,
             format!(
-                r#"#[allow(dead_code)]
+                r#"#[allow(unused)]
 pub const WASM_BINARY: &[u8] = include_bytes!("{}");
-#[allow(dead_code)]
+#[allow(unused)]
 pub const WASM_BINARY_OPT: &[u8] = include_bytes!("{}");
-#[allow(dead_code)]
+#[allow(unused)]
 pub const WASM_BINARY_META: &[u8] = include_bytes!("{}");
 "#,
                 to_path.display(),

--- a/utils/wasm-builder/test-program/Cargo.lock
+++ b/utils/wasm-builder/test-program/Cargo.lock
@@ -182,7 +182,7 @@ source = "git+https://github.com/gear-tech/gear.git#9cc70eb1b6f24a3480dde48ddedd
 
 [[package]]
 name = "gear-wasm-builder"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/utils/wasm-builder/test-program/src/lib.rs
+++ b/utils/wasm-builder/test-program/src/lib.rs
@@ -41,7 +41,7 @@ mod tests {
 
     #[test]
     #[cfg(not(debug_assertions))]
-    fn release_wasm_exists() {
+    fn release_wasm() {
         assert_eq!(
             fs::read("target/wasm32-unknown-unknown/release/test_program.wasm").unwrap(),
             code::WASM_BINARY,


### PR DESCRIPTION
Minor fixes in `gear-wasm-builder`.

- Build WASM in release mode regardless of the selected profile.
- Beautify `wasm_binary.rs` a little bit. 

@gear-tech/dev 
