### PR TITLE
Replace log::error! and warn! with debug! to a specific target

### DIFF
--- a/core/src/gas.rs
+++ b/core/src/gas.rs
@@ -175,7 +175,11 @@ pub fn instrument(code: &[u8]) -> Result<Vec<u8>, InstrumentError> {
     use pwasm_utils::rules::{InstructionType, Metering};
 
     let module = parity_wasm::elements::Module::from_bytes(code).map_err(|e| {
-        log::error!("Error decoding module: {}", e);
+        log::debug!(
+            target: "essential",
+            "Error decoding module: {}",
+            e,
+        );
         InstrumentError::Decode
     })?;
 
@@ -194,12 +198,19 @@ pub fn instrument(code: &[u8]) -> Result<Vec<u8>, InstrumentError> {
         "env",
     )
     .map_err(|_module| {
-        log::error!("Error injecting gas counter");
+        log::debug!(
+            target: "essential",
+            "Error injecting gas counter",
+        );
         InstrumentError::GasInjection
     })?;
 
     parity_wasm::elements::serialize(instrumented_module).map_err(|e| {
-        log::error!("Error encoding module: {}", e);
+        log::debug!(
+            target: "essential",
+            "Error encoding module: {}",
+            e,
+        );
         InstrumentError::Encode
     })
 }

--- a/lazy-pages/src/unix.rs
+++ b/lazy-pages/src/unix.rs
@@ -123,20 +123,25 @@ pub unsafe fn init_lazy_pages() -> bool {
     if cfg!(target_os = "linux") {
         let res = signal::sigaction(signal::SIGSEGV, &sig_action);
         if let Err(err_no) = res {
-            log::error!(
+            log::debug!(
+                target: "essential",
                 "Cannot set sigsegv handler: {}",
-                errno::Errno(err_no as i32)
+                errno::Errno(err_no as i32),
             );
             return false;
         }
     } else if cfg!(target_os = "macos") {
         let res = signal::sigaction(signal::SIGBUS, &sig_action);
         if let Err(err_no) = res {
-            log::error!("Cannot set sigbus handler: {}", errno::Errno(err_no as i32));
+            log::debug!(
+                target: "essential",
+                "Cannot set sigbus handler: {}",
+                errno::Errno(err_no as i32),
+            );
             return false;
         }
     } else {
-        log::debug!("Lazy pages doesn't support this OS");
+        log::debug!("Lazy pages are not supported on this OS");
         return false;
     }
 

--- a/pallets/gear/src/manager.rs
+++ b/pallets/gear/src/manager.rs
@@ -306,7 +306,11 @@ where
                         );
                     }
                 } else {
-                    log::error!("Failed to get limit of {:?}", message_id);
+                    log::debug!(
+                        target: "essential",
+                        "Failed to get limit of {:?}",
+                        message_id,
+                    );
                 }
             }
             Err(err) => {
@@ -448,15 +452,20 @@ where
                             );
                         }
                     } else {
-                        log::error!("Failed to get limit of {:?}", message_id);
+                        log::debug!(
+                            target: "essential",
+                            "Failed to get limit of {:?}",
+                            message_id,
+                        );
                     }
                 }
                 Err(err) => {
-                    log::error!(
+                    log::debug!(
+                        target: "essential",
                         "Error charging {:?} gas rent of getting out of waitlist for message_id {:?}: {:?}",
                         chargeable_amount,
                         message_id,
-                        err
+                        err,
                     )
                 }
             };

--- a/pallets/usage/src/lib.rs
+++ b/pallets/usage/src/lib.rs
@@ -236,8 +236,8 @@ pub mod pallet {
 
             let res = Self::waitlist_usage(now);
             if let Err(e) = res {
-                log::error!(
-                    target: "runtime::usage",
+                log::debug!(
+                    target: "essential",
                     "Error in offchain worker at {:?}: {:?}", now, e,
                 )
             }
@@ -274,8 +274,9 @@ pub mod pallet {
                                     Some((actual_fee, origin, dispatch, msg_gas_balance))
                                 },
                                 _ => {
-                                    log::error!(
-                                        "Message in wait list doesn't have associated gas - can't charge rent"
+                                    log::debug!(
+                                        target: "essential",
+                                        "Message in wait list doesn't have associated gas - can't charge rent",
                                     );
                                     None
                                 }
@@ -286,7 +287,8 @@ pub mod pallet {
                 .for_each(|(fee, origin, dispatch, msg_gas_balance)| {
                     let msg_id = dispatch.message.id;
                     if let Err(e) = <T as pallet_gear::Config>::GasHandler::spend(msg_id, fee) {
-                        log::error!(
+                        log::debug!(
+                            target: "essential",
                             "Error spending {:?} gas from {:?}: {:?}",
                             fee, msg_id, e
                         );
@@ -372,9 +374,10 @@ pub mod pallet {
                         } else {
                                 // Wait init messages can't reach that, because if program init failed,
                                 // then all waiting messages are moved to queue deleted.
-                                log::error!(
+                                log::debug!(
+                                    target: "essential",
                                     "Program {:?} isn't in storage, but message with that dest is in WL",
-                                    program_id
+                                    program_id,
                                 )
                             }
                     } else {

--- a/pallets/usage/src/lib.rs
+++ b/pallets/usage/src/lib.rs
@@ -305,7 +305,11 @@ pub mod pallet {
                                 who,
                                 user_reward,
                             ) {
-                                log::warn!("Failed to repatriate reserved amount: {:?}", e);
+                                log::debug!(
+                                    target: "essential",
+                                    "Failed to repatriate reserved amount: {:?}",
+                                    e,
+                                );
                             }
                             if let Some(author) = Authorship::<T>::author() {
                                 if let Err(e) = T::PaymentProvider::withhold_reserved(
@@ -313,7 +317,11 @@ pub mod pallet {
                                     &author,
                                     validator_reward,
                                 ) {
-                                    log::warn!("Failed to repatriate reserved amount: {:?}", e);
+                                    log::debug!(
+                                        target: "essential",
+                                        "Failed to repatriate reserved amount: {:?}",
+                                        e,
+                                    );
                                 }
                             }
                         }
@@ -324,7 +332,11 @@ pub mod pallet {
                                     &author,
                                     total_reward,
                                 ) {
-                                    log::warn!("Failed to repatriate reserved amount: {:?}", e);
+                                    log::debug!(
+                                        target: "essential",
+                                        "Failed to repatriate reserved amount: {:?}",
+                                        e,
+                                    );
                                 }
                             }
                         }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 330,
+    spec_version: 340,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
In order not to flood users logs with irrelevant messages (while sync'ing the node) use the `error` or `warn` log levels sparingly.
Instead, it is recommended to use `log::debug!` and direct the messages to the `essential` target which will be enabled on validators' nodes by default via a CLI flag (the latter feature will be implemented in a separate PR).