### PR TITLE
Handle possible errors in `core-processor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7684,6 +7684,7 @@ dependencies = [
 name = "tests-common"
 version = "0.1.0"
 dependencies = [
+ "gear-backend-common",
  "gear-backend-wasmtime",
  "gear-core",
  "gear-core-processor",

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -243,9 +243,7 @@ impl EnvExt for Ext {
             .alloc(pages_num, mem)
             .map_err(|_e| "Allocation error");
 
-        if result.is_err() {
-            return self.return_and_store_err(result);
-        }
+        let page_number = self.return_and_store_err(result)?;
 
         // Returns back greedily used gas for grow
         let new_mem_size = mem.size().raw();
@@ -254,7 +252,7 @@ impl EnvExt for Ext {
             self.config.mem_grow_cost * (pages_num.raw() - grow_pages_num) as u64;
 
         // Returns back greedily used gas for allocations
-        let first_page = result.unwrap().raw();
+        let first_page = page_number.raw();
         let last_page = first_page + pages_num.raw() - 1;
         let mut new_alloced_pages_num = 0;
         for page in first_page..=last_page {
@@ -267,7 +265,7 @@ impl EnvExt for Ext {
 
         self.refund_gas(gas_to_return_back as u32)?;
 
-        self.return_and_store_err(result)
+        Ok(page_number)
     }
 
     fn block_height(&self) -> u32 {

--- a/core-processor/src/lib.rs
+++ b/core-processor/src/lib.rs
@@ -52,6 +52,6 @@ pub use ext::Ext;
 pub use ext::ProcessorExt;
 pub use handler::handle_journal;
 pub use id::{next_message_id, next_system_reply_message_id, BlakeMessageIdGenerator};
-pub use processor::{process, process_many};
+pub use processor::process;
 
 use gear_core::message::ExitCode;

--- a/core-processor/src/processor.rs
+++ b/core-processor/src/processor.rs
@@ -133,7 +133,11 @@ fn process_error(
 /// Helper function for journal creation in success case
 fn process_success(
     kind: SuccessfulDispatchResultKind,
-    DispatchResult {
+    dispatch_result: DispatchResult,
+) -> Vec<JournalNote> {
+    use SuccessfulDispatchResultKind::*;
+
+    let DispatchResult {
         dispatch,
         generated_dispatches,
         awakening,
@@ -142,9 +146,7 @@ fn process_success(
         page_update,
         nonce,
         ..
-    }: DispatchResult,
-) -> Vec<JournalNote> {
-    use SuccessfulDispatchResultKind::*;
+    } = dispatch_result;
 
     let mut journal = Vec::new();
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 360,
+    spec_version: 370,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 370,
+    spec_version: 380,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/tests/common/Cargo.toml
+++ b/tests/common/Cargo.toml
@@ -10,4 +10,5 @@ gstd = { path = "../../gstd", features = ["debug"] }
 gear-core = { path = "../../core" }
 codec = { package = "parity-scale-codec", version = "2", default-features = false }
 gear-backend-wasmtime = { path = "../../core-backend/wasmtime" }
+gear-backend-common = { path = "../../core-backend/common" }
 core-processor = { package = "gear-core-processor", path = "../../core-processor" }

--- a/tests/common/src/lib.rs
+++ b/tests/common/src/lib.rs
@@ -18,12 +18,14 @@
 
 use codec::{Decode, Encode, Error as CodecError};
 use core_processor::{
-    common::{DispatchOutcome, ExecutableActor, JournalHandler},
+    common::{DispatchOutcome, ExecutableActor, JournalHandler, JournalNote},
     configs::BlockInfo,
-    Ext,
+    Ext, ProcessorExt,
 };
+use gear_backend_common::{Environment, IntoExtInfo};
 use gear_backend_wasmtime::WasmtimeEnvironment;
 use gear_core::{
+    env::Ext as EnvExt,
     memory::PageNumber,
     message::{Dispatch, DispatchKind, Message, MessageId},
     program::{Program, ProgramId},
@@ -604,7 +606,7 @@ impl RunnerContext {
                 let actors = self.actors.clone();
                 let origins = vec![messages[0].message.source(); messages.len()];
 
-                core_processor::process_many::<Ext, WasmtimeEnvironment<Ext>>(
+                process_many::<Ext, WasmtimeEnvironment<Ext>>(
                     actors,
                     messages,
                     BlockInfo {
@@ -644,4 +646,59 @@ impl Default for RunnerContext {
             gas_spent: BTreeMap::new(),
         }
     }
+}
+
+/// Process multiple dispatches into multiple programs and return journal notes for update.
+pub fn process_many<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environment<A>>(
+    mut actors: BTreeMap<ProgramId, Option<ExecutableActor>>,
+    dispatches: Vec<Dispatch>,
+    block_info: BlockInfo,
+    existential_deposit: u128,
+    // Will go away some time soon
+    origins: Vec<ProgramId>,
+) -> Vec<JournalNote> {
+    let mut journal = Vec::new();
+
+    assert_eq!(dispatches.len(), origins.len());
+
+    for (dispatch, origin) in dispatches.into_iter().zip(origins.into_iter()) {
+        let actor = actors
+            .get_mut(&dispatch.message.dest())
+            .expect("Program wasn't found in programs");
+
+        let current_journal = core_processor::process::<A, E>(
+            actor.clone(),
+            dispatch,
+            block_info,
+            existential_deposit,
+            origin,
+        );
+
+        for note in &current_journal {
+            if let Some(actor) = actor {
+                match note {
+                    JournalNote::UpdateNonce { nonce, .. } => {
+                        actor.program.set_message_nonce(*nonce)
+                    }
+                    JournalNote::UpdatePage {
+                        page_number, data, ..
+                    } => {
+                        if let Some(data) = data {
+                            actor
+                                .program
+                                .set_page(*page_number, data)
+                                .expect("Can't fail");
+                        } else {
+                            actor.program.remove_page(*page_number);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        journal.extend(current_journal);
+    }
+
+    journal
 }


### PR DESCRIPTION
Resolves #768 

- eliminate `expect` in `process`
- remove `unwrap` in `EnvExt::alloc`
- remove `unreachable` in `process_success`
- move `process_many` to `tests/common` (it's not called by other modules)

@gear-tech/dev 
