### PR TITLE
Add more Gear crates to docs generating

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,9 @@ jobs:
 
       - name: Build docs
         run: |
-          cargo doc -p gear-core -p galloc -p gcore -p gstd --no-deps
+          cargo doc -p galloc -p gcore -p gear-backend-common -p gear-backend-sandbox \
+                -p gear-core -p gear-core-processor -p gear-lazy-pages \
+                -p gstd -p gtest -p gear-wasm-builder --no-deps
           echo "<html><head><meta http-equiv=\"refresh\" content=\"0; url=/galloc/index.html\" /></head><body></body></html>" > ./target/doc/index.html
 
       - name: Copy logo image

--- a/gcore/src/msg.rs
+++ b/gcore/src/msg.rs
@@ -157,7 +157,7 @@ pub fn load(buffer: &mut [u8]) {
 /// program account to the reply message target account.
 ///
 /// Reply message transactions will be posted only after processing is finished,
-/// similar to the standard message [`send`].
+/// similar to the standard message [`send`](crate::msg::send).
 ///
 /// # Examples
 ///
@@ -190,7 +190,8 @@ pub fn reply(payload: &[u8], value: u128) -> MessageId {
 
 /// Some programs can reply on their messages to other programs, i.e. check
 /// another program's state and use it as a parameter for its own business
-/// logic. Basic implementation is covered in [`reply`] function.
+/// logic. Basic implementation is covered in [`reply`](crate::msg::reply)
+/// function.
 ///
 /// This function allows sending reply messages filled with payload parts sent
 /// via ['reply_push'] during the message handling. Finalization of the
@@ -230,7 +231,8 @@ pub fn reply_commit(value: u128) -> MessageId {
 ///
 /// Some programs can reply on their messages to other programs, i.e. check
 /// another program's state and use it as a parameter for its own business
-/// logic. Basic implementation is covered in [`reply`] function.
+/// logic. Basic implementation is covered in [`reply`](crate::msg::reply)
+/// function.
 ///
 /// This function allows filling the reply payload parts via ['reply_push']
 /// during the message `handling`. The payload can consist of several parts.
@@ -281,14 +283,14 @@ pub fn reply_to() -> MessageId {
 /// Send a new message to the program or user.
 ///
 /// Gear allows programs to communicate to each other and users via messages.
-/// [`send`] function allows sending such messages.
+/// [`send`](crate::msg::send) function allows sending such messages.
 ///
 /// First argument is the address of the target account.
 /// Second argument is message payload in bytes.
 /// Last argument is the value to be transferred from the current program
 /// account to the message target account.
 /// Send transaction will be posted only after the execution of processing is
-/// finished, similar to the reply message [`reply`].
+/// finished, similar to the reply message [`reply`](crate::msg::reply).
 ///
 /// # Examples
 ///
@@ -327,14 +329,14 @@ pub fn send(program: ActorId, payload: &[u8], value: u128) -> MessageId {
 /// Send a new message to the program or user, with gas limit.
 ///
 /// Gear allows programs to communicate to each other and users via messages.
-/// [`send`] function allows sending such messages.
+/// [`send`](crate::msg::send) function allows sending such messages.
 ///
 /// First argument is the address of the target account.
 /// Second argument is message payload in bytes.
 /// Last argument is the value to be transferred from the current program
 /// account to the message target account.
 /// Send transaction will be posted only after the execution of processing is
-/// finished, similar to the reply message [`reply`].
+/// finished, similar to the reply message [`reply`](crate::msg::reply).
 ///
 /// # Examples
 ///
@@ -401,7 +403,7 @@ pub fn send_with_gas(program: ActorId, payload: &[u8], gas_limit: u64, value: u1
 ///
 /// # See also
 ///
-/// [`send`] allows to send message in one step.
+/// [`send`](crate::msg::send) allows to send message in one step.
 ///
 /// [`send_push`], [`send_init`] functions allows to form a message to send in
 /// parts.
@@ -446,7 +448,7 @@ pub fn send_commit(handle: MessageHandle, program: ActorId, value: u128) -> Mess
 ///
 /// # See also
 ///
-/// [`send`] allows to send message in one step.
+/// [`send`](crate::msg::send) allows to send message in one step.
 ///
 /// [`send_push`], [`send_init`] functions allows to form a message to send in
 /// parts.
@@ -489,7 +491,7 @@ pub fn send_commit_with_gas(
 /// ```
 ///
 /// # See also
-/// [`send`] allows to send message in one step.
+/// [`send`](crate::msg::send) allows to send message in one step.
 ///
 /// [`send_push`], [`send_commit`] functions allows to form a message to send in
 /// parts.
@@ -518,7 +520,7 @@ pub fn send_init() -> MessageHandle {
 ///
 /// # See also
 ///
-/// [`send`] allows to send a message in one step.
+/// [`send`](crate::msg::send) allows to send a message in one step.
 ///
 /// [`send_init`], [`send_commit`] functions allows to form and send a message
 /// to send in parts.

--- a/gstd/src/msg/async.rs
+++ b/gstd/src/msg/async.rs
@@ -38,7 +38,7 @@ use futures::future::FusedFuture;
 /// implements `Future` trait. Program interrupts until the reply is received.
 /// As soon as the reply is received, the function checks it's exit code and
 /// returns `Ok()` with decoded structure inside or `Err()` in case of exit code
-/// does not equal 0. For decode-related errors (https://docs.rs/parity-scale-codec/2.3.1/parity_scale_codec/struct.Error.html),
+/// does not equal 0. For decode-related errors (<https://docs.rs/parity-scale-codec/2.3.1/parity_scale_codec/struct.Error.html>),
 /// Gear returns the native one after decode.
 pub struct CodecMessageFuture<T> {
     waiting_reply_to: MessageId,
@@ -77,7 +77,7 @@ impl<D: Decode> FusedFuture for CodecMessageFuture<D> {
 /// implements `Future` trait. Program interrupts until the reply is received.
 /// As soon as the reply is received, the function checks it's exit code and
 /// returns `Ok()` with raw bytes inside or `Err()` in case of exit code does
-/// not equal 0. For decode-related errors (https://docs.rs/parity-scale-codec/2.3.1/parity_scale_codec/struct.Error.html),
+/// not equal 0. For decode-related errors (<https://docs.rs/parity-scale-codec/2.3.1/parity_scale_codec/struct.Error.html>),
 /// Gear returns the native one after decode.
 pub struct MessageFuture {
     waiting_reply_to: MessageId,
@@ -114,7 +114,7 @@ impl FusedFuture for MessageFuture {
 /// with one difference - it takes the structure in, then encodes it
 /// and sends it in bytes. When receiving the message, it decodes the bytes.
 /// So the input should be SCALE codeс encodable, output - decodable
-/// (https://docs.substrate.io/v3/advanced/scale-codec/).
+/// (<https://docs.substrate.io/v3/advanced/scale-codec/>).
 /// The program will be interrupted (waiting for a reply) if an `.await`
 /// has been called on the `CodecMessageFuture` object returned by the function.
 pub fn send_and_wait_for_reply<D: Decode, E: Encode>(

--- a/gstd/src/msg/basic.rs
+++ b/gstd/src/msg/basic.rs
@@ -176,7 +176,7 @@ pub fn load_bytes() -> Vec<u8> {
 /// program account to the reply message target account.
 ///
 /// Reply message transactions will be posted only after processing is finished,
-/// similar to the standard message [`send`].
+/// similar to the standard message [`send`](crate::msg::send).
 ///
 /// # Examples
 ///
@@ -200,7 +200,8 @@ pub fn reply_bytes<T: AsRef<[u8]>>(payload: T, value: u128) -> MessageId {
 ///
 /// Some programs can reply on their messages to other programs, i.e. check
 /// another program's state and use it as a parameter for its own business
-/// logic. Basic implementation is covered in [`reply`] function.
+/// logic. Basic implementation is covered in [`reply`](crate::msg::reply)
+/// function.
 ///
 /// This function allows sending reply messages filled with payload parts sent
 /// via ['reply_push'] during the message handling. Finalization of the
@@ -233,7 +234,8 @@ pub fn reply_commit(value: u128) -> MessageId {
 ///
 /// Some programs can reply on their messages to other programs, i.e. check
 /// another program's state and use it as a parameter for its own business
-/// logic. Basic implementation is covered in [`reply`] function.
+/// logic. Basic implementation is covered in [`reply`](crate::msg::reply)
+/// function.
 ///
 /// This function allows filling the reply payload parts via ['reply_push']
 /// during the message `handling`. The payload can consist of several parts.
@@ -282,7 +284,7 @@ pub fn reply_to() -> MessageId {
 /// Send a new message to the program or user.
 ///
 /// Gear allows programs to communicate to each other and users via messages.
-/// [`send`] function allows sending such messages.
+/// [`send`](crate::msg::send) function allows sending such messages.
 ///
 /// First argument is the address of the target account.
 /// Second argument is message payload in bytes.
@@ -290,7 +292,7 @@ pub fn reply_to() -> MessageId {
 /// account to the message target account.
 ///
 /// Send transaction will be posted only after the execution of processing is
-/// finished, similar to the reply message [`reply`].
+/// finished, similar to the reply message [`reply`](crate::msg::reply).
 ///
 /// # Examples
 ///
@@ -316,7 +318,7 @@ pub fn send_bytes<T: AsRef<[u8]>>(program: ActorId, payload: T, value: u128) -> 
 /// Send a new message to the program or user.
 ///
 /// Gear allows programs to communicate to each other and users via messages.
-/// [`send`] function allows sending such messages.
+/// [`send`](crate::msg::send) function allows sending such messages.
 ///
 /// First argument is the address of the target account.
 /// Second argument is message payload in bytes.
@@ -326,7 +328,7 @@ pub fn send_bytes<T: AsRef<[u8]>>(program: ActorId, payload: T, value: u128) -> 
 /// account to the message target account.
 ///
 /// Send transaction will be posted only after the execution of processing is
-/// finished, similar to the reply message [`reply`].
+/// finished, similar to the reply message [`reply`](crate::msg::reply).
 ///
 /// # Examples
 ///
@@ -382,7 +384,7 @@ pub fn send_bytes_with_gas<T: AsRef<[u8]>>(
 ///
 /// # See also
 ///
-/// [`send`] allows to send message in one step.
+/// [`send`](crate::msg::send) allows to send message in one step.
 ///
 /// [`send_push`], [`send_init`] functions allows to form a message to send in
 /// parts.
@@ -420,7 +422,7 @@ pub fn send_commit(handle: MessageHandle, program: ActorId, value: u128) -> Mess
 ///
 /// # See also
 ///
-/// [`send`] allows to send message in one step.
+/// [`send`](crate::msg::send) allows to send message in one step.
 ///
 /// [`send_push`], [`send_init`] functions allows to form a message to send in
 /// parts.
@@ -453,7 +455,7 @@ pub fn send_commit_with_gas(
 /// ```
 ///
 /// # See also
-/// [`send`] allows to send message in one step.
+/// [`send`](crate::msg::send) allows to send message in one step.
 ///
 /// [`send_push`], [`send_commit`] functions allows to form a message to send in
 /// parts.
@@ -482,7 +484,7 @@ pub fn send_init() -> MessageHandle {
 ///
 /// # See also
 ///
-/// [`send`] allows to send a message in one step.
+/// [`send`](crate::msg::send) allows to send a message in one step.
 ///
 /// [`send_init`], [`send_commit`] functions allows to form and send a message
 /// to send in parts.

--- a/gstd/src/msg/encoded.rs
+++ b/gstd/src/msg/encoded.rs
@@ -18,7 +18,7 @@
 
 //! Module with messaging functions (`load`, `reply`, `send`) for operating
 //! with messages arguments as with data structure instead of bytes array
-//! decoded/encoded via SCALE Codec (https://docs.substrate.io/v3/advanced/scale-codec/).
+//! decoded/encoded via SCALE Codec (<https://docs.substrate.io/v3/advanced/scale-codec/>).
 
 use crate::errors::{ContractError, Result};
 use crate::prelude::convert::AsRef;
@@ -27,7 +27,7 @@ use codec::{Decode, Encode};
 
 /// `load` returns Result, where Ok case contains a message payload decoded into
 /// the struct of specified type, or as a generic argument. In case of Err,
-/// contains a decoding error ContractError::Decode. For decode-related errors (https://docs.rs/parity-scale-codec/2.3.1/parity_scale_codec/struct.Error.html),
+/// contains a decoding error ContractError::Decode. For decode-related errors (<https://docs.rs/parity-scale-codec/2.3.1/parity_scale_codec/struct.Error.html>),
 /// Gear returns the native one after decode.
 ///
 /// Example:

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -20,7 +20,7 @@
 //! In runtime data for contract wasm memory pages can be loaded in lazy manner.
 //! All pages, which is supposed to be lazy, must be mprotected before contract execution.
 //! During execution data from storage is loaded for all pages, which has been accesed.
-//! See also [handle_sigsegv].
+//! See also `handle_sigsegv`.
 
 use std::{cell::RefCell, collections::BTreeMap};
 


### PR DESCRIPTION
Added crates to be shown on https://docs.gear.rs:

- `gear-backend-common`
- `gear-backend-sandbox`
- `gear-core-processor` 
- `gear-lazy-pages` 
- `gtest`
- `gear-wasm-builder`

Also, minor fixes in doc generating have been made.

Please tell me if we want to add something else.

@gear-tech/dev 
