### PR TITLE
Workaround to falling `gear-test` for Apple M1 CPUs

### DIFF
--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -56,10 +56,8 @@ impl<E: Ext + 'static> WasmtimeEnvironment<E> {
         result.add_func_i32("gas", funcs::gas);
         result.add_func_into_i32("gr_block_height", funcs::block_height);
         result.add_func_into_i64("gr_block_timestamp", funcs::block_timestamp);
-        result.add_func_i32_i32_i32_i32_i32_i64_i32_i32(
-            "gr_create_program_wgas",
-            funcs::create_program_wgas,
-        );
+        result
+            .add_func_i32_i32_i32_i32_i32_i32("gr_create_program_wgas", funcs::create_program_wgas);
         result.add_func_to_i32("gr_exit_code", funcs::exit_code);
         result.add_func_into_i64("gr_gas_available", funcs::gas_available);
         result.add_func_i32_i32("gr_debug", funcs::debug);
@@ -169,16 +167,13 @@ impl<E: Ext + 'static> WasmtimeEnvironment<E> {
         );
     }
 
-    fn add_func_i32_i32_i32_i32_i32_i64_i32_i32<F>(
-        &mut self,
-        key: &'static str,
-        func: fn(LaterExt<E>) -> F,
-    ) where
-        F: 'static + Fn(i32, i32, i32, i32, i32, i64, i32, i32) -> Result<(), &'static str>,
+    fn add_func_i32_i32_i32_i32_i32_i32<F>(&mut self, key: &'static str, func: fn(LaterExt<E>) -> F)
+    where
+        F: 'static + Fn(i32, i32, i32, i32, i32, i32) -> Result<(), &'static str>,
     {
         self.funcs.insert(
             key,
-            Func::wrap(&self.store, Self::wrap8(func(self.ext.clone()))),
+            Func::wrap(&self.store, Self::wrap6(func(self.ext.clone()))),
         );
     }
 
@@ -254,12 +249,6 @@ impl<E: Ext + 'static> WasmtimeEnvironment<E> {
         func: impl Fn(T0, T1, T2, T3, T4, T5) -> Result<R, &'static str>,
     ) -> impl Fn(T0, T1, T2, T3, T4, T5) -> Result<R, Trap> {
         move |a, b, c, d, e, f| func(a, b, c, d, e, f).map_err(Trap::new)
-    }
-
-    fn wrap8<T0, T1, T2, T3, T4, T5, T6, T7, R>(
-        func: impl Fn(T0, T1, T2, T3, T4, T5, T6, T7) -> Result<R, &'static str>,
-    ) -> impl Fn(T0, T1, T2, T3, T4, T5, T6, T7) -> Result<R, Trap> {
-        move |a, b, c, d, e, f, g, h| func(a, b, c, d, e, f, g, h).map_err(Trap::new)
     }
 }
 

--- a/gcore/src/general.rs
+++ b/gcore/src/general.rs
@@ -172,4 +172,8 @@ impl CodeHash {
     pub fn as_slice(&self) -> &[u8] {
         &self.0[..]
     }
+
+    pub(crate) fn iter(&self) -> core::slice::Iter<u8> {
+        self.0.iter()
+    }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 340,
+    spec_version: 350,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
After releasing program from program creation feature we faced problems with the new sys-call. When wasmtime was used as core-backend, it could not work well when lots of arguments were provided for the [func-wrap](https://docs.rs/wasmtime/latest/wasmtime/struct.Func.html#method.wrap). A workaround here is to serialize together fix length params of `create_program_with_gas` function into one buffer and provide one pointer to the multiple params.

@gear-tech/dev 
