### PR TITLE
Provide active and terminated program checks

### DIFF
--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -303,9 +303,6 @@ impl Debug for State {
                     .actors
                     .iter()
                     .filter_map(|(id, actor)| {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
                         actor.as_ref().map(|actor| {
                             (
                                 *id,
@@ -313,46 +310,13 @@ impl Debug for State {
                                     actor.balance,
                                     actor
                                         .program
-=======
-                        actor.
-                            clone()
-                            .map(|ExecutableActor { program, balance }| {
-(
-=======
-                        actor.clone().map(|ExecutableActor { program, balance }| {
-=======
-                        actor.as_ref().map(|actor| {
->>>>>>> refactor + panic then message to user in dispatch queue
-                            (
->>>>>>> pre-commit corrections
-                                *id,
-                                (
-<<<<<<< HEAD
-                                    balance,
-                                    program
->>>>>>> Added track of terminated programs into state. Update gear-test active or terminated check
-=======
-                                    actor.balance,
-                                    actor
-                                        .program
->>>>>>> refactor + panic then message to user in dispatch queue
                                         .get_pages()
                                         .keys()
                                         .cloned()
                                         .collect::<BTreeSet<PageNumber>>(),
                                 ),
-<<<<<<< HEAD
-<<<<<<< HEAD
                             )
                         })
-=======
-                            )}
-                        )
->>>>>>> Added track of terminated programs into state. Update gear-test active or terminated check
-=======
-                            )
-                        })
->>>>>>> pre-commit corrections
                     })
                     .collect::<BTreeMap<ProgramId, (u128, BTreeSet<PageNumber>)>>(),
             )

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -303,10 +303,8 @@ impl Debug for State {
                     .actors
                     .iter()
                     .filter_map(|(id, actor)| {
-                        actor.
-                            clone()
-                            .map(|ExecutableActor { program, balance }| {
-(
+                        actor.clone().map(|ExecutableActor { program, balance }| {
+                            (
                                 *id,
                                 (
                                     balance,
@@ -316,8 +314,8 @@ impl Debug for State {
                                         .cloned()
                                         .collect::<BTreeSet<PageNumber>>(),
                                 ),
-                            )}
-                        )
+                            )
+                        })
                     })
                     .collect::<BTreeMap<ProgramId, (u128, BTreeSet<PageNumber>)>>(),
             )

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -303,12 +303,13 @@ impl Debug for State {
                     .actors
                     .iter()
                     .filter_map(|(id, actor)| {
-                        actor.clone().map(|ExecutableActor { program, balance }| {
+                        actor.as_ref().map(|actor| {
                             (
                                 *id,
                                 (
-                                    balance,
-                                    program
+                                    actor.balance,
+                                    actor
+                                        .program
                                         .get_pages()
                                         .keys()
                                         .cloned()

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -305,6 +305,7 @@ impl Debug for State {
                     .filter_map(|(id, actor)| {
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
                         actor.as_ref().map(|actor| {
                             (
                                 *id,
@@ -319,13 +320,22 @@ impl Debug for State {
 (
 =======
                         actor.clone().map(|ExecutableActor { program, balance }| {
+=======
+                        actor.as_ref().map(|actor| {
+>>>>>>> refactor + panic then message to user in dispatch queue
                             (
 >>>>>>> pre-commit corrections
                                 *id,
                                 (
+<<<<<<< HEAD
                                     balance,
                                     program
 >>>>>>> Added track of terminated programs into state. Update gear-test active or terminated check
+=======
+                                    actor.balance,
+                                    actor
+                                        .program
+>>>>>>> refactor + panic then message to user in dispatch queue
                                         .get_pages()
                                         .keys()
                                         .cloned()

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -304,6 +304,7 @@ impl Debug for State {
                     .iter()
                     .filter_map(|(id, actor)| {
 <<<<<<< HEAD
+<<<<<<< HEAD
                         actor.as_ref().map(|actor| {
                             (
                                 *id,
@@ -316,6 +317,10 @@ impl Debug for State {
                             clone()
                             .map(|ExecutableActor { program, balance }| {
 (
+=======
+                        actor.clone().map(|ExecutableActor { program, balance }| {
+                            (
+>>>>>>> pre-commit corrections
                                 *id,
                                 (
                                     balance,
@@ -327,12 +332,17 @@ impl Debug for State {
                                         .collect::<BTreeSet<PageNumber>>(),
                                 ),
 <<<<<<< HEAD
+<<<<<<< HEAD
                             )
                         })
 =======
                             )}
                         )
 >>>>>>> Added track of terminated programs into state. Update gear-test active or terminated check
+=======
+                            )
+                        })
+>>>>>>> pre-commit corrections
                     })
                     .collect::<BTreeMap<ProgramId, (u128, BTreeSet<PageNumber>)>>(),
             )

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -287,7 +287,7 @@ pub struct State {
     /// Log records.
     pub log: Vec<StoredMessage>,
     /// State of each executable actor.
-    pub actors: BTreeMap<ProgramId, ExecutableActor>,
+    pub actors: BTreeMap<ProgramId, Option<ExecutableActor>>,
     /// Is current state failed.
     pub current_failed: bool,
 }
@@ -302,17 +302,21 @@ impl Debug for State {
                 &self
                     .actors
                     .iter()
-                    .map(|(id, ExecutableActor { program, balance })| {
-                        (
-                            *id,
-                            (
-                                *balance,
-                                program
-                                    .get_pages()
-                                    .keys()
-                                    .cloned()
-                                    .collect::<BTreeSet<PageNumber>>(),
-                            ),
+                    .filter_map(|(id, actor)| {
+                        actor.
+                            clone()
+                            .map(|ExecutableActor { program, balance }| {
+(
+                                *id,
+                                (
+                                    balance,
+                                    program
+                                        .get_pages()
+                                        .keys()
+                                        .cloned()
+                                        .collect::<BTreeSet<PageNumber>>(),
+                                ),
+                            )}
                         )
                     })
                     .collect::<BTreeMap<ProgramId, (u128, BTreeSet<PageNumber>)>>(),

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -303,6 +303,7 @@ impl Debug for State {
                     .actors
                     .iter()
                     .filter_map(|(id, actor)| {
+<<<<<<< HEAD
                         actor.as_ref().map(|actor| {
                             (
                                 *id,
@@ -310,13 +311,28 @@ impl Debug for State {
                                     actor.balance,
                                     actor
                                         .program
+=======
+                        actor.
+                            clone()
+                            .map(|ExecutableActor { program, balance }| {
+(
+                                *id,
+                                (
+                                    balance,
+                                    program
+>>>>>>> Added track of terminated programs into state. Update gear-test active or terminated check
                                         .get_pages()
                                         .keys()
                                         .cloned()
                                         .collect::<BTreeSet<PageNumber>>(),
                                 ),
+<<<<<<< HEAD
                             )
                         })
+=======
+                            )}
+                        )
+>>>>>>> Added track of terminated programs into state. Update gear-test active or terminated check
                     })
                     .collect::<BTreeMap<ProgramId, (u128, BTreeSet<PageNumber>)>>(),
             )

--- a/gear-test/spec/test_create_program.yaml
+++ b/gear-test/spec/test_create_program.yaml
@@ -25,6 +25,7 @@ fixtures:
 
     expected:
       - programs:
+        ids:
           - kind: id
             value: 1
 

--- a/gear-test/spec/test_create_program.yaml
+++ b/gear-test/spec/test_create_program.yaml
@@ -72,9 +72,10 @@ fixtures:
 
       - step: 2
         programs:
-          - kind: id
-            value: 1
-          - *address
+          ids:
+            - kind: id
+              value: 1
+            - *address
         messages:
           - destination:  *address
             init: true

--- a/gear-test/spec/test_failed_program_msg_handling.yaml
+++ b/gear-test/spec/test_failed_program_msg_handling.yaml
@@ -26,6 +26,10 @@ fixtures:
     expected:
       # no active programs in the state
       - programs:
+        - kind: id
+          value: 1
+          terminated: true
+
         log:
           # Trap in init generates trap reply
           - destination: 1000001

--- a/gear-test/spec/test_failed_program_msg_handling.yaml
+++ b/gear-test/spec/test_failed_program_msg_handling.yaml
@@ -24,7 +24,7 @@ fixtures:
           value: unknown
 
     expected:
-      - exact-program: true
+      - exact_program: true
 
       # no active programs in the state
       - programs:

--- a/gear-test/spec/test_failed_program_msg_handling.yaml
+++ b/gear-test/spec/test_failed_program_msg_handling.yaml
@@ -21,7 +21,7 @@ fixtures:
           value: 100
         payload:
           kind: utf-8
-          value: unknownspec_version correction v2
+          value: unknown
 
     expected:
 

--- a/gear-test/spec/test_failed_program_msg_handling.yaml
+++ b/gear-test/spec/test_failed_program_msg_handling.yaml
@@ -24,6 +24,8 @@ fixtures:
           value: unknown
 
     expected:
+      - exact: true
+
       # no active programs in the state
       - programs:
         - kind: id

--- a/gear-test/spec/test_failed_program_msg_handling.yaml
+++ b/gear-test/spec/test_failed_program_msg_handling.yaml
@@ -24,13 +24,14 @@ fixtures:
           value: unknownspec_version correction v2
 
     expected:
-      - exact_program: true
 
       # no active programs in the state
       - programs:
-        - kind: id
-          value: 1
-          terminated: true
+        only: true
+        ids:
+          - kind: id
+            value: 1
+            terminated: true
 
         log:
           # Trap in init generates trap reply

--- a/gear-test/spec/test_failed_program_msg_handling.yaml
+++ b/gear-test/spec/test_failed_program_msg_handling.yaml
@@ -24,7 +24,7 @@ fixtures:
           value: unknown
 
     expected:
-      - exact: true
+      - exact-program: true
 
       # no active programs in the state
       - programs:

--- a/gear-test/spec/test_failed_program_msg_handling.yaml
+++ b/gear-test/spec/test_failed_program_msg_handling.yaml
@@ -21,7 +21,7 @@ fixtures:
           value: 100
         payload:
           kind: utf-8
-          value: unknown
+          value: unknownspec_version correction v2
 
     expected:
       - exact_program: true

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -559,7 +559,7 @@ where
                         .map(|program| (program.address.to_program_id(), program.terminated.unwrap_or_default()))
                         .collect();
                     // Final state returns only active programs
-                    let actual_prog_ids = final_state.actors.iter().map(|(id, actor)| (*id, actor.is_some())).collect();
+                    let actual_prog_ids = final_state.actors.iter().map(|(id, actor)| (*id, actor.is_none())).collect();
                     if let Err(prog_id_errors) =
                         check_active_programs(expected_prog_ids, &actual_prog_ids, false)
                     {

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -556,10 +556,19 @@ where
                 if let Some(programs) = &exp.programs {
                     let expected_prog_ids = programs
                         .iter()
-                        .map(|program| (program.address.to_program_id(), program.terminated.unwrap_or_default()))
+                        .map(|program| {
+                            (
+                                program.address.to_program_id(),
+                                program.terminated.unwrap_or_default(),
+                            )
+                        })
                         .collect();
-                    // Final state returns only active programs
-                    let actual_prog_ids = final_state.actors.iter().map(|(id, actor)| (*id, actor.is_none())).collect();
+
+                    let actual_prog_ids = final_state
+                        .actors
+                        .iter()
+                        .map(|(id, actor)| (*id, actor.is_none()))
+                        .collect();
                     if let Err(prog_id_errors) =
                         check_active_programs(expected_prog_ids, &actual_prog_ids, false)
                     {
@@ -577,7 +586,7 @@ where
                             .actors
                             .clone()
                             .into_iter()
-                            .filter_map(|(_ , v)| v)
+                            .filter_map(|(_, v)| v)
                             .map(|v| v.program)
                             .collect();
                         if let Err(alloc_errors) = check_allocations(&progs, alloc) {

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -439,7 +439,7 @@ pub fn check_memory(
     }
 }
 
-fn check_programs_state(
+pub fn check_programs_state(
     expected_programs: &BTreeMap<ProgramId, bool>,
     actual_programs: &BTreeMap<ProgramId, bool>,
     only: bool,

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -442,11 +442,11 @@ pub fn check_memory(
 fn check_programs_state(
     expected_programs: &BTreeMap<ProgramId, bool>,
     actual_programs: &BTreeMap<ProgramId, bool>,
-    exact: bool,
+    only: bool,
 ) -> Result<(), Vec<String>> {
     let mut errors = Vec::new();
 
-    if exact {
+    if only {
         if actual_programs.len() != expected_programs.len() {
             errors.push(format!(
                 "Different lens of actual and expected programs: actual length={}, expected length={}",
@@ -569,6 +569,7 @@ where
                 }
                 if let Some(programs) = &exp.programs {
                     let expected_prog_ids = programs
+                        .ids
                         .iter()
                         .map(|program| {
                             (
@@ -587,7 +588,7 @@ where
                     if let Err(prog_id_errors) = check_programs_state(
                         &expected_prog_ids,
                         &actual_prog_ids,
-                        exp.exact_programs.unwrap_or_default(),
+                        programs.only.unwrap_or_default(),
                     ) {
                         errors.push(format!("step: {:?}", exp.step));
                         errors.extend(

--- a/gear-test/src/manager.rs
+++ b/gear-test/src/manager.rs
@@ -100,11 +100,6 @@ impl CollectState for InMemoryExtManager {
             })
             .collect();
 
-        let actors = actors
-            .into_iter()
-            .filter_map(|(id, a_opt)| a_opt.map(|a| (id, a)))
-            .collect();
-
         State {
             dispatch_queue,
             log,

--- a/gear-test/src/proc.rs
+++ b/gear-test/src/proc.rs
@@ -1,7 +1,7 @@
 // This file is part of Gear.
 
 // Copyright (C) 2021-2022 Gear Technologies Inc.
-// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+// SPDX-License-Identifier: GPL-3.0-or-l&&ater WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -281,12 +281,14 @@ where
                 .unwrap_or(0) as u64;
 
             if let Some((dispatch, gas_limit)) = state.dispatch_queue.pop_front() {
-                let actor = state.actors.get(&dispatch.destination()).cloned();
-
                 let program_id = dispatch.destination();
 
+                let actor = state.actors.get(&program_id).cloned();
+
                 let journal = core_processor::process::<Ext, E>(
-                    actor.unwrap_or_default(),
+                    actor.unwrap_or_else(|| {
+                        panic!("Error: Message to user {:?} in dispatch queue!", program_id)
+                    }),
                     dispatch.into_incoming(gas_limit),
                     BlockInfo { height, timestamp },
                     EXISTENTIAL_DEPOSIT,
@@ -307,16 +309,18 @@ where
     } else {
         let mut counter = 0;
         while let Some((dispatch, gas_limit)) = state.dispatch_queue.pop_front() {
-            let actor = state.actors.get(&dispatch.destination()).cloned();
+            let program_id = dispatch.destination();
+
+            let actor = state.actors.get(&program_id).cloned();
             let timestamp = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .map(|d| d.as_millis())
                 .unwrap_or(0) as u64;
 
-            let program_id = dispatch.destination();
-
             let journal = core_processor::process::<Ext, E>(
-                actor.unwrap_or_default(),
+                actor.unwrap_or_else(|| {
+                    panic!("Error: Message to user {:?} in dispatch queue!", program_id)
+                }),
                 dispatch.into_incoming(gas_limit),
                 BlockInfo {
                     height: counter,

--- a/gear-test/src/proc.rs
+++ b/gear-test/src/proc.rs
@@ -308,7 +308,6 @@ where
         let mut counter = 0;
         while let Some((dispatch, gas_limit)) = state.dispatch_queue.pop_front() {
             let actor = state.actors.get(&dispatch.destination()).cloned();
-
             let timestamp = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .map(|d| d.as_millis())
@@ -330,7 +329,7 @@ where
             );
             counter += 1;
 
-            core_processor::handle_journal(journal, journal_handler);
+                core_processor::handle_journal(journal, journal_handler);
 
             state = journal_handler.collect();
 

--- a/gear-test/src/proc.rs
+++ b/gear-test/src/proc.rs
@@ -1,7 +1,7 @@
 // This file is part of Gear.
 
 // Copyright (C) 2021-2022 Gear Technologies Inc.
-// SPDX-License-Identifier: GPL-3.0-or-l&&ater WITH Classpath-exception-2.0
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/gear-test/src/proc.rs
+++ b/gear-test/src/proc.rs
@@ -286,7 +286,7 @@ where
                 let program_id = dispatch.destination();
 
                 let journal = core_processor::process::<Ext, E>(
-                    actor,
+                    actor.unwrap_or_default(),
                     dispatch.into_incoming(gas_limit),
                     BlockInfo { height, timestamp },
                     EXISTENTIAL_DEPOSIT,
@@ -317,7 +317,7 @@ where
             let program_id = dispatch.destination();
 
             let journal = core_processor::process::<Ext, E>(
-                actor,
+                actor.unwrap_or_default(),
                 dispatch.into_incoming(gas_limit),
                 BlockInfo {
                     height: counter,

--- a/gear-test/src/proc.rs
+++ b/gear-test/src/proc.rs
@@ -329,7 +329,7 @@ where
             );
             counter += 1;
 
-                core_processor::handle_journal(journal, journal_handler);
+            core_processor::handle_journal(journal, journal_handler);
 
             state = journal_handler.collect();
 

--- a/gear-test/src/proc.rs
+++ b/gear-test/src/proc.rs
@@ -333,6 +333,7 @@ where
             core_processor::handle_journal(journal, journal_handler);
 
             state = journal_handler.collect();
+
             log::debug!("{:?}", state);
             results.push((state.clone(), Ok(())));
         }

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -102,8 +102,9 @@ pub struct Expectation {
     /// Flag, which points that errors are allowed. Could be used to check traps.
     #[serde(rename = "allowError")]
     pub allow_error: Option<bool>,
+    /// If this flag turned on, we check that only tested programs was executed
+    pub exact: Option<bool>,
     /// Expected active programs (not failed in the init) ids
-    #[serde(rename = "programs")]
     pub programs: Option<Vec<ChainProgram>>,
 }
 

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -76,13 +76,6 @@ pub struct Code {
     pub path: String,
 }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-
->>>>>>> Added track of terminated programs into state. Update gear-test active or terminated check
-=======
->>>>>>> pre-commit corrections
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ChainProgram {
     #[serde(flatten)]

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -77,9 +77,12 @@ pub struct Code {
 }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 
 >>>>>>> Added track of terminated programs into state. Update gear-test active or terminated check
+=======
+>>>>>>> pre-commit corrections
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ChainProgram {
     #[serde(flatten)]

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -102,7 +102,7 @@ pub struct Expectation {
     /// Flag, which points that errors are allowed. Could be used to check traps.
     #[serde(rename = "allowError")]
     pub allow_error: Option<bool>,
-    /// If this flag turned on, we check that only tested programs was executed
+    /// If this flag turned on, we check that only tested programs were executed
     pub exact_programs: Option<bool>,
     /// Expected active programs (not failed in the init) ids
     pub programs: Option<Vec<ChainProgram>>,

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -76,7 +76,6 @@ pub struct Code {
     pub path: String,
 }
 
-
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ChainProgram {
     #[serde(flatten)]

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -108,8 +108,6 @@ pub struct Expectation {
     /// Flag, which points that errors are allowed. Could be used to check traps.
     #[serde(rename = "allowError")]
     pub allow_error: Option<bool>,
-    /// If this flag turned on, we check that only tested programs were executed
-    pub exact_programs: Option<bool>,
     /// Expected active programs (not failed in the init) ids
     pub programs: Option<Programs>,
 }

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -108,6 +108,8 @@ pub struct Expectation {
     /// Flag, which points that errors are allowed. Could be used to check traps.
     #[serde(rename = "allowError")]
     pub allow_error: Option<bool>,
+    /// If this flag turned on, we check that only tested programs was executed
+    pub exact: Option<bool>,
     /// Expected active programs (not failed in the init) ids
     pub programs: Option<Programs>,
 }

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -108,7 +108,7 @@ pub struct Expectation {
     /// Flag, which points that errors are allowed. Could be used to check traps.
     #[serde(rename = "allowError")]
     pub allow_error: Option<bool>,
-    /// If this flag turned on, we check that only tested programs was executed
+    /// If this flag turned on, we check that only tested programs were executed
     pub exact_programs: Option<bool>,
     /// Expected active programs (not failed in the init) ids
     pub programs: Option<Programs>,

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -109,7 +109,7 @@ pub struct Expectation {
     #[serde(rename = "allowError")]
     pub allow_error: Option<bool>,
     /// If this flag turned on, we check that only tested programs was executed
-    pub exact: Option<bool>,
+    pub exact_programs: Option<bool>,
     /// Expected active programs (not failed in the init) ids
     pub programs: Option<Programs>,
 }

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -114,8 +114,12 @@ pub struct Expectation {
     pub exact_programs: Option<bool>,
 =======
     /// If this flag turned on, we check that only tested programs was executed
+<<<<<<< HEAD
     pub exact: Option<bool>,
 >>>>>>> refactor + panic then message to user in dispatch queue
+=======
+    pub exact_programs: Option<bool>,
+>>>>>>> Correct error messages
     /// Expected active programs (not failed in the init) ids
     pub programs: Option<Vec<ChainProgram>>,
 }

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -90,6 +90,12 @@ pub struct ChainProgram {
     pub(crate) terminated: Option<bool>,
 }
 
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct Programs {
+    pub only: Option<bool>,
+    pub ids: Vec<ChainProgram>,
+}
+
 /// Expected data after running messages, defined in the fixture.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Expectation {
@@ -109,9 +115,8 @@ pub struct Expectation {
     /// Flag, which points that errors are allowed. Could be used to check traps.
     #[serde(rename = "allowError")]
     pub allow_error: Option<bool>,
-    pub exact_programs: Option<bool>,
     /// Expected active programs (not failed in the init) ids
-    pub programs: Option<Vec<ChainProgram>>,
+    pub programs: Option<Programs>,
 }
 
 /// Data describing program being tested.

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -79,8 +79,8 @@ pub struct Code {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ChainProgram {
     #[serde(flatten)]
-    pub(crate) address: ChainAddress,
-    pub(crate) terminated: Option<bool>,
+    pub address: ChainAddress,
+    pub terminated: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -76,6 +76,14 @@ pub struct Code {
     pub path: String,
 }
 
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ChainProgram {
+    #[serde(flatten)]
+    pub(crate) address: ChainAddress,
+    pub(crate) terminated: Option<bool>,
+}
+
 /// Expected data after running messages, defined in the fixture.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Expectation {
@@ -97,7 +105,7 @@ pub struct Expectation {
     pub allow_error: Option<bool>,
     /// Expected active programs (not failed in the init) ids
     #[serde(rename = "programs")]
-    pub active_programs: Option<Vec<ChainAddress>>,
+    pub programs: Option<Vec<ChainProgram>>,
 }
 
 /// Data describing program being tested.

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -109,17 +109,7 @@ pub struct Expectation {
     /// Flag, which points that errors are allowed. Could be used to check traps.
     #[serde(rename = "allowError")]
     pub allow_error: Option<bool>,
-<<<<<<< HEAD
-    /// If this flag turned on, we check that only tested programs were executed
     pub exact_programs: Option<bool>,
-=======
-    /// If this flag turned on, we check that only tested programs was executed
-<<<<<<< HEAD
-    pub exact: Option<bool>,
->>>>>>> refactor + panic then message to user in dispatch queue
-=======
-    pub exact_programs: Option<bool>,
->>>>>>> Correct error messages
     /// Expected active programs (not failed in the init) ids
     pub programs: Option<Vec<ChainProgram>>,
 }

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -109,10 +109,6 @@ pub struct Expectation {
     /// If this flag turned on, we check that only tested programs were executed
     pub exact_programs: Option<bool>,
     /// Expected active programs (not failed in the init) ids
-<<<<<<< HEAD
-=======
-    #[serde(rename = "programs")]
->>>>>>> Added track of terminated programs into state. Update gear-test active or terminated check
     pub programs: Option<Vec<ChainProgram>>,
 }
 

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -103,7 +103,7 @@ pub struct Expectation {
     #[serde(rename = "allowError")]
     pub allow_error: Option<bool>,
     /// If this flag turned on, we check that only tested programs was executed
-    pub exact: Option<bool>,
+    pub exact_programs: Option<bool>,
     /// Expected active programs (not failed in the init) ids
     pub programs: Option<Vec<ChainProgram>>,
 }

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -76,6 +76,10 @@ pub struct Code {
     pub path: String,
 }
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> Added track of terminated programs into state. Update gear-test active or terminated check
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ChainProgram {
     #[serde(flatten)]
@@ -105,6 +109,10 @@ pub struct Expectation {
     /// If this flag turned on, we check that only tested programs were executed
     pub exact_programs: Option<bool>,
     /// Expected active programs (not failed in the init) ids
+<<<<<<< HEAD
+=======
+    #[serde(rename = "programs")]
+>>>>>>> Added track of terminated programs into state. Update gear-test active or terminated check
     pub programs: Option<Vec<ChainProgram>>,
 }
 

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -109,8 +109,13 @@ pub struct Expectation {
     /// Flag, which points that errors are allowed. Could be used to check traps.
     #[serde(rename = "allowError")]
     pub allow_error: Option<bool>,
+<<<<<<< HEAD
     /// If this flag turned on, we check that only tested programs were executed
     pub exact_programs: Option<bool>,
+=======
+    /// If this flag turned on, we check that only tested programs was executed
+    pub exact: Option<bool>,
+>>>>>>> refactor + panic then message to user in dispatch queue
     /// Expected active programs (not failed in the init) ids
     pub programs: Option<Vec<ChainProgram>>,
 }

--- a/pallets/gear-debug/src/lib.rs
+++ b/pallets/gear-debug/src/lib.rs
@@ -88,7 +88,7 @@ pub mod pallet {
 
     impl fmt::Debug for ProgramInfo {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            f.debug_struct("ProgramDetails")
+            f.debug_struct("ProgramInfo")
                 .field("static_pages", &self.static_pages)
                 .field(
                     "persistent_pages",

--- a/pallets/gear-debug/src/lib.rs
+++ b/pallets/gear-debug/src/lib.rs
@@ -100,7 +100,7 @@ pub mod pallet {
     }
 
     #[derive(Encode, Decode, Clone, PartialEq, TypeInfo, Debug)]
-    pub enum Terminatable {
+    pub enum ProgramState {
         Active(ProgramInfo),
         Terminated,
     }
@@ -108,7 +108,7 @@ pub mod pallet {
     #[derive(Encode, Decode, Clone, PartialEq, TypeInfo, Debug)]
     pub struct ProgramDetails {
         pub id: H256,
-        pub info: Terminatable,
+        pub state: ProgramState,
     }
 
     #[derive(Debug, Encode, Decode, Clone, Default, PartialEq, TypeInfo)]
@@ -179,15 +179,15 @@ pub mod pallet {
             )
             .map(|(id, p)| ProgramDetails {
                 id,
-                info: if let Program::Active(active) = p {
-                    Terminatable::Active(ProgramInfo {
+                state: if let Program::Active(active) = p {
+                    ProgramState::Active(ProgramInfo {
                         static_pages: active.static_pages,
                         persistent_pages: common::get_program_pages(id, active.persistent_pages)
                             .expect("active program exists, therefore pages do"),
                         code_hash: active.code_hash,
                     })
                 } else {
-                    Terminatable::Terminated
+                    ProgramState::Terminated
                 },
             })
             .collect();

--- a/pallets/gear-debug/src/tests.rs
+++ b/pallets/gear-debug/src/tests.rs
@@ -108,7 +108,7 @@ fn debug_mode_works() {
                 dispatch_queue: vec![],
                 programs: vec![crate::ProgramDetails {
                     id: program_id_1,
-                    info: crate::Terminatable::Active(crate::ProgramInfo {
+                    state: crate::ProgramState::Active(crate::ProgramInfo {
                         static_pages: 16,
                         persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
                         code_hash: generate_code_hash(&code_1),
@@ -138,7 +138,7 @@ fn debug_mode_works() {
                 programs: vec![
                     crate::ProgramDetails {
                         id: program_id_2,
-                        info: crate::Terminatable::Active(crate::ProgramInfo {
+                        state: crate::ProgramState::Active(crate::ProgramInfo {
                             static_pages: 16,
                             persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
                             code_hash: generate_code_hash(&code_2),
@@ -146,7 +146,7 @@ fn debug_mode_works() {
                     },
                     crate::ProgramDetails {
                         id: program_id_1,
-                        info: crate::Terminatable::Active(crate::ProgramInfo {
+                        state: crate::ProgramState::Active(crate::ProgramInfo {
                             static_pages: 16,
                             persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
                             code_hash: generate_code_hash(&code_1),
@@ -214,7 +214,7 @@ fn debug_mode_works() {
                 programs: vec![
                     crate::ProgramDetails {
                         id: program_id_2,
-                        info: crate::Terminatable::Active(crate::ProgramInfo {
+                        state: crate::ProgramState::Active(crate::ProgramInfo {
                             static_pages: 16,
                             persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
                             code_hash: generate_code_hash(&code_2),
@@ -222,7 +222,7 @@ fn debug_mode_works() {
                     },
                     crate::ProgramDetails {
                         id: program_id_1,
-                        info: crate::Terminatable::Active(crate::ProgramInfo {
+                        state: crate::ProgramState::Active(crate::ProgramInfo {
                             static_pages: 16,
                             persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
                             code_hash: generate_code_hash(&code_1),
@@ -243,7 +243,7 @@ fn debug_mode_works() {
                 programs: vec![
                     crate::ProgramDetails {
                         id: program_id_2,
-                        info: crate::Terminatable::Active(crate::ProgramInfo {
+                        state: crate::ProgramState::Active(crate::ProgramInfo {
                             static_pages: 16,
                             persistent_pages: (0..20).map(|v| (v, vec![0; 65536])).collect(),
                             code_hash: generate_code_hash(&code_2),
@@ -251,7 +251,7 @@ fn debug_mode_works() {
                     },
                     crate::ProgramDetails {
                         id: program_id_1,
-                        info: crate::Terminatable::Active(crate::ProgramInfo {
+                        state: crate::ProgramState::Active(crate::ProgramInfo {
                             static_pages: 16,
                             persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
                             code_hash: generate_code_hash(&code_1),

--- a/pallets/gear-debug/src/tests.rs
+++ b/pallets/gear-debug/src/tests.rs
@@ -108,9 +108,11 @@ fn debug_mode_works() {
                 dispatch_queue: vec![],
                 programs: vec![crate::ProgramDetails {
                     id: program_id_1,
-                    static_pages: 16,
-                    persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
-                    code_hash: generate_code_hash(&code_1),
+                    info: crate::Terminatable::Active(crate::ProgramInfo {
+                        static_pages: 16,
+                        persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
+                        code_hash: generate_code_hash(&code_1),
+                    }),
                 }],
             })
             .into(),
@@ -136,15 +138,19 @@ fn debug_mode_works() {
                 programs: vec![
                     crate::ProgramDetails {
                         id: program_id_2,
-                        static_pages: 16,
-                        persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
-                        code_hash: generate_code_hash(&code_2),
+                        info: crate::Terminatable::Active(crate::ProgramInfo {
+                            static_pages: 16,
+                            persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
+                            code_hash: generate_code_hash(&code_2),
+                        }),
                     },
                     crate::ProgramDetails {
                         id: program_id_1,
-                        static_pages: 16,
-                        persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
-                        code_hash: generate_code_hash(&code_1),
+                        info: crate::Terminatable::Active(crate::ProgramInfo {
+                            static_pages: 16,
+                            persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
+                            code_hash: generate_code_hash(&code_1),
+                        }),
                     },
                 ],
             })
@@ -208,15 +214,19 @@ fn debug_mode_works() {
                 programs: vec![
                     crate::ProgramDetails {
                         id: program_id_2,
-                        static_pages: 16,
-                        persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
-                        code_hash: generate_code_hash(&code_2),
+                        info: crate::Terminatable::Active(crate::ProgramInfo {
+                            static_pages: 16,
+                            persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
+                            code_hash: generate_code_hash(&code_2),
+                        }),
                     },
                     crate::ProgramDetails {
                         id: program_id_1,
-                        static_pages: 16,
-                        persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
-                        code_hash: generate_code_hash(&code_1),
+                        info: crate::Terminatable::Active(crate::ProgramInfo {
+                            static_pages: 16,
+                            persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
+                            code_hash: generate_code_hash(&code_1),
+                        }),
                     },
                 ],
             })
@@ -233,15 +243,19 @@ fn debug_mode_works() {
                 programs: vec![
                     crate::ProgramDetails {
                         id: program_id_2,
-                        static_pages: 16,
-                        persistent_pages: (0..20).map(|v| (v, vec![0; 65536])).collect(),
-                        code_hash: generate_code_hash(&code_2),
+                        info: crate::Terminatable::Active(crate::ProgramInfo {
+                            static_pages: 16,
+                            persistent_pages: (0..20).map(|v| (v, vec![0; 65536])).collect(),
+                            code_hash: generate_code_hash(&code_2),
+                        }),
                     },
                     crate::ProgramDetails {
                         id: program_id_1,
-                        static_pages: 16,
-                        persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
-                        code_hash: generate_code_hash(&code_1),
+                        info: crate::Terminatable::Active(crate::ProgramInfo {
+                            static_pages: 16,
+                            persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
+                            code_hash: generate_code_hash(&code_1),
+                        }),
                     },
                 ],
             })

--- a/pallets/gear-debug/src/tests.rs
+++ b/pallets/gear-debug/src/tests.rs
@@ -108,7 +108,7 @@ fn debug_mode_works() {
                 dispatch_queue: vec![],
                 programs: vec![crate::ProgramDetails {
                     id: program_id_1,
-                    state: crate::ProgramState  ::Active(crate::ProgramInfo {
+                    state: crate::ProgramState::Active(crate::ProgramInfo {
                         static_pages: 16,
                         persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
                         code_hash: generate_code_hash(&code_1),

--- a/pallets/gear-debug/src/tests.rs
+++ b/pallets/gear-debug/src/tests.rs
@@ -186,13 +186,12 @@ fn debug_mode_works() {
         System::assert_last_event(
             crate::Event::DebugDataSnapshot(DebugData {
                 dispatch_queue: vec![
-                    // message will have reverse order since the first one requeued to the end
                     StoredDispatch::new(
                         DispatchKind::Handle,
                         StoredMessage::new(
-                            MessageId::from_origin(message_id_2),
+                            MessageId::from_origin(message_id_1),
                             1.into(),
-                            ProgramId::from_origin(program_id_2),
+                            ProgramId::from_origin(program_id_1),
                             Default::default(),
                             0,
                             None,
@@ -202,9 +201,9 @@ fn debug_mode_works() {
                     StoredDispatch::new(
                         DispatchKind::Handle,
                         StoredMessage::new(
-                            MessageId::from_origin(message_id_1),
+                            MessageId::from_origin(message_id_2),
                             1.into(),
-                            ProgramId::from_origin(program_id_1),
+                            ProgramId::from_origin(program_id_2),
                             Default::default(),
                             0,
                             None,

--- a/pallets/gear-debug/src/tests.rs
+++ b/pallets/gear-debug/src/tests.rs
@@ -108,7 +108,7 @@ fn debug_mode_works() {
                 dispatch_queue: vec![],
                 programs: vec![crate::ProgramDetails {
                     id: program_id_1,
-                    state: crate::ProgramState::Active(crate::ProgramInfo {
+                    state: crate::ProgramState  ::Active(crate::ProgramInfo {
                         static_pages: 16,
                         persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
                         code_hash: generate_code_hash(&code_1),
@@ -186,12 +186,13 @@ fn debug_mode_works() {
         System::assert_last_event(
             crate::Event::DebugDataSnapshot(DebugData {
                 dispatch_queue: vec![
+                    // message will have reverse order since the first one requeued to the end
                     StoredDispatch::new(
                         DispatchKind::Handle,
                         StoredMessage::new(
-                            MessageId::from_origin(message_id_1),
+                            MessageId::from_origin(message_id_2),
                             1.into(),
-                            ProgramId::from_origin(program_id_1),
+                            ProgramId::from_origin(program_id_2),
                             Default::default(),
                             0,
                             None,
@@ -201,9 +202,9 @@ fn debug_mode_works() {
                     StoredDispatch::new(
                         DispatchKind::Handle,
                         StoredMessage::new(
-                            MessageId::from_origin(message_id_2),
+                            MessageId::from_origin(message_id_1),
                             1.into(),
-                            ProgramId::from_origin(program_id_2),
+                            ProgramId::from_origin(program_id_1),
                             Default::default(),
                             0,
                             None,

--- a/pallets/gear/src/manager.rs
+++ b/pallets/gear/src/manager.rs
@@ -96,7 +96,7 @@ where
             }
             (id, actor)
         })
-        .collect();
+        .collect::<BTreeMap<_, Option<_>>>();
 
         let dispatch_queue = common::dispatch_iter()
             .map(|dispatch| {

--- a/pallets/gear/src/manager.rs
+++ b/pallets/gear/src/manager.rs
@@ -55,6 +55,49 @@ pub enum HandleKind {
     Reply(H256, ExitCode),
 }
 
+impl<T: Config> CollectState for ExtManager<T>
+where
+    T::AccountId: Origin,
+{
+    fn collect(&self) -> State {
+        let actors = PrefixIterator::<H256>::new(
+            STORAGE_PROGRAM_PREFIX.to_vec(),
+            STORAGE_PROGRAM_PREFIX.to_vec(),
+            |key, _| Ok(H256::from_slice(key)),
+        )
+        .filter_map(|k| {
+            self.get_executable_actor(k)
+                .map(|actor| (actor.program.id(), actor))
+        })
+        .map(|(id, mut actor)| {
+            let pages_data = {
+                let page_numbers = actor.program.get_pages().keys().map(|k| k.raw()).collect();
+                let data = common::get_program_pages(id.into_origin(), page_numbers)
+                    .expect("active program exists, therefore pages do");
+                data.into_iter().map(|(k, v)| (k.into(), v)).collect()
+            };
+            let _ = actor.program.set_pages(pages_data);
+            (id, Some(actor))
+        })
+        .collect::<BTreeMap<_, Option<_>>>();
+
+        let dispatch_queue = common::dispatch_iter()
+            .map(|dispatch| {
+                let gas = T::GasHandler::get_limit(dispatch.message.id)
+                    .map(|(gas, _id)| gas)
+                    .unwrap_or(0);
+                dispatch.into_dispatch(gas)
+            })
+            .collect();
+
+        State {
+            dispatch_queue,
+            actors,
+            ..Default::default()
+        }
+    }
+}
+
 impl<T: Config> Default for ExtManager<T>
 where
     T::AccountId: Origin,

--- a/pallets/gear/src/manager.rs
+++ b/pallets/gear/src/manager.rs
@@ -107,8 +107,6 @@ where
             })
             .collect();
 
-            
-
         State {
             dispatch_queue,
             actors,

--- a/pallets/gear/src/manager.rs
+++ b/pallets/gear/src/manager.rs
@@ -91,7 +91,7 @@ where
             }
             (id, actor)
         })
-        .collect::<BTreeMap<_, Option<_>>>();
+        .collect();
 
         let dispatch_queue = common::dispatch_iter()
             .map(|dispatch| {

--- a/pallets/gear/src/manager.rs
+++ b/pallets/gear/src/manager.rs
@@ -21,12 +21,13 @@ use crate::{
     MessageInfo, Pallet,
 };
 use codec::{Decode, Encode};
-use common::{DAGBasedLedger, GasPrice, Origin, Program};
+use common::{DAGBasedLedger, GasPrice, Origin, Program, STORAGE_PROGRAM_PREFIX};
 use core_processor::common::{
-    DispatchOutcome as CoreDispatchOutcome, ExecutableActor, JournalHandler,
+    CollectState, DispatchOutcome as CoreDispatchOutcome, ExecutableActor, JournalHandler, State,
 };
-use frame_support::traits::{
-    BalanceStatus, Currency, ExistenceRequirement, Get, Imbalance, ReservableCurrency,
+use frame_support::{
+    storage::PrefixIterator,
+    traits::{BalanceStatus, Currency, ExistenceRequirement, Get, Imbalance, ReservableCurrency},
 };
 use gear_core::{
     code::Code,
@@ -40,7 +41,11 @@ use sp_runtime::{
     traits::{UniqueSaturatedInto, Zero},
     SaturatedConversion,
 };
-use sp_std::{collections::btree_set::BTreeSet, marker::PhantomData, prelude::*};
+use sp_std::{
+    collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+    marker::PhantomData,
+    prelude::*,
+};
 
 pub struct ExtManager<T: Config> {
     // Messages with these destinations will be forcibly pushed to the queue.

--- a/pallets/gear/src/manager.rs
+++ b/pallets/gear/src/manager.rs
@@ -91,7 +91,7 @@ where
             }
             (id, actor)
         })
-        .collect();
+        .collect::<BTreeMap<_, Option<_>>>();
 
         let dispatch_queue = common::dispatch_iter()
             .map(|dispatch| {

--- a/pallets/gear/src/manager.rs
+++ b/pallets/gear/src/manager.rs
@@ -96,7 +96,7 @@ where
             }
             (id, actor)
         })
-        .collect::<BTreeMap<_, Option<_>>>();
+        .collect();
 
         let dispatch_queue = common::dispatch_iter()
             .map(|dispatch| {

--- a/pallets/gear/src/manager.rs
+++ b/pallets/gear/src/manager.rs
@@ -96,16 +96,18 @@ where
             }
             (id, actor)
         })
-        .collect();
+        .collect::<BTreeMap<_, Option<_>>>();
 
         let dispatch_queue = common::dispatch_iter()
             .map(|dispatch| {
-                let gas = T::GasHandler::get_limit(dispatch.message.id)
+                let gas = T::GasHandler::get_limit(dispatch.message().id().into_origin())
                     .map(|(gas, _id)| gas)
                     .unwrap_or(0);
-                dispatch.into_dispatch(gas)
+                (dispatch, gas)
             })
             .collect();
+
+            
 
         State {
             dispatch_queue,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 530,
+    spec_version: 540,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/utils/gear-runtime-test-cli/src/command.rs
+++ b/utils/gear-runtime-test-cli/src/command.rs
@@ -34,6 +34,7 @@ use gear_core::{
 };
 
 use gear_common::{DAGBasedLedger, Origin as _};
+use gear_test::sample::ChainProgram;
 use gear_test::{
     check::read_test_from_file,
     js::{MetaData, MetaType},
@@ -393,6 +394,36 @@ fn run_fixture(test: &'_ sample::Test, fixture: &sample::Fixture) -> ColoredStri
                     if let Err(alloc_errors) = gear_test::check::check_allocations(&progs, alloc) {
                         errors.push(format!("step: {:?}", exp.step));
                         errors.extend(alloc_errors);
+                    }
+                }
+
+                let actual_programs = programs
+                    .iter()
+                    .filter_map(|(program_id, h256)| {
+                        gear_common::get_program(*h256)
+                            .map(|program| (*program_id, program.is_active()))
+                    })
+                    .collect();
+
+                if let Some(programs_struct) = &exp.programs {
+                    let expected_programs = programs_struct
+                        .ids
+                        .iter()
+                        .map(|program: &ChainProgram| {
+                            (
+                                program.address.to_program_id(),
+                                program.terminated.unwrap_or_default(),
+                            )
+                        })
+                        .collect();
+
+                    if let Err(state_errors) = gear_test::check::check_programs_state(
+                        &expected_programs,
+                        &actual_programs,
+                        programs_struct.only.unwrap_or_default(),
+                    ) {
+                        errors.push(format!("step: {:?}", exp.step));
+                        errors.extend(state_errors);
                     }
                 }
 

--- a/utils/gear-runtime-test-cli/src/command.rs
+++ b/utils/gear-runtime-test-cli/src/command.rs
@@ -43,7 +43,7 @@ use gear_test::{
     sample::PayloadVariant,
 };
 use pallet_gear::Pallet as GearPallet;
-use pallet_gear_debug::{DebugData, Terminatable};
+use pallet_gear_debug::{DebugData, ProgramState};
 use rayon::prelude::*;
 use sc_cli::{CliConfiguration, SharedParams};
 use sc_service::Configuration;
@@ -367,7 +367,7 @@ fn run_fixture(test: &'_ sample::Test, fixture: &sample::Fixture) -> ColoredStri
                     .programs
                     .iter()
                     .filter_map(|p| {
-                        if let Terminatable::Active(info) = &p.info {
+                        if let ProgramState::Active(info) = &p.state {
                             if let Some((pid, _)) = programs.iter().find(|(_, v)| v == &&p.id) {
                                 let code = gear_common::get_code(info.code_hash)
                                     .expect("code should be in the storage");
@@ -406,7 +406,7 @@ fn run_fixture(test: &'_ sample::Test, fixture: &sample::Fixture) -> ColoredStri
                     .iter()
                     .filter_map(|p| {
                         if let Some((pid, _)) = programs.iter().find(|(_, v)| v == &&p.id) {
-                            Some((*pid, p.info == Terminatable::Terminated))
+                            Some((*pid, p.state == ProgramState::Terminated))
                         } else {
                             None
                         }


### PR DESCRIPTION
Resolves #661.

I added track of terminated programs into state. 
Rewrite active programs checking in gear-test, that way it also checks terminated programs.
It should work without rewriting existing .yaml files.
Issue seem to be resolved, but I have technical issues with tests, so can't be sure yet.

@gear-tech/dev 