### PR TITLE
gear-wasm-builder: Fix target WASM path when using in workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2239,7 +2239,7 @@ dependencies = [
 
 [[package]]
 name = "gear-wasm-builder"
-version = "0.2.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2239,7 +2239,7 @@ dependencies = [
 
 [[package]]
 name = "gear-wasm-builder"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/utils/wasm-builder/Cargo.toml
+++ b/utils/wasm-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gear-wasm-builder"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 description = "Utility for building Gear programs"

--- a/utils/wasm-builder/Cargo.toml
+++ b/utils/wasm-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gear-wasm-builder"
-version = "0.2.0"
+version = "0.1.2"
 edition = "2021"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 description = "Utility for building Gear programs"

--- a/utils/wasm-builder/README.md
+++ b/utils/wasm-builder/README.md
@@ -10,7 +10,7 @@ This is a helper crate that can be used in build scripts for building Gear progr
 # ...
 
 [build-dependencies]
-gear-wasm-builder = "0.2.0"
+gear-wasm-builder = "0.1.2"
 
 # ...
 ```

--- a/utils/wasm-builder/README.md
+++ b/utils/wasm-builder/README.md
@@ -10,7 +10,7 @@ This is a helper crate that can be used in build scripts for building Gear progr
 # ...
 
 [build-dependencies]
-gear-wasm-builder = "0.1.1"
+gear-wasm-builder = "0.2.0"
 
 # ...
 ```

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -33,7 +33,7 @@ use crate::{builder_error::BuilderError, insert_stack_end_export};
 pub struct WasmProject {
     original_dir: PathBuf,
     out_dir: PathBuf,
-    wasm_subdir: PathBuf,
+    target_dir: PathBuf,
     file_base_name: Option<String>,
     profile: String,
 }
@@ -57,7 +57,14 @@ impl WasmProject {
             .expect("Path should have subdirs in the `target` dir")
             .as_os_str();
 
-        let wasm_subdir = PathBuf::from("target/wasm32-unknown-unknown").join(profile);
+        let mut target_dir = out_dir.clone();
+        while target_dir.pop() {
+            if target_dir.ends_with("target") {
+                break;
+            }
+        }
+        target_dir.push("wasm32-unknown-unknown");
+        target_dir.push(profile);
 
         let profile = if profile == "debug" {
             "dev".to_string()
@@ -68,7 +75,7 @@ impl WasmProject {
         WasmProject {
             original_dir,
             out_dir,
-            wasm_subdir,
+            target_dir,
             file_base_name: None,
             profile,
         }
@@ -156,16 +163,20 @@ impl WasmProject {
             .out_dir
             .join("target/wasm32-unknown-unknown/release")
             .join(format!("{}.wasm", &file_base_name));
-        let to_dir = self.original_dir.join(&self.wasm_subdir);
-        fs::create_dir_all(&to_dir)?;
 
-        let to_path = to_dir.join(format!("{}.wasm", &file_base_name));
+        fs::create_dir_all(&self.target_dir)?;
+
+        let to_path = self.target_dir.join(format!("{}.wasm", &file_base_name));
         fs::copy(&from_path, &to_path).context("unable to copy WASM file")?;
 
-        let to_opt_path = to_dir.join(format!("{}.opt.wasm", &file_base_name));
+        let to_opt_path = self
+            .target_dir
+            .join(format!("{}.opt.wasm", &file_base_name));
         Self::generate_opt(&from_path, &to_opt_path)?;
 
-        let to_meta_path = to_dir.join(format!("{}.meta.wasm", &file_base_name));
+        let to_meta_path = self
+            .target_dir
+            .join(format!("{}.meta.wasm", &file_base_name));
         Self::generate_meta(&from_path, &to_meta_path)?;
 
         let wasm_binary_path = self.out_dir.join("wasm_binary_path.txt");

--- a/utils/wasm-builder/test-program/Cargo.lock
+++ b/utils/wasm-builder/test-program/Cargo.lock
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "arrayvec"
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "gear-wasm-builder"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",


### PR DESCRIPTION
- Write output WASM files to the workspace target directory instead of the package one when using in the workspace.

@gear-tech/dev 
