### PR TITLE
Align gas_limit in a message with the value locked in gas handler

### DIFF
--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -433,7 +433,17 @@ pub mod pallet {
             if T::DebugInfo::is_remap_id_enabled() {
                 T::DebugInfo::remap_id();
             }
-            while let Some(dispatch) = common::dequeue_dispatch() {
+            while let Some(mut dispatch) = common::dequeue_dispatch() {
+                // Update message gas limit for it may have changed in the meantime
+                if let Some((actual_gas_locked, _)) = T::GasHandler::get(dispatch.message.id) {
+                    log::debug!(
+                        "Updating message {} gas limit: {} -> {}",
+                        dispatch.message.id,
+                        dispatch.message.gas_limit,
+                        actual_gas_locked
+                    );
+                    dispatch.message.gas_limit = actual_gas_locked;
+                }
                 // Check whether we have enough of gas allowed for message processing
                 if dispatch.message.gas_limit > GasAllowance::<T>::get() {
                     common::queue_dispatch(dispatch);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 230,
+    spec_version: 240,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Sometimes the value of `gas_limit` field of a `Message` can diverge from the value locked in the `GasHandler` (f.k.a. value tree or gas tree). This can happen, for instance, when a message sends out another message sharing with it some of its gas and after the other message has been processed and the gas tree node consumed, the leftover returns to the original message node. This is not reflected in the `gas_limit` field of the `Message` struct.

This PR fixes this situation and eliminates a basis for discrepancies.
