### PR TITLE
Add `.gitattributes` configuration file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 * text eol=lf
+
+**/Cargo.lock linguist-generated=true
+**/package-lock.json linguist-generated=true


### PR DESCRIPTION
Git usually automatically converts line endings to CRLF on Windows. It is useful to keep them according to EditorConfig. Also, it can break bash scripts