### PR TITLE
Patch 1 for program from program creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,6 +2020,7 @@ name = "gear-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "blake2-rfc",
  "derive_more",
  "hashbrown 0.12.0",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1964,6 +1964,9 @@ dependencies = [
 [[package]]
 name = "gcore"
 version = "0.1.0"
+dependencies = [
+ "hex-literal",
+]
 
 [[package]]
 name = "gear-backend-common"

--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -255,7 +255,7 @@ pub fn send_push<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32, i32, i32) -> Result<(
     }
 }
 
-pub fn create_program<E: Ext>(
+pub fn create_program_wgas<E: Ext>(
     ext: LaterExt<E>,
 ) -> impl Fn(i32, i32, i32, i32, i32, i64, i32, i32) -> Result<(), &'static str> {
     move |code_hash_ptr: i32,

--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -187,7 +187,7 @@ pub fn send<E: Ext>(
           value_ptr: i32,
           message_id_ptr: i32| {
         let result = ext.with(|ext: &mut E| -> Result<(), &'static str> {
-            let dest: ProgramId = get_id(ext, program_id_ptr as usize).into();
+            let dest: ProgramId = get_bytes32(ext, program_id_ptr as usize).into();
             let payload = get_vec(ext, payload_ptr as usize, payload_len as usize);
             let value = get_u128(ext, value_ptr as usize);
             let message_id = ext.send(OutgoingPacket::new(dest, payload.into(), None, value))?;
@@ -229,7 +229,7 @@ pub fn send_commit<E: Ext>(
 ) -> impl Fn(i32, i32, i32, i32) -> Result<(), &'static str> {
     move |handle_ptr: i32, message_id_ptr: i32, program_id_ptr: i32, value_ptr: i32| {
         ext.with(|ext: &mut E| -> Result<(), &'static str> {
-            let dest: ProgramId = get_id(ext, program_id_ptr as usize).into();
+            let dest: ProgramId = get_bytes32(ext, program_id_ptr as usize).into();
             let value = get_u128(ext, value_ptr as usize);
             let message_id = ext.send_commit(
                 handle_ptr as _,

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -34,8 +34,8 @@ use gear_core::{
     env::Ext,
     gas::GasAmount,
     memory::{Memory, PageBuf, PageNumber},
-    message::{MessageId, OutgoingMessage, PayloadStore, ReplyMessage},
-    program::ProgramId,
+    message::{MessageId, OutgoingMessage, PayloadStore, ProgramInitMessage, ReplyMessage},
+    program::{CodeHash, ProgramId},
 };
 
 pub const EXIT_TRAP_STR: &str = "exit";
@@ -58,9 +58,11 @@ pub struct ExtInfo {
     pub pages: BTreeSet<PageNumber>,
     pub accessed_pages: BTreeMap<PageNumber, Vec<u8>>,
     pub outgoing: Vec<OutgoingMessage>,
+    pub init_messages: Vec<ProgramInitMessage>,
     pub reply: Option<ReplyMessage>,
     pub awakening: Vec<MessageId>,
     pub nonce: u64,
+    pub program_candidates_data: BTreeMap<CodeHash, Vec<(ProgramId, MessageId)>>,
     pub payload_store: Option<PayloadStore>,
 
     pub trap_explanation: Option<&'static str>,

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -142,6 +142,7 @@ where
         env_builder.add_host_func("env", "gr_wait", funcs::wait);
         env_builder.add_host_func("env", "gr_wake", funcs::wake);
         env_builder.add_host_func("env", "gas", funcs::gas);
+        env_builder.add_host_func("env", "gr_create_program", funcs::create_program);
 
         let mut runtime = Runtime::new(ext);
 

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -119,6 +119,7 @@ where
         env_builder.add_host_func("env", "free", funcs::free);
         env_builder.add_host_func("env", "gr_block_height", funcs::block_height);
         env_builder.add_host_func("env", "gr_block_timestamp", funcs::block_timestamp);
+        env_builder.add_host_func("env", "gr_create_program", funcs::create_program);
         env_builder.add_host_func("env", "gr_exit", funcs::exit);
         env_builder.add_host_func("env", "gr_exit_code", funcs::exit_code);
         env_builder.add_host_func("env", "gr_send", funcs::send);
@@ -142,7 +143,6 @@ where
         env_builder.add_host_func("env", "gr_wait", funcs::wait);
         env_builder.add_host_func("env", "gr_wake", funcs::wake);
         env_builder.add_host_func("env", "gas", funcs::gas);
-        env_builder.add_host_func("env", "gr_create_program", funcs::create_program);
 
         let mut runtime = Runtime::new(ext);
 

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -119,7 +119,7 @@ where
         env_builder.add_host_func("env", "free", funcs::free);
         env_builder.add_host_func("env", "gr_block_height", funcs::block_height);
         env_builder.add_host_func("env", "gr_block_timestamp", funcs::block_timestamp);
-        env_builder.add_host_func("env", "gr_create_program", funcs::create_program);
+        env_builder.add_host_func("env", "gr_create_program_wgas", funcs::create_program_wgas);
         env_builder.add_host_func("env", "gr_exit", funcs::exit);
         env_builder.add_host_func("env", "gr_exit_code", funcs::exit_code);
         env_builder.add_host_func("env", "gr_send", funcs::send);

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -74,7 +74,7 @@ pub fn send<E: Ext + Into<ExtInfo>>(ctx: &mut Runtime<E>, args: &[Value]) -> Sys
     let result = ctx
         .ext
         .with(|ext| {
-            let dest: ProgramId = funcs::get_id(ext, program_id_ptr).into();
+            let dest: ProgramId = funcs::get_bytes32(ext, program_id_ptr).into();
             let payload = funcs::get_vec(ext, payload_ptr, payload_len);
             let value = funcs::get_u128(ext, value_ptr);
             let message_id = ext.send(OutgoingPacket::new(dest, payload.into(), None, value))?;
@@ -132,7 +132,7 @@ pub fn send_commit<E: Ext + Into<ExtInfo>>(ctx: &mut Runtime<E>, args: &[Value])
 
     ctx.ext
         .with(|ext| {
-            let dest: ProgramId = funcs::get_id(ext, program_id_ptr).into();
+            let dest: ProgramId = funcs::get_bytes32(ext, program_id_ptr).into();
             let value = funcs::get_u128(ext, value_ptr);
             let message_id = ext.send_commit(
                 handle_ptr,

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -542,7 +542,7 @@ pub fn wake<E: Ext + Into<ExtInfo>>(ctx: &mut Runtime<E>, args: &[Value]) -> Sys
         })?
 }
 
-pub fn create_program<E: Ext + Into<ExtInfo>>(
+pub fn create_program_wgas<E: Ext + Into<ExtInfo>>(
     ctx: &mut Runtime<E>,
     args: &[Value],
 ) -> Result<ReturnValue, HostError> {

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -56,6 +56,7 @@ impl<E: Ext + 'static> WasmtimeEnvironment<E> {
         result.add_func_i32("gas", funcs::gas);
         result.add_func_into_i32("gr_block_height", funcs::block_height);
         result.add_func_into_i64("gr_block_timestamp", funcs::block_timestamp);
+        result.add_func_i32_i32_i32_i32_i32_i64_i32_i32("gr_create_program", funcs::create_program);
         result.add_func_to_i32("gr_exit_code", funcs::exit_code);
         result.add_func_into_i64("gr_gas_available", funcs::gas_available);
         result.add_func_i32_i32("gr_debug", funcs::debug);
@@ -78,7 +79,6 @@ impl<E: Ext + 'static> WasmtimeEnvironment<E> {
         result.add_func("gr_leave", funcs::leave);
         result.add_func("gr_wait", funcs::wait);
         result.add_func_i32("gr_wake", funcs::wake);
-        result.add_func_i32_i32_i32_i32_i32_i64_i32_i32("gr_create_program", funcs::create_program);
 
         result
     }

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -78,6 +78,7 @@ impl<E: Ext + 'static> WasmtimeEnvironment<E> {
         result.add_func("gr_leave", funcs::leave);
         result.add_func("gr_wait", funcs::wait);
         result.add_func_i32("gr_wake", funcs::wake);
+        result.add_func_i32_i32_i32_i32_i32_i64_i32_i32("gr_create_program", funcs::create_program);
 
         result
     }
@@ -162,6 +163,19 @@ impl<E: Ext + 'static> WasmtimeEnvironment<E> {
         );
     }
 
+    fn add_func_i32_i32_i32_i32_i32_i64_i32_i32<F>(
+        &mut self,
+        key: &'static str,
+        func: fn(LaterExt<E>) -> F,
+    ) where
+        F: 'static + Fn(i32, i32, i32, i32, i32, i64, i32, i32) -> Result<(), &'static str>,
+    {
+        self.funcs.insert(
+            key,
+            Func::wrap(&self.store, Self::wrap8(func(self.ext.clone()))),
+        );
+    }
+
     fn add_func_i32_to_u32<F>(&mut self, key: &'static str, func: fn(LaterExt<E>) -> F)
     where
         F: 'static + Fn(i32) -> Result<u32, &'static str>,
@@ -228,6 +242,12 @@ impl<E: Ext + 'static> WasmtimeEnvironment<E> {
         func: impl Fn(T0, T1, T2, T3, T4, T5) -> Result<R, &'static str>,
     ) -> impl Fn(T0, T1, T2, T3, T4, T5) -> Result<R, Trap> {
         move |a, b, c, d, e, f| func(a, b, c, d, e, f).map_err(Trap::new)
+    }
+
+    fn wrap8<T0, T1, T2, T3, T4, T5, T6, T7, R>(
+        func: impl Fn(T0, T1, T2, T3, T4, T5, T6, T7) -> Result<R, &'static str>,
+    ) -> impl Fn(T0, T1, T2, T3, T4, T5, T6, T7) -> Result<R, Trap> {
+        move |a, b, c, d, e, f, g, h| func(a, b, c, d, e, f, g, h).map_err(Trap::new)
     }
 }
 

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -56,7 +56,10 @@ impl<E: Ext + 'static> WasmtimeEnvironment<E> {
         result.add_func_i32("gas", funcs::gas);
         result.add_func_into_i32("gr_block_height", funcs::block_height);
         result.add_func_into_i64("gr_block_timestamp", funcs::block_timestamp);
-        result.add_func_i32_i32_i32_i32_i32_i64_i32_i32("gr_create_program", funcs::create_program);
+        result.add_func_i32_i32_i32_i32_i32_i64_i32_i32(
+            "gr_create_program_wgas",
+            funcs::create_program_wgas,
+        );
         result.add_func_to_i32("gr_exit_code", funcs::exit_code);
         result.add_func_into_i64("gr_gas_available", funcs::gas_available);
         result.add_func_i32_i32("gr_debug", funcs::debug);

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0"
 
 [dependencies]
 anyhow = { version = "1.0.54", default-features = false }
+blake2-rfc = { version = "0.2.16", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.2.0", features = [
     "derive",
 ], default-features = false }

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -25,7 +25,7 @@ use anyhow::Result;
 use codec::{Decode, Encode};
 
 use crate::memory::PageNumber;
-use crate::message::{ExitCode, MessageId, OutgoingPacket, ReplyPacket};
+use crate::message::{ExitCode, MessageId, OutgoingPacket, ProgramInitPacket, ReplyPacket};
 use crate::program::ProgramId;
 
 /// Page access rights.
@@ -143,6 +143,9 @@ pub trait Ext {
 
     /// Wake the waiting message and move it to the processing queue.
     fn wake(&mut self, waker_id: MessageId) -> Result<(), &'static str>;
+
+    /// Send init message to create a new program
+    fn create_program(&mut self, packet: ProgramInitPacket) -> Result<ProgramId, &'static str>;
 }
 
 /// Struct for interacting with Ext
@@ -293,6 +296,12 @@ mod tests {
         }
         fn wake(&mut self, _waker_id: MessageId) -> Result<(), &'static str> {
             Ok(())
+        }
+        fn create_program(
+            &mut self,
+            _packet: ProgramInitPacket,
+        ) -> Result<ProgramId, &'static str> {
+            Ok(Default::default())
         }
     }
 

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -486,6 +486,7 @@ impl ProgramInitMessage {
             gas_limit,
             value,
         } = self;
+        let gas_limit = Some(gas_limit);
         Message {
             id,
             source,

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -24,6 +24,7 @@ use anyhow::Result;
 use codec::{Decode, Encode};
 use core::convert::TryFrom;
 use core::{cmp, fmt};
+use scale_info::TypeInfo;
 
 use crate::memory::{PageBuf, PageNumber};
 
@@ -31,7 +32,18 @@ use crate::memory::{PageBuf, PageNumber};
 ///
 /// 256-bit program identifier. In production environments, should be the result of a cryptohash function.
 #[derive(
-    Clone, Copy, Decode, Default, Encode, derive_more::From, Hash, PartialEq, Eq, PartialOrd, Ord,
+    Clone,
+    Copy,
+    Decode,
+    Default,
+    Encode,
+    derive_more::From,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    TypeInfo,
 )]
 pub struct ProgramId([u8; 32]);
 

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -285,6 +285,35 @@ impl Program {
     }
 }
 
+/// Blake2b hash of the program code.
+#[derive(Clone, Copy, Debug, Decode, Encode, Ord, PartialOrd, Eq, PartialEq)]
+pub struct CodeHash([u8; 32]);
+
+impl CodeHash {
+    /// Get inner (32 bytes) array representation
+    pub fn inner(&self) -> [u8; 32] {
+        self.0
+    }
+
+    /// Create new `CodeHash` bytes.
+    ///
+    /// Will panic if slice is not 32 bytes length.
+    pub fn from_slice(s: &[u8]) -> Self {
+        if s.len() != 32 {
+            panic!("Slice is not 32 bytes length")
+        };
+        let mut id = CodeHash([0u8; 32]);
+        id.0[..].copy_from_slice(s);
+        id
+    }
+}
+
+impl From<[u8; 32]> for CodeHash {
+    fn from(data: [u8; 32]) -> Self {
+        CodeHash(data)
+    }
+}
+
 #[cfg(test)]
 /// This module contains tests of `fn encode_hex(bytes: &[u8]) -> String`
 /// and ProgramId's `fn from_slice(s: &[u8]) -> Self` constructor

--- a/gcore/Cargo.toml
+++ b/gcore/Cargo.toml
@@ -9,3 +9,6 @@ license = "GPL-3.0"
 [features]
 debug=[]
 
+[dev-dependencies]
+hex-literal = "0.3.4"
+

--- a/gcore/src/general.rs
+++ b/gcore/src/general.rs
@@ -145,3 +145,31 @@ impl ActorId {
         &mut self.0[..]
     }
 }
+
+#[derive(Clone, Copy, Debug, Default, Hash, Ord, PartialEq, PartialOrd, Eq)]
+pub struct CodeHash(pub [u8; 32]);
+
+impl From<[u8; 32]> for CodeHash {
+    fn from(v: [u8; 32]) -> Self {
+        CodeHash(v)
+    }
+}
+
+impl CodeHash {
+    /// Create a new `H256` from 32-byte slice `s`.
+    ///
+    /// Panics if the supplied slice length is other than 32.
+    pub fn from_slice(s: &[u8]) -> Self {
+        if s.len() != 32 {
+            panic!("The slice must contain 32 u8 to be casted to H256");
+        }
+        let mut ret = CodeHash([0u8; 32]);
+        ret.0[..].copy_from_slice(s);
+        ret
+    }
+
+    /// Get `H256` represented as a slice of `u8`.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+}

--- a/gcore/src/msg.rs
+++ b/gcore/src/msg.rs
@@ -30,7 +30,7 @@ use crate::{ActorId, CodeHash, MessageId};
 
 mod sys {
     extern "C" {
-        pub fn gr_create_program(
+        pub fn gr_create_program_wgas(
             code_hash: *const u8,
             salt_ptr: *const u8,
             salt_len: u32,
@@ -540,7 +540,7 @@ pub fn value() -> u128 {
 ///         hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a")
 ///             .into();
 ///     let new_program_id =
-///         msg::create_program(submitted_code, &get().to_le_bytes(), b"", 10_000, 0);
+///         msg::create_program_wgas(submitted_code, &get().to_le_bytes(), b"", 10_000, 0);
 /// }
 /// ```
 /// Another case for salt is to receive it as an input:
@@ -552,7 +552,7 @@ pub fn value() -> u128 {
 ///     # let submitted_code: CodeHash = hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a").into();
 ///     let mut salt = vec![0u8; msg::size()];
 ///     msg::load(&mut salt[..]);
-///     let new_program_id = msg::create_program(submitted_code, &salt, b"", 10_000, 0);
+///     let new_program_id = msg::create_program_wgas(submitted_code, &salt, b"", 10_000, 0);
 /// }
 /// ```
 ///
@@ -565,11 +565,11 @@ pub fn value() -> u128 {
 ///     # let submitted_code: CodeHash = hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a").into();
 ///     # let mut salt = vec![0u8; msg::size()];
 ///     # msg::load(&mut salt[..]);
-///     let new_program_id = msg::create_program(submitted_code, &salt, b"", 10_000, 0);
+///     let new_program_id = msg::create_program_wgas(submitted_code, &salt, b"", 10_000, 0);
 ///     msg::send(new_program_id, b"payload for a new program", 10_000, 0);
 /// }
 /// ```
-pub fn create_program(
+pub fn create_program_wgas(
     code_hash: CodeHash,
     salt: &[u8],
     payload: &[u8],
@@ -578,7 +578,7 @@ pub fn create_program(
 ) -> ActorId {
     unsafe {
         let mut program_id = ActorId::default();
-        sys::gr_create_program(
+        sys::gr_create_program_wgas(
             code_hash.as_slice().as_ptr(),
             salt.as_ptr(),
             salt.len() as _,

--- a/gcore/src/msg.rs
+++ b/gcore/src/msg.rs
@@ -26,7 +26,7 @@
 //! reply to the initial message.
 
 use crate::MessageHandle;
-use crate::{ActorId, MessageId};
+use crate::{ActorId, CodeHash, MessageId};
 
 mod sys {
     extern "C" {
@@ -63,6 +63,16 @@ mod sys {
         pub fn gr_size() -> u32;
         pub fn gr_source(program: *mut u8);
         pub fn gr_value(val: *mut u8);
+        pub fn gr_create_program(
+            code_hash: *const u8,
+            salt_ptr: *const u8,
+            salt_len: u32,
+            data_ptr: *const u8,
+            data_len: u32,
+            gas_limit: u64,
+            value_ptr: *const u8,
+            program_id_ptr: *mut u8,
+        );
     }
 }
 
@@ -490,4 +500,94 @@ pub fn value() -> u128 {
         sys::gr_value(value_data.as_mut_ptr());
     }
     u128::from_le_bytes(value_data)
+}
+
+/// Creates a new program and returns its address.
+///
+/// The function creates a program initialization message and, as
+/// any message send function in the crate, this one requires common additional
+/// data for message execution, such as:
+/// 1. `payload` that can be used in `init` function of the newly deployed
+/// "child" program; 2. `gas_limit`, provided for the program initialization;
+/// 3. `value`, sent with the message.
+/// Code of newly creating program must be represented as blake2b hash
+/// (`code_hash` parameter).
+///
+/// # Examples
+///
+/// In order to generate an address for a new program `salt` must be provided.
+/// Control of salt uniqueness is fully on a program developer side.
+///
+/// Basically we can use "automatic" salt generation ("nonce"):
+/// ```
+/// use gcore::msg;
+/// use gcore::CodeHash;
+///
+/// static mut NONCE: i32 = 0;
+///
+/// fn increase() {
+///     unsafe {
+///         NONCE += 1;
+///     }
+/// }
+///
+/// fn get() -> i32 {
+///     unsafe { NONCE }
+/// }
+///
+/// pub unsafe extern "C" fn handle() {
+///     let submitted_code: CodeHash =
+///         hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a")
+///             .into();
+///     let new_program_id =
+///         msg::create_program(submitted_code, &get().to_le_bytes(), b"", 10_000, 0);
+/// }
+/// ```
+/// Another case for salt is to receive it as an input:
+/// ```
+/// use gcore::msg;
+/// # use gcore::CodeHash;
+///
+/// pub unsafe extern "C" fn handle() {
+///     # let submitted_code: CodeHash = hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a").into();
+///     let mut salt = vec![0u8; msg::size()];
+///     msg::load(&mut salt[..]);
+///     let new_program_id = msg::create_program(submitted_code, &salt, b"", 10_000, 0);
+/// }
+/// ```
+///
+/// What's more, messages can be sent to a new program:
+/// ```
+/// use gcore::msg;
+/// # use gcore::CodeHash;
+///
+/// pub unsafe extern "C" fn handle() {
+///     # let submitted_code: CodeHash = hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a").into();
+///     # let mut salt = vec![0u8; msg::size()];
+///     # msg::load(&mut salt[..]);
+///     let new_program_id = msg::create_program(submitted_code, &salt, b"", 10_000, 0);
+///     msg::send(new_program_id, b"payload for a new program", 10_000, 0);
+/// }
+/// ```
+pub fn create_program(
+    code_hash: CodeHash,
+    salt: &[u8],
+    payload: &[u8],
+    gas_limit: u64,
+    value: u128,
+) -> ActorId {
+    unsafe {
+        let mut program_id = ActorId::default();
+        sys::gr_create_program(
+            code_hash.as_slice().as_ptr(),
+            salt.as_ptr(),
+            salt.len() as _,
+            payload.as_ptr(),
+            payload.len() as _,
+            gas_limit,
+            value.to_le_bytes().as_ptr(),
+            program_id.as_mut_slice().as_mut_ptr(),
+        );
+        program_id
+    }
 }

--- a/gcore/src/msg.rs
+++ b/gcore/src/msg.rs
@@ -26,20 +26,10 @@
 //! reply to the initial message.
 
 use crate::MessageHandle;
-use crate::{ActorId, CodeHash, MessageId};
+use crate::{ActorId, MessageId};
 
 mod sys {
     extern "C" {
-        pub fn gr_create_program_wgas(
-            code_hash: *const u8,
-            salt_ptr: *const u8,
-            salt_len: u32,
-            data_ptr: *const u8,
-            data_len: u32,
-            gas_limit: u64,
-            value_ptr: *const u8,
-            program_id_ptr: *mut u8,
-        );
         pub fn gr_exit_code() -> i32;
         pub fn gr_msg_id(val: *mut u8);
         pub fn gr_read(at: u32, len: u32, dest: *mut u8);
@@ -500,94 +490,4 @@ pub fn value() -> u128 {
         sys::gr_value(value_data.as_mut_ptr());
     }
     u128::from_le_bytes(value_data)
-}
-
-/// Creates a new program and returns its address.
-///
-/// The function creates a program initialization message and, as
-/// any message send function in the crate, this one requires common additional
-/// data for message execution, such as:
-/// 1. `payload` that can be used in `init` function of the newly deployed
-/// "child" program; 2. `gas_limit`, provided for the program initialization;
-/// 3. `value`, sent with the message.
-/// Code of newly creating program must be represented as blake2b hash
-/// (`code_hash` parameter).
-///
-/// # Examples
-///
-/// In order to generate an address for a new program `salt` must be provided.
-/// Control of salt uniqueness is fully on a program developer side.
-///
-/// Basically we can use "automatic" salt generation ("nonce"):
-/// ```
-/// use gcore::msg;
-/// use gcore::CodeHash;
-///
-/// static mut NONCE: i32 = 0;
-///
-/// fn increase() {
-///     unsafe {
-///         NONCE += 1;
-///     }
-/// }
-///
-/// fn get() -> i32 {
-///     unsafe { NONCE }
-/// }
-///
-/// pub unsafe extern "C" fn handle() {
-///     let submitted_code: CodeHash =
-///         hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a")
-///             .into();
-///     let new_program_id =
-///         msg::create_program_wgas(submitted_code, &get().to_le_bytes(), b"", 10_000, 0);
-/// }
-/// ```
-/// Another case for salt is to receive it as an input:
-/// ```
-/// use gcore::msg;
-/// # use gcore::CodeHash;
-///
-/// pub unsafe extern "C" fn handle() {
-///     # let submitted_code: CodeHash = hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a").into();
-///     let mut salt = vec![0u8; msg::size()];
-///     msg::load(&mut salt[..]);
-///     let new_program_id = msg::create_program_wgas(submitted_code, &salt, b"", 10_000, 0);
-/// }
-/// ```
-///
-/// What's more, messages can be sent to a new program:
-/// ```
-/// use gcore::msg;
-/// # use gcore::CodeHash;
-///
-/// pub unsafe extern "C" fn handle() {
-///     # let submitted_code: CodeHash = hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a").into();
-///     # let mut salt = vec![0u8; msg::size()];
-///     # msg::load(&mut salt[..]);
-///     let new_program_id = msg::create_program_wgas(submitted_code, &salt, b"", 10_000, 0);
-///     msg::send(new_program_id, b"payload for a new program", 10_000, 0);
-/// }
-/// ```
-pub fn create_program_wgas(
-    code_hash: CodeHash,
-    salt: &[u8],
-    payload: &[u8],
-    gas_limit: u64,
-    value: u128,
-) -> ActorId {
-    unsafe {
-        let mut program_id = ActorId::default();
-        sys::gr_create_program_wgas(
-            code_hash.as_slice().as_ptr(),
-            salt.as_ptr(),
-            salt.len() as _,
-            payload.as_ptr(),
-            payload.len() as _,
-            gas_limit,
-            value.to_le_bytes().as_ptr(),
-            program_id.as_mut_slice().as_mut_ptr(),
-        );
-        program_id
-    }
 }

--- a/gcore/src/msg.rs
+++ b/gcore/src/msg.rs
@@ -30,6 +30,16 @@ use crate::{ActorId, CodeHash, MessageId};
 
 mod sys {
     extern "C" {
+        pub fn gr_create_program(
+            code_hash: *const u8,
+            salt_ptr: *const u8,
+            salt_len: u32,
+            data_ptr: *const u8,
+            data_len: u32,
+            gas_limit: u64,
+            value_ptr: *const u8,
+            program_id_ptr: *mut u8,
+        );
         pub fn gr_exit_code() -> i32;
         pub fn gr_msg_id(val: *mut u8);
         pub fn gr_read(at: u32, len: u32, dest: *mut u8);
@@ -63,16 +73,6 @@ mod sys {
         pub fn gr_size() -> u32;
         pub fn gr_source(program: *mut u8);
         pub fn gr_value(val: *mut u8);
-        pub fn gr_create_program(
-            code_hash: *const u8,
-            salt_ptr: *const u8,
-            salt_len: u32,
-            data_ptr: *const u8,
-            data_len: u32,
-            gas_limit: u64,
-            value_ptr: *const u8,
-            program_id_ptr: *mut u8,
-        );
     }
 }
 

--- a/gcore/src/prog.rs
+++ b/gcore/src/prog.rs
@@ -1,0 +1,126 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Program creation API for Gear programs.
+
+use crate::{ActorId, CodeHash};
+
+mod sys {
+    extern "C" {
+        pub fn gr_create_program_wgas(
+            code_hash: *const u8,
+            salt_ptr: *const u8,
+            salt_len: u32,
+            data_ptr: *const u8,
+            data_len: u32,
+            gas_limit: u64,
+            value_ptr: *const u8,
+            program_id_ptr: *mut u8,
+        );
+    }
+}
+
+/// Creates a new program and returns its address.
+///
+/// The function creates a program initialization message and, as
+/// any message send function in the crate, this one requires common additional
+/// data for message execution, such as:
+/// 1. `payload` that can be used in `init` function of the newly deployed
+/// "child" program; 2. `gas_limit`, provided for the program initialization;
+/// 3. `value`, sent with the message.
+/// Code of newly creating program must be represented as blake2b hash
+/// (`code_hash` parameter).
+///
+/// # Examples
+///
+/// In order to generate an address for a new program `salt` must be provided.
+/// Control of salt uniqueness is fully on a program developer side.
+///
+/// Basically we can use "automatic" salt generation ("nonce"):
+/// ```
+/// use gcore::prog;
+/// use gcore::CodeHash;
+///
+/// static mut NONCE: i32 = 0;
+///
+/// fn increase() {
+///     unsafe {
+///         NONCE += 1;
+///     }
+/// }
+///
+/// fn get() -> i32 {
+///     unsafe { NONCE }
+/// }
+///
+/// pub unsafe extern "C" fn handle() {
+///     let submitted_code: CodeHash =
+///         hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a")
+///             .into();
+///     let new_program_id =
+///         prog::create_program_wgas(submitted_code, &get().to_le_bytes(), b"", 10_000, 0);
+/// }
+/// ```
+/// Another case for salt is to receive it as an input:
+/// ```
+/// use gcore::{msg, prog};
+/// # use gcore::CodeHash;
+///
+/// pub unsafe extern "C" fn handle() {
+///     # let submitted_code: CodeHash = hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a").into();
+///     let mut salt = vec![0u8; msg::size()];
+///     msg::load(&mut salt[..]);
+///     let new_program_id = prog::create_program_wgas(submitted_code, &salt, b"", 10_000, 0);
+/// }
+/// ```
+///
+/// What's more, messages can be sent to a new program:
+/// ```
+/// use gcore::{msg, prog};
+/// # use gcore::CodeHash;
+///
+/// pub unsafe extern "C" fn handle() {
+///     # let submitted_code: CodeHash = hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a").into();
+///     # let mut salt = vec![0u8; msg::size()];
+///     # msg::load(&mut salt[..]);
+///     let new_program_id = prog::create_program_wgas(submitted_code, &salt, b"", 10_000, 0);
+///     msg::send(new_program_id, b"payload for a new program", 10_000, 0);
+/// }
+/// ```
+pub fn create_program_wgas(
+    code_hash: CodeHash,
+    salt: &[u8],
+    payload: &[u8],
+    gas_limit: u64,
+    value: u128,
+) -> ActorId {
+    unsafe {
+        let mut program_id = ActorId::default();
+        sys::gr_create_program_wgas(
+            code_hash.as_slice().as_ptr(),
+            salt.as_ptr(),
+            salt.len() as _,
+            payload.as_ptr(),
+            payload.len() as _,
+            gas_limit,
+            value.to_le_bytes().as_ptr(),
+            program_id.as_mut_slice().as_mut_ptr(),
+        );
+        program_id
+    }
+}

--- a/gcore/src/prog.rs
+++ b/gcore/src/prog.rs
@@ -1,6 +1,6 @@
 // This file is part of Gear.
 
-// Copyright (C) 2021 Gear Technologies Inc.
+// Copyright (C) 2022 Gear Technologies Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify
@@ -73,7 +73,7 @@ mod sys {
 ///         hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a")
 ///             .into();
 ///     let new_program_id =
-///         prog::create_program_wgas(submitted_code, &get().to_le_bytes(), b"", 10_000, 0);
+///         prog::create_program_with_gas(submitted_code, &get().to_le_bytes(), b"", 10_000, 0);
 /// }
 /// ```
 /// Another case for salt is to receive it as an input:
@@ -85,7 +85,7 @@ mod sys {
 ///     # let submitted_code: CodeHash = hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a").into();
 ///     let mut salt = vec![0u8; msg::size()];
 ///     msg::load(&mut salt[..]);
-///     let new_program_id = prog::create_program_wgas(submitted_code, &salt, b"", 10_000, 0);
+///     let new_program_id = prog::create_program_with_gas(submitted_code, &salt, b"", 10_000, 0);
 /// }
 /// ```
 ///
@@ -98,11 +98,11 @@ mod sys {
 ///     # let submitted_code: CodeHash = hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a").into();
 ///     # let mut salt = vec![0u8; msg::size()];
 ///     # msg::load(&mut salt[..]);
-///     let new_program_id = prog::create_program_wgas(submitted_code, &salt, b"", 10_000, 0);
-///     msg::send(new_program_id, b"payload for a new program", 10_000, 0);
+///     let new_program_id = prog::create_program_with_gas(submitted_code, &salt, b"", 10_000, 0);
+///     msg::send_with_gas(new_program_id, b"payload for a new program", 10_000, 0);
 /// }
 /// ```
-pub fn create_program_wgas(
+pub fn create_program_with_gas(
     code_hash: CodeHash,
     salt: &[u8],
     payload: &[u8],

--- a/gstd/src/common/primitives.rs
+++ b/gstd/src/common/primitives.rs
@@ -174,3 +174,75 @@ impl From<gcore::MessageId> for MessageId {
         Self(other.0)
     }
 }
+
+#[derive(
+    Clone, Copy, Debug, Default, Hash, Ord, PartialEq, PartialOrd, Eq, TypeInfo, Decode, Encode,
+)]
+pub struct CodeHash([u8; 32]);
+
+impl CodeHash {
+    pub const fn new(arr: [u8; 32]) -> Self {
+        Self(arr)
+    }
+
+    pub fn from_slice(slice: &[u8]) -> Result<Self> {
+        if slice.len() != 32 {
+            return Err(ContractError::Convert("Slice should be 32 length"));
+        }
+
+        let mut ret: Self = Default::default();
+        ret.0.as_mut().copy_from_slice(slice);
+
+        Ok(ret)
+    }
+}
+
+impl AsRef<[u8]> for CodeHash {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl AsMut<[u8]> for CodeHash {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0.as_mut()
+    }
+}
+
+impl From<[u8; 32]> for CodeHash {
+    fn from(arr: [u8; 32]) -> Self {
+        Self(arr)
+    }
+}
+
+impl From<CodeHash> for [u8; 32] {
+    fn from(other: CodeHash) -> Self {
+        other.0
+    }
+}
+
+impl From<H256> for CodeHash {
+    fn from(h256: H256) -> Self {
+        Self::new(h256.to_fixed_bytes())
+    }
+}
+
+impl From<gcore::CodeHash> for CodeHash {
+    fn from(other: gcore::CodeHash) -> Self {
+        Self(other.0)
+    }
+}
+
+impl From<CodeHash> for gcore::CodeHash {
+    fn from(other: CodeHash) -> Self {
+        Self(other.0)
+    }
+}
+
+impl TryFrom<&[u8]> for CodeHash {
+    type Error = ContractError;
+
+    fn try_from(slice: &[u8]) -> Result<Self> {
+        Self::from_slice(slice)
+    }
+}

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -34,6 +34,7 @@ pub mod lock;
 pub mod macros;
 pub mod msg;
 pub mod prelude;
+pub mod prog;
 
 pub use async_runtime::{message_loop, record_reply};
 pub use common::errors;

--- a/gstd/src/msg/basic.rs
+++ b/gstd/src/msg/basic.rs
@@ -19,7 +19,7 @@
 //! Module with basic messaging functions wrapped from `gcore` to `gstd`.
 
 use crate::prelude::{convert::AsRef, vec, Vec};
-use crate::{ActorId, MessageId};
+use crate::{ActorId, CodeHash, MessageId};
 use codec::Output;
 
 /// Message handle.
@@ -473,4 +473,21 @@ pub fn source() -> ActorId {
 /// ```
 pub fn value() -> u128 {
     gcore::msg::value()
+}
+
+pub fn create_program<T1: AsRef<[u8]>, T2: AsRef<[u8]>>(
+    code_hash: CodeHash,
+    salt: T1,
+    payload: T2,
+    gas_limit: u64,
+    value: u128,
+) -> ActorId {
+    gcore::msg::create_program(
+        code_hash.into(),
+        salt.as_ref(),
+        payload.as_ref(),
+        gas_limit,
+        value,
+    )
+    .into()
 }

--- a/gstd/src/msg/basic.rs
+++ b/gstd/src/msg/basic.rs
@@ -19,7 +19,7 @@
 //! Module with basic messaging functions wrapped from `gcore` to `gstd`.
 
 use crate::prelude::{convert::AsRef, vec, Vec};
-use crate::{ActorId, CodeHash, MessageId};
+use crate::{ActorId, MessageId};
 use codec::Output;
 
 /// Message handle.
@@ -473,21 +473,4 @@ pub fn source() -> ActorId {
 /// ```
 pub fn value() -> u128 {
     gcore::msg::value()
-}
-
-pub fn create_program_wgas<T1: AsRef<[u8]>, T2: AsRef<[u8]>>(
-    code_hash: CodeHash,
-    salt: T1,
-    payload: T2,
-    gas_limit: u64,
-    value: u128,
-) -> ActorId {
-    gcore::msg::create_program_wgas(
-        code_hash.into(),
-        salt.as_ref(),
-        payload.as_ref(),
-        gas_limit,
-        value,
-    )
-    .into()
 }

--- a/gstd/src/msg/basic.rs
+++ b/gstd/src/msg/basic.rs
@@ -475,14 +475,14 @@ pub fn value() -> u128 {
     gcore::msg::value()
 }
 
-pub fn create_program<T1: AsRef<[u8]>, T2: AsRef<[u8]>>(
+pub fn create_program_wgas<T1: AsRef<[u8]>, T2: AsRef<[u8]>>(
     code_hash: CodeHash,
     salt: T1,
     payload: T2,
     gas_limit: u64,
     value: u128,
 ) -> ActorId {
-    gcore::msg::create_program(
+    gcore::msg::create_program_wgas(
         code_hash.into(),
         salt.as_ref(),
         payload.as_ref(),

--- a/gstd/src/prog/mod.rs
+++ b/gstd/src/prog/mod.rs
@@ -1,6 +1,6 @@
 // This file is part of Gear.
 
-// Copyright (C) 2021 Gear Technologies Inc.
+// Copyright (C) 2022 Gear Technologies Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify
@@ -21,7 +21,7 @@
 use crate::{ActorId, CodeHash};
 use codec::Encode;
 
-pub fn create_program_wgas<T1: Encode, T2: Encode>(
+pub fn create_program_with_gas<T1: Encode, T2: Encode>(
     code_hash: CodeHash,
     salt: T1,
     payload: T2,
@@ -30,5 +30,5 @@ pub fn create_program_wgas<T1: Encode, T2: Encode>(
 ) -> ActorId {
     let salt = salt.encode();
     let payload = payload.encode();
-    gcore::prog::create_program_wgas(code_hash.into(), &salt, &payload, gas_limit, value).into()
+    gcore::prog::create_program_with_gas(code_hash.into(), &salt, &payload, gas_limit, value).into()
 }

--- a/gstd/src/prog/mod.rs
+++ b/gstd/src/prog/mod.rs
@@ -18,17 +18,21 @@
 
 //! Program creation module
 
-use crate::{ActorId, CodeHash};
-use codec::Encode;
+use crate::{prelude::convert::AsRef, ActorId, CodeHash};
 
-pub fn create_program_with_gas<T1: Encode, T2: Encode>(
+pub fn create_program_with_gas<T1: AsRef<[u8]>, T2: AsRef<[u8]>>(
     code_hash: CodeHash,
     salt: T1,
     payload: T2,
     gas_limit: u64,
     value: u128,
 ) -> ActorId {
-    let salt = salt.encode();
-    let payload = payload.encode();
-    gcore::prog::create_program_with_gas(code_hash.into(), &salt, &payload, gas_limit, value).into()
+    gcore::prog::create_program_with_gas(
+        code_hash.into(),
+        salt.as_ref(),
+        payload.as_ref(),
+        gas_limit,
+        value,
+    )
+    .into()
 }

--- a/gstd/src/prog/mod.rs
+++ b/gstd/src/prog/mod.rs
@@ -16,17 +16,19 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#![no_std]
-#![cfg_attr(feature = "strict", deny(warnings))]
-#![doc(html_logo_url = "https://docs.gear.rs/logo.svg")]
+//! Program creation module
 
-pub mod exec;
-pub mod msg;
-pub mod prog;
+use crate::{ActorId, CodeHash};
+use codec::Encode;
 
-mod general;
-pub use general::*;
-
-mod utils;
-#[cfg(feature = "debug")]
-pub use utils::ext;
+pub fn create_program_wgas<T1: Encode, T2: Encode>(
+    code_hash: CodeHash,
+    salt: T1,
+    payload: T2,
+    gas_limit: u64,
+    value: u128,
+) -> ActorId {
+    let salt = salt.encode();
+    let payload = payload.encode();
+    gcore::prog::create_program_wgas(code_hash.into(), &salt, &payload, gas_limit, value).into()
+}

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -60,6 +60,7 @@ impl From<LazyPagesExt> for ExtInfo {
 
         let (
             MessageState {
+                init_messages,
                 outgoing,
                 reply,
                 awakening,
@@ -70,6 +71,8 @@ impl From<LazyPagesExt> for ExtInfo {
         let gas_amount: GasAmount = ext.inner.gas_counter.into();
 
         let trap_explanation = ext.inner.error_explanation;
+
+        let program_candidates_data = ext.inner.program_candidates_data;
 
         ExtInfo {
             gas_amount,
@@ -82,6 +85,8 @@ impl From<LazyPagesExt> for ExtInfo {
             payload_store: Some(store),
             trap_explanation,
             exit_argument: ext.inner.exit_argument,
+            init_messages,
+            program_candidates_data,
         }
     }
 }
@@ -109,6 +114,7 @@ impl ProcessorExt for LazyPagesExt {
                 existential_deposit,
                 error_explanation,
                 exit_argument,
+                program_candidates_data: Default::default(), // to be changed
             },
             lazy_pages_enabled: false,
         }
@@ -316,5 +322,12 @@ impl EnvExt for LazyPagesExt {
 
     fn value_available(&self) -> u128 {
         self.inner.value_available()
+    }
+
+    fn create_program(
+        &mut self,
+        packet: gear_core::message::ProgramInitPacket,
+    ) -> Result<ProgramId, &'static str> {
+        self.inner.create_program(packet)
     }
 }

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -24,7 +24,7 @@ use core_processor::{
 use gear_backend_common::ExtInfo;
 use gear_core::{
     env::Ext as EnvExt,
-    gas::{GasAmount, GasCounter, ValueCounter},
+    gas::{GasCounter, ValueCounter},
     memory::{MemoryContext, PageBuf, PageNumber},
     message::{MessageContext, MessageId, MessageState, OutgoingPacket, ReplyPacket},
     program::ProgramId,
@@ -68,14 +68,8 @@ impl From<LazyPagesExt> for ExtInfo {
             store,
         ) = ext.inner.message_context.drain();
 
-        let gas_amount: GasAmount = ext.inner.gas_counter.into();
-
-        let trap_explanation = ext.inner.error_explanation;
-
-        let program_candidates_data = ext.inner.program_candidates_data;
-
         ExtInfo {
-            gas_amount,
+            gas_amount: ext.inner.gas_counter.into(),
             pages: ext.inner.memory_context.allocations().clone(),
             accessed_pages,
             outgoing,
@@ -83,10 +77,10 @@ impl From<LazyPagesExt> for ExtInfo {
             awakening,
             nonce,
             payload_store: Some(store),
-            trap_explanation,
+            trap_explanation: ext.inner.error_explanation,
             exit_argument: ext.inner.exit_argument,
             init_messages,
-            program_candidates_data,
+            program_candidates_data: ext.inner.program_candidates_data,
         }
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 290,
+    spec_version: 300,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 280,
+    spec_version: 290,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/utils/wasm-builder/test-program/Cargo.lock
+++ b/utils/wasm-builder/test-program/Cargo.lock
@@ -541,6 +541,7 @@ name = "gear-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "blake2-rfc",
  "derive_more",
  "hashbrown 0.12.0",
  "log",


### PR DESCRIPTION
Creating program from program implementation is on `st-create-program-from-program-iter1` branch and quite big. To make it easy for review, I decided to divide it to separate PRs.

This is the first one.

**Release notes**: a new sys-call for sending init messages in program is introduced.

@gear-tech/dev 
