### PR TITLE
New `gear-wasm-builder` integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,9 +1956,7 @@ version = "0.1.0"
 name = "gear-backend-common"
 version = "0.1.0"
 dependencies = [
- "gear-common",
  "gear-core",
- "gear-runtime-interface",
  "log",
 ]
 
@@ -1971,7 +1969,6 @@ dependencies = [
  "gear-core",
  "log",
  "parity-wasm 0.42.2",
- "sp-io",
  "sp-sandbox",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7596,9 +7596,9 @@ dependencies = [
 name = "tests-btree"
 version = "0.1.0"
 dependencies = [
+ "gear-wasm-builder",
  "gstd",
  "parity-scale-codec",
- "substrate-wasm-builder",
  "tests-common",
 ]
 
@@ -7618,9 +7618,9 @@ name = "tests-distributor"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "gear-wasm-builder",
  "gstd",
  "parity-scale-codec",
- "substrate-wasm-builder",
  "tests-common",
 ]
 
@@ -7628,33 +7628,33 @@ dependencies = [
 name = "tests-exit-handle"
 version = "0.1.0"
 dependencies = [
+ "gear-wasm-builder",
  "gstd",
- "substrate-wasm-builder",
 ]
 
 [[package]]
 name = "tests-exit-init"
 version = "0.1.0"
 dependencies = [
+ "gear-wasm-builder",
  "gstd",
- "substrate-wasm-builder",
 ]
 
 [[package]]
 name = "tests-init-wait"
 version = "0.1.0"
 dependencies = [
+ "gear-wasm-builder",
  "gstd",
- "substrate-wasm-builder",
 ]
 
 [[package]]
 name = "tests-messages"
 version = "0.1.0"
 dependencies = [
+ "gear-wasm-builder",
  "gstd",
  "parity-scale-codec",
- "substrate-wasm-builder",
  "tests-common",
 ]
 
@@ -7663,9 +7663,9 @@ name = "tests-node"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "gear-wasm-builder",
  "gstd",
  "parity-scale-codec",
- "substrate-wasm-builder",
  "tests-common",
 ]
 
@@ -7674,9 +7674,9 @@ name = "tests-wait-wake"
 version = "0.1.0"
 dependencies = [
  "gear-core",
+ "gear-wasm-builder",
  "gstd",
  "parity-scale-codec",
- "substrate-wasm-builder",
  "tests-common",
 ]
 

--- a/core-backend/common/Cargo.toml
+++ b/core-backend/common/Cargo.toml
@@ -7,7 +7,4 @@ license = "GPL-3.0"
 
 [dependencies]
 gear-core = { path = "../../core" }
-gear-runtime-interface = { path = "../../runtime-interface", default-features = false }
-common = { package = "gear-common", path = "../../common", default-features = false }
-
 log = { version = "0.4.14", default-features = false }

--- a/core-backend/sandbox/Cargo.toml
+++ b/core-backend/sandbox/Cargo.toml
@@ -11,10 +11,9 @@ gear-backend-common = { path = "../common" }
 common = { package = "gear-common", path = "../../common", default-features = false }
 
 parity-wasm = { version = "0.42.2", default-features = false }
-sp-io = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false }
 sp-sandbox = { version = "0.10.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false }
 log = { version = "0.4.14", default-features = false }
 
 [features]
 default = ["std"]
-std = ["sp-sandbox/std", "log/std"]
+std = ["common/std", "sp-sandbox/std", "parity-wasm/std", "log/std"]

--- a/core-processor/Cargo.toml
+++ b/core-processor/Cargo.toml
@@ -2,14 +2,15 @@
 name = "gear-core-processor"
 version = "0.1.0"
 authors = ["Gear Technologies"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 
 [dependencies]
 gear-core = { path = "../core" }
 gear-backend-common = { path = "../core-backend/common" }
-gear-runtime-interface = { path = "../runtime-interface", default-features = false }
-common = { package = "gear-common", path = "../common", default-features = false }
+gear-runtime-interface = { path = "../runtime-interface", default-features = false, optional = true }
+
+common = { package = "gear-common", path = "../common", default-features = false, optional = true }
 
 blake2-rfc = { version = "0.2.16", default-features = false }
 codec = { package = "parity-scale-codec", version = "2", features = ["derive"], default-features = false }
@@ -17,4 +18,4 @@ log = { version = "0.4.14", default-features = false }
 
 [features]
 strict = []
-lazy-pages = []
+lazy-pages = ["gear-runtime-interface", "common"]

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -28,15 +28,40 @@ use alloc::{
     collections::{BTreeMap, BTreeSet},
     vec::Vec,
 };
-use common::Origin;
-use core::convert::TryFrom;
 use gear_backend_common::{BackendReport, Environment, TerminationReason};
 use gear_core::{
     gas::{self, ChargeResult, GasCounter},
     memory::{MemoryContext, PageBuf, PageNumber},
     message::{Dispatch, MessageContext},
-    program::Program,
+    program::{Program, ProgramId},
 };
+
+#[cfg(feature = "lazy-pages")]
+fn load_pages(
+    program_id: ProgramId,
+    initial_pages: &mut BTreeMap<PageNumber, Option<Box<PageBuf>>>,
+) {
+    use common::Origin;
+    // In case we don't enable lazy-pages, then we loads data for all pages, which has no data, now.
+    let prog_id_hash = program_id.into_origin();
+    initial_pages
+        .iter_mut()
+        .filter(|(_x, y)| y.is_none())
+        .for_each(|(x, y)| {
+            let data = common::get_program_page_data(prog_id_hash, x.raw())
+                .expect("Page data must be in storage");
+            y.replace(Box::from(PageBuf::try_from(data).expect(
+                "Must be able to convert vec to PageBuf, may be vec has wrong size",
+            )));
+        });
+}
+
+#[cfg(not(feature = "lazy-pages"))]
+fn load_pages(
+    _program_id: ProgramId,
+    _initial_pages: &mut BTreeMap<PageNumber, Option<Box<PageBuf>>>,
+) {
+}
 
 /// Execute wasm with dispatch and return dispatch result.
 pub fn execute_wasm<E: Environment<Ext>>(
@@ -156,18 +181,7 @@ pub fn execute_wasm<E: Environment<Ext>>(
         lazy_pages::try_to_enable_lazy_pages(initial_pages);
 
     if lazy_pages_enabled.is_none() && has_no_data_pages.is_some() {
-        // In case we don't enable lazy-pages, then we loads data for all pages, which has no data, now.
-        let prog_id_hash = program_id.into_origin();
-        initial_pages
-            .iter_mut()
-            .filter(|(_x, y)| y.is_none())
-            .for_each(|(x, y)| {
-                let data = common::get_program_page_data(prog_id_hash, x.raw())
-                    .expect("Page data must be in storage");
-                y.replace(Box::from(PageBuf::try_from(data).expect(
-                    "Must be able to convert vec to PageBuf, may be vec has wrong size",
-                )));
-            });
+        load_pages(program_id, initial_pages);
     }
 
     // Creating externalities.

--- a/core-processor/src/lazy_pages.rs
+++ b/core-processor/src/lazy_pages.rs
@@ -19,118 +19,172 @@
 //! Lazy pages support runtime functions
 
 use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
-use common::Origin;
-use core::convert::TryFrom;
 use gear_core::memory::{PageBuf, PageNumber};
 use gear_core::program::ProgramId;
-use gear_runtime_interface as gear_ri;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct LazyPagesEnabled;
+#[derive(Debug, Clone)]
 pub struct HasNoDataPages;
 
-/// Try to enable and initialize lazy pages env
-pub fn try_to_enable_lazy_pages(
-    memory_pages: &BTreeMap<PageNumber, Option<Box<PageBuf>>>,
-) -> (Option<LazyPagesEnabled>, Option<HasNoDataPages>) {
-    // Each page which has no data in `memory_pages` is supposed to be lazy page candidate
-    if !memory_pages.iter().any(|(_, buf)| buf.is_none()) {
-        log::debug!("lazy-pages: there is no pages to be lazy");
+pub use implementation::*;
+
+#[cfg(not(feature = "lazy-pages"))]
+mod implementation {
+    use super::*;
+
+    /// Try to enable and initialize lazy pages env
+    pub fn try_to_enable_lazy_pages(
+        _memory_pages: &BTreeMap<PageNumber, Option<Box<PageBuf>>>,
+    ) -> (Option<LazyPagesEnabled>, Option<HasNoDataPages>) {
         (None, None)
-    } else if !cfg!(feature = "lazy-pages")
-        || cfg!(target_family = "wasm")
-        || !gear_ri::gear_ri::init_lazy_pages()
-    {
-        // TODO: to support in Wasm runtime we must change embedded executor to host executor.
-        // TODO: also we cannot support for validators in relay-chain,
-        // but it can be fixed in future only.
-        log::debug!("lazy-pages: disabled or unsupported");
-        (None, Some(HasNoDataPages))
-    } else {
-        log::debug!("lazy-pages: enabled");
-        (Some(LazyPagesEnabled), Some(HasNoDataPages))
+    }
+
+    /// Protect and save storage keys for pages which has no data
+    pub fn protect_pages_and_init_info(
+        _memory_pages: &BTreeMap<PageNumber, Option<Box<PageBuf>>>,
+        _prog_id: ProgramId,
+        _wasm_mem_begin_addr: usize,
+    ) {
+    }
+
+    /// Lazy pages contract post execution actions
+    pub fn post_execution_actions(
+        _memory_pages: &mut BTreeMap<PageNumber, Option<Box<PageBuf>>>,
+        _wasm_mem_begin_addr: usize,
+    ) {
+    }
+
+    /// Remove lazy-pages protection, returns wasm memory begin addr
+    pub fn remove_lazy_pages_prot(_mem_addr: usize) {}
+
+    /// Protect lazy-pages and set new wasm mem addr if it has been changed
+    pub fn protect_lazy_pages_and_update_wasm_mem_addr(_old_mem_addr: usize, _new_mem_addr: usize) {
+    }
+
+    /// Returns list of current lazy pages numbers
+    pub fn get_lazy_pages_numbers() -> Vec<u32> {
+        Default::default()
     }
 }
 
-/// Protect and save storage keys for pages which has no data
-pub fn protect_pages_and_init_info(
-    memory_pages: &BTreeMap<PageNumber, Option<Box<PageBuf>>>,
-    prog_id: ProgramId,
-    wasm_mem_begin_addr: usize,
-) {
-    let lazy_pages = memory_pages
-        .iter()
-        .filter(|(_num, buf)| buf.is_none())
-        .map(|(num, _buf)| num.raw())
-        .collect::<Vec<u32>>();
-    let prog_id_hash = prog_id.into_origin();
+#[cfg(feature = "lazy-pages")]
+mod implementation {
+    use super::*;
 
-    gear_ri::gear_ri::reset_lazy_pages_info();
+    use common::Origin;
+    use core::convert::TryFrom;
+    use gear_runtime_interface as gear_ri;
 
-    gear_ri::gear_ri::set_wasm_mem_begin_addr(wasm_mem_begin_addr as u64);
-
-    lazy_pages.iter().for_each(|p| {
-        common::save_page_lazy_info(prog_id_hash, *p);
-    });
-
-    gear_ri::gear_ri::mprotect_wasm_pages(
-        wasm_mem_begin_addr as u64,
-        &lazy_pages,
-        false,
-        false,
-        false,
-    );
-}
-
-/// Lazy pages contract post execution actions
-pub fn post_execution_actions(
-    memory_pages: &mut BTreeMap<PageNumber, Option<Box<PageBuf>>>,
-    wasm_mem_begin_addr: usize,
-) {
-    // Loads data for released lazy pages. Data which was before execution.
-    let released_pages = gear_ri::gear_ri::get_released_pages();
-    released_pages.into_iter().for_each(|page| {
-        let data = gear_ri::gear_ri::get_released_page_old_data(page);
-        memory_pages.insert(
-            (page).into(),
-            Option::from(Box::new(
-                PageBuf::try_from(data).expect("Must be able to convert"),
-            )),
-        );
-    });
-
-    // Removes protections from lazy pages
-    let lazy_pages = gear_ri::gear_ri::get_wasm_lazy_pages_numbers();
-    gear_ri::gear_ri::mprotect_wasm_pages(
-        wasm_mem_begin_addr as u64,
-        &lazy_pages,
-        true,
-        true,
-        false,
-    );
-}
-
-/// Remove lazy-pages protection, returns wasm memory begin addr
-pub fn remove_lazy_pages_prot(mem_addr: usize) {
-    let lazy_pages = gear_ri::gear_ri::get_wasm_lazy_pages_numbers();
-    gear_ri::gear_ri::mprotect_wasm_pages(mem_addr as u64, &lazy_pages, true, true, false);
-}
-
-/// Protect lazy-pages and set new wasm mem addr if it has been changed
-pub fn protect_lazy_pages_and_update_wasm_mem_addr(old_mem_addr: usize, new_mem_addr: usize) {
-    if new_mem_addr != old_mem_addr {
-        log::debug!(
-            "backend executor has changed wasm mem buff: from {:#x} to {:#x}",
-            old_mem_addr,
-            new_mem_addr
-        );
-        gear_ri::gear_ri::set_wasm_mem_begin_addr(new_mem_addr as u64);
+    /// Try to enable and initialize lazy pages env
+    pub fn try_to_enable_lazy_pages(
+        memory_pages: &BTreeMap<PageNumber, Option<Box<PageBuf>>>,
+    ) -> (Option<LazyPagesEnabled>, Option<HasNoDataPages>) {
+        // Each page which has no data in `memory_pages` is supposed to be lazy page candidate
+        if !memory_pages.iter().any(|(_, buf)| buf.is_none()) {
+            log::debug!("lazy-pages: there is no pages to be lazy");
+            (None, None)
+        } else if !cfg!(feature = "lazy-pages")
+            || cfg!(target_family = "wasm")
+            || !gear_ri::gear_ri::init_lazy_pages()
+        {
+            // TODO: to support in Wasm runtime we must change embedded executor to host executor.
+            // TODO: also we cannot support for validators in relay-chain,
+            // but it can be fixed in future only.
+            log::debug!("lazy-pages: disabled or unsupported");
+            (None, Some(HasNoDataPages))
+        } else {
+            log::debug!("lazy-pages: enabled");
+            (Some(LazyPagesEnabled), Some(HasNoDataPages))
+        }
     }
-    let lazy_pages = gear_ri::gear_ri::get_wasm_lazy_pages_numbers();
-    gear_ri::gear_ri::mprotect_wasm_pages(new_mem_addr as u64, &lazy_pages, false, false, false);
-}
 
-/// Returns list of current lazy pages numbers
-pub fn get_lazy_pages_numbers() -> Vec<u32> {
-    gear_ri::gear_ri::get_wasm_lazy_pages_numbers()
+    /// Protect and save storage keys for pages which has no data
+    pub fn protect_pages_and_init_info(
+        memory_pages: &BTreeMap<PageNumber, Option<Box<PageBuf>>>,
+        prog_id: ProgramId,
+        wasm_mem_begin_addr: usize,
+    ) {
+        let lazy_pages = memory_pages
+            .iter()
+            .filter(|(_num, buf)| buf.is_none())
+            .map(|(num, _buf)| num.raw())
+            .collect::<Vec<u32>>();
+        let prog_id_hash = prog_id.into_origin();
+
+        gear_ri::gear_ri::reset_lazy_pages_info();
+
+        gear_ri::gear_ri::set_wasm_mem_begin_addr(wasm_mem_begin_addr as u64);
+
+        lazy_pages.iter().for_each(|p| {
+            common::save_page_lazy_info(prog_id_hash, *p);
+        });
+
+        gear_ri::gear_ri::mprotect_wasm_pages(
+            wasm_mem_begin_addr as u64,
+            &lazy_pages,
+            false,
+            false,
+            false,
+        );
+    }
+
+    /// Lazy pages contract post execution actions
+    pub fn post_execution_actions(
+        memory_pages: &mut BTreeMap<PageNumber, Option<Box<PageBuf>>>,
+        wasm_mem_begin_addr: usize,
+    ) {
+        // Loads data for released lazy pages. Data which was before execution.
+        let released_pages = gear_ri::gear_ri::get_released_pages();
+        released_pages.into_iter().for_each(|page| {
+            let data = gear_ri::gear_ri::get_released_page_old_data(page);
+            memory_pages.insert(
+                (page).into(),
+                Option::from(Box::new(
+                    PageBuf::try_from(data).expect("Must be able to convert"),
+                )),
+            );
+        });
+
+        // Removes protections from lazy pages
+        let lazy_pages = gear_ri::gear_ri::get_wasm_lazy_pages_numbers();
+        gear_ri::gear_ri::mprotect_wasm_pages(
+            wasm_mem_begin_addr as u64,
+            &lazy_pages,
+            true,
+            true,
+            false,
+        );
+    }
+
+    /// Remove lazy-pages protection, returns wasm memory begin addr
+    pub fn remove_lazy_pages_prot(mem_addr: usize) {
+        let lazy_pages = gear_ri::gear_ri::get_wasm_lazy_pages_numbers();
+        gear_ri::gear_ri::mprotect_wasm_pages(mem_addr as u64, &lazy_pages, true, true, false);
+    }
+
+    /// Protect lazy-pages and set new wasm mem addr if it has been changed
+    pub fn protect_lazy_pages_and_update_wasm_mem_addr(old_mem_addr: usize, new_mem_addr: usize) {
+        if new_mem_addr != old_mem_addr {
+            log::debug!(
+                "backend executor has changed wasm mem buff: from {:#x} to {:#x}",
+                old_mem_addr,
+                new_mem_addr
+            );
+            gear_ri::gear_ri::set_wasm_mem_begin_addr(new_mem_addr as u64);
+        }
+        let lazy_pages = gear_ri::gear_ri::get_wasm_lazy_pages_numbers();
+        gear_ri::gear_ri::mprotect_wasm_pages(
+            new_mem_addr as u64,
+            &lazy_pages,
+            false,
+            false,
+            false,
+        );
+    }
+
+    /// Returns list of current lazy pages numbers
+    pub fn get_lazy_pages_numbers() -> Vec<u32> {
+        gear_ri::gear_ri::get_wasm_lazy_pages_numbers()
+    }
 }

--- a/gtest/Cargo.toml
+++ b/gtest/Cargo.toml
@@ -11,7 +11,7 @@ gear-backend-wasmtime = { path = "../core-backend/wasmtime" }
 core-processor = { package = "gear-core-processor", path = "../core-processor" }
 
 codec = { package = "parity-scale-codec", version = "2", features = ["derive"] }
-logger = { package = "log", version = "0.4.14", default-features = false }
+logger = { package = "log", version = "0.4.14" }
 hex = "0.4.3"
 colored = "2.0.0"
 env_logger = "0.9.0"

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -1401,8 +1401,6 @@ fn defer_program_initialization() {
 fn wake_messages_after_program_inited() {
     use tests_init_wait::WASM_BINARY;
 
-    println!("size {}", WASM_BINARY.to_vec().len());
-
     init_logger();
     new_test_ext().execute_with(|| {
         System::reset_events();

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -22,7 +22,7 @@ use frame_support::{assert_noop, assert_ok};
 use frame_system::Pallet as SystemPallet;
 use gear_runtime_interface as gear_ri;
 use pallet_balances::{self, Pallet as BalancesPallet};
-use tests_distributor::{Request, WASM_BINARY_BLOATY};
+use tests_distributor::{Request, WASM_BINARY};
 
 use super::{
     manager::HandleKind,
@@ -1033,7 +1033,7 @@ fn distributor_initialize() {
 
         assert_ok!(GearPallet::<Test>::submit_program(
             Origin::signed(USER_1).into(),
-            WASM_BINARY_BLOATY.expect("Wasm binary missing!").to_vec(),
+            WASM_BINARY.to_vec(),
             DEFAULT_SALT.to_vec(),
             EMPTY_PAYLOAD.to_vec(),
             10_000_000,
@@ -1062,14 +1062,11 @@ fn distributor_distribute() {
         // Initial value in all gas trees is 0
         assert_eq!(<Test as Config>::GasHandler::total_supply(), 0);
 
-        let program_id = generate_program_id(
-            WASM_BINARY_BLOATY.expect("Wasm binary missing!"),
-            DEFAULT_SALT,
-        );
+        let program_id = generate_program_id(WASM_BINARY, DEFAULT_SALT);
 
         assert_ok!(GearPallet::<Test>::submit_program(
             Origin::signed(USER_1).into(),
-            WASM_BINARY_BLOATY.expect("Wasm binary missing!").to_vec(),
+            WASM_BINARY.to_vec(),
             DEFAULT_SALT.to_vec(),
             EMPTY_PAYLOAD.to_vec(),
             10_000_000,
@@ -1213,7 +1210,7 @@ fn test_code_is_not_resetted_within_program_submission() {
 
 #[test]
 fn messages_to_uninitialized_program_wait() {
-    use tests_init_wait::WASM_BINARY_BLOATY;
+    use tests_init_wait::WASM_BINARY;
 
     init_logger();
     new_test_ext().execute_with(|| {
@@ -1221,7 +1218,7 @@ fn messages_to_uninitialized_program_wait() {
 
         assert_ok!(GearPallet::<Test>::submit_program(
             Origin::signed(1).into(),
-            WASM_BINARY_BLOATY.expect("Wasm binary missing!").to_vec(),
+            WASM_BINARY.to_vec(),
             vec![],
             Vec::new(),
             50_000_000u64,
@@ -1265,7 +1262,7 @@ fn messages_to_uninitialized_program_wait() {
 
 #[test]
 fn uninitialized_program_should_accept_replies() {
-    use tests_init_wait::WASM_BINARY_BLOATY;
+    use tests_init_wait::WASM_BINARY;
 
     init_logger();
     new_test_ext().execute_with(|| {
@@ -1273,7 +1270,7 @@ fn uninitialized_program_should_accept_replies() {
 
         assert_ok!(GearPallet::<Test>::submit_program(
             Origin::signed(USER_1).into(),
-            WASM_BINARY_BLOATY.expect("Wasm binary missing!").to_vec(),
+            WASM_BINARY.to_vec(),
             vec![],
             Vec::new(),
             99_000_000u64,
@@ -1327,7 +1324,7 @@ fn uninitialized_program_should_accept_replies() {
 
 #[test]
 fn defer_program_initialization() {
-    use tests_init_wait::WASM_BINARY_BLOATY;
+    use tests_init_wait::WASM_BINARY;
 
     init_logger();
     new_test_ext().execute_with(|| {
@@ -1335,7 +1332,7 @@ fn defer_program_initialization() {
 
         assert_ok!(GearPallet::<Test>::submit_program(
             Origin::signed(USER_1).into(),
-            WASM_BINARY_BLOATY.expect("Wasm binary missing!").to_vec(),
+            WASM_BINARY.to_vec(),
             vec![],
             Vec::new(),
             99_000_000u64,
@@ -1402,7 +1399,9 @@ fn defer_program_initialization() {
 
 #[test]
 fn wake_messages_after_program_inited() {
-    use tests_init_wait::WASM_BINARY_BLOATY;
+    use tests_init_wait::WASM_BINARY;
+
+    println!("size {}", WASM_BINARY.to_vec().len());
 
     init_logger();
     new_test_ext().execute_with(|| {
@@ -1410,7 +1409,7 @@ fn wake_messages_after_program_inited() {
 
         assert_ok!(GearPallet::<Test>::submit_program(
             Origin::signed(USER_1).into(),
-            WASM_BINARY_BLOATY.expect("Wasm binary missing!").to_vec(),
+            WASM_BINARY.to_vec(),
             vec![],
             Vec::new(),
             99_000_000u64,
@@ -1510,13 +1509,13 @@ fn test_message_processing_for_non_existing_destination() {
 
 #[test]
 fn exit_init() {
-    use tests_exit_init::WASM_BINARY_BLOATY;
+    use tests_exit_init::WASM_BINARY;
 
     init_logger();
     new_test_ext().execute_with(|| {
         System::reset_events();
 
-        let code = WASM_BINARY_BLOATY.expect("Wasm binary missing!").to_vec();
+        let code = WASM_BINARY.to_vec();
         assert_ok!(GearPallet::<Test>::submit_program(
             Origin::signed(USER_1).into(),
             code.clone(),
@@ -1553,13 +1552,13 @@ fn exit_init() {
 
 #[test]
 fn exit_handle() {
-    use tests_exit_handle::WASM_BINARY_BLOATY;
+    use tests_exit_handle::WASM_BINARY;
 
     init_logger();
     new_test_ext().execute_with(|| {
         System::reset_events();
 
-        let code = WASM_BINARY_BLOATY.expect("Wasm binary missing!").to_vec();
+        let code = WASM_BINARY.to_vec();
         assert_ok!(GearPallet::<Test>::submit_program(
             Origin::signed(USER_1).into(),
             code.clone(),

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -79,6 +79,7 @@ std = [
 	"pallet-authorship/std",
 	"pallet-balances/std",
 	"pallet-gear/std",
+	"pallet-gear-debug/std",
 	"pallet-usage/std",
 	"pallet-gas/std",
 	"pallet-gear-rpc-runtime-api/std",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 220,
+    spec_version: 230,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/scripts/check-spec.sh
+++ b/scripts/check-spec.sh
@@ -4,10 +4,16 @@ set -e
 
 PACKAGES_REQUIRE_BUMP_SPEC="common core core-backend node pallets runtime-interface lazy-pages"
 
-CURRENT_BRANCH="$(git branch --show-current)"
+SPEC_ON_MASTER="$(git diff origin/master | sed -n -r "s/^\-[[:space:]]+spec_version: +([0-9]+),$/\1/p")"
+ACTUAL_SPEC="$(git diff origin/master | sed -n -r "s/^\+[[:space:]]+spec_version: +([0-9]+),$/\1/p")"
 
-SPEC_ON_MASTER="$(git diff $CURRENT_BRANCH origin/master | sed -n -r "s/^\-[[:space:]]+spec_version: +([0-9]+),$/\1/p")"
-ACTUAL_SPEC="$(git diff $CURRENT_BRANCH origin/master | sed -n -r "s/^\+[[:space:]]+spec_version: +([0-9]+),$/\1/p")"
+if [ -z "$SPEC_ON_MASTER" ]; then
+    SPEC_ON_MASTER="0"
+fi
+
+if [ -z "$ACTUAL_SPEC" ]; then
+    ACTUAL_SPEC="0"
+fi
 
 for package in $(git diff --name-only $CURRENT_BRANCH origin/master | grep -v "README.md$" | cut -d "/" -f1 | uniq); do
     if [[ " ${PACKAGES_REQUIRE_BUMP_SPEC[@]} " =~ " ${package} " ]]; then
@@ -28,5 +34,5 @@ if [ "$UPDATED_SPEC" != "true" ]; then
     fi
 fi
 
-printf "\n   Spec version is correct:\n\n"
+printf "\n   Spec version is correct!\n\n"
 exit 0

--- a/tests/btree/Cargo.toml
+++ b/tests/btree/Cargo.toml
@@ -10,7 +10,7 @@ gstd = { path = "../../gstd", features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
 
 [build-dependencies]
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+gear-wasm-builder = { path = "../../utils/wasm-builder" }
 
 [dev-dependencies]
 common = { package = "tests-common", path = "../common" }

--- a/tests/btree/build.rs
+++ b/tests/btree/build.rs
@@ -16,12 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use substrate_wasm_builder::WasmBuilder;
-
 fn main() {
-    // regular build
-    WasmBuilder::new()
-        .with_current_project()
-        .import_memory()
-        .build();
+    gear_wasm_builder::build();
 }

--- a/tests/btree/src/lib.rs
+++ b/tests/btree/src/lib.rs
@@ -24,8 +24,7 @@ use codec::{Decode, Encode};
 use gstd::prelude::*;
 
 #[cfg(feature = "std")]
-#[cfg(test)]
-mod native {
+mod code {
     include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 }
 
@@ -97,19 +96,11 @@ mod wasm {
 #[cfg(test)]
 #[cfg(feature = "std")]
 mod tests {
-    use super::native;
     use super::{Reply, Request};
-
     use common::{InitProgram, RunnerContext};
 
-    #[test]
-    fn binary_available() {
-        assert!(native::WASM_BINARY.is_some());
-        assert!(native::WASM_BINARY_BLOATY.is_some());
-    }
-
     fn wasm_code() -> &'static [u8] {
-        native::WASM_BINARY_BLOATY.expect("wasm binary exists")
+        super::code::WASM_BINARY_OPT
     }
 
     #[test]

--- a/tests/distributor/Cargo.toml
+++ b/tests/distributor/Cargo.toml
@@ -10,7 +10,7 @@ gstd = { path = "../../gstd", features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
 
 [build-dependencies]
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+gear-wasm-builder = { path = "../../utils/wasm-builder" }
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/tests/distributor/build.rs
+++ b/tests/distributor/build.rs
@@ -16,12 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use substrate_wasm_builder::WasmBuilder;
-
 fn main() {
-    // regular build
-    WasmBuilder::new()
-        .with_current_project()
-        .import_memory()
-        .build();
+    gear_wasm_builder::build();
 }

--- a/tests/distributor/src/lib.rs
+++ b/tests/distributor/src/lib.rs
@@ -21,12 +21,12 @@
 use codec::{Decode, Encode};
 
 #[cfg(feature = "std")]
-mod native {
+mod code {
     include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 }
 
 #[cfg(feature = "std")]
-pub use native::{WASM_BINARY, WASM_BINARY_BLOATY};
+pub use code::WASM_BINARY_OPT as WASM_BINARY;
 
 #[derive(Encode, Debug, Decode, PartialEq)]
 pub enum Request {
@@ -228,18 +228,11 @@ mod wasm {
 #[cfg(test)]
 #[cfg(feature = "std")]
 mod tests {
-    use super::{native, Reply, Request};
-
+    use super::{Reply, Request};
     use common::*;
 
-    #[test]
-    fn binary_available() {
-        assert!(native::WASM_BINARY.is_some());
-        assert!(native::WASM_BINARY_BLOATY.is_some());
-    }
-
     fn wasm_code() -> &'static [u8] {
-        native::WASM_BINARY_BLOATY.expect("wasm binary exists")
+        super::code::WASM_BINARY_OPT
     }
 
     #[test]

--- a/tests/exit-handle/Cargo.toml
+++ b/tests/exit-handle/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 gstd = { path = "../../gstd", features = ["debug"] }
 
 [build-dependencies]
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+gear-wasm-builder = { path = "../../utils/wasm-builder" }
 
 [lib]
 

--- a/tests/exit-handle/build.rs
+++ b/tests/exit-handle/build.rs
@@ -1,8 +1,21 @@
-use substrate_wasm_builder::WasmBuilder;
+// This file is part of Gear.
+
+// Copyright (C) 2021 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 fn main() {
-    WasmBuilder::new()
-        .with_current_project()
-        .import_memory()
-        .build();
+    gear_wasm_builder::build();
 }

--- a/tests/exit-handle/src/lib.rs
+++ b/tests/exit-handle/src/lib.rs
@@ -2,12 +2,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]
-mod native {
+mod code {
     include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 }
 
 #[cfg(feature = "std")]
-pub use native::{WASM_BINARY, WASM_BINARY_BLOATY};
+pub use code::WASM_BINARY_OPT as WASM_BINARY;
 
 #[cfg(not(feature = "std"))]
 mod wasm {

--- a/tests/exit-init/Cargo.toml
+++ b/tests/exit-init/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 gstd = { path = "../../gstd", features = ["debug"] }
 
 [build-dependencies]
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+gear-wasm-builder = { path = "../../utils/wasm-builder" }
 
 [lib]
 

--- a/tests/exit-init/build.rs
+++ b/tests/exit-init/build.rs
@@ -1,8 +1,21 @@
-use substrate_wasm_builder::WasmBuilder;
+// This file is part of Gear.
+
+// Copyright (C) 2021 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 fn main() {
-    WasmBuilder::new()
-        .with_current_project()
-        .import_memory()
-        .build();
+    gear_wasm_builder::build();
 }

--- a/tests/exit-init/src/lib.rs
+++ b/tests/exit-init/src/lib.rs
@@ -2,12 +2,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]
-mod native {
+mod code {
     include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 }
 
 #[cfg(feature = "std")]
-pub use native::{WASM_BINARY, WASM_BINARY_BLOATY};
+pub use code::WASM_BINARY_OPT as WASM_BINARY;
 
 #[cfg(not(feature = "std"))]
 mod wasm {

--- a/tests/init-wait/Cargo.toml
+++ b/tests/init-wait/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 gstd = { path = "../../gstd", features = ["debug"] }
 
 [build-dependencies]
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+gear-wasm-builder = { path = "../../utils/wasm-builder" }
 
 [lib]
 

--- a/tests/init-wait/build.rs
+++ b/tests/init-wait/build.rs
@@ -1,8 +1,21 @@
-use substrate_wasm_builder::WasmBuilder;
+// This file is part of Gear.
+
+// Copyright (C) 2021 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 fn main() {
-    WasmBuilder::new()
-        .with_current_project()
-        .import_memory()
-        .build();
+    gear_wasm_builder::build();
 }

--- a/tests/init-wait/src/lib.rs
+++ b/tests/init-wait/src/lib.rs
@@ -3,12 +3,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]
-mod native {
+mod code {
     include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 }
 
 #[cfg(feature = "std")]
-pub use native::{WASM_BINARY, WASM_BINARY_BLOATY};
+pub use code::WASM_BINARY_OPT as WASM_BINARY;
 
 #[cfg(not(feature = "std"))]
 mod wasm {

--- a/tests/messages/Cargo.toml
+++ b/tests/messages/Cargo.toml
@@ -10,7 +10,7 @@ gstd = { path = "../../gstd", features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
 
 [build-dependencies]
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+gear-wasm-builder = { path = "../../utils/wasm-builder" }
 
 [dev-dependencies]
 common = { package = "tests-common", path = "../common" }

--- a/tests/messages/build.rs
+++ b/tests/messages/build.rs
@@ -1,9 +1,21 @@
-use substrate_wasm_builder::WasmBuilder;
+// This file is part of Gear.
+
+// Copyright (C) 2021 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 fn main() {
-    // regular build
-    WasmBuilder::new()
-        .with_current_project()
-        .import_memory()
-        .build();
+    gear_wasm_builder::build();
 }

--- a/tests/messages/src/lib.rs
+++ b/tests/messages/src/lib.rs
@@ -4,8 +4,7 @@
 use codec::{Decode, Encode};
 
 #[cfg(feature = "std")]
-#[cfg(test)]
-mod native {
+mod code {
     include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 }
 
@@ -103,18 +102,11 @@ mod wasm {
 #[cfg(test)]
 #[cfg(feature = "std")]
 mod tests {
-    use super::{native, Request};
-
+    use super::Request;
     use common::{RunResult, RunnerContext};
 
-    #[test]
-    fn binary_available() {
-        assert!(native::WASM_BINARY.is_some());
-        assert!(native::WASM_BINARY_BLOATY.is_some());
-    }
-
     fn wasm_code() -> &'static [u8] {
-        native::WASM_BINARY_BLOATY.expect("wasm binary exists")
+        super::code::WASM_BINARY_OPT
     }
 
     #[test]

--- a/tests/node/Cargo.toml
+++ b/tests/node/Cargo.toml
@@ -10,7 +10,7 @@ gstd = { path = "../../gstd", features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
 
 [build-dependencies]
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+gear-wasm-builder = { path = "../../utils/wasm-builder" }
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/tests/node/build.rs
+++ b/tests/node/build.rs
@@ -16,12 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use substrate_wasm_builder::WasmBuilder;
-
 fn main() {
-    // regular build
-    WasmBuilder::new()
-        .with_current_project()
-        .import_memory()
-        .build();
+    gear_wasm_builder::build();
 }

--- a/tests/node/src/lib.rs
+++ b/tests/node/src/lib.rs
@@ -22,8 +22,7 @@
 use codec::{Decode, Encode};
 
 #[cfg(feature = "std")]
-#[cfg(test)]
-mod native {
+mod code {
     include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 }
 
@@ -58,10 +57,9 @@ pub enum Reply {
 mod wasm {
     extern crate alloc;
 
+    use super::{Initialization, Operation, Reply, Request};
     use alloc::collections::BTreeSet;
     use gstd::{debug, exec, msg, prelude::*, ActorId, MessageId};
-
-    use super::{Initialization, Operation, Reply, Request};
 
     #[derive(Clone)]
     enum TransitionState {
@@ -296,17 +294,11 @@ mod wasm {
 #[cfg(test)]
 #[cfg(feature = "std")]
 mod tests {
-    use super::{native, Initialization, Operation, Reply, Request};
+    use super::{Initialization, Operation, Reply, Request};
     use common::*;
 
-    #[test]
-    fn binary_available() {
-        assert!(native::WASM_BINARY.is_some());
-        assert!(native::WASM_BINARY_BLOATY.is_some());
-    }
-
     fn wasm_code() -> &'static [u8] {
-        native::WASM_BINARY_BLOATY.expect("wasm binary exists")
+        super::code::WASM_BINARY_OPT
     }
 
     #[test]

--- a/tests/wait_wake/Cargo.toml
+++ b/tests/wait_wake/Cargo.toml
@@ -10,7 +10,7 @@ gstd = { path = "../../gstd", features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
 
 [build-dependencies]
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+gear-wasm-builder = { path = "../../utils/wasm-builder" }
 
 [dev-dependencies]
 gear-core = { path = "../../core" }

--- a/tests/wait_wake/build.rs
+++ b/tests/wait_wake/build.rs
@@ -1,9 +1,21 @@
-use substrate_wasm_builder::WasmBuilder;
+// This file is part of Gear.
+
+// Copyright (C) 2021 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 fn main() {
-    // regular build
-    WasmBuilder::new()
-        .with_current_project()
-        .import_memory()
-        .build();
+    gear_wasm_builder::build();
 }

--- a/tests/wait_wake/src/lib.rs
+++ b/tests/wait_wake/src/lib.rs
@@ -5,8 +5,7 @@
 use codec::{Decode, Encode};
 
 #[cfg(feature = "std")]
-#[cfg(test)]
-mod native {
+mod code {
     include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 }
 
@@ -20,10 +19,9 @@ pub enum Request {
 mod wasm {
     extern crate alloc;
 
+    use super::Request;
     use codec::{Decode, Encode};
     use gstd::{exec, msg, prelude::*, ActorId, MessageId};
-
-    use super::Request;
 
     static mut ECHOES: BTreeMap<MessageId, u32> = BTreeMap::new();
 
@@ -58,19 +56,13 @@ mod wasm {
 #[cfg(test)]
 #[cfg(feature = "std")]
 mod tests {
-    use super::{native, Request};
+    use super::Request;
     use common::*;
     use gear_core::message::MessageId;
     use std::convert::TryInto;
 
-    #[test]
-    fn binary_available() {
-        assert!(native::WASM_BINARY.is_some());
-        assert!(native::WASM_BINARY_BLOATY.is_some());
-    }
-
     fn wasm_code() -> &'static [u8] {
-        native::WASM_BINARY_BLOATY.expect("wasm binary exists")
+        super::code::WASM_BINARY_OPT
     }
 
     #[test]

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -167,6 +167,10 @@ impl WasmProject {
         let to_meta_path = to_dir.join(format!("{}.meta.wasm", &file_base_name));
         Self::generate_meta(&from_path, &to_meta_path)?;
 
+        let wasm_binary_path = self.out_dir.join("wasm_binary_path.txt");
+        fs::write(&wasm_binary_path, format!("{}", to_opt_path.display()))
+            .context("unable to write `wasm_binary_path.txt`")?;
+
         let wasm_binary_rs = self.out_dir.join("wasm_binary.rs");
         fs::write(
             &wasm_binary_rs,
@@ -177,14 +181,13 @@ pub const WASM_BINARY: &[u8] = include_bytes!("{}");
 pub const WASM_BINARY_OPT: &[u8] = include_bytes!("{}");
 #[allow(unused)]
 pub const WASM_BINARY_META: &[u8] = include_bytes!("{}");
-
 "#,
                 to_path.display(),
                 to_opt_path.display(),
                 to_meta_path.display(),
             ),
         )
-        .context("unable to write `wasm_bimary.rs`")?;
+        .context("unable to write `wasm_binary.rs`")?;
 
         Ok(())
     }

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -171,11 +171,14 @@ impl WasmProject {
         fs::write(
             &wasm_binary_rs,
             format!(
-                r#"
-                    pub const WASM_BINARY: &[u8] = include_bytes!("{}");
-                    pub const WASM_BINARY_OPT: &[u8] = include_bytes!("{}");
-                    pub const WASM_BINARY_META: &[u8] = include_bytes!("{}");
-                "#,
+                r#"#[allow(unused)]
+pub const WASM_BINARY: &[u8] = include_bytes!("{}");
+#[allow(unused)]
+pub const WASM_BINARY_OPT: &[u8] = include_bytes!("{}");
+#[allow(unused)]
+pub const WASM_BINARY_META: &[u8] = include_bytes!("{}");
+
+"#,
                 to_path.display(),
                 to_opt_path.display(),
                 to_meta_path.display(),

--- a/utils/wasm-builder/test-program/Cargo.lock
+++ b/utils/wasm-builder/test-program/Cargo.lock
@@ -3,16 +3,138 @@
 version = 3
 
 [[package]]
-name = "anyhow"
-version = "1.0.53"
+name = "addr2line"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
+checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
+dependencies = [
+ "gimli 0.24.0",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli 0.26.1",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a99269dff3bc004caa411f38845c20303f1e393ca2bd6581576fa3a7f59577d"
+
+[[package]]
+name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
 
 [[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+dependencies = [
+ "addr2line 0.17.0",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.27.1",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitvec"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "blake2-rfc"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
+dependencies = [
+ "arrayvec 0.4.12",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "bs58"
@@ -64,10 +186,195 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ca3560686e7c9c7ed7e0fe77469f2410ba5d7781b1acaa9adc8d8deea28e3e"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf9bf1ffffb6ce3d2e5ebc83549bd2436426c99b31cc550d521364cbe35d276"
+dependencies = [
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+ "gimli 0.24.0",
+ "log",
+ "regalloc",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc21936a5a6d07e23849ffe83e5c1f6f50305c074f4b2970ca50c13bf55b821"
+dependencies = [
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca5b6ffaa87560bebe69a5446449da18090b126037920b0c1c6d5945f72faf6b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6b4a8bef04f82e4296782646f733c641d09497df2fabf791323fefaa44c64c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b783b351f966fce33e3c03498cb116d16d97a8f9978164a60920bd0d3a99c"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77c88d3dd48021ff1e37e978a00098524abd3513444ae252c08d37b310b3d2a"
+dependencies = [
+ "cranelift-codegen",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-wasm"
+version = "0.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb6d408e2da77cdbbd65466298d44c86ae71c1785d2ab0d8657753cdb4d9d89"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "itertools",
+ "log",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "wasmparser",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
 
 [[package]]
 name = "crunchy"
@@ -81,8 +388,10 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn",
 ]
 
@@ -98,6 +407,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "fixed-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +439,12 @@ checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
  "static_assertions",
 ]
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -170,7 +510,6 @@ dependencies = [
 [[package]]
 name = "galloc"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#9cc70eb1b6f24a3480dde48ddedd6127ce136fce"
 dependencies = [
  "dlmalloc",
 ]
@@ -178,7 +517,48 @@ dependencies = [
 [[package]]
 name = "gcore"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#9cc70eb1b6f24a3480dde48ddedd6127ce136fce"
+
+[[package]]
+name = "gear-backend-common"
+version = "0.1.0"
+dependencies = [
+ "gear-core",
+ "log",
+]
+
+[[package]]
+name = "gear-backend-wasmtime"
+version = "0.1.0"
+dependencies = [
+ "gear-backend-common",
+ "gear-core",
+ "wasmtime",
+]
+
+[[package]]
+name = "gear-core"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "hashbrown 0.12.0",
+ "log",
+ "parity-scale-codec",
+ "parity-wasm",
+ "pwasm-utils",
+ "scale-info",
+]
+
+[[package]]
+name = "gear-core-processor"
+version = "0.1.0"
+dependencies = [
+ "blake2-rfc",
+ "gear-backend-common",
+ "gear-core",
+ "log",
+ "parity-scale-codec",
+]
 
 [[package]]
 name = "gear-wasm-builder"
@@ -192,9 +572,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "gimli"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+
+[[package]]
 name = "gstd"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#9cc70eb1b6f24a3480dde48ddedd6127ce136fce"
 dependencies = [
  "bs58",
  "futures",
@@ -210,10 +617,48 @@ dependencies = [
 [[package]]
 name = "gstd-codegen"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#9cc70eb1b6f24a3480dde48ddedd6127ce136fce"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "gtest"
+version = "0.1.0"
+dependencies = [
+ "colored",
+ "env_logger",
+ "gear-backend-wasmtime",
+ "gear-core",
+ "gear-core-processor",
+ "hex",
+ "log",
+ "parity-scale-codec",
+ "path-clean",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -221,6 +666,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "impl-codec"
@@ -243,10 +694,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.11.2",
+ "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -272,15 +749,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg",
+]
+
+[[package]]
+name = "more-asserts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
+dependencies = [
+ "crc32fast",
+ "indexmap",
+]
+
+[[package]]
+name = "object"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+
+[[package]]
 name = "parity-scale-codec"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.2",
+ "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
+ "serde",
 ]
 
 [[package]]
@@ -302,6 +862,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
 
 [[package]]
+name = "paste"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+
+[[package]]
+name = "path-clean"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +884,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "primitive-types"
@@ -345,6 +923,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eca0fa5dd7c4c96e184cec588f0b1db1ee3165e678db21c09793105acb17e6f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "pwasm-utils"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +949,129 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
+name = "regalloc"
+version = "0.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
+dependencies = [
+ "log",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "region"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
+dependencies = [
+ "bitflags",
+ "libc",
+ "mach",
+ "winapi",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -393,6 +1103,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
@@ -435,6 +1151,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,11 +1186,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
+
+[[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "test-program"
 version = "0.1.0"
 dependencies = [
  "gear-wasm-builder",
  "gstd",
+ "gtest",
 ]
 
 [[package]]
@@ -511,3 +1261,225 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasmparser"
+version = "0.78.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
+
+[[package]]
+name = "wasmtime"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b310b9d20fcf59385761d1ade7a3ef06aecc380e3d3172035b919eaf7465d9f7"
+dependencies = [
+ "anyhow",
+ "backtrace",
+ "bincode",
+ "cfg-if",
+ "cpp_demangle",
+ "indexmap",
+ "lazy_static",
+ "libc",
+ "log",
+ "paste",
+ "psm",
+ "region",
+ "rustc-demangle",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-jit",
+ "wasmtime-profiling",
+ "wasmtime-runtime",
+ "winapi",
+]
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c525b39f062eada7db3c1298287b96dcb6e472b9f6b22501300b28d9fa7582f6"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-wasm",
+ "target-lexicon",
+ "wasmparser",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-debug"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d2a763e7a6fc734218e0e463196762a4f409c483063d81e0e85f96343b2e0a"
+dependencies = [
+ "anyhow",
+ "gimli 0.24.0",
+ "more-asserts",
+ "object 0.24.0",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64d0c2d881c31b0d65c1f2695e022d71eb60b9fbdd336aacca28208b58eac90"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-wasm",
+ "gimli 0.24.0",
+ "indexmap",
+ "log",
+ "more-asserts",
+ "serde",
+ "thiserror",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmtime-jit"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4539ea734422b7c868107e2187d7746d8affbcaa71916d72639f53757ad707"
+dependencies = [
+ "addr2line 0.15.2",
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "cranelift-wasm",
+ "gimli 0.24.0",
+ "log",
+ "more-asserts",
+ "object 0.24.0",
+ "rayon",
+ "region",
+ "serde",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser",
+ "wasmtime-cranelift",
+ "wasmtime-debug",
+ "wasmtime-environ",
+ "wasmtime-obj",
+ "wasmtime-profiling",
+ "wasmtime-runtime",
+ "winapi",
+]
+
+[[package]]
+name = "wasmtime-obj"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1a8ff85246d091828e2225af521a6208ed28c997bb5c39eb697366dc2e2f2b"
+dependencies = [
+ "anyhow",
+ "more-asserts",
+ "object 0.24.0",
+ "target-lexicon",
+ "wasmtime-debug",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-profiling"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24364d522dcd67c897c8fffc42e5bdfc57207bbb6d7eeade0da9d4a7d70105b"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "lazy_static",
+ "libc",
+ "serde",
+ "target-lexicon",
+ "wasmtime-environ",
+ "wasmtime-runtime",
+]
+
+[[package]]
+name = "wasmtime-runtime"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51e57976e8a19a18a18e002c6eb12e5769554204238e47ff155fda1809ef0f7"
+dependencies = [
+ "anyhow",
+ "backtrace",
+ "cc",
+ "cfg-if",
+ "indexmap",
+ "lazy_static",
+ "libc",
+ "log",
+ "mach",
+ "memoffset",
+ "more-asserts",
+ "rand",
+ "region",
+ "thiserror",
+ "wasmtime-environ",
+ "winapi",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"

--- a/utils/wasm-builder/test-program/Cargo.toml
+++ b/utils/wasm-builder/test-program/Cargo.toml
@@ -10,7 +10,7 @@ gstd = { path = "../../../gstd", features = ["debug"] }
 gtest = { path = "../../../gtest" }
 
 [build-dependencies]
-gear-wasm-builder = { path = "../" }
+gear-wasm-builder = { path = ".." }
 
 # To exclude this project from the outer workspace
 [workspace]

--- a/utils/wasm-builder/test-program/Cargo.toml
+++ b/utils/wasm-builder/test-program/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-gstd = { git = "https://github.com/gear-tech/gear.git", features = ["debug"] }
+gstd = { path = "../../../gstd", features = ["debug"] }
+
+[dev-dependencies]
+gtest = { path = "../../../gtest" }
 
 [build-dependencies]
 gear-wasm-builder = { path = "../" }

--- a/utils/wasm-builder/test-program/build.rs
+++ b/utils/wasm-builder/test-program/build.rs
@@ -1,3 +1,21 @@
+// This file is part of Gear.
+
+// Copyright (C) 2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 fn main() {
     gear_wasm_builder::build();
 }

--- a/utils/wasm-builder/test-program/src/lib.rs
+++ b/utils/wasm-builder/test-program/src/lib.rs
@@ -5,12 +5,33 @@ use gstd::{debug, msg};
 #[no_mangle]
 pub unsafe extern "C" fn handle() {
     debug!("handle()");
-    msg::reply(b"Hello world!", 0, 0);
+    msg::reply_bytes("Hello world!", 0, 0);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn init() {
     debug!("init()");
+}
+
+#[cfg(test)]
+mod gtest_tests {
+   extern crate std;
+
+   use gtest::{Program, System, Log};
+
+   #[test]
+   fn init_self() {
+       let system = System::new();
+       system.init_logger();
+
+       let this_program = Program::current(&system);
+
+       let res = this_program.send_bytes(123, "INIT");
+       assert!(res.log().is_empty());
+
+       let res = this_program.send_bytes(123, "Hi");
+       assert!(res.contains(&Log::builder().source(1).dest(123).payload_bytes("Hello world!")));
+   }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes:
- Unused deps removed from some core crates
- `gear-core-processor` now compiles for native again. These changes are hot fix, lazy-pages layer should be reworked!
- Standalone tests migrated on our custom builder
- New miss case fixed in check_spec script
- New program initialization syntax for `gtest`, using our `build.rs`:
```rust
use gtest::{Program, System, Log};

   #[test]
   fn init_self() {
       let system = System::new();

       let this_contract = Program::current(&system); // or current_with_id(.., &system)

       let res = this_contract(100001, "Hello!");
       assert!(res.contains(&Log::builder().source(1).dest(100001).payload_bytes("World!")));
   }
```

@gear-tech/dev 