### PR TITLE
change to wasm opt in gear test spec

### DIFF
--- a/gear-test/spec/test_async.yaml
+++ b/gear-test/spec/test_async.yaml
@@ -2,28 +2,28 @@ title: Async-await
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_async.wasm
+    path: target/wasm32-unknown-unknown/release/demo_async.opt.wasm
     init_message:
       kind: utf-8
       value: "{2},{3},{4}"
 
   - id: 2
-    path: target/wasm32-unknown-unknown/release/demo_ping.wasm
+    path: target/wasm32-unknown-unknown/release/demo_ping.opt.wasm
 
   - id: 3
-    path: target/wasm32-unknown-unknown/release/demo_ping.wasm
+    path: target/wasm32-unknown-unknown/release/demo_ping.opt.wasm
 
   - id: 4
-    path: target/wasm32-unknown-unknown/release/demo_ping.wasm
+    path: target/wasm32-unknown-unknown/release/demo_ping.opt.wasm
 
   - id: 5
-    path: target/wasm32-unknown-unknown/release/demo_mutex.wasm
+    path: target/wasm32-unknown-unknown/release/demo_mutex.opt.wasm
     init_message:
       kind: utf-8
       value: "{2}"
 
   - id: 6
-    path: target/wasm32-unknown-unknown/release/demo_rwlock_write.wasm
+    path: target/wasm32-unknown-unknown/release/demo_rwlock_write.opt.wasm
     init_message:
       kind: utf-8
       value: "{2}"

--- a/gear-test/spec/test_async_init.yaml
+++ b/gear-test/spec/test_async_init.yaml
@@ -4,7 +4,7 @@ programs:
   - id:
       kind: account
       value: alice
-    path: target/wasm32-unknown-unknown/release/demo_bot.wasm
+    path: target/wasm32-unknown-unknown/release/demo_bot.opt.wasm
     init_message:
       kind: custom
       value:
@@ -17,7 +17,7 @@ programs:
   - id:
       kind: account
       value: bob
-    path: target/wasm32-unknown-unknown/release/demo_bot.wasm
+    path: target/wasm32-unknown-unknown/release/demo_bot.opt.wasm
     init_message:
       kind: custom
       value:
@@ -30,7 +30,7 @@ programs:
   - id:
       kind: account
       value: eve
-    path: target/wasm32-unknown-unknown/release/demo_bot.wasm
+    path: target/wasm32-unknown-unknown/release/demo_bot.opt.wasm
     init_message:
       kind: custom
       value:
@@ -41,7 +41,7 @@ programs:
               reply: "0x03"
 
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_async_init.wasm
+    path: target/wasm32-unknown-unknown/release/demo_async_init.opt.wasm
     init_message: &init
       kind: custom
       value:

--- a/gear-test/spec/test_async_multisig.yaml
+++ b/gear-test/spec/test_async_multisig.yaml
@@ -2,7 +2,7 @@ title: Async-multisig (well known cases)
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_async_multisig.wasm
+    path: target/wasm32-unknown-unknown/release/demo_async_multisig.opt.wasm
     init_message:
       kind: custom
       value:
@@ -14,7 +14,7 @@ programs:
           - "0x{bob}"
 
   - id: 2
-    path: target/wasm32-unknown-unknown/release/demo_async_multisig.wasm
+    path: target/wasm32-unknown-unknown/release/demo_async_multisig.opt.wasm
     init_message:
       kind: custom
       value:
@@ -29,7 +29,7 @@ programs:
           - "0x{alice}"
 
   - id: 3
-    path: target/wasm32-unknown-unknown/release/demo_async_multisig.wasm
+    path: target/wasm32-unknown-unknown/release/demo_async_multisig.opt.wasm
     init_message:
       kind: custom
       value:
@@ -47,7 +47,7 @@ programs:
   - id:
       kind: account
       value: bob
-    path: target/wasm32-unknown-unknown/release/demo_bot.wasm
+    path: target/wasm32-unknown-unknown/release/demo_bot.opt.wasm
     init_message:
       kind: custom
       value:
@@ -78,7 +78,7 @@ programs:
   - id:
       kind: account
       value: eve
-    path: target/wasm32-unknown-unknown/release/demo_bot.wasm
+    path: target/wasm32-unknown-unknown/release/demo_bot.opt.wasm
     init_message:
       kind: custom
       value:
@@ -112,7 +112,7 @@ programs:
   - id:
       kind: account
       value: alice
-    path: target/wasm32-unknown-unknown/release/demo_bot.wasm
+    path: target/wasm32-unknown-unknown/release/demo_bot.opt.wasm
     init_message:
       kind: custom
       value:

--- a/gear-test/spec/test_async_sign.yaml
+++ b/gear-test/spec/test_async_sign.yaml
@@ -2,7 +2,7 @@ title: Async-sign (well known cases)
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_async_sign.wasm
+    path: target/wasm32-unknown-unknown/release/demo_async_sign.opt.wasm
     init_message:
       kind: custom
       value:
@@ -14,7 +14,7 @@ programs:
   - id:
       kind: ss58
       value: 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
-    path: target/wasm32-unknown-unknown/release/demo_bot.wasm
+    path: target/wasm32-unknown-unknown/release/demo_bot.opt.wasm
     init_message:
       kind: custom
       value:
@@ -39,7 +39,7 @@ programs:
   - id:
       kind: account
       value: eve
-    path: target/wasm32-unknown-unknown/release/demo_bot.wasm
+    path: target/wasm32-unknown-unknown/release/demo_bot.opt.wasm
     init_message:
       kind: custom
       value: []

--- a/gear-test/spec/test_capacitor.yaml
+++ b/gear-test/spec/test_capacitor.yaml
@@ -2,7 +2,7 @@ title: Basic capacitor check
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_capacitor.wasm
+    path: target/wasm32-unknown-unknown/release/demo_capacitor.opt.wasm
     init_message:
       kind: utf-8
       value: "200"

--- a/gear-test/spec/test_chat.yaml
+++ b/gear-test/spec/test_chat.yaml
@@ -2,17 +2,17 @@ title: basic
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/room.wasm
+    path: target/wasm32-unknown-unknown/release/room.opt.wasm
     init_message:
       kind: utf-8
       value: test
   - id: 2
-    path: target/wasm32-unknown-unknown/release/bot.wasm
+    path: target/wasm32-unknown-unknown/release/bot.opt.wasm
     init_message:
       kind: utf-8
       value: bob {1}
   - id: 3
-    path: target/wasm32-unknown-unknown/release/bot.wasm
+    path: target/wasm32-unknown-unknown/release/bot.opt.wasm
     init_message:
       kind: utf-8
       value: alice {1}

--- a/gear-test/spec/test_collector.yaml
+++ b/gear-test/spec/test_collector.yaml
@@ -2,7 +2,7 @@ title: collector-1
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_collector.wasm
+    path: target/wasm32-unknown-unknown/release/demo_collector.opt.wasm
 
 fixtures:
   - title: collector pass 2 messages

--- a/gear-test/spec/test_decoder.yaml
+++ b/gear-test/spec/test_decoder.yaml
@@ -2,7 +2,7 @@ title: Decoder
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_decoder.wasm
+    path: target/wasm32-unknown-unknown/release/demo_decoder.opt.wasm
 
 fixtures:
   - title: decoder

--- a/gear-test/spec/test_exit_code.yaml
+++ b/gear-test/spec/test_exit_code.yaml
@@ -2,13 +2,13 @@ title: Async-await
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_exit_code.wasm
+    path: target/wasm32-unknown-unknown/release/demo_exit_code.opt.wasm
 
   - id: 2
-    path: target/wasm32-unknown-unknown/release/demo_panicker.wasm
+    path: target/wasm32-unknown-unknown/release/demo_panicker.opt.wasm
 
   - id: 3
-    path: target/wasm32-unknown-unknown/release/demo_ping.wasm
+    path: target/wasm32-unknown-unknown/release/demo_ping.opt.wasm
 
 fixtures:
   - title: normal

--- a/gear-test/spec/test_failed_program_msg_handling.yaml
+++ b/gear-test/spec/test_failed_program_msg_handling.yaml
@@ -6,7 +6,7 @@ programs:
     source:
       kind: id
       value: 1000001
-    path: target/wasm32-unknown-unknown/release/demo_futures_unordered.wasm
+    path: target/wasm32-unknown-unknown/release/demo_futures_unordered.opt.wasm
     init_message:
       kind: utf-8
       value: "invalid input for init"

--- a/gear-test/spec/test_futures_unordered.yaml
+++ b/gear-test/spec/test_futures_unordered.yaml
@@ -2,25 +2,25 @@ title: Futures-unordered
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_futures_unordered.wasm
+    path: target/wasm32-unknown-unknown/release/demo_futures_unordered.opt.wasm
     init_message:
       kind: utf-8
       value: "{2},{3}"
 
   - id: 2
-    path: target/wasm32-unknown-unknown/release/demo_async.wasm
+    path: target/wasm32-unknown-unknown/release/demo_async.opt.wasm
     init_message:
       kind: utf-8
       value: "{3},{4},{5}"
 
   - id: 3
-    path: target/wasm32-unknown-unknown/release/demo_ping.wasm
+    path: target/wasm32-unknown-unknown/release/demo_ping.opt.wasm
 
   - id: 4
-    path: target/wasm32-unknown-unknown/release/demo_ping.wasm
+    path: target/wasm32-unknown-unknown/release/demo_ping.opt.wasm
 
   - id: 5
-    path: target/wasm32-unknown-unknown/release/demo_ping.wasm
+    path: target/wasm32-unknown-unknown/release/demo_ping.opt.wasm
 
 fixtures:
   - title: futures-unordered

--- a/gear-test/spec/test_guestbook.yaml
+++ b/gear-test/spec/test_guestbook.yaml
@@ -2,7 +2,7 @@ title: guestbook test
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/guestbook.wasm
+    path: target/wasm32-unknown-unknown/release/guestbook.opt.wasm
     init_message:
       kind: utf-8
       value: test

--- a/gear-test/spec/test_gui.yaml
+++ b/gear-test/spec/test_gui.yaml
@@ -2,7 +2,7 @@ title: gui test
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_gui_test.wasm
+    path: target/wasm32-unknown-unknown/release/demo_gui_test.opt.wasm
     init_message:
       kind: custom
       value:

--- a/gear-test/spec/test_i32.yaml
+++ b/gear-test/spec/test_i32.yaml
@@ -2,12 +2,12 @@ title: basic
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_sum.wasm
+    path: target/wasm32-unknown-unknown/release/demo_sum.opt.wasm
     init_message:
       kind: utf-8
       value: "{2}"
   - id: 2
-    path: target/wasm32-unknown-unknown/release/demo_fib.wasm
+    path: target/wasm32-unknown-unknown/release/demo_fib.opt.wasm
 
 fixtures:
   - title: fibonacci-sum

--- a/gear-test/spec/test_incomplete_async_payloads.yaml
+++ b/gear-test/spec/test_incomplete_async_payloads.yaml
@@ -2,13 +2,13 @@ title: Incomplete-async-payloads
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_incomplete_async_payloads.wasm
+    path: target/wasm32-unknown-unknown/release/demo_incomplete_async_payloads.opt.wasm
     init_message:
       kind: utf-8
       value: "{2}"
 
   - id: 2
-    path: target/wasm32-unknown-unknown/release/demo_ping.wasm
+    path: target/wasm32-unknown-unknown/release/demo_ping.opt.wasm
 
 fixtures:
   - title: incomplete-async-payloads

--- a/gear-test/spec/test_mem.yaml
+++ b/gear-test/spec/test_mem.yaml
@@ -2,7 +2,7 @@ title: Memory test
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_mem.wasm
+    path: target/wasm32-unknown-unknown/release/demo_mem.opt.wasm
 
 fixtures:
   - title: Test for memory result

--- a/gear-test/spec/test_meta.yaml
+++ b/gear-test/spec/test_meta.yaml
@@ -2,7 +2,7 @@ title: Meta ping (simple check)
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_meta.wasm
+    path: target/wasm32-unknown-unknown/release/demo_meta.opt.wasm
     init_message:
       kind: custom
       value:

--- a/gear-test/spec/test_multiping.yaml
+++ b/gear-test/spec/test_multiping.yaml
@@ -2,7 +2,7 @@ title: Multiping
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_multiping.wasm
+    path: target/wasm32-unknown-unknown/release/demo_multiping.opt.wasm
 
 fixtures:
   - title: multiping

--- a/gear-test/spec/test_ping.yaml
+++ b/gear-test/spec/test_ping.yaml
@@ -2,7 +2,7 @@ title: Ping-pong
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_ping.wasm
+    path: target/wasm32-unknown-unknown/release/demo_ping.opt.wasm
     source:
       kind: account
       value: alice

--- a/gear-test/spec/test_program_id.yaml
+++ b/gear-test/spec/test_program_id.yaml
@@ -2,7 +2,7 @@ title: Program_id test
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_program_id.wasm
+    path: target/wasm32-unknown-unknown/release/demo_program_id.opt.wasm
 
 fixtures:
   - title: program_id

--- a/gear-test/spec/test_rwlock.yaml
+++ b/gear-test/spec/test_rwlock.yaml
@@ -2,13 +2,13 @@ title: Async RwLock
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_rwlock.wasm
+    path: target/wasm32-unknown-unknown/release/demo_rwlock.opt.wasm
     init_message:
       kind: utf-8
       value: "{2}"
 
   - id: 2
-    path: target/wasm32-unknown-unknown/release/demo_ping.wasm
+    path: target/wasm32-unknown-unknown/release/demo_ping.opt.wasm
 
 fixtures:
   - title: rwlock wide

--- a/gear-test/spec/test_state_rollback.yaml
+++ b/gear-test/spec/test_state_rollback.yaml
@@ -2,7 +2,7 @@ title: State-rollback
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_state_rollback.wasm
+    path: target/wasm32-unknown-unknown/release/demo_state_rollback.opt.wasm
 
 fixtures:
   - title: state-rollback

--- a/gear-test/spec/test_sync_dont_duplicate.yaml
+++ b/gear-test/spec/test_sync_dont_duplicate.yaml
@@ -2,13 +2,13 @@ title: Async-duplicates-sync
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_sync_duplicate.wasm
+    path: target/wasm32-unknown-unknown/release/demo_sync_duplicate.opt.wasm
     init_message:
       kind: utf-8
       value: "{2}"
 
   - id: 2
-    path: target/wasm32-unknown-unknown/release/demo_ping.wasm
+    path: target/wasm32-unknown-unknown/release/demo_ping.opt.wasm
 
 fixtures:
   - title: async-duplicates-sync

--- a/gear-test/spec/test_trap.yaml
+++ b/gear-test/spec/test_trap.yaml
@@ -2,7 +2,7 @@ title: Trap test
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_panicker.wasm
+    path: target/wasm32-unknown-unknown/release/demo_panicker.opt.wasm
 
 fixtures:
   - title: Test for trap result

--- a/gear-test/spec/test_vec.yaml
+++ b/gear-test/spec/test_vec.yaml
@@ -2,12 +2,12 @@ title: basic
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_sum.wasm
+    path: target/wasm32-unknown-unknown/release/demo_sum.opt.wasm
     init_message:
       kind: utf-8
       value: "{2}"
   - id: 2
-    path: target/wasm32-unknown-unknown/release/demo_vec.wasm
+    path: target/wasm32-unknown-unknown/release/demo_vec.opt.wasm
 
 fixtures:
   - title: test-vec (2 * 65536 * size_of(u8) = 128 KiB = 2 pages)

--- a/gear-test/spec/test_wait.yaml
+++ b/gear-test/spec/test_wait.yaml
@@ -2,7 +2,7 @@ title: Wait test
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_wait.wasm
+    path: target/wasm32-unknown-unknown/release/demo_wait.opt.wasm
 
 fixtures:
   - title: wait

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -236,7 +236,8 @@ pub fn check_messages(
                                     (false, false) => MetaType::HandleInput,
                                 };
 
-                                let path: String = path.replace(".wasm", ".meta.wasm");
+                                let path: String =
+                                    crate::sample::get_meta_wasm_path(String::from(path));
 
                                 let json = MetaData::Json(proc::parse_payload(
                                     serde_json::to_string(&v).expect("Cannot convert to string"),

--- a/gear-test/src/proc.rs
+++ b/gear-test/src/proc.rs
@@ -164,7 +164,7 @@ where
 
                     let json = MetaData::Json(payload);
 
-                    let wasm = program_path.replace(".wasm", ".meta.wasm");
+                    let wasm = crate::sample::get_meta_wasm_path(program_path);
 
                     json.convert(&wasm, &meta_type)
                         .expect("Unable to get bytes")
@@ -213,16 +213,15 @@ where
 
                 let json = MetaData::Json(payload);
 
-                let wasm = test
-                    .programs
-                    .iter()
-                    .filter(|p| p.id == message.destination)
-                    .last()
-                    .expect("Program not found")
-                    .path
-                    .clone()
-                    .replace(".wasm", ".meta.wasm");
-
+                let wasm = crate::sample::get_meta_wasm_path(
+                    test.programs
+                        .iter()
+                        .filter(|p| p.id == message.destination)
+                        .last()
+                        .expect("Program not found")
+                        .path
+                        .clone(),
+                );
                 json.convert(&wasm, &meta_type)
                     .expect("Unable to get bytes")
                     .into_bytes()

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -227,6 +227,12 @@ pub struct Test {
     pub fixtures: Vec<Fixture>,
 }
 
+pub fn get_meta_wasm_path(wasm_path: String) -> String {
+    wasm_path
+        .replace(".opt.wasm", ".wasm")
+        .replace(".wasm", ".meta.wasm")
+}
+
 #[test]
 fn check_sample() {
     let yaml = r#"
@@ -253,7 +259,18 @@ fn check_sample() {
     "#;
 
     let test: Test = serde_yaml::from_str(yaml).unwrap();
+    let path = test.programs.get(0).expect("Must have one").path.clone();
 
     assert_eq!(test.fixtures[0].messages.len(), 1);
     assert_eq!(test.fixtures[0].messages.len(), 1);
+    assert_eq!(
+        path,
+        "examples/target/wasm32-unknown-unknown/release/demo_ping.wasm"
+    );
+
+    let meta_wasm = get_meta_wasm_path(path);
+    assert_eq!(
+        meta_wasm,
+        "examples/target/wasm32-unknown-unknown/release/demo_ping.meta.wasm"
+    );
 }

--- a/utils/gear-runtime-test-cli/src/command.rs
+++ b/utils/gear-runtime-test-cli/src/command.rs
@@ -134,7 +134,7 @@ fn init_fixture(
 
                     let json = MetaData::Json(payload);
 
-                    let wasm = program_path.replace(".wasm", ".meta.wasm");
+                    let wasm = gear_test::sample::get_meta_wasm_path(program_path);
 
                     json.convert(&wasm, &meta_type)
                         .expect("Unable to get bytes")
@@ -224,16 +224,15 @@ fn run_fixture(test: &'_ sample::Test, fixture: &sample::Fixture) -> ColoredStri
 
                         let json = MetaData::Json(payload);
 
-                        let wasm = test
-                            .programs
-                            .iter()
-                            .filter(|p| p.id == message.destination)
-                            .last()
-                            .expect("Program not found")
-                            .path
-                            .clone()
-                            .replace(".wasm", ".meta.wasm");
-
+                        let wasm = gear_test::sample::get_meta_wasm_path(
+                            test.programs
+                                .iter()
+                                .filter(|p| p.id == message.destination)
+                                .last()
+                                .expect("Program not found")
+                                .path
+                                .clone(),
+                        );
                         json.convert(&wasm, &meta_type)
                             .expect("Unable to get bytes")
                             .into_bytes()


### PR DESCRIPTION
Currently we run wasm files in gear-gtest and rtest, but in fact it's supposed that opt should be runned as contract code, so we must test in first place.
