### PR TITLE
Getter for initial user of messaging

### DIFF
--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -108,11 +108,11 @@ pub fn exit<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static str
     }
 }
 
-pub fn initiator<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static str> {
-    move |initiator_ptr: i32| {
+pub fn origin<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static str> {
+    move |origin_ptr: i32| {
         ext.with(|ext: &mut E| {
-            let id = ext.initiator();
-            ext.set_mem(initiator_ptr as _, id.as_slice());
+            let id = ext.origin();
+            ext.set_mem(origin_ptr as _, id.as_slice());
         })
     }
 }

--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -108,6 +108,15 @@ pub fn exit<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static str
     }
 }
 
+pub fn initiator<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static str> {
+    move |initiator_ptr: i32| {
+        ext.with(|ext: &mut E| {
+            let id = ext.initiator();
+            ext.set_mem(initiator_ptr as _, id.as_slice());
+        })
+    }
+}
+
 pub fn msg_id<E: Ext>(ext: LaterExt<E>) -> impl Fn(i32) -> Result<(), &'static str> {
     move |msg_id_ptr: i32| {
         ext.with(|ext: &mut E| {

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -121,6 +121,7 @@ where
         env_builder.add_host_func("env", "gr_block_timestamp", funcs::block_timestamp);
         env_builder.add_host_func("env", "gr_exit", funcs::exit);
         env_builder.add_host_func("env", "gr_exit_code", funcs::exit_code);
+        env_builder.add_host_func("env", "gr_initiator", funcs::initiator);
         env_builder.add_host_func("env", "gr_send", funcs::send);
         env_builder.add_host_func("env", "gr_send_commit", funcs::send_commit);
         env_builder.add_host_func("env", "gr_send_init", funcs::send_init);

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -122,7 +122,7 @@ where
         env_builder.add_host_func("env", "gr_create_program_wgas", funcs::create_program_wgas);
         env_builder.add_host_func("env", "gr_exit", funcs::exit);
         env_builder.add_host_func("env", "gr_exit_code", funcs::exit_code);
-        env_builder.add_host_func("env", "gr_initiator", funcs::initiator);
+        env_builder.add_host_func("env", "gr_origin", funcs::origin);
         env_builder.add_host_func("env", "gr_send", funcs::send);
         env_builder.add_host_func("env", "gr_send_wgas", funcs::send_wgas);
         env_builder.add_host_func("env", "gr_send_commit", funcs::send_commit);

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -282,6 +282,24 @@ pub fn block_timestamp<E: Ext + Into<ExtInfo>>(
     return_i64(block_timestamp)
 }
 
+pub fn initiator<E: Ext + Into<ExtInfo>>(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
+    let mut args = args.iter();
+
+    let initiator_ptr = pop_i32(&mut args)?;
+
+    ctx.ext
+        .with(|ext| {
+            let initiator = ext.initiator();
+            ext.set_mem(initiator_ptr, initiator.as_slice());
+            Ok(())
+        })
+        .and_then(|res| res.map(|_| ReturnValue::Unit))
+        .map_err(|_| {
+            ctx.trap = Some("Trapping: unable to get initiator");
+            HostError
+        })
+}
+
 pub fn reply<E: Ext + Into<ExtInfo>>(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
     let mut args = args.iter();
 

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -342,20 +342,20 @@ pub fn block_timestamp<E: Ext + Into<ExtInfo>>(
     return_i64(block_timestamp)
 }
 
-pub fn initiator<E: Ext + Into<ExtInfo>>(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
+pub fn origin<E: Ext + Into<ExtInfo>>(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
     let mut args = args.iter();
 
-    let initiator_ptr = pop_i32(&mut args)?;
+    let origin_ptr = pop_i32(&mut args)?;
 
     ctx.ext
         .with(|ext| {
-            let initiator = ext.initiator();
-            ext.set_mem(initiator_ptr, initiator.as_slice());
+            let origin = ext.origin();
+            ext.set_mem(origin_ptr, origin.as_slice());
             Ok(())
         })
         .and_then(|res| res.map(|_| ReturnValue::Unit))
         .map_err(|_| {
-            ctx.trap = Some("Trapping: unable to get initiator");
+            ctx.trap = Some("Trapping: unable to get origin");
             HostError
         })
 }

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -84,7 +84,7 @@ pub fn send<E: Ext + Into<ExtInfo>>(ctx: &mut Runtime<E>, args: &[Value]) -> Sys
             Ok(())
         })
         .and_then(|res| res.map(|_| ReturnValue::Unit))
-        .map_err(|_err| {
+        .map_err(|_| {
             ctx.trap = Some("Trapping: unable to send message");
             HostError
         });
@@ -112,7 +112,7 @@ pub fn send_commit<E: Ext + Into<ExtInfo>>(ctx: &mut Runtime<E>, args: &[Value])
             Ok(())
         })
         .and_then(|res| res.map(|_| ReturnValue::Unit))
-        .map_err(|_err| {
+        .map_err(|_| {
             ctx.trap = Some("Trapping: unable to send message");
             HostError
         })
@@ -122,8 +122,8 @@ pub fn send_init<E: Ext + Into<ExtInfo>>(ctx: &mut Runtime<E>, _args: &[Value]) 
     ctx.ext
         .with(|ext| ext.send_init())
         .and_then(|res| res.map(|handle| ReturnValue::Value(Value::I32(handle as i32))))
-        .map_err(|err| {
-            ctx.trap = Some(err);
+        .map_err(|_| {
+            ctx.trap = Some("Trapping: unable to initiate message sending");
             HostError
         })
 }
@@ -141,8 +141,8 @@ pub fn send_push<E: Ext + Into<ExtInfo>>(ctx: &mut Runtime<E>, args: &[Value]) -
             ext.send_push(handle_ptr, &payload)
         })
         .and_then(|res| res.map(|_| ReturnValue::Unit))
-        .map_err(|err| {
-            ctx.trap = Some(err);
+        .map_err(|_| {
+            ctx.trap = Some("Trapping: unable to push message payload");
             HostError
         })
 }
@@ -438,8 +438,8 @@ pub fn msg_id<E: Ext + Into<ExtInfo>>(ctx: &mut Runtime<E>, args: &[Value]) -> S
             Ok(())
         })
         .and_then(|res| res.map(|_| ReturnValue::Unit))
-        .map_err(|err| {
-            ctx.trap = Some(err);
+        .map_err(|_| {
+            ctx.trap = Some("Trapping: unable to get message id");
             HostError
         })
 }

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -60,6 +60,7 @@ impl<E: Ext + 'static> WasmtimeEnvironment<E> {
         result.add_func_into_i64("gr_gas_available", funcs::gas_available);
         result.add_func_i32_i32("gr_debug", funcs::debug);
         result.add_func_i32("gr_exit", funcs::exit);
+        result.add_func_i32("gr_initiator", funcs::initiator);
         result.add_func_i32("gr_msg_id", funcs::msg_id);
         result.add_func_i32("gr_program_id", funcs::program_id);
         result.add_func_i32_i32_i32("gr_read", funcs::read);

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -64,7 +64,7 @@ impl<E: Ext + 'static> WasmtimeEnvironment<E> {
         result.add_func_into_i64("gr_gas_available", funcs::gas_available);
         result.add_func_i32_i32("gr_debug", funcs::debug);
         result.add_func_i32("gr_exit", funcs::exit);
-        result.add_func_i32("gr_initiator", funcs::initiator);
+        result.add_func_i32("gr_origin", funcs::origin);
         result.add_func_i32("gr_msg_id", funcs::msg_id);
         result.add_func_i32("gr_program_id", funcs::program_id);
         result.add_func_i32_i32_i32("gr_read", funcs::read);

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -252,6 +252,13 @@ pub struct ExecutableActor {
     pub balance: u128,
 }
 
+/// Execution context.
+#[derive(Clone, Debug, Decode, Encode)]
+pub struct ExecutionContext {
+    /// Original initiator.
+    pub initiator: ProgramId,
+}
+
 #[derive(Clone, Default)]
 /// In-memory state.
 pub struct State {

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -269,8 +269,8 @@ pub struct ExecutableActor {
 /// Execution context.
 #[derive(Clone, Debug, Decode, Encode)]
 pub struct ExecutionContext {
-    /// Original initiator.
-    pub initiator: ProgramId,
+    /// Original user.
+    pub origin: ProgramId,
 }
 
 #[derive(Clone, Default)]

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -175,7 +175,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + Into<ExtInfo> + 'static, E: Envir
         settings.existential_deposit,
         None,
         None,
-        context.initiator,
+        context.origin,
         Default::default(),
     );
 

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -17,7 +17,9 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    common::{DispatchResult, DispatchResultKind, ExecutableActor, ExecutionError},
+    common::{
+        DispatchResult, DispatchResultKind, ExecutableActor, ExecutionContext, ExecutionError,
+    },
     configs::ExecutionSettings,
     ext::ProcessorExt,
     id::BlakeMessageIdGenerator,
@@ -38,6 +40,7 @@ use gear_core::{
 pub fn execute_wasm<A: ProcessorExt + EnvExt + Into<ExtInfo> + 'static, E: Environment<A>>(
     actor: ExecutableActor,
     dispatch: Dispatch,
+    context: ExecutionContext,
     settings: ExecutionSettings,
 ) -> Result<DispatchResult, ExecutionError> {
     let mut env: E = Default::default();
@@ -172,6 +175,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + Into<ExtInfo> + 'static, E: Envir
         settings.existential_deposit,
         None,
         None,
+        context.initiator,
     );
 
     let lazy_pages_enabled = ext.try_to_enable_lazy_pages(program_id, initial_pages);

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -48,7 +48,7 @@ pub trait ProcessorExt {
         existential_deposit: u128,
         error_explanation: Option<&'static str>,
         exit_argument: Option<ProgramId>,
-        initiator: ProgramId,
+        origin: ProgramId,
         program_candidates_data: BTreeMap<CodeHash, Vec<(ProgramId, MessageId)>>,
     ) -> Self;
 
@@ -102,8 +102,8 @@ pub struct Ext {
     pub error_explanation: Option<&'static str>,
     /// Contains argument to the `exit` if it was called.
     pub exit_argument: Option<ProgramId>,
-    /// Communication initiator
-    pub initiator: ProgramId,
+    /// Communication origin
+    pub origin: ProgramId,
     /// Map of code hashes to program ids of future programs, which are planned to be
     /// initialized with the corresponding code (with the same code hash).
     pub program_candidates_data: BTreeMap<CodeHash, Vec<(ProgramId, MessageId)>>,
@@ -121,7 +121,7 @@ impl ProcessorExt for Ext {
         existential_deposit: u128,
         error_explanation: Option<&'static str>,
         exit_argument: Option<ProgramId>,
-        initiator: ProgramId,
+        origin: ProgramId,
         program_candidates_data: BTreeMap<CodeHash, Vec<(ProgramId, MessageId)>>,
     ) -> Self {
         Self {
@@ -134,7 +134,7 @@ impl ProcessorExt for Ext {
             existential_deposit,
             error_explanation,
             exit_argument,
-            initiator,
+            origin,
             program_candidates_data,
         }
     }
@@ -270,8 +270,8 @@ impl EnvExt for Ext {
         self.block_info.timestamp
     }
 
-    fn initiator(&self) -> ProgramId {
-        self.initiator
+    fn origin(&self) -> ProgramId {
+        self.origin
     }
 
     fn send_init(&mut self) -> Result<usize, &'static str> {

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -47,6 +47,7 @@ pub trait ProcessorExt {
         existential_deposit: u128,
         error_explanation: Option<&'static str>,
         exit_argument: Option<ProgramId>,
+        initiator: ProgramId,
     ) -> Self;
 
     /// Try to enable and initialize lazy pages env
@@ -99,6 +100,8 @@ pub struct Ext {
     pub error_explanation: Option<&'static str>,
     /// Contains argument to the `exit` if it was called.
     pub exit_argument: Option<ProgramId>,
+    /// Communication initiator
+    pub initiator: ProgramId,
 }
 
 /// Empty implementation for non-substrate (and non-lazy-pages) using
@@ -113,6 +116,7 @@ impl ProcessorExt for Ext {
         existential_deposit: u128,
         error_explanation: Option<&'static str>,
         exit_argument: Option<ProgramId>,
+        initiator: ProgramId,
     ) -> Self {
         Self {
             gas_counter,
@@ -124,6 +128,7 @@ impl ProcessorExt for Ext {
             existential_deposit,
             error_explanation,
             exit_argument,
+            initiator,
         }
     }
 
@@ -257,6 +262,10 @@ impl EnvExt for Ext {
 
     fn block_timestamp(&self) -> u64 {
         self.block_info.timestamp
+    }
+
+    fn initiator(&self) -> ProgramId {
+        self.initiator
     }
 
     fn send_init(&mut self) -> Result<usize, &'static str> {

--- a/core-processor/src/processor.rs
+++ b/core-processor/src/processor.rs
@@ -83,9 +83,8 @@ pub fn process_many<A: ProcessorExt + EnvExt + Into<ExtInfo> + 'static, E: Envir
     let mut journal = Vec::new();
 
     assert_eq!(dispatches.len(), initiators.len());
-    let mut initiators = initiators.into_iter();
 
-    for dispatch in dispatches {
+    for (dispatch, initiator) in dispatches.into_iter().zip(initiators.into_iter()) {
         let actor = actors
             .get_mut(&dispatch.message.dest())
             .expect("Program wasn't found in programs");
@@ -95,9 +94,7 @@ pub fn process_many<A: ProcessorExt + EnvExt + Into<ExtInfo> + 'static, E: Envir
             dispatch,
             block_info,
             existential_deposit,
-            initiators
-                .next()
-                .expect("Can't fail. Lengths checked above"),
+            initiator,
         );
 
         for note in &current_journal {

--- a/core-processor/src/processor.rs
+++ b/core-processor/src/processor.rs
@@ -40,14 +40,14 @@ pub fn process<A: ProcessorExt + EnvExt + Into<ExtInfo> + 'static, E: Environmen
     dispatch: Dispatch,
     block_info: BlockInfo,
     existential_deposit: u128,
-    initiator: ProgramId,
+    origin: ProgramId,
 ) -> Vec<JournalNote> {
     if let Err(exit_code) = check_is_executable(actor.as_ref(), &dispatch) {
         process_non_executable(dispatch, exit_code)
     } else {
         let actor = actor.expect("message is not executed if actor is none");
         let execution_settings = ExecutionSettings::new(block_info, existential_deposit);
-        let execution_context = ExecutionContext { initiator };
+        let execution_context = ExecutionContext { origin };
         let initial_nonce = actor.program.message_nonce();
 
         match executor::execute_wasm::<A, E>(
@@ -79,13 +79,13 @@ pub fn process_many<A: ProcessorExt + EnvExt + Into<ExtInfo> + 'static, E: Envir
     block_info: BlockInfo,
     existential_deposit: u128,
     // Will go away some time soon
-    initiators: Vec<ProgramId>,
+    origins: Vec<ProgramId>,
 ) -> Vec<JournalNote> {
     let mut journal = Vec::new();
 
-    assert_eq!(dispatches.len(), initiators.len());
+    assert_eq!(dispatches.len(), origins.len());
 
-    for (dispatch, initiator) in dispatches.into_iter().zip(initiators.into_iter()) {
+    for (dispatch, origin) in dispatches.into_iter().zip(origins.into_iter()) {
         let actor = actors
             .get_mut(&dispatch.message.dest())
             .expect("Program wasn't found in programs");
@@ -95,7 +95,7 @@ pub fn process_many<A: ProcessorExt + EnvExt + Into<ExtInfo> + 'static, E: Envir
             dispatch,
             block_info,
             existential_deposit,
-            initiator,
+            origin,
         );
 
         for note in &current_journal {

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -54,7 +54,7 @@ pub trait Ext {
 
     /// Get the id of the user who initiated communication with blockchain,
     /// during which, currently processing message was created.
-    fn initiator(&self) -> ProgramId;
+    fn origin(&self) -> ProgramId;
 
     /// Initialize a new incomplete message for another program and return its handle.
     fn send_init(&mut self) -> Result<usize, &'static str>;
@@ -229,7 +229,7 @@ mod tests {
         fn block_timestamp(&self) -> u64 {
             0
         }
-        fn initiator(&self) -> ProgramId {
+        fn origin(&self) -> ProgramId {
             ProgramId::from(0)
         }
         fn send_init(&mut self) -> Result<usize, &'static str> {

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -18,15 +18,15 @@
 
 //! Environment for running a module.
 
+use crate::{
+    memory::PageNumber,
+    message::{ExitCode, MessageId, OutgoingPacket, ReplyPacket},
+    program::ProgramId,
+};
 use alloc::rc::Rc;
-use core::cell::RefCell;
-
 use anyhow::Result;
 use codec::{Decode, Encode};
-
-use crate::memory::PageNumber;
-use crate::message::{ExitCode, MessageId, OutgoingPacket, ReplyPacket};
-use crate::program::ProgramId;
+use core::cell::RefCell;
 
 /// Page access rights.
 #[derive(Clone, Debug, Encode, Decode, PartialEq, Eq, Copy)]
@@ -51,6 +51,10 @@ pub trait Ext {
 
     /// Get the current block timestamp.
     fn block_timestamp(&self) -> u64;
+
+    /// Get the id of the user who initiated communication with blockchain,
+    /// during which, currently processing message was created.
+    fn initiator(&self) -> ProgramId;
 
     /// Initialize a new incomplete message for another program and return its handle.
     fn send_init(&mut self) -> Result<usize, &'static str>;
@@ -221,6 +225,9 @@ mod tests {
         }
         fn block_timestamp(&self) -> u64 {
             0
+        }
+        fn initiator(&self) -> ProgramId {
+            ProgramId::from(0)
         }
         fn send_init(&mut self) -> Result<usize, &'static str> {
             Ok(0)

--- a/gcore/src/exec.rs
+++ b/gcore/src/exec.rs
@@ -30,7 +30,7 @@ mod sys {
         pub fn gr_exit(value_dest_ptr: *const u8) -> !;
         pub fn gr_gas_available() -> u64;
         pub fn gr_program_id(val: *mut u8);
-        pub fn gr_initiator(initiator_ptr: *mut u8);
+        pub fn gr_origin(origin_ptr: *mut u8);
         pub fn gr_leave() -> !;
         pub fn gr_value_available(val: *mut u8);
         pub fn gr_wait() -> !;
@@ -240,11 +240,11 @@ pub fn program_id() -> ActorId {
 ///
 /// pub unsafe extern "C" fn handle() {
 ///     // ...
-///     let _user = exec::initiator();
+///     let _user = exec::origin();
 /// }
 /// ```
-pub fn initiator() -> ActorId {
+pub fn origin() -> ActorId {
     let mut actor_id = ActorId::default();
-    unsafe { sys::gr_initiator(actor_id.as_mut_slice().as_mut_ptr()) };
+    unsafe { sys::gr_origin(actor_id.as_mut_slice().as_mut_ptr()) };
     actor_id
 }

--- a/gcore/src/exec.rs
+++ b/gcore/src/exec.rs
@@ -30,6 +30,7 @@ mod sys {
         pub fn gr_exit(value_dest_ptr: *const u8) -> !;
         pub fn gr_gas_available() -> u64;
         pub fn gr_program_id(val: *mut u8);
+        pub fn gr_initiator(initiator_ptr: *mut u8);
         pub fn gr_leave() -> !;
         pub fn gr_value_available(val: *mut u8);
         pub fn gr_wait() -> !;
@@ -230,5 +231,24 @@ pub fn wake(waker_id: MessageId) {
 pub fn program_id() -> ActorId {
     let mut actor_id = ActorId::default();
     unsafe { sys::gr_program_id(actor_id.as_mut_slice().as_mut_ptr()) }
+    actor_id
+}
+
+/// Return the id of original user who initiated communication with blockchain,
+/// during which, currently processing message was created.
+///
+/// # Examples
+///
+/// ```
+/// use gcore::{exec, ActorId};
+///
+/// pub unsafe extern "C" fn handle() {
+///     // ...
+///     let _user = exec::initiator();
+/// }
+/// ```
+pub fn initiator() -> ActorId {
+    let mut actor_id = ActorId::default();
+    unsafe { sys::gr_initiator(actor_id.as_mut_slice().as_mut_ptr()) };
     actor_id
 }

--- a/gear-test/src/proc.rs
+++ b/gear-test/src/proc.rs
@@ -121,6 +121,7 @@ where
         message.into(),
         block_info,
         EXISTENTIAL_DEPOSIT,
+        Default::default(),
     );
 
     core_processor::handle_journal(journal, journal_handler);
@@ -278,6 +279,7 @@ where
                     dispatch,
                     BlockInfo { height, timestamp },
                     EXISTENTIAL_DEPOSIT,
+                    Default::default(),
                 );
 
                 core_processor::handle_journal(journal, journal_handler);
@@ -307,6 +309,7 @@ where
                     timestamp,
                 },
                 EXISTENTIAL_DEPOSIT,
+                Default::default(),
             );
             counter += 1;
 

--- a/gstd/src/exec.rs
+++ b/gstd/src/exec.rs
@@ -190,9 +190,9 @@ pub fn program_id() -> ActorId {
 ///
 /// pub unsafe extern "C" fn handle() {
 ///     // ...
-///     let _user = exec::initiator();
+///     let _user = exec::origin();
 /// }
 /// ```
-pub fn initiator() -> ActorId {
-    gcore::exec::initiator().into()
+pub fn origin() -> ActorId {
+    gcore::exec::origin().into()
 }

--- a/gstd/src/exec.rs
+++ b/gstd/src/exec.rs
@@ -183,3 +183,20 @@ pub fn wake(waker_id: MessageId) {
 pub fn program_id() -> ActorId {
     gcore::exec::program_id().into()
 }
+
+/// Return the id of original user who initiated communication with blockchain,
+/// during which, currently processing message was created.
+///
+/// # Examples
+///
+/// ```
+/// use gstd::{exec, ActorId};
+///
+/// pub unsafe extern "C" fn handle() {
+///     // ...
+///     let _user = exec::initiator();
+/// }
+/// ```
+pub fn initiator() -> ActorId {
+    gcore::exec::initiator().into()
+}

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -60,7 +60,7 @@ pub(crate) struct ExtManager {
     pub(crate) wait_init_list: BTreeMap<ProgramId, Vec<MessageId>>,
 
     // Last run info
-    pub(crate) initiator: ProgramId,
+    pub(crate) origin: ProgramId,
     pub(crate) msg_id: MessageId,
     pub(crate) log: Vec<Message>,
     pub(crate) main_failed: bool,
@@ -174,7 +174,7 @@ impl ExtManager {
                         },
                         self.block_info,
                         crate::EXISTENTIAL_DEPOSIT,
-                        self.initiator,
+                        self.origin,
                     );
 
                     core_processor::handle_journal(journal, self);
@@ -257,9 +257,9 @@ impl ExtManager {
         }
     }
 
-    fn prepare_for(&mut self, msg_id: MessageId, initiator: ProgramId) {
+    fn prepare_for(&mut self, msg_id: MessageId, origin: ProgramId) {
         self.msg_id = msg_id;
-        self.initiator = initiator;
+        self.origin = origin;
         self.log.clear();
         self.main_failed = false;
         self.others_failed = false;

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -60,6 +60,7 @@ pub(crate) struct ExtManager {
     pub(crate) wait_init_list: BTreeMap<ProgramId, Vec<MessageId>>,
 
     // Last run info
+    pub(crate) initiator: ProgramId,
     pub(crate) msg_id: MessageId,
     pub(crate) log: Vec<Message>,
     pub(crate) main_failed: bool,
@@ -119,7 +120,7 @@ impl ExtManager {
     }
 
     pub(crate) fn run_message(&mut self, message: Message) -> RunResult {
-        self.prepare_for(message.id());
+        self.prepare_for(message.id(), message.source());
 
         if self.actors.contains_key(&message.dest()) {
             self.message_queue.push_back(message);
@@ -173,6 +174,7 @@ impl ExtManager {
                         },
                         self.block_info,
                         crate::EXISTENTIAL_DEPOSIT,
+                        self.initiator,
                     );
 
                     core_processor::handle_journal(journal, self);
@@ -257,8 +259,9 @@ impl ExtManager {
         }
     }
 
-    fn prepare_for(&mut self, msg_id: MessageId) {
+    fn prepare_for(&mut self, msg_id: MessageId, initiator: ProgramId) {
         self.msg_id = msg_id;
+        self.initiator = initiator;
         self.log.clear();
         self.main_failed = false;
         self.others_failed = false;

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -97,6 +97,7 @@ impl ProcessorExt for LazyPagesExt {
         existential_deposit: u128,
         error_explanation: Option<&'static str>,
         exit_argument: Option<ProgramId>,
+        initiator: ProgramId,
     ) -> Self {
         Self {
             inner: Ext {
@@ -109,6 +110,7 @@ impl ProcessorExt for LazyPagesExt {
                 existential_deposit,
                 error_explanation,
                 exit_argument,
+                initiator,
             },
             lazy_pages_enabled: false,
         }
@@ -216,6 +218,10 @@ impl EnvExt for LazyPagesExt {
 
     fn block_timestamp(&self) -> u64 {
         self.inner.block_timestamp()
+    }
+
+    fn initiator(&self) -> ProgramId {
+        self.inner.initiator()
     }
 
     fn send_init(&mut self) -> Result<usize, &'static str> {

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -96,7 +96,7 @@ impl ProcessorExt for LazyPagesExt {
         existential_deposit: u128,
         error_explanation: Option<&'static str>,
         exit_argument: Option<ProgramId>,
-        initiator: ProgramId,
+        origin: ProgramId,
         program_candidates_data: BTreeMap<CodeHash, Vec<(ProgramId, MessageId)>>,
     ) -> Self {
         Self {
@@ -110,7 +110,7 @@ impl ProcessorExt for LazyPagesExt {
                 existential_deposit,
                 error_explanation,
                 exit_argument,
-                initiator,
+                origin,
                 program_candidates_data,
             },
             lazy_pages_enabled: false,
@@ -221,8 +221,8 @@ impl EnvExt for LazyPagesExt {
         self.inner.block_timestamp()
     }
 
-    fn initiator(&self) -> ProgramId {
-        self.inner.initiator()
+    fn origin(&self) -> ProgramId {
+        self.inner.origin()
     }
 
     fn send_init(&mut self) -> Result<usize, &'static str> {

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -457,7 +457,7 @@ pub mod pallet {
             while let Some(dispatch) = common::dequeue_dispatch() {
                 // Update message gas limit for it may have changed in the meantime
 
-                let (gas_limit, initiator) = T::GasHandler::get_limit(*dispatch.message_id())
+                let (gas_limit, origin) = T::GasHandler::get_limit(*dispatch.message_id())
                     .expect("Should never fail if ValueNode works properly");
 
                 log::debug!(
@@ -518,7 +518,7 @@ pub mod pallet {
                     dispatch.into_dispatch(gas_limit),
                     block_info,
                     existential_deposit,
-                    ProgramId::from_origin(initiator),
+                    ProgramId::from_origin(origin),
                 );
 
                 core_processor::handle_journal(journal, &mut ext_manager);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 290,
+    spec_version: 310,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 280,
+    spec_version: 290,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/scripts/check-spec.sh
+++ b/scripts/check-spec.sh
@@ -2,37 +2,50 @@
 
 set -e
 
-PACKAGES_REQUIRE_BUMP_SPEC="common core core-backend node pallets runtime-interface lazy-pages"
+SELF="$0"
+ROOT_DIR="$(cd "$(dirname "$SELF")"/.. && pwd)"
+
+check_spec() {
+    # $1 is master version, $2 is actual one and $3 changes requirement
+    version="$(echo $1 $2 $3 | awk '{
+        if ($3 == "true")
+            if ($1 > $2)
+                if ($1 - $2 >= 50 && $2 == 100)
+                    print "" # Ok case. We have reseted the network
+                else
+                    print "be bumped from",$1 # Should be bumped and be greater than master one
+            else if ($1 == $2)
+                print "be bumped from", $2 # We should bump for next version
+            else
+                print "" # Ok case. We had our spec bumped
+        else if ($1 - $2 >= 50 && $2 == 100)
+            print "" # Ok case. We have reseted the network
+        else if ($1 != $2)
+            print "equal",$1
+    }')"
+
+    if [ -z "$version" ]
+    then
+        printf "\n   Spec version is correct.\n\n"
+    else
+        printf "\n   Spec version should $version.\n\n"
+        exit 1
+    fi
+}
+
+PACKAGES_REQUIRE_BUMP_SPEC="common core core-backend core-processor node pallets runtime-interface lazy-pages"
 
 SPEC_ON_MASTER="$(git diff origin/master | sed -n -r "s/^\-[[:space:]]+spec_version: +([0-9]+),$/\1/p")"
-ACTUAL_SPEC="$(git diff origin/master | sed -n -r "s/^\+[[:space:]]+spec_version: +([0-9]+),$/\1/p")"
+ACTUAL_SPEC="$(cat $ROOT_DIR/runtime/src/lib.rs | grep "spec_version: " | awk -F " " '{print substr($2, 1, length($2)-1)}')"
 
 if [ -z "$SPEC_ON_MASTER" ]; then
-    SPEC_ON_MASTER="0"
+    SPEC_ON_MASTER=$ACTUAL_SPEC
 fi
 
-if [ -z "$ACTUAL_SPEC" ]; then
-    ACTUAL_SPEC="0"
-fi
-
-for package in $(git diff --name-only $CURRENT_BRANCH origin/master | grep -v "README.md$" | cut -d "/" -f1 | uniq); do
+for package in $(git diff --name-only origin/master | grep ".rs$" | cut -d "/" -f1 | uniq); do
     if [[ " ${PACKAGES_REQUIRE_BUMP_SPEC[@]} " =~ " ${package} " ]]; then
-        UPDATED_SPEC="true"
-        if [ "$SPEC_ON_MASTER" = "$ACTUAL_SPEC" ]; then
-            printf "\n   These files were changed:\n\n"
-            echo "$(git diff --name-only origin/master | grep "^$package")"
-            printf "\n   Spec version should be bumped!\n\n"
-            exit 1
-        fi
+        CHANGES="true"
     fi
 done
 
-if [ "$UPDATED_SPEC" != "true" ]; then
-    if [ "$SPEC_ON_MASTER" != "$ACTUAL_SPEC" ]; then
-        printf "\n   Spec versions are different, but they shouldn't!\n\n"
-        exit 1
-    fi
-fi
-
-printf "\n   Spec version is correct!\n\n"
-exit 0
+check_spec "$SPEC_ON_MASTER" "$ACTUAL_SPEC" "$CHANGES"

--- a/tests/common/src/lib.rs
+++ b/tests/common/src/lib.rs
@@ -422,6 +422,7 @@ impl RunnerContext {
             payload_store: None,
         };
         let message_id = dispatch.message.id;
+        let initiator = dispatch.message.source;
 
         let journal = core_processor::process::<Ext, WasmtimeEnvironment<Ext>>(
             Some(actor),
@@ -431,6 +432,7 @@ impl RunnerContext {
                 timestamp: 1,
             },
             EXISTENTIAL_DEPOSIT,
+            initiator,
         );
 
         core_processor::handle_journal(journal, &mut Journal { context: self });
@@ -583,6 +585,7 @@ impl RunnerContext {
             let journal = {
                 let messages = std::mem::take(&mut self.dispatch_queue);
                 let actors = self.actors.clone();
+                let initiators = vec![messages[0].message.source(); messages.len()];
 
                 core_processor::process_many::<Ext, WasmtimeEnvironment<Ext>>(
                     actors,
@@ -592,6 +595,7 @@ impl RunnerContext {
                         timestamp: 1,
                     },
                     EXISTENTIAL_DEPOSIT,
+                    initiators,
                 )
             };
 

--- a/tests/common/src/lib.rs
+++ b/tests/common/src/lib.rs
@@ -435,7 +435,7 @@ impl RunnerContext {
             payload_store: None,
         };
         let message_id = dispatch.message.id;
-        let initiator = dispatch.message.source;
+        let origin = dispatch.message.source;
 
         let journal = core_processor::process::<Ext, WasmtimeEnvironment<Ext>>(
             Some(actor),
@@ -445,7 +445,7 @@ impl RunnerContext {
                 timestamp: 1,
             },
             EXISTENTIAL_DEPOSIT,
-            initiator,
+            origin,
         );
 
         core_processor::handle_journal(journal, &mut Journal { context: self });
@@ -598,7 +598,7 @@ impl RunnerContext {
             let journal = {
                 let messages = std::mem::take(&mut self.dispatch_queue);
                 let actors = self.actors.clone();
-                let initiators = vec![messages[0].message.source(); messages.len()];
+                let origins = vec![messages[0].message.source(); messages.len()];
 
                 core_processor::process_many::<Ext, WasmtimeEnvironment<Ext>>(
                     actors,
@@ -608,7 +608,7 @@ impl RunnerContext {
                         timestamp: 1,
                     },
                     EXISTENTIAL_DEPOSIT,
-                    initiators,
+                    origins,
                 )
             };
 


### PR DESCRIPTION
By @LouiseMedova's request:

Provides an ability to get the id of original user who initiated communication with blockchain, during which, currently processing message was created.

Integration for `gear-test` won't be realized, until we hadn't done with #649 

@gear-tech/dev 
