### PR TITLE
Skip fixtures feature introduced

### DIFF
--- a/gear-test/spec/test_create_program.yaml
+++ b/gear-test/spec/test_create_program.yaml
@@ -1,5 +1,7 @@
 title: Test create_program sys-call
 
+must_skip: true
+
 codes:
   # Save child's code
   - path: examples/create-program/child_contract.wasm

--- a/gear-test/spec/test_create_program.yaml
+++ b/gear-test/spec/test_create_program.yaml
@@ -1,6 +1,6 @@
 title: Test create_program sys-call
 
-must_skip: true
+skip: true
 
 codes:
   # Save child's code

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -476,7 +476,7 @@ where
     JH: JournalHandler + CollectState + ExecutionContext,
     E: Environment<Ext>,
 {
-    if let Some(true) = test.must_skip {
+    if let Some(true) = test.skip {
         return "Skipped".bright_yellow();
     }
     match proc::init_fixture::<E, JH>(test, fixture_no, &mut journal_handler) {

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -476,6 +476,9 @@ where
     JH: JournalHandler + CollectState + ExecutionContext,
     E: Environment<Ext>,
 {
+    if let Some(true) = test.must_skip {
+        return "Skipped".bright_yellow();
+    }
     match proc::init_fixture::<E, JH>(test, fixture_no, &mut journal_handler) {
         Ok(()) => {
             let last_exp_steps = test.fixtures[fixture_no].expected.last().unwrap().step;
@@ -668,7 +671,7 @@ where
                         skip_memory,
                     )
                 };
-                if output != "Ok".bright_green() {
+                if !(output.starts_with("Ok") | output.starts_with("Skipped")) {
                     map.read()
                         .unwrap()
                         .get(&thread::current().id())

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -671,7 +671,7 @@ where
                         skip_memory,
                     )
                 };
-                if !(output.starts_with("Ok") | output.starts_with("Skipped")) {
+                if !(output.starts_with("Ok") || output.starts_with("Skipped")) {
                     map.read()
                         .unwrap()
                         .get(&thread::current().id())

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -221,7 +221,7 @@ pub struct Message {
 pub struct Test {
     /// Flag which defines whether test should be skipped.
     /// TODO: remove after resolving https://github.com/gear-tech/gear/pull/739
-    pub must_skip: Option<bool>,
+    pub skip: Option<bool>,
     /// Code that are needed to be submitted for tests
     pub codes: Option<Vec<Code>>,
     /// Programs and related data used for tests

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -219,6 +219,9 @@ pub struct Message {
 /// Main model describing test structure
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Test {
+    /// Flag which defines whether test should be skipped.
+    /// TODO: remove after resolving https://github.com/gear-tech/gear/pull/739
+    pub must_skip: Option<bool>,
     /// Code that are needed to be submitted for tests
     pub codes: Option<Vec<Code>>,
     /// Programs and related data used for tests


### PR DESCRIPTION
This hot fix is introduced until we decide finally on having salt in `create_program_with_gas` function. If salt remains, then the solution in #739 will be merged. Otherwise, we take salt management responsibility and introduce it in https://github.com/gear-tech/gear/issues/703