### PR TITLE
use gear_common::set_program to store empty program

### DIFF
--- a/utils/gear-runtime-test-cli/src/command.rs
+++ b/utils/gear-runtime-test-cli/src/command.rs
@@ -16,6 +16,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(unused_must_use)]
+
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -182,7 +184,7 @@ fn run_fixture(test: &'_ sample::Test, fixture: &sample::Fixture) -> ColoredStri
             code_hash: H256::default(),
             state: gear_common::ProgramState::Initialized,
         };
-        gear_common::set_program(id.clone(), program, Default::default());
+        gear_common::set_program(*id, program, Default::default());
     }
 
     // Enable remapping of the source and destination of messages

--- a/utils/gear-runtime-test-cli/src/command.rs
+++ b/utils/gear-runtime-test-cli/src/command.rs
@@ -192,7 +192,7 @@ fn run_fixture(test: &'_ sample::Test, fixture: &sample::Fixture) -> ColoredStri
 
     match init_fixture(test, &mut snapshots, &mut mailbox) {
         Ok(()) => {
-            log::info!("programs: {:?}", &programs);
+            log::trace!("programs: {:?}", &programs);
             let mut errors = vec![];
             let mut expected_log = vec![];
 
@@ -255,15 +255,12 @@ fn run_fixture(test: &'_ sample::Test, fixture: &sample::Fixture) -> ColoredStri
                     };
                     gear_common::queue_dispatch(QueuedDispatch::new_handle(msg))
                 } else {
-                    log::info!(
-                        "{:?}",
-                        GearPallet::<Runtime>::send_message(
-                            Origin::from(Some(AccountId32::unchecked_from(1000001.into_origin()))),
-                            dest,
-                            payload,
-                            gas_limit,
-                            value,
-                        )
+                    GearPallet::<Runtime>::send_message(
+                        Origin::from(Some(AccountId32::unchecked_from(1000001.into_origin()))),
+                        dest,
+                        payload,
+                        gas_limit,
+                        value,
                     );
                 }
 
@@ -359,7 +356,7 @@ fn run_fixture(test: &'_ sample::Test, fixture: &sample::Fixture) -> ColoredStri
             }
 
             if !expected_log.is_empty() {
-                log::info!("mailbox: {:?}", &mailbox);
+                log::trace!("mailbox: {:?}", &mailbox);
 
                 let messages: Vec<CoreMessage> = mailbox
                     .iter_mut()
@@ -368,7 +365,7 @@ fn run_fixture(test: &'_ sample::Test, fixture: &sample::Fixture) -> ColoredStri
 
                 for message in &messages {
                     if let Ok(utf8) = core::str::from_utf8(message.payload()) {
-                        log::info!("log({})", utf8)
+                        log::trace!("log({})", utf8)
                     }
                 }
 


### PR DESCRIPTION

- use gear_common::set_program to store empty program
- log::debug -> log::trace

@gear-tech/dev 