### PR TITLE
Use default message root id for rpc call

### DIFF
--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -350,7 +350,7 @@ pub mod pallet {
         ) -> Result<u64, Vec<u8>> {
             let mut ext_manager = ExtManager::<T>::default();
 
-            let root_message_id = Self::next_message_id(source);
+            let root_message_id = Default::default();
 
             let dispatch = match kind {
                 HandleKind::Init(ref code) => {


### PR DESCRIPTION
RPC calls doesn't affect storage. So there is no problem in default message id, because it can't be placed in real one. But the think is when we try to properly use Pallet::next_message_id nonce doesn't increment and we run into the same id, e.g, for first extrinsic and first rpc call in block, what leads to conflicts in GasValueTree.

@gear-tech/dev 
