### PR TITLE
Avoid env vars in `gtest::Program::current()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,6 +2244,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "log",
+ "pathdiff",
  "pwasm-utils",
  "thiserror",
  "toml",
@@ -4782,6 +4783,12 @@ name = "path-clean"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pbkdf2"

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -115,12 +115,11 @@ impl<'a> Program<'a> {
         system: &'a System,
         id: I,
     ) -> Self {
-        let path_file = env::var("OUT_DIR")
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| env::current_dir().expect("Unable to get current dir"));
-        let path_file = path_file.join("wasm_binary_path.txt");
+        let current_dir = env::current_dir().expect("Unable to get current dir");
+        let path_file = current_dir.join(".binpath");
         let path_bytes = fs::read(path_file).expect("Unable to read path bytes");
-        let path = String::from_utf8(path_bytes).expect("Invalid path");
+        let relative_path: PathBuf = String::from_utf8(path_bytes).expect("Invalid path").into();
+        let path = current_dir.join(relative_path);
 
         Self::from_file_with_id(system, id, path)
     }

--- a/utils/wasm-builder/Cargo.toml
+++ b/utils/wasm-builder/Cargo.toml
@@ -15,3 +15,4 @@ pwasm-utils = "0.19.0"
 toml = "0.5.8"
 thiserror = "1.0.30"
 log = "0.4.14"
+pathdiff = { version = "0.2.1", default-features = false }

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -159,6 +159,7 @@ impl WasmProject {
             .file_base_name
             .as_ref()
             .expect("Run `WasmProject::create_project()` first");
+
         let from_path = self
             .out_dir
             .join("target/wasm32-unknown-unknown/release")
@@ -179,9 +180,12 @@ impl WasmProject {
             .join(format!("{}.meta.wasm", &file_base_name));
         Self::generate_meta(&from_path, &to_meta_path)?;
 
-        let wasm_binary_path = self.out_dir.join("wasm_binary_path.txt");
-        fs::write(&wasm_binary_path, format!("{}", to_opt_path.display()))
-            .context("unable to write `wasm_binary_path.txt`")?;
+        let wasm_binary_path = self.original_dir.join(".binpath");
+
+        let relative_path_to_opt = pathdiff::diff_paths(&to_opt_path, &self.original_dir).expect("Unable to calculate relative path");
+
+        fs::write(&wasm_binary_path, format!("{}", relative_path_to_opt.display()))
+            .context("unable to write `.binpath`")?;
 
         let wasm_binary_rs = self.out_dir.join("wasm_binary.rs");
         fs::write(

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -182,10 +182,14 @@ impl WasmProject {
 
         let wasm_binary_path = self.original_dir.join(".binpath");
 
-        let relative_path_to_opt = pathdiff::diff_paths(&to_opt_path, &self.original_dir).expect("Unable to calculate relative path");
+        let relative_path_to_opt = pathdiff::diff_paths(&to_opt_path, &self.original_dir)
+            .expect("Unable to calculate relative path");
 
-        fs::write(&wasm_binary_path, format!("{}", relative_path_to_opt.display()))
-            .context("unable to write `.binpath`")?;
+        fs::write(
+            &wasm_binary_path,
+            format!("{}", relative_path_to_opt.display()),
+        )
+        .context("unable to write `.binpath`")?;
 
         let wasm_binary_rs = self.out_dir.join("wasm_binary.rs");
         fs::write(

--- a/utils/wasm-builder/test-program/.gitignore
+++ b/utils/wasm-builder/test-program/.gitignore
@@ -1,1 +1,2 @@
 Cargo.lock
+.binpath

--- a/utils/wasm-builder/test-program/Cargo.lock
+++ b/utils/wasm-builder/test-program/Cargo.lock
@@ -564,11 +564,12 @@ dependencies = [
 
 [[package]]
 name = "gear-wasm-builder"
-version = "0.2.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "cargo_metadata",
  "log",
+ "pathdiff",
  "pwasm-utils",
  "thiserror",
  "toml",
@@ -885,6 +886,12 @@ name = "path-clean"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pin-project-lite"


### PR DESCRIPTION
By @SabaunT request.

First motivation: `Program::current` wasn't working out of common `cargo test` command due to absence of `OUT_DIR` env var, what made `cargo nextest` incompatible with this feature. 

- Path to opt binary now writes in `crate_root/.binpath`
- Path in `.binpath` now not absolute - it's relative, what allows to avoid username appearing in it. 

@gear-tech/dev 
