### PR TITLE
switch to new allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,7 +1321,7 @@ dependencies = [
 [[package]]
 name = "dlmalloc"
 version = "0.1.4"
-source = "git+https://github.com/gear-tech/dlmalloc-rust.git?rev=703192a04d55a75899a69ca8c9f70810de421797#703192a04d55a75899a69ca8c9f70810de421797"
+source = "git+https://github.com/gear-tech/dlmalloc-rust.git?rev=e76ae98#e76ae9869ea4d386e758d7ed5d983ba2a25d7629"
 dependencies = [
  "libc",
  "libc_print",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "dlmalloc"
 version = "0.1.4"
-source = "git+https://github.com/gear-tech/dlmalloc-rust.git?rev=703192a04d55a75899a69ca8c9f70810de421797#703192a04d55a75899a69ca8c9f70810de421797"
+source = "git+https://github.com/gear-tech/dlmalloc-rust.git?rev=e76ae98#e76ae9869ea4d386e758d7ed5d983ba2a25d7629"
 dependencies = [
  "libc",
  "libc_print",

--- a/galloc/Cargo.toml
+++ b/galloc/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
-dlmalloc = { git = "https://github.com/gear-tech/dlmalloc-rust.git", rev = "703192a04d55a75899a69ca8c9f70810de421797" }
+dlmalloc = { git = "https://github.com/gear-tech/dlmalloc-rust.git", rev = "e76ae98", default-features = false, features = ["global"] }
 
 [features]
 debug = ["dlmalloc/debug"]

--- a/galloc/Cargo.toml
+++ b/galloc/Cargo.toml
@@ -7,7 +7,6 @@ license = "GPL-3.0"
 
 [dependencies]
 # add "checks" feature to enable hard checks in allocator
-# dlmalloc = { git = "https://github.com/gear-tech/dlmalloc-rust.git", rev = "703192a04d55a75899a69ca8c9f70810de421797" }
 dlmalloc = { git = "https://github.com/gear-tech/dlmalloc-rust.git", rev = "e76ae98", default-features = false, features = ["global"] }
 
 [features]

--- a/galloc/Cargo.toml
+++ b/galloc/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
+# add "checks" feature to enable hard checks in allocator
 dlmalloc = { git = "https://github.com/gear-tech/dlmalloc-rust.git", rev = "e76ae98", default-features = false, features = ["global"] }
 
 [features]

--- a/galloc/Cargo.toml
+++ b/galloc/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0"
 
 [dependencies]
 # add "checks" feature to enable hard checks in allocator
+# dlmalloc = { git = "https://github.com/gear-tech/dlmalloc-rust.git", rev = "703192a04d55a75899a69ca8c9f70810de421797" }
 dlmalloc = { git = "https://github.com/gear-tech/dlmalloc-rust.git", rev = "e76ae98", default-features = false, features = ["global"] }
 
 [features]

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -508,6 +508,11 @@ pub mod pallet {
 
                 // Check whether we have enough of gas allowed for message processing
                 if gas_limit > GasAllowance::<T>::get() {
+                    log::debug!(
+                        "Not enought gas for processing: gas_limit = {}, allowance = {}",
+                        gas_limit,
+                        GasAllowance::<T>::get(),
+                    );
                     common::queue_dispatch(dispatch);
                     break;
                 }

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -1285,7 +1285,7 @@ fn uninitialized_program_should_accept_replies() {
             WASM_BINARY.to_vec(),
             vec![],
             Vec::new(),
-            99_000_000u64,
+            90_000_000u64,
             0u128
         ));
 
@@ -2250,7 +2250,7 @@ fn resume_program_works() {
             code.clone(),
             vec![],
             Vec::new(),
-            100_000_000u64,
+            90_000_000u64,
             0u128
         ));
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 390,
+    spec_version: 400,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Resolves #648 
switch to new allocator with new features:
1) windows gags to be able use wasm builder on windows
2) make new feature "checks" which enables hard debug checks in allocator - so "debug" feature now does not run this checks, only simple assertions