### PR TITLE
Update docker-compose.yaml.j2

### DIFF
--- a/ansible/tasks/docker/docker-compose.yaml.j2
+++ b/ansible/tasks/docker/docker-compose.yaml.j2
@@ -8,8 +8,6 @@ services:
       - "9944:9944"
       - "9615:9615"
     image: schernovgear/gear:nightly
-    environment:
-      - RUST_LOG="essential=debug"
     volumes:
       - "/home/ec2-user/gear-data/:/gear/"
     command: gear-node --base-path /gear/  --prometheus-external {% if rpc is not defined %} --validator  --telemetry-url 'ws://telemetry-backend-shard.gear-tech.io:32001/submit 0' {% endif %} {% if rpc is defined %} --unsafe-ws-external --unsafe-rpc-external  --telemetry-url 'ws://telemetry-backend-shard.gear-tech.io:32001/submit 0' --rpc-methods Unsafe --rpc-cors all {% endif %} {% if bootnodeId is defined %} --bootnodes /ip4/{{ bootnode }}/tcp/30333/p2p/{{ bootnodeId }} {% endif %}


### PR DESCRIPTION
containers not start with following error:
Error: GlobalLoggerError(DirectiveParseError(ParseError { kind: Other(None) }))
