### PR TITLE
Unify code hash generation

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -40,7 +40,7 @@ use sp_std::{
 
 use gear_core::{
     message::{DispatchKind, PayloadStore},
-    program::{Program as NativeProgram, ProgramId},
+    program::{CodeHash, Program as NativeProgram, ProgramId},
 };
 
 pub use storage_queue::Iterator;
@@ -97,6 +97,16 @@ impl Origin for H256 {
 
     fn from_origin(val: H256) -> Self {
         val
+    }
+}
+
+impl Origin for CodeHash {
+    fn into_origin(self) -> H256 {
+        self.inner().into()
+    }
+
+    fn from_origin(val: H256) -> Self {
+        val.to_fixed_bytes().into()
     }
 }
 
@@ -761,7 +771,7 @@ mod tests {
     fn program_decoded() {
         sp_io::TestExternalities::new_empty().execute_with(|| {
             let code = b"pretended wasm code".to_vec();
-            let code_hash: H256 = sp_io::hashing::blake2_256(&code[..]).into();
+            let code_hash: H256 = CodeHash::generate(&code).into_origin();
             let program_id = H256::from_low_u64_be(1);
             let program = ActiveProgram {
                 static_pages: 256,

--- a/common/src/native.rs
+++ b/common/src/native.rs
@@ -18,7 +18,7 @@
 
 use gear_core::{
     message::{Dispatch as CoreDispatch, Message as CoreMessage, MessageId},
-    program::{Program as CoreProgram, ProgramId},
+    program::{CodeHash, Program as CoreProgram, ProgramId},
 };
 
 use primitive_types::H256;
@@ -112,7 +112,7 @@ impl From<CoreDispatch> for Dispatch {
 }
 
 pub fn set_program(program: CoreProgram) {
-    let code_hash = sp_io::hashing::blake2_256(program.code()).into();
+    let code_hash = CodeHash::generate(program.code()).into_origin();
     // This code is only used in tests and is redundant for
     // production.
     if !crate::code_exists(code_hash) {

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -333,6 +333,12 @@ impl Program {
 pub struct CodeHash([u8; 32]);
 
 impl CodeHash {
+    /// Instantiates [`CodeHash`] by computing blake2b hash of the program `code`.
+    pub fn generate(code: &[u8]) -> Self {
+        let blake2b_hash = blake2_rfc::blake2b::blake2b(32, &[], code);
+        Self::from_slice(blake2b_hash.as_bytes())
+    }
+
     /// Get inner (32 bytes) array representation
     pub fn inner(&self) -> [u8; 32] {
         self.0

--- a/gear-test/src/manager.rs
+++ b/gear-test/src/manager.rs
@@ -51,8 +51,7 @@ impl InMemoryExtManager {
 
 impl ExecutionContext for InMemoryExtManager {
     fn store_code(&mut self, code: &[u8]) {
-        let code_hash = sp_io::hashing::blake2_256(code).into();
-        self.codes.insert(code_hash, code.to_vec());
+        self.codes.insert(CodeHash::generate(code), code.to_vec());
     }
     fn store_program(&mut self, program: gear_core::program::Program, _init_message_id: MessageId) {
         self.waiting_init.insert(program.id(), vec![]);

--- a/pallets/gear-debug/src/tests.rs
+++ b/pallets/gear-debug/src/tests.rs
@@ -21,7 +21,10 @@
 use super::*;
 use crate::mock::*;
 use common::{self, Origin as _, QueuedDispatch, QueuedMessage};
-use gear_core::{message::DispatchKind, program::ProgramId};
+use gear_core::{
+    message::DispatchKind,
+    program::{CodeHash, ProgramId},
+};
 use pallet_gear::DebugInfo;
 use pallet_gear::Pallet as PalletGear;
 use sp_core::H256;
@@ -42,9 +45,12 @@ fn parse_wat(source: &str) -> Vec<u8> {
         .to_vec()
 }
 
-pub fn program_id(code: &[u8]) -> H256 {
-    let code_hash = sp_io::hashing::blake2_256(code).into();
-    ProgramId::generate(code_hash, b"salt").into_origin()
+fn generate_program_id(code: &[u8]) -> H256 {
+    ProgramId::generate(CodeHash::generate(code), b"salt").into_origin()
+}
+
+fn generate_code_hash(code: &[u8]) -> H256 {
+    CodeHash::generate(code).into_origin()
 }
 
 #[test]
@@ -76,8 +82,8 @@ fn debug_mode_works() {
         let code_1 = parse_wat(wat_1);
         let code_2 = parse_wat(wat_2);
 
-        let program_id_1 = program_id(&code_1);
-        let program_id_2 = program_id(&code_2);
+        let program_id_1 = generate_program_id(&code_1);
+        let program_id_2 = generate_program_id(&code_2);
 
         PalletGear::<Test>::submit_program(
             Origin::signed(1).into(),
@@ -103,7 +109,7 @@ fn debug_mode_works() {
                     id: program_id_1,
                     static_pages: 16,
                     persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
-                    code_hash: H256::from(sp_io::hashing::blake2_256(&code_1)),
+                    code_hash: generate_code_hash(&code_1),
                     nonce: 0u64,
                 }],
             })
@@ -132,14 +138,14 @@ fn debug_mode_works() {
                         id: program_id_2,
                         static_pages: 16,
                         persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
-                        code_hash: H256::from(sp_io::hashing::blake2_256(&code_2)),
+                        code_hash: generate_code_hash(&code_2),
                         nonce: 0u64,
                     },
                     crate::ProgramDetails {
                         id: program_id_1,
                         static_pages: 16,
                         persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
-                        code_hash: H256::from(sp_io::hashing::blake2_256(&code_1)),
+                        code_hash: generate_code_hash(&code_1),
                         nonce: 0u64,
                     },
                 ],
@@ -207,14 +213,14 @@ fn debug_mode_works() {
                         id: program_id_2,
                         static_pages: 16,
                         persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
-                        code_hash: H256::from(sp_io::hashing::blake2_256(&code_2)),
+                        code_hash: generate_code_hash(&code_2),
                         nonce: 0u64,
                     },
                     crate::ProgramDetails {
                         id: program_id_1,
                         static_pages: 16,
                         persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
-                        code_hash: H256::from(sp_io::hashing::blake2_256(&code_1)),
+                        code_hash: generate_code_hash(&code_1),
                         nonce: 0u64,
                     },
                 ],
@@ -234,14 +240,14 @@ fn debug_mode_works() {
                         id: program_id_2,
                         static_pages: 16,
                         persistent_pages: (0..20).map(|v| (v, vec![0; 65536])).collect(),
-                        code_hash: H256::from(sp_io::hashing::blake2_256(&code_2)),
+                        code_hash: generate_code_hash(&code_2),
                         nonce: 0u64,
                     },
                     crate::ProgramDetails {
                         id: program_id_1,
                         static_pages: 16,
                         persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
-                        code_hash: H256::from(sp_io::hashing::blake2_256(&code_1)),
+                        code_hash: generate_code_hash(&code_1),
                         nonce: 0u64,
                     },
                 ],

--- a/pallets/gear/src/benchmarking.rs
+++ b/pallets/gear/src/benchmarking.rs
@@ -21,6 +21,7 @@
 use super::*;
 use codec::Encode;
 use common::Origin;
+use gear_core::program::CodeHash;
 use parity_wasm::elements::*;
 use sp_core::H256;
 use sp_io::hashing::blake2_256;
@@ -149,7 +150,7 @@ fn generate_wasm3(payload: Vec<u8>) -> Result<Vec<u8>, &'static str> {
 }
 
 fn set_program(program_id: H256, code: Vec<u8>, static_pages: u32, nonce: u64) {
-    let code_hash = sp_io::hashing::blake2_256(&code).into();
+    let code_hash = CodeHash::generate(&code).into_origin();
     common::set_program(
         program_id,
         common::ActiveProgram {
@@ -172,7 +173,7 @@ benchmarks! {
         let c in 0 .. MAX_CODE_LEN;
         let caller: T::AccountId = account("caller", 0, 0);
         let code = vec![0u8; c as usize];
-        let code_hash: H256 = sp_io::hashing::blake2_256(&code).into();
+        let code_hash: H256 = CodeHash::generate(&code).into_origin();
     }: _(RawOrigin::Signed(caller), code)
     verify {
         assert!(common::code_exists(code_hash));

--- a/pallets/gear/src/manager.rs
+++ b/pallets/gear/src/manager.rs
@@ -144,7 +144,7 @@ where
             "Must has empty persistent pages, has {:?}",
             program.get_pages()
         );
-        let code_hash: H256 = sp_io::hashing::blake2_256(program.code()).into();
+        let code_hash = CodeHash::generate(program.code()).into_origin();
         assert!(
             common::code_exists(code_hash),
             "Program set must be called only when code exists",

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -1141,14 +1141,12 @@ fn distributor_distribute() {
     });
 }
 
-// TODO #512 All `submit_code` tests should be changed to testing program creation from program logic.
-
 #[test]
 fn test_code_submission_pass() {
     init_logger();
     new_test_ext().execute_with(|| {
         let code = ProgramCodeKind::Default.to_bytes();
-        let code_hash = sp_io::hashing::blake2_256(&code).into();
+        let code_hash = generate_code_hash(&code).into();
 
         assert_ok!(GearPallet::<Test>::submit_code(
             Origin::signed(USER_1),
@@ -1194,7 +1192,7 @@ fn test_code_is_not_submitted_twice_after_program_submission() {
     init_logger();
     new_test_ext().execute_with(|| {
         let code = ProgramCodeKind::Default.to_bytes();
-        let code_hash = sp_io::hashing::blake2_256(&code).into();
+        let code_hash = generate_code_hash(&code).into();
 
         // First submit program, which will set code and metadata
         assert_ok!(GearPallet::<Test>::submit_program(
@@ -1221,7 +1219,7 @@ fn test_code_is_not_resetted_within_program_submission() {
     init_logger();
     new_test_ext().execute_with(|| {
         let code = ProgramCodeKind::Default.to_bytes();
-        let code_hash = sp_io::hashing::blake2_256(&code).into();
+        let code_hash = generate_code_hash(&code).into();
 
         // First submit code
         assert_ok!(GearPallet::<Test>::submit_code(
@@ -1523,7 +1521,7 @@ fn test_message_processing_for_non_existing_destination() {
     new_test_ext().execute_with(|| {
         let program_id = submit_program_default(USER_1, ProgramCodeKind::GreedyInit).expect("todo");
         let code_hash =
-            sp_io::hashing::blake2_256(ProgramCodeKind::GreedyInit.to_bytes().as_slice()).into();
+            generate_code_hash(ProgramCodeKind::GreedyInit.to_bytes().as_slice()).into();
         let user_balance_before = BalancesPallet::<Test>::free_balance(USER_1);
 
         // After running, first message will end up with init failure, so destination address won't exist.
@@ -1611,11 +1609,10 @@ fn test_create_program_no_code_hash() {
         let factory_code = PROGRAM_FACTORY_WASM_BINARY;
         let factory_id = generate_program_id(&factory_code, DEFAULT_SALT);
 
-        let valid_code_hash =
-            sp_io::hashing::blake2_256(ProgramCodeKind::Default.to_bytes().as_slice());
+        let valid_code_hash = generate_code_hash(ProgramCodeKind::Default.to_bytes().as_slice());
         let invalid_prog_code_kind = ProgramCodeKind::Custom(non_constructable_wat);
         let invalid_prog_code_hash =
-            sp_io::hashing::blake2_256(invalid_prog_code_kind.to_bytes().as_slice());
+            generate_code_hash(invalid_prog_code_kind.to_bytes().as_slice());
 
         // Creating factory
         assert_ok!(GearPallet::<Test>::submit_program(
@@ -1705,7 +1702,7 @@ fn test_create_program_simple() {
         let factory_code = PROGRAM_FACTORY_WASM_BINARY;
         let factory_id = generate_program_id(&factory_code, DEFAULT_SALT);
         let child_code = ProgramCodeKind::Default.to_bytes();
-        let child_code_hash = sp_io::hashing::blake2_256(child_code.as_slice());
+        let child_code_hash = generate_code_hash(&child_code);
 
         // Submit the code
         assert_ok!(GearPallet::<Test>::submit_code(
@@ -1796,7 +1793,7 @@ fn test_create_program_duplicate() {
         let factory_code = PROGRAM_FACTORY_WASM_BINARY;
         let factory_id = generate_program_id(&factory_code, DEFAULT_SALT);
         let child_code = ProgramCodeKind::Default.to_bytes();
-        let child_code_hash = sp_io::hashing::blake2_256(child_code.as_slice());
+        let child_code_hash = generate_code_hash(&child_code);
 
         // Submit the code
         assert_ok!(GearPallet::<Test>::submit_code(
@@ -1887,7 +1884,7 @@ fn test_create_program_duplicate_in_one_execution() {
         let factory_id = generate_program_id(&factory_code, DEFAULT_SALT);
 
         let child_code = ProgramCodeKind::Default.to_bytes();
-        let child_code_hash = sp_io::hashing::blake2_256(&child_code);
+        let child_code_hash = generate_code_hash(&child_code);
 
         assert_ok!(GearPallet::<Test>::submit_code(
             Origin::signed(USER_2),
@@ -1969,8 +1966,8 @@ fn test_create_program_miscellaneous() {
         let child1_code = ProgramCodeKind::Default.to_bytes();
         let child2_code = ProgramCodeKind::Custom(child2_wat).to_bytes();
 
-        let child1_code_hash = sp_io::hashing::blake2_256(&child1_code);
-        let child2_code_hash = sp_io::hashing::blake2_256(&child2_code);
+        let child1_code_hash = generate_code_hash(&child1_code);
+        let child2_code_hash = generate_code_hash(&child2_code);
 
         assert_ok!(GearPallet::<Test>::submit_code(
             Origin::signed(USER_2),
@@ -2058,7 +2055,7 @@ fn exit_handle() {
         System::reset_events();
 
         let code = WASM_BINARY.to_vec();
-        let code_hash = sp_io::hashing::blake2_256(&code).into();
+        let code_hash = generate_code_hash(&code).into();
         assert_ok!(GearPallet::<Test>::submit_program(
             Origin::signed(USER_1).into(),
             code.clone(),
@@ -2118,7 +2115,7 @@ mod utils {
     use sp_core::H256;
     use sp_std::convert::TryFrom;
 
-    use gear_core::program::ProgramId;
+    use gear_core::program::{CodeHash, ProgramId};
 
     use super::{
         assert_ok, pallet, run_to_block, BalancesPallet, Event, GearPallet, MessageInfo, MockEvent,
@@ -2222,7 +2219,7 @@ mod utils {
                     .and_then(|p| common::ActiveProgram::try_from(p).ok())
                     .expect("program must exist")
                     .code_hash,
-                sp_io::hashing::blake2_256(&expected_code).into(),
+                generate_code_hash(&expected_code).into(),
                 "can invoke send to mailbox only from `ProgramCodeKind::OutgoingWithValueInHandle` program"
             );
         }
@@ -2231,7 +2228,7 @@ mod utils {
     }
 
     pub(super) fn increase_prog_balance_for_mailbox_test(sender: AccountId, program_id: H256) {
-        let expected_code_hash: H256 = sp_io::hashing::blake2_256(
+        let expected_code_hash: H256 = generate_code_hash(
             ProgramCodeKind::OutgoingWithValueInHandle
                 .to_bytes()
                 .as_slice(),
@@ -2282,8 +2279,11 @@ mod utils {
     }
 
     pub(super) fn generate_program_id(code: &[u8], salt: &[u8]) -> H256 {
-        let code_hash = sp_io::hashing::blake2_256(code).into();
-        ProgramId::generate(code_hash, salt).into_origin()
+        ProgramId::generate(CodeHash::generate(code), salt).into_origin()
+    }
+
+    pub(super) fn generate_code_hash(code: &[u8]) -> [u8; 32] {
+        CodeHash::generate(code).inner()
     }
 
     pub(super) fn send_default_message(from: AccountId, to: H256) -> DispatchResultWithPostInfo {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 330,
+    spec_version: 340,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/utils/gear-runtime-test-cli/src/command.rs
+++ b/utils/gear-runtime-test-cli/src/command.rs
@@ -27,9 +27,10 @@ use colored::{ColoredString, Colorize};
 
 use gear_runtime::{Origin, Runtime};
 
-use gear_core::message::Message as CoreMessage;
-use gear_core::program::Program as CoreProgram;
-use gear_core::program::ProgramId;
+use gear_core::{
+    message::Message as CoreMessage,
+    program::{CodeHash, Program as CoreProgram, ProgramId},
+};
 
 use gear_common::{DAGBasedLedger, Origin as _, QueuedDispatch, QueuedMessage};
 use gear_test::{
@@ -173,10 +174,9 @@ fn run_fixture(test: &'_ sample::Test, fixture: &sample::Fixture) -> ColoredStri
         .map(|program| {
             let program_path = program.path.clone();
             let code = std::fs::read(&program_path).unwrap();
-            let code_hash = sp_io::hashing::blake2_256(&code).into();
             let salt = program.id.to_program_id().as_slice().to_vec();
 
-            let id = ProgramId::generate(code_hash, &salt);
+            let id = ProgramId::generate(CodeHash::generate(&code), &salt);
 
             progs_n_paths.push((program.path.as_ref(), id));
 


### PR DESCRIPTION
As @breathx proposed, later we will introduce traits to compute ids/hashes and such things (because hash function can be changed). It will be easier to do that if id/hash computations are performed in one place - as associated function of corresponding types. Also need these changes to resolve cleaner other issue I'm working on.

@gear-tech/dev 
