### PR TITLE
Small amendment of GasHandler API

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -171,8 +171,11 @@ pub trait DAGBasedLedger {
         amount: Self::Balance,
     ) -> Result<Self::PositiveImbalance, DispatchError>;
 
-    /// Get value item by it's ID, if exists.
-    fn get_limit(key: Self::Key) -> Option<(Self::Balance, Self::ExternalOrigin)>;
+    /// Get the external origin for a key, if the latter exists.
+    fn get_origin(key: Self::Key) -> Option<Self::ExternalOrigin>;
+
+    /// Get value item by it's ID, if exists, and the key of an ancestor that sets this limit.
+    fn get_limit(key: Self::Key) -> Option<(Self::Balance, Self::Key)>;
 
     /// Consume underlying value.
     ///

--- a/pallets/gas/src/lib.rs
+++ b/pallets/gas/src/lib.rs
@@ -250,15 +250,17 @@ where
         Ok(PositiveImbalance::new(amount))
     }
 
-    fn get_limit(key: H256) -> Option<(u64, H256)> {
-        Self::value_view(key).map(|node| {
-            let value = node.inner_value().unwrap_or_else(|| {
-                Self::get_limit(node.parent().expect("Either value or parent present"))
-                    .expect("Value should exist if tree exists")
-                    .0
-            });
+    fn get_origin(key: H256) -> Option<H256> {
+        Self::value_view(key).map(|node| Self::node_root_origin(&node))
+    }
 
-            (value, Self::node_root_origin(&node))
+    fn get_limit(key: H256) -> Option<(u64, H256)> {
+        Self::value_view(key).and_then(|node| {
+            if let Some(value) = node.inner_value() {
+                Some((value, key))
+            } else {
+                node.parent().and_then(Self::get_limit)
+            }
         })
     }
 

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -496,7 +496,9 @@ pub mod pallet {
             while let Some(dispatch) = common::dequeue_dispatch() {
                 // Update message gas limit for it may have changed in the meantime
 
-                let (gas_limit, origin) = T::GasHandler::get_limit(*dispatch.message_id())
+                let msg_id = *dispatch.message_id();
+
+                let (gas_limit, _) = T::GasHandler::get_limit(msg_id)
                     .expect("Should never fail if ValueNode works properly");
 
                 log::debug!(
@@ -551,6 +553,9 @@ pub mod pallet {
                 } else {
                     None
                 };
+
+                let origin = <T as Config>::GasHandler::get_origin(msg_id)
+                    .expect("Gas node is guaranteed to exist for the key due to earlier checks");
 
                 let journal = core_processor::process::<
                     ext::LazyPagesExt,

--- a/pallets/gear/src/manager.rs
+++ b/pallets/gear/src/manager.rs
@@ -287,7 +287,7 @@ where
 
         match T::GasHandler::spend(message_id, amount) {
             Ok(_) => {
-                if let Some((_, origin)) = T::GasHandler::get_limit(message_id) {
+                if let Some(origin) = T::GasHandler::get_origin(message_id) {
                     let charge = T::GasPrice::gas_price(amount);
                     if let Some(author) = Authorship::<T>::author() {
                         let _ = <T as Config>::Currency::repatriate_reserved(
@@ -436,7 +436,7 @@ where
 
             match T::GasHandler::spend(message_id.into_origin(), chargeable_amount) {
                 Ok(_) => {
-                    if let Some((_, origin)) = T::GasHandler::get_limit(message_id.into_origin()) {
+                    if let Some(origin) = T::GasHandler::get_origin(message_id.into_origin()) {
                         let charge = T::GasPrice::gas_price(chargeable_amount);
                         if let Some(author) = Authorship::<T>::author() {
                             let _ = <T as Config>::Currency::repatriate_reserved(

--- a/pallets/usage/src/lib.rs
+++ b/pallets/usage/src/lib.rs
@@ -404,7 +404,9 @@ pub mod pallet {
                 _ => Err(DispatchError::BadOrigin),
             }?;
 
-            let total_collected = Self::do_rent_collection(payees_list, who.as_ref());
+            let total_collected = Self::do_rent_collection(payees_list.clone(), who.as_ref());
+
+            log::debug!("Collected {} from {:?}", total_collected, payees_list);
 
             if total_collected > 0 {
                 Self::deposit_event(Event::WaitListRentCollected(total_collected));

--- a/pallets/usage/src/mock.rs
+++ b/pallets/usage/src/mock.rs
@@ -168,7 +168,7 @@ impl pallet_authorship::Config for Test {
     type EventHandler = ();
 }
 
-type Extrinsic = TestXt<Call, ()>;
+pub(crate) type Extrinsic = TestXt<Call, ()>;
 
 impl<LocalCall> frame_system::offchain::SendTransactionTypes<LocalCall> for Test
 where
@@ -255,4 +255,16 @@ pub(crate) fn get_current_offchain_time() -> u64 {
 pub(crate) fn get_offchain_storage_value<T: Decode>(key: &[u8]) -> Option<T> {
     let storage_value_ref = StorageValueRef::persistent(key);
     storage_value_ref.get::<T>().ok().flatten()
+}
+
+pub(crate) fn decode_txs(pool: Arc<RwLock<PoolState>>) -> Vec<Extrinsic> {
+    pool.read()
+        .transactions
+        .iter()
+        .cloned()
+        .map(|bytes| {
+            let tx = Extrinsic::decode(&mut &bytes[..]).unwrap();
+            tx
+        })
+        .collect::<Vec<_>>()
 }

--- a/pallets/usage/src/offchain.rs
+++ b/pallets/usage/src/offchain.rs
@@ -82,8 +82,8 @@ use codec::{Decode, Encode};
 use frame_support::{traits::Get, RuntimeDebug};
 use frame_system::offchain::SubmitTransaction;
 use frame_system::pallet_prelude::*;
+use sp_core::hexdisplay::HexDisplay;
 use sp_runtime::offchain::storage::StorageValueRef;
-// use sp_std::convert::TryInto;
 
 // Off-chain worker constants
 pub const STORAGE_LAST_KEY: &[u8] = b"g::ocw::last::key";
@@ -107,10 +107,21 @@ impl sp_std::fmt::Debug for OffchainError {
     }
 }
 
-#[derive(Encode, Decode, Clone, PartialEq, RuntimeDebug, scale_info::TypeInfo)]
+#[derive(Encode, Decode, Clone, PartialEq, scale_info::TypeInfo)]
 pub struct PayeeInfo {
     pub program_id: H256,
     pub message_id: H256,
+}
+
+impl core::fmt::Debug for PayeeInfo {
+    fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
+        write!(
+            f,
+            "PayeeInfo {{ program_id: 0x{}…, message_id: 0x{}… }}",
+            HexDisplay::from(&self.program_id[..4].to_vec()),
+            HexDisplay::from(&self.message_id[..4].to_vec())
+        )
+    }
 }
 
 #[derive(Encode, Decode, Default, Clone, PartialEq, RuntimeDebug, scale_info::TypeInfo)]
@@ -158,13 +169,16 @@ impl<T: Config> Pallet<T> {
             }
         }
 
+        let new_last_key = new_last_key.unwrap_or(prefix);
         log::debug!(
-            target: "runtime::usage",
-            "Sending {:?} invoices to {:?} at block {:?}. Last visited key is {:?}.",
-            counter, entries, now, new_last_key,
+            "Sending {} invoices to {:?} at block {:?}. Last visited key is 0x{}.",
+            counter,
+            entries,
+            now,
+            HexDisplay::from(&new_last_key),
         );
 
-        storage_value_ref.set(&new_last_key.unwrap_or(prefix));
+        storage_value_ref.set(&new_last_key);
 
         Self::send_transaction(entries)
     }
@@ -173,9 +187,7 @@ impl<T: Config> Pallet<T> {
         let call = Call::collect_waitlist_rent { payees_list: data };
 
         SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into()).map_err(|_| {
-            log::debug!(
-                target: "runtime::usage",
-                "Failure sending unsigned transaction");
+            log::debug!("Failure sending unsigned transaction");
             OffchainError::SubmitTransaction
         })
     }

--- a/pallets/usage/src/tests.rs
+++ b/pallets/usage/src/tests.rs
@@ -216,7 +216,8 @@ fn ocw_interval_stretches_for_large_wait_list() {
         let num_batches = 7_u32;
 
         // Populate wait list with `Test::MaxBatchSize` x `num_bathces` messages
-        let num_entries = <Test as Config>::MaxBatchSize::get().saturating_mul(num_batches) as u64;
+        let batch_size = <Test as Config>::MaxBatchSize::get() as u64;
+        let num_entries = batch_size.saturating_mul(num_batches as u64);
         assert_eq!(num_entries, 70);
         populate_wait_list(num_entries, 10, 1, vec![10_000; num_entries as usize]);
 
@@ -236,11 +237,45 @@ fn ocw_interval_stretches_for_large_wait_list() {
         // From block 15 on we expect to have a new transaction every block
         run_to_block_with_ocw(15);
         assert_eq!(pool.read().transactions.len(), 3);
-        // New "invoicing" round has started, as well
+
+        // New "invoicing" round has started
         assert_eq!(
             get_offchain_storage_value(offchain::STORAGE_ROUND_STARTED_AT),
             Some(15_u32)
         );
+
+        // The last tx in the pool contains batch #1 of messages
+        let latest_tx = decode_txs(pool.clone())[..]
+            .last()
+            .expect("Checked above")
+            .clone();
+        assert!(matches!(
+            latest_tx.call,
+            mock::Call::Usage(pallet::Call::collect_waitlist_rent { .. })
+        ));
+        if let mock::Call::Usage(pallet::Call::collect_waitlist_rent { payees_list }) =
+            latest_tx.call
+        {
+            for (
+                i,
+                PayeeInfo {
+                    program_id,
+                    message_id,
+                },
+            ) in payees_list.into_iter().enumerate()
+            {
+                let i = i as u64;
+                assert_eq!(
+                    (program_id, message_id),
+                    (
+                        (i + 1).into_origin(),
+                        (100_u64 * (num_entries as u64) + i + 1).into_origin()
+                    )
+                );
+            }
+        } else {
+            unreachable!()
+        }
 
         // Last seen key in the wait list should be that of the 10th message
         assert_eq!(
@@ -253,6 +288,39 @@ fn ocw_interval_stretches_for_large_wait_list() {
 
         run_to_block_with_ocw(16);
         assert_eq!(pool.read().transactions.len(), 4);
+
+        // The last tx in the pool now contains batch #2 of messages
+        let latest_tx = decode_txs(pool.clone())[..]
+            .last()
+            .expect("Checked above")
+            .clone();
+        assert!(matches!(
+            latest_tx.call,
+            mock::Call::Usage(pallet::Call::collect_waitlist_rent { .. })
+        ));
+        if let mock::Call::Usage(pallet::Call::collect_waitlist_rent { payees_list }) =
+            latest_tx.call
+        {
+            for (
+                i,
+                PayeeInfo {
+                    program_id,
+                    message_id,
+                },
+            ) in payees_list.into_iter().enumerate()
+            {
+                let i = i as u64;
+                assert_eq!(
+                    (program_id, message_id),
+                    (
+                        (batch_size + i + 1).into_origin(),
+                        (100_u64 * (num_entries as u64) + batch_size + i + 1).into_origin()
+                    )
+                );
+            }
+        } else {
+            unreachable!()
+        }
 
         // Last seen key in the wait list should be that of the 20th message
         assert_eq!(

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 410,
+    spec_version: 420,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Following the introduction of messages with unspecified concrete gas limit (that is, derived from some upstream message), the `GasHandler` API has been changed:
- the `get_limit(key)` function now returns the pair of the available gas for a message and the id of the tree node that sets this limit (previously returned the external origin as the second item in the pair);
- to get the external origin, the `get_origin(key)` method has been introduced.

Apart from the API change, a possibility to actually process the mock transaction pool has been added to the tests in `pallet-usage`.