### PR TITLE
Revert "use patched ring to fix CI (#795)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5527,7 +5527,8 @@ checksum = "51dd4445360338dab5116712bee1388dc727991d51969558a8882ab552e6db30"
 [[package]]
 name = "ring"
 version = "0.16.20"
-source = "git+https://github.com/gear-tech/ring.git?branch=v0.16.20-fix-nightly-pregenerated#44e94bb8ba66666992cae013f99341d25df5ba4b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,3 @@ members = [
     "utils/wasm-proc",
     "utils/wasm-builder",
 ]
-
-[patch.crates-io]
-ring = { git = "https://github.com/gear-tech/ring.git", branch = "v0.16.20-fix-nightly-pregenerated" }


### PR DESCRIPTION
This reverts commit 47d84922f72aab829d5ee0c48039b0cee20e4a43.

@gear-tech/dev 
