### PR TITLE
Add docs to `gstd` utility functions

### DIFF
--- a/examples/meta/src/lib.rs
+++ b/examples/meta/src/lib.rs
@@ -164,5 +164,5 @@ pub unsafe extern "C" fn meta_state() -> *mut [i32; 2] {
             .collect::<Vec<Wallet>>()
             .encode(),
     };
-    gstd::macros::util::to_leak_ptr(encoded)
+    gstd::util::to_leak_ptr(encoded)
 }

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -40,6 +40,7 @@ pub use common::errors;
 pub use common::handlers::*;
 pub use common::primitives::*;
 pub use gstd_codegen::{async_init, async_main};
+pub use macros::util;
 
 pub use prelude::*;
 

--- a/gstd/src/macros/mod.rs
+++ b/gstd/src/macros/mod.rs
@@ -23,6 +23,7 @@ mod debug;
 mod export;
 mod metadata;
 
+/// Utility functions.
 pub mod util {
     use crate::prelude::{Box, String, Vec};
     use codec::Encode;
@@ -30,6 +31,7 @@ pub mod util {
 
     pub use scale_info::MetaType;
 
+    /// Generate a registry from given meta types and encode it to hex.
     pub fn to_hex_registry(meta_types: Vec<MetaType>) -> String {
         let mut registry = Registry::new();
         registry.register_types(meta_types);
@@ -38,6 +40,7 @@ pub mod util {
         hex::encode(registry.encode())
     }
 
+    /// Convert a given reference to a raw pointer.
     pub fn to_wasm_ptr<T: AsRef<[u8]>>(bytes: T) -> *mut [i32; 2] {
         Box::into_raw(Box::new([
             bytes.as_ref().as_ptr() as _,
@@ -45,6 +48,10 @@ pub mod util {
         ]))
     }
 
+    /// Convert a given vector to a raw pointer and prevent its deallocating.
+    ///
+    /// It operates similar to [`to_wasm_ptr`] except that it consumes the input
+    /// and make it leak by calling [`core::mem::forget`].
     pub fn to_leak_ptr(bytes: impl Into<Vec<u8>>) -> *mut [i32; 2] {
         let bytes = bytes.into();
         let ptr = Box::into_raw(Box::new([bytes.as_ptr() as _, bytes.len() as _]));


### PR DESCRIPTION
By request from @AndrePanin.

- Add docs for utility functions in `gstd`.
- Make `utils` importable directly from `gstd` as more intuitive (e.g. `gstd::util::to_leak_ptr()` instead of `gstd::macros::util::to_leak_ptr()`).

@gear-tech/dev 
