### PR TITLE
Modify node startup scripts to enable essential debug logging

### DIFF
--- a/ansible/tasks/docker/docker-compose.yaml.j2
+++ b/ansible/tasks/docker/docker-compose.yaml.j2
@@ -8,6 +8,8 @@ services:
       - "9944:9944"
       - "9615:9615"
     image: schernovgear/gear:nightly
+    environment:
+      - RUST_LOG="essential=debug"
     volumes:
       - "/home/ec2-user/gear-data/:/gear/"
     command: gear-node --base-path /gear/  --prometheus-external {% if rpc is not defined %} --validator  --telemetry-url 'ws://telemetry-backend-shard.gear-tech.io:32001/submit 0' {% endif %} {% if rpc is defined %} --unsafe-ws-external --unsafe-rpc-external  --telemetry-url 'ws://telemetry-backend-shard.gear-tech.io:32001/submit 0' --rpc-methods Unsafe --rpc-cors all {% endif %} {% if bootnodeId is defined %} --bootnodes /ip4/{{ bootnode }}/tcp/30333/p2p/{{ bootnodeId }} {% endif %}

--- a/pallets/usage/src/mock.rs
+++ b/pallets/usage/src/mock.rs
@@ -18,7 +18,7 @@
 
 use crate as pallet_usage;
 use codec::Decode;
-use frame_support::traits::{FindAuthor, OffchainWorker, OnInitialize};
+use frame_support::traits::{ConstU64, FindAuthor, OffchainWorker, OnInitialize};
 use frame_support::{construct_runtime, parameter_types};
 use frame_system as system;
 use parking_lot::RwLock;
@@ -73,7 +73,7 @@ impl pallet_balances::Config for Test {
 parameter_types! {
     pub const BlockHashCount: u64 = 250;
     pub const SS58Prefix: u8 = 42;
-    pub const ExistentialDeposit: u64 = 1;
+    pub const ExistentialDeposit: u64 = 100;
 }
 
 impl system::Config for Test {
@@ -129,7 +129,6 @@ parameter_types! {
     pub const WaitListTraversalInterval: u32 = 5;
     pub const MaxBatchSize: u32 = 10;
     pub const ExpirationDuration: u64 = 3000;
-    pub const TrapReplyExistentialGasLimit: u64 = 1000;
     pub const ExternalSubmitterRewardFraction: Perbill = Perbill::from_percent(10);
 }
 
@@ -140,7 +139,7 @@ impl pallet_usage::Config for Test {
     type WaitListTraversalInterval = WaitListTraversalInterval;
     type ExpirationDuration = ExpirationDuration;
     type MaxBatchSize = MaxBatchSize;
-    type TrapReplyExistentialGasLimit = TrapReplyExistentialGasLimit;
+    type TrapReplyExistentialGasLimit = ConstU64<1000>;
     type ExternalSubmitterRewardFraction = ExternalSubmitterRewardFraction;
 }
 
@@ -197,7 +196,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
             (8, 1_000_000_u128),
             (9, 1_000_000_u128),
             (10, 1_000_000_u128),
-            (BLOCK_AUTHOR, 1_u128),
+            (BLOCK_AUTHOR, 101_u128),
         ],
     }
     .assimilate_storage(&mut t)

--- a/pallets/usage/src/tests.rs
+++ b/pallets/usage/src/tests.rs
@@ -386,7 +386,7 @@ fn rent_charge_works() {
         assert_eq!(wl[9].1, 10);
 
         // Check that the collected rent adds up
-        assert_eq!(Balances::free_balance(&BLOCK_AUTHOR), 6001);
+        assert_eq!(Balances::free_balance(&BLOCK_AUTHOR), 6101);
     });
 }
 
@@ -441,7 +441,7 @@ fn trap_reply_message_is_sent() {
             ],
         ));
 
-        // The first message still was charge the amount in excess
+        // The first message still was charged the amount in excess
         assert_eq!(Balances::reserved_balance(&1), 1_000);
 
         // The second message wasn't charged at all before emitting trap reply
@@ -527,6 +527,41 @@ fn external_submitter_gets_rewarded() {
         // Check that the collected rent adds up:
         // 10% goes to the external user, the rest - to a validator
         assert_eq!(Balances::free_balance(&10), 1_000_600);
-        assert_eq!(Balances::free_balance(&BLOCK_AUTHOR), 5401);
+        assert_eq!(Balances::free_balance(&BLOCK_AUTHOR), 5501);
+    });
+}
+
+#[test]
+fn dust_discarded_with_noop() {
+    init_logger();
+    new_test_ext().execute_with(|| {
+        // Message sender has reserved just above `T::TrapReplyExistentialGasLimit`
+        assert_ok!(<Balances as ReservableCurrency<_>>::reserve(&1, 1_100));
+
+        run_to_block(10);
+
+        // Populate wait list with 2 messages
+        populate_wait_list(1, 10, 1, vec![1_100]);
+
+        let wl = wait_list_contents()
+            .into_iter()
+            .map(|(d, n)| (d.message, n))
+            .collect::<Vec<_>>();
+        assert_eq!(wl.len(), 1);
+
+        run_to_block(15);
+
+        // Calling the unsigned version of the extrinsic
+        assert_ok!(Usage::collect_waitlist_rent(
+            Origin::signed(11), // AccountId without any balance
+            vec![PayeeInfo {
+                program_id: 1.into_origin(),
+                message_id: 101.into_origin()
+            },],
+        ));
+
+        // The amount destined to the tx submitter is below `ExistentialDeposit`
+        // It should have been removed as dust, no change in the beneficiary free balance
+        assert_eq!(Balances::free_balance(&11), 0);
     });
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 340,
+    spec_version: 350,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Having decreased the default log level for some messages we still need them to be visible on validators nodes. Enabling `RUST_LOG` environment variable in docker-compose template for that.

On a separate note, added test for the case that originally resurfaced the issue (removing "dust" destination accounts upon currency transfer in `pallet-balances`) in `pallet-usage`.