### PR TITLE
Make `msg::send*` and `msg::reply*` functions fallible

### DIFF
--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -24,11 +24,11 @@ extern crate alloc;
 
 pub mod funcs;
 
-use alloc::string::String;
 use alloc::{
     borrow::Cow,
     boxed::Box,
     collections::{BTreeMap, BTreeSet},
+    string::String,
     vec::Vec,
 };
 use gear_core::{

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -24,6 +24,7 @@ use core::{
     slice::Iter,
 };
 use gear_backend_common::{funcs, EXIT_TRAP_STR, LEAVE_TRAP_STR, WAIT_TRAP_STR};
+use gear_backend_common::{IntoErrorCode, OnSuccessCode};
 use gear_core::{
     env::Ext,
     ids::{MessageId, ProgramId},
@@ -92,10 +93,11 @@ impl<E: Ext + 'static> FuncsHandler<E> {
                 let dest: ProgramId = funcs::get_bytes32(&ctx.memory, program_id_ptr)?.into();
                 let payload = funcs::get_vec(&ctx.memory, payload_ptr, payload_len)?;
                 let value = funcs::get_u128(&ctx.memory, value_ptr)?;
-                let message_id = ext.send(HandlePacket::new(dest, payload, value))?;
-                wto(ctx, message_id_ptr, message_id.as_ref())
+                ext.send(HandlePacket::new(dest, payload, value))
+                    .on_success_code(|message_id| wto(ctx, message_id_ptr, message_id.as_ref()))
             })
-            .and_then(|res| res.map(|_| ReturnValue::Unit))
+            .map_err(Into::into)
+            .and_then(|res| res.map(Value::I32).map(ReturnValue::Value))
             .map_err(|_err| {
                 ctx.trap = Some("Trapping: unable to send message");
                 HostError
@@ -120,11 +122,11 @@ impl<E: Ext + 'static> FuncsHandler<E> {
                 let dest: ProgramId = funcs::get_bytes32(&ctx.memory, program_id_ptr)?.into();
                 let payload = funcs::get_vec(&ctx.memory, payload_ptr, payload_len)?;
                 let value = funcs::get_u128(&ctx.memory, value_ptr)?;
-                let message_id =
-                    ext.send(HandlePacket::new_with_gas(dest, payload, gas_limit, value))?;
-                wto(ctx, message_id_ptr, message_id.as_ref())
+                ext.send(HandlePacket::new_with_gas(dest, payload, gas_limit, value))
+                    .on_success_code(|message_id| wto(ctx, message_id_ptr, message_id.as_ref()))
             })
-            .and_then(|res| res.map(|_| ReturnValue::Unit))
+            .map_err(Into::into)
+            .and_then(|res| res.map(Value::I32).map(ReturnValue::Value))
             .map_err(|_| {
                 ctx.trap = Some("Trapping: unable to send message");
                 HostError
@@ -145,13 +147,14 @@ impl<E: Ext + 'static> FuncsHandler<E> {
             .with(|ext| {
                 let dest: ProgramId = funcs::get_bytes32(&ctx.memory, program_id_ptr)?.into();
                 let value = funcs::get_u128(&ctx.memory, value_ptr)?;
-                let message_id = ext.send_commit(
+                ext.send_commit(
                     handle_ptr,
                     HandlePacket::new(dest, Default::default(), value),
-                )?;
-                wto(ctx, message_id_ptr, message_id.as_ref())
+                )
+                .on_success_code(|message_id| wto(ctx, message_id_ptr, message_id.as_ref()))
             })
-            .and_then(|res| res.map(|_| ReturnValue::Unit))
+            .map_err(Into::into)
+            .and_then(|res| res.map(Value::I32).map(ReturnValue::Value))
             .map_err(|_err| {
                 ctx.trap = Some("Trapping: unable to send message");
                 HostError
@@ -172,12 +175,13 @@ impl<E: Ext + 'static> FuncsHandler<E> {
             .with(|ext| {
                 let dest: ProgramId = funcs::get_bytes32(&ctx.memory, program_id_ptr)?.into();
                 let value = funcs::get_u128(&ctx.memory, value_ptr)?;
-                let message_id = ext.send_commit(
+                ext.send_commit(
                     handle_ptr,
                     HandlePacket::new_with_gas(dest, Default::default(), gas_limit, value),
-                )?;
-                wto(ctx, message_id_ptr, message_id.as_ref())
+                )
+                .on_success_code(|message_id| wto(ctx, message_id_ptr, message_id.as_ref()))
             })
+            .map_err(Into::into)
             .and_then(|res| res.map(|_| ReturnValue::Unit))
             .map_err(|_| {
                 ctx.trap = Some("Trapping: unable to send message");
@@ -185,10 +189,19 @@ impl<E: Ext + 'static> FuncsHandler<E> {
             })
     }
 
-    pub fn send_init(ctx: &mut Runtime<E>, _args: &[Value]) -> SyscallOutput {
+    pub fn send_init(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
+        let mut args = args.iter();
+
+        let handle_ptr = pop_i32(&mut args)?;
+
         ctx.ext
-            .with(|ext| ext.send_init())
-            .and_then(|res| res.map(|handle| ReturnValue::Value(Value::I32(handle as i32))))
+            .clone()
+            .with(|ext| {
+                ext.send_init()
+                    .on_success_code(|handle| wto(ctx, handle_ptr, &handle.to_le_bytes()))
+            })
+            .map_err(Into::into)
+            .and_then(|res| res.map(|handle| ReturnValue::Value(Value::I32(handle))))
             .map_err(|_| {
                 ctx.trap = Some("Trapping: unable to initiate message sending");
                 HostError
@@ -205,9 +218,9 @@ impl<E: Ext + 'static> FuncsHandler<E> {
         ctx.ext
             .with(|ext| {
                 let payload = funcs::get_vec(&ctx.memory, payload_ptr, payload_len)?;
-                ext.send_push(handle_ptr, &payload)
+                ext.send_push(handle_ptr, &payload).into_error_code()
             })
-            .and_then(|res| res.map(|_| ReturnValue::Unit))
+            .and_then(|res| res.map(Value::I32).map(ReturnValue::Value))
             .map_err(|_| {
                 ctx.trap = Some("Trapping: unable to push message payload");
                 HostError

--- a/core-backend/sandbox/src/lib.rs
+++ b/core-backend/sandbox/src/lib.rs
@@ -18,7 +18,7 @@
 
 //! Provide sp-sandbox support.
 
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -119,7 +119,7 @@ impl<E: Ext + IntoExtInfo> Environment<E> for WasmtimeEnvironment<E> {
             funcs::send_commit_wgas(&mut store, memory),
         );
         funcs.insert("gr_send_commit", funcs::send_commit(&mut store, memory));
-        funcs.insert("gr_send_init", funcs::send_init(&mut store));
+        funcs.insert("gr_send_init", funcs::send_init(&mut store, memory));
         funcs.insert("gr_send_push", funcs::send_push(&mut store, memory));
         funcs.insert("gr_size", funcs::size(&mut store));
         funcs.insert("gr_source", funcs::source(&mut store, memory));

--- a/core-backend/wasmtime/src/funcs.rs
+++ b/core-backend/wasmtime/src/funcs.rs
@@ -23,6 +23,7 @@ use crate::memory::MemoryWrap;
 use alloc::format;
 use alloc::{string::String, vec};
 use gear_backend_common::funcs::*;
+use gear_backend_common::{IntoErrorCode, OnSuccessCode};
 use gear_backend_common::{EXIT_TRAP_STR, LEAVE_TRAP_STR, WAIT_TRAP_STR};
 use gear_core::{
     env::Ext,
@@ -312,18 +313,20 @@ impl<E: Ext + 'static> FuncsHandler<E> {
                          value_ptr: i32,
                          message_id_ptr: i32| {
             let ext = caller.data().ext.clone();
-            ext.with(|ext: &mut E| -> Result<(), String> {
+            ext.with(|ext: &mut E| -> Result<i32, String> {
                 let mem_wrap = get_caller_memory(&mut caller, &mem);
                 let dest: ProgramId = get_bytes32(&mem_wrap, program_id_ptr as usize)?.into();
                 let payload = get_vec(&mem_wrap, payload_ptr as usize, payload_len as usize)?;
                 let value = get_u128(&mem_wrap, value_ptr as usize)?;
-                let message_id = ext.send(HandlePacket::new(dest, payload, value))?;
-                write_to_caller_memory(
-                    &mut caller,
-                    &mem,
-                    message_id_ptr as isize as _,
-                    message_id.as_ref(),
-                )
+                ext.send(HandlePacket::new(dest, payload, value))
+                    .on_success_code(|message_id| {
+                        write_to_caller_memory(
+                            &mut caller,
+                            &mem,
+                            message_id_ptr as isize as _,
+                            message_id.as_ref(),
+                        )
+                    })
             })
             .map_err(Trap::new)?
             .map_err(|_| "Trapping: unable to send message")
@@ -341,23 +344,25 @@ impl<E: Ext + 'static> FuncsHandler<E> {
                          value_ptr: i32,
                          message_id_ptr: i32| {
             let ext = caller.data().ext.clone();
-            ext.with(|ext: &mut E| -> Result<(), String> {
+            ext.with(|ext: &mut E| -> Result<i32, String> {
                 let mem_wrap = get_caller_memory(&mut caller, &mem);
                 let dest: ProgramId = get_bytes32(&mem_wrap, program_id_ptr as usize)?.into();
                 let payload = get_vec(&mem_wrap, payload_ptr as usize, payload_len as usize)?;
                 let value = get_u128(&mem_wrap, value_ptr as usize)?;
-                let message_id = ext.send(HandlePacket::new_with_gas(
+                ext.send(HandlePacket::new_with_gas(
                     dest,
                     payload,
                     gas_limit as _,
                     value,
-                ))?;
-                write_to_caller_memory(
-                    &mut caller,
-                    &mem,
-                    message_id_ptr as isize as _,
-                    message_id.as_ref(),
-                )
+                ))
+                .on_success_code(|message_id| {
+                    write_to_caller_memory(
+                        &mut caller,
+                        &mem,
+                        message_id_ptr as isize as _,
+                        message_id.as_ref(),
+                    )
+                })
             })
             .map_err(Trap::new)?
             .map_err(|_| "Trapping: unable to send message")
@@ -373,20 +378,22 @@ impl<E: Ext + 'static> FuncsHandler<E> {
                          program_id_ptr: i32,
                          value_ptr: i32| {
             let ext = caller.data().ext.clone();
-            ext.with(|ext: &mut E| -> Result<(), String> {
+            ext.with(|ext: &mut E| -> Result<i32, String> {
                 let mem_wrap = get_caller_memory(&mut caller, &mem);
                 let dest: ProgramId = get_bytes32(&mem_wrap, program_id_ptr as usize)?.into();
                 let value = get_u128(&mem_wrap, value_ptr as usize)?;
-                let message_id = ext.send_commit(
+                ext.send_commit(
                     handle_ptr as _,
                     HandlePacket::new(dest, Default::default(), value),
-                )?;
-                write_to_caller_memory(
-                    &mut caller,
-                    &mem,
-                    message_id_ptr as isize as _,
-                    message_id.as_ref(),
                 )
+                .on_success_code(|message_id| {
+                    write_to_caller_memory(
+                        &mut caller,
+                        &mem,
+                        message_id_ptr as isize as _,
+                        message_id.as_ref(),
+                    )
+                })
             })
             .map_err(Trap::new)?
             .map_err(|e| format!("Trapping: unable to commit and send message: {}", e))
@@ -403,20 +410,22 @@ impl<E: Ext + 'static> FuncsHandler<E> {
                          gas_limit: i64,
                          value_ptr: i32| {
             let ext = caller.data().ext.clone();
-            ext.with(|ext: &mut E| -> Result<(), String> {
+            ext.with(|ext: &mut E| -> Result<i32, String> {
                 let mem_wrap = get_caller_memory(&mut caller, &mem);
                 let dest: ProgramId = get_bytes32(&mem_wrap, program_id_ptr as usize)?.into();
                 let value = get_u128(&mem_wrap, value_ptr as usize)?;
-                let message_id = ext.send_commit(
+                ext.send_commit(
                     handle_ptr as _,
                     HandlePacket::new_with_gas(dest, Default::default(), gas_limit as _, value),
-                )?;
-                write_to_caller_memory(
-                    &mut caller,
-                    &mem,
-                    message_id_ptr as isize as _,
-                    message_id.as_ref(),
                 )
+                .on_success_code(|message_id| {
+                    write_to_caller_memory(
+                        &mut caller,
+                        &mem,
+                        message_id_ptr as isize as _,
+                        message_id.as_ref(),
+                    )
+                })
             })
             .map_err(Trap::new)?
             .map_err(|_| "Trapping: unable to commit and send message")
@@ -425,14 +434,23 @@ impl<E: Ext + 'static> FuncsHandler<E> {
         Func::wrap(store, func)
     }
 
-    pub fn send_init(store: &mut Store<StoreData<E>>) -> Func {
-        let func = move |caller: Caller<'_, StoreData<E>>| {
-            let ext = &caller.data().ext;
-            ext.with(|ext: &mut E| ext.send_init())
-                .map_err(Trap::new)?
-                .map_err(|_| "Trapping: unable to init message")
-                .map_err(Trap::new)
-                .map(|handle| handle as i32)
+    pub fn send_init(store: &mut Store<StoreData<E>>, mem: WasmtimeMemory) -> Func {
+        let func = move |mut caller: Caller<'_, StoreData<E>>, handle_ptr: i32| {
+            let ext = caller.data().ext.clone();
+            ext.with(|ext: &mut E| {
+                ext.send_init().on_success_code(|handle| {
+                    write_to_caller_memory(
+                        &mut caller,
+                        &mem,
+                        handle_ptr as _,
+                        &handle.to_le_bytes(),
+                    )
+                })
+            })
+            .map_err(Trap::new)?
+            .map_err(|_| "Trapping: unable to init message")
+            .map_err(Trap::new)
+            .map(|handle| handle as i32)
         };
         Func::wrap(store, func)
     }
@@ -446,7 +464,7 @@ impl<E: Ext + 'static> FuncsHandler<E> {
             ext.with(|ext: &mut E| {
                 let mem_wrap = get_caller_memory(&mut caller, &mem);
                 let payload = get_vec(&mem_wrap, payload_ptr as usize, payload_len as usize)?;
-                ext.send_push(handle_ptr as _, &payload)
+                ext.send_push(handle_ptr as _, &payload).into_error_code()
             })
             .map_err(Trap::new)?
             .map_err(|_| "Trapping: unable to push payload into message")

--- a/examples/async-init/src/lib.rs
+++ b/examples/async-init/src/lib.rs
@@ -44,7 +44,8 @@ async fn init() {
     let mut requests: Vec<_> = [APPROVER_FIRST, APPROVER_SECOND, APPROVER_THIRD]
         .iter()
         .map(|s| msg::send_bytes_and_wait_for_reply(*s, b"", 0))
-        .collect();
+        .collect::<Result<_, _>>()
+        .unwrap();
 
     let mut threshold = 0usize;
     while !requests.is_empty() {
@@ -73,7 +74,8 @@ async fn main() {
     ]
     .iter()
     .map(|s| msg::send_bytes_and_wait_for_reply(*s, b"", 0))
-    .collect();
+    .collect::<Result<_, _>>()
+    .unwrap();
 
     let _ = future::select_all(requests).await;
 

--- a/examples/async-init/src/lib.rs
+++ b/examples/async-init/src/lib.rs
@@ -79,5 +79,5 @@ async fn main() {
 
     let _ = future::select_all(requests).await;
 
-    msg::reply(b"PONG", 0);
+    msg::reply(b"PONG", 0).unwrap();
 }

--- a/examples/async-sign/src/lib.rs
+++ b/examples/async-sign/src/lib.rs
@@ -49,7 +49,9 @@ async fn main() {
     let request = SignRequest { message };
 
     let sign_response: Result<SignResponse, _> =
-        msg::send_and_wait_for_reply(unsafe { SIGNATORY }, &request, 0).await;
+        msg::send_and_wait_for_reply(unsafe { SIGNATORY }, &request, 0)
+            .unwrap()
+            .await;
 
     let verified = sign_response
         .ok()
@@ -71,6 +73,6 @@ async fn main() {
         .unwrap_or(false);
 
     if verified {
-        msg::send_bytes(unsafe { DESTINATION }, request.message, 0);
+        msg::send_bytes(unsafe { DESTINATION }, request.message, 0).unwrap();
     }
 }

--- a/examples/async/src/lib.rs
+++ b/examples/async/src/lib.rs
@@ -63,9 +63,9 @@ async fn main() {
             .expect("Error in async message processing");
 
         if reply1 == b"PONG" && reply2 == b"PONG" && reply3 == b"PONG" {
-            msg::reply(b"SUCCESS", 0);
+            msg::reply(b"SUCCESS", 0).unwrap();
         } else {
-            msg::reply(b"FAIL", 0);
+            msg::reply(b"FAIL", 0).unwrap();
         }
     }
 }

--- a/examples/async/src/lib.rs
+++ b/examples/async/src/lib.rs
@@ -50,12 +50,15 @@ async fn main() {
     let message = String::from_utf8(msg::load_bytes()).expect("Invalid message: should be utf-8");
     if message == "START" {
         let reply1 = msg::send_bytes_and_wait_for_reply(unsafe { DEST_0 }, b"PING", 0)
+            .expect("Error in sending message")
             .await
             .expect("Error in async message processing");
         let reply2 = msg::send_bytes_and_wait_for_reply(unsafe { DEST_1 }, b"PING", 0)
+            .expect("Error in sending message")
             .await
             .expect("Error in async message processing");
         let reply3 = msg::send_bytes_and_wait_for_reply(unsafe { DEST_2 }, b"PING", 0)
+            .expect("Error in sending message")
             .await
             .expect("Error in async message processing");
 

--- a/examples/binaries/btree/src/lib.rs
+++ b/examples/binaries/btree/src/lib.rs
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn handle() {
         }
     };
 
-    msg::reply(reply, 0);
+    msg::reply(reply, 0).unwrap();
 }
 
 fn state() -> &'static mut BTreeMap<u32, u32> {
@@ -85,7 +85,7 @@ fn process(request: Request) -> Reply {
 #[no_mangle]
 pub unsafe extern "C" fn init() {
     STATE = Some(BTreeMap::new());
-    msg::reply((), 0);
+    msg::reply((), 0).unwrap();
 }
 
 #[cfg(test)]

--- a/examples/binaries/distributor/src/lib.rs
+++ b/examples/binaries/distributor/src/lib.rs
@@ -132,7 +132,7 @@ impl Program {
         };
 
         debug!("Handle request finished");
-        msg::reply(reply, 0);
+        msg::reply(reply, 0).unwrap();
     }
 
     async fn handle_receive(amount: u64) -> Reply {
@@ -212,7 +212,7 @@ pub unsafe extern "C" fn handle_reply() {
 #[no_mangle]
 pub unsafe extern "C" fn init() {
     STATE = Some(ProgramState::default());
-    msg::reply((), 0);
+    msg::reply((), 0).unwrap();
     debug!("Program initialized");
 }
 

--- a/examples/binaries/distributor/src/lib.rs
+++ b/examples/binaries/distributor/src/lib.rs
@@ -88,6 +88,7 @@ impl Program {
         async move {
             let reply_bytes =
                 msg::send_bytes_and_wait_for_reply(program_handle, &encoded_request[..], 0)
+                    .expect("Error in message sending")
                     .await
                     .expect("Error in async message processing");
 

--- a/examples/binaries/exit-handle/src/lib.rs
+++ b/examples/binaries/exit-handle/src/lib.rs
@@ -17,7 +17,7 @@ mod wasm {
     pub unsafe extern "C" fn handle() {
         exec::exit(msg::source());
         // should not be executed
-        msg::reply(b"reply", 0);
+        msg::reply(b"reply", 0).unwrap();
     }
 
     #[no_mangle]

--- a/examples/binaries/exit-init/src/lib.rs
+++ b/examples/binaries/exit-init/src/lib.rs
@@ -20,6 +20,6 @@ mod wasm {
     pub unsafe extern "C" fn init() {
         exec::exit(msg::source());
         // should not be executed
-        msg::reply(b"reply", 0);
+        msg::reply(b"reply", 0).unwrap();
     }
 }

--- a/examples/binaries/init-wait/src/code.rs
+++ b/examples/binaries/init-wait/src/code.rs
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn init() {
             }
 
             INIT_MESSAGE = msg::id();
-            msg::send(msg::source(), b"PING", 0);
+            msg::send(msg::source(), b"PING", 0).unwrap();
             STATE = State::WaitForReply;
             exec::wait();
         }

--- a/examples/binaries/init-wait/src/code.rs
+++ b/examples/binaries/init-wait/src/code.rs
@@ -1,4 +1,4 @@
-use gstd::{exec, msg, MessageId, BTreeMap};
+use gstd::{exec, msg, BTreeMap, MessageId};
 
 #[derive(PartialEq, Debug)]
 enum State {
@@ -17,7 +17,7 @@ pub unsafe extern "C" fn handle() {
         panic!("not initialized");
     }
 
-    msg::reply(b"Hello, world!", 0);
+    msg::reply(b"Hello, world!", 0).unwrap();
 }
 
 #[no_mangle]
@@ -29,11 +29,7 @@ pub unsafe extern "C" fn init() {
             }
 
             INIT_MESSAGE = msg::id();
-            msg::send(
-                msg::source(),
-                b"PING",
-                0,
-            );
+            msg::send(msg::source(), b"PING", 0);
             STATE = State::WaitForReply;
             exec::wait();
         }

--- a/examples/binaries/node/src/lib.rs
+++ b/examples/binaries/node/src/lib.rs
@@ -94,7 +94,7 @@ pub unsafe extern "C" fn handle() {
         }
     };
 
-    msg::reply(reply, 0);
+    msg::reply(reply, 0).unwrap();
 }
 
 fn state() -> &'static mut NodeState {
@@ -281,7 +281,7 @@ pub unsafe extern "C" fn init() {
         transition: None,
     });
 
-    msg::reply((), 0);
+    msg::reply((), 0).unwrap();
 }
 
 #[cfg(test)]

--- a/examples/binaries/node/src/lib.rs
+++ b/examples/binaries/node/src/lib.rs
@@ -141,7 +141,7 @@ fn process(request: Request) -> Reply {
                 .get(transition.query_index)
                 .expect("Checked above that it has that number of elements; qed");
 
-            transition.last_sent_message_id = msg::send(*next_sub_node, request, 0);
+            transition.last_sent_message_id = msg::send(*next_sub_node, request, 0).unwrap();
 
             state().transition = Some(transition);
 
@@ -184,7 +184,8 @@ fn process(request: Request) -> Reply {
                         .query_list
                         .get(0)
                         .expect("Checked above that sub_nodes is not empty; qed");
-                    transition.last_sent_message_id = msg::send(first_sub_node, request, 0);
+                    transition.last_sent_message_id =
+                        msg::send(first_sub_node, request, 0).unwrap();
                     state().transition = Some(transition);
                     exec::wait()
                 } else {
@@ -221,7 +222,8 @@ fn process(request: Request) -> Reply {
 
                     transition.message_id = msg::id();
 
-                    transition.last_sent_message_id = msg::send(first_sub_node, request, 0);
+                    transition.last_sent_message_id =
+                        msg::send(first_sub_node, request, 0).unwrap();
 
                     state().transition = Some(transition);
 

--- a/examples/binaries/program-factory/src/lib.rs
+++ b/examples/binaries/program-factory/src/lib.rs
@@ -67,7 +67,7 @@ mod wasm {
                     100_000,
                     0,
                 );
-                msg::send_with_gas(new_program_id, b"", 100_001, 0);
+                msg::send_with_gas(new_program_id, b"", 100_001, 0).unwrap();
 
                 COUNTER += 1;
             }
@@ -76,7 +76,7 @@ mod wasm {
                     let submitted_code = code_hash.into();
                     let new_program_id =
                         prog::create_program_with_gas(submitted_code, &salt, [], gas_limit, 0);
-                    let msg_id = msg::send_with_gas(new_program_id, b"", 100_001, 0);
+                    let msg_id = msg::send_with_gas(new_program_id, b"", 100_001, 0).unwrap();
                 }
             }
         };

--- a/examples/binaries/program-factory/src/lib.rs
+++ b/examples/binaries/program-factory/src/lib.rs
@@ -114,7 +114,7 @@ mod tests {
 
         let mut file =
             std::fs::File::create(dir.as_path()).expect("internal error: can't create tmp file");
-        file.write(data)
+        file.write_all(data)
             .expect("internal error: can't write to tmp");
 
         dir

--- a/examples/binaries/wait_wake/src/lib.rs
+++ b/examples/binaries/wait_wake/src/lib.rs
@@ -56,13 +56,13 @@ fn process_request(request: Request) {
 
 #[no_mangle]
 pub unsafe extern "C" fn init() {
-    msg::reply((), 0);
+    msg::reply((), 0).unwrap();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn handle() {
     if let Some(reply) = ECHOES.get_or_insert_with(BTreeMap::new).remove(&msg::id()) {
-        msg::reply(reply, 0);
+        msg::reply(reply, 0).unwrap();
     } else {
         msg::load::<Request>().map(process_request).unwrap();
     }

--- a/examples/block-info/src/lib.rs
+++ b/examples/block-info/src/lib.rs
@@ -11,5 +11,5 @@ pub unsafe extern "C" fn handle() {
     debug!("Timestamp: {:?}", bt);
 
     let bh = exec::block_height();
-    msg::reply_bytes(format!("{}_{}", payload, bh), 0);
+    msg::reply_bytes(format!("{}_{}", payload, bh), 0).unwrap();
 }

--- a/examples/bot/src/lib.rs
+++ b/examples/bot/src/lib.rs
@@ -164,7 +164,7 @@ pub unsafe extern "C" fn handle() {
         .get_mut(&msg::load_bytes())
         .and_then(|i| i.next());
     if let Some(r) = reply {
-        msg::reply_bytes(r, 0);
+        msg::reply_bytes(r, 0).unwrap();
     }
 }
 
@@ -173,7 +173,7 @@ pub unsafe extern "C" fn init() {
     let maybe_handlers: Result<Vec<Handler>, _> = msg::load();
 
     maybe_handlers
-        .map_err(|_| msg::reply(b"bot; failed to decode `Vec<Handler>`", 0))
+        .map_err(|_| msg::reply(b"bot; failed to decode `Vec<Handler>`", 0).unwrap())
         .map(|v| {
             HANDLERS.reserve(v.len());
             v

--- a/examples/capacitor/src/lib.rs
+++ b/examples/capacitor/src/lib.rs
@@ -22,7 +22,7 @@ pub unsafe extern "C" fn handle() {
     if CHARGE >= LIMIT {
         debug!("Discharge #{} due to limit {}", CHARGE, LIMIT);
 
-        msg::send_bytes(msg::source(), format!("Discharged: {}", CHARGE), 0);
+        msg::send_bytes(msg::source(), format!("Discharged: {}", CHARGE), 0).unwrap();
         DISCHARGE_HISTORY.push(CHARGE);
         CHARGE = 0;
     }

--- a/examples/chat/bot/src/lib.rs
+++ b/examples/chat/bot/src/lib.rs
@@ -78,7 +78,8 @@ pub unsafe extern "C" fn init() {
                     under_name: name.to_string().into_bytes(),
                 },
                 0,
-            );
+            )
+            .unwrap();
         }
         _ => {
             debug!("INITIALIZATION FAILED");

--- a/examples/chat/room/src/lib.rs
+++ b/examples/chat/room/src/lib.rs
@@ -64,7 +64,8 @@ unsafe fn room(room_msg: RoomMessage) {
                             .into_bytes(),
                         ),
                         0,
-                    );
+                    )
+                    .unwrap();
                 }
             }
         }

--- a/examples/collector/src/lib.rs
+++ b/examples/collector/src/lib.rs
@@ -22,7 +22,7 @@ pub unsafe extern "C" fn handle() {
                 acc
             });
 
-        msg::send_bytes(msg::source(), collapsed, 0);
+        msg::send_bytes(msg::source(), collapsed, 0).unwrap();
 
         COUNTER = 0;
     } else {

--- a/examples/create-program/src/lib.rs
+++ b/examples/create-program/src/lib.rs
@@ -35,7 +35,7 @@ pub unsafe extern "C" fn handle() {
             );
             debug!("A new program is created {:?}", new_program_id);
 
-            let msg_id = msg::send(new_program_id, b"", 0);
+            let msg_id = msg::send(new_program_id, b"", 0).unwrap();
             debug!("Sent to a new program message with id {:?}", msg_id);
 
             COUNTER += 1;
@@ -50,7 +50,7 @@ pub unsafe extern "C" fn handle() {
             );
             debug!("A new program is created {:?}", new_program_id);
 
-            let msg_id = msg::send(new_program_id, b"", 0);
+            let msg_id = msg::send(new_program_id, b"", 0).unwrap();
             debug!("Sent to a new program message with id {:?}", msg_id);
         }
         _ => {

--- a/examples/decoder/src/lib.rs
+++ b/examples/decoder/src/lib.rs
@@ -31,14 +31,16 @@ pub unsafe extern "C" fn handle() {
         }
     }
 
-    let handle = msg::send_init();
+    let handle = msg::send_init().unwrap();
 
     for vertex in &code {
         leaves.sort();
         leaves.reverse();
         let leaf = leaves.pop().expect("An error occured during calculating");
 
-        handle.push(format!("[{}, {}];", leaf + 1, vertex + 1));
+        handle
+            .push(format!("[{}, {}];", leaf + 1, vertex + 1))
+            .unwrap();
 
         degrees[*vertex] -= 1;
 
@@ -47,7 +49,9 @@ pub unsafe extern "C" fn handle() {
         }
     }
 
-    handle.push(format!("[{}, {}]", leaves[0] + 1, leaves[1] + 1));
+    handle
+        .push(format!("[{}, {}]", leaves[0] + 1, leaves[1] + 1))
+        .unwrap();
 
-    handle.commit(msg::source(), 0);
+    handle.commit(msg::source(), 0).unwrap();
 }

--- a/examples/exit-code/src/lib.rs
+++ b/examples/exit-code/src/lib.rs
@@ -6,5 +6,5 @@ static mut HOST: ActorId = ActorId::new([0u8; 32]);
 
 #[no_mangle]
 pub unsafe extern "C" fn handle_reply() {
-    msg::send_bytes(HOST, msg::exit_code().to_string(), 0);
+    msg::send_bytes(HOST, msg::exit_code().to_string(), 0).unwrap();
 }

--- a/examples/fib/src/lib.rs
+++ b/examples/fib/src/lib.rs
@@ -27,7 +27,8 @@ pub unsafe extern "C" fn handle() {
         msg::source(),
         make_fib(new_msg as usize)[new_msg as usize - 1],
         0,
-    );
+    )
+    .unwrap();
 
     debug!("{:?} total message(s) stored: ", MESSAGE_LOG.len());
 

--- a/examples/fungible-token/src/lib.rs
+++ b/examples/fungible-token/src/lib.rs
@@ -74,7 +74,7 @@ impl FungibleToken {
             to: H256::from_slice(account.as_ref()),
             amount,
         };
-        msg::reply(Event::Transfer(transfer_data), 0);
+        msg::reply(Event::Transfer(transfer_data), 0).unwrap();
     }
     fn burn(&mut self, account: &ActorId, amount: u128) {
         let zero = ActorId::new(H256::zero().to_fixed_bytes());
@@ -91,7 +91,7 @@ impl FungibleToken {
             to: H256::zero(),
             amount,
         };
-        msg::reply(Event::Transfer(transfer_data), 0);
+        msg::reply(Event::Transfer(transfer_data), 0).unwrap();
     }
     fn transfer(&mut self, sender: &ActorId, recipient: &ActorId, amount: u128) {
         let zero = ActorId::new(H256::zero().to_fixed_bytes());
@@ -113,7 +113,7 @@ impl FungibleToken {
             to: H256::from_slice(recipient.as_ref()),
             amount,
         };
-        msg::reply(Event::Transfer(transfer_data), 0);
+        msg::reply(Event::Transfer(transfer_data), 0).unwrap();
     }
     fn approve(&mut self, owner: &ActorId, spender: &ActorId, amount: u128) {
         let zero = ActorId::new(H256::zero().to_fixed_bytes());
@@ -133,7 +133,7 @@ impl FungibleToken {
             spender: H256::from_slice(spender.as_ref()),
             amount,
         };
-        msg::reply(Event::Approval(approve_data), 0);
+        msg::reply(Event::Approval(approve_data), 0).unwrap();
     }
     fn get_allowance(&self, owner: &ActorId, spender: &ActorId) -> u128 {
         *self

--- a/examples/futures-unordered/src/lib.rs
+++ b/examples/futures-unordered/src/lib.rs
@@ -36,8 +36,8 @@ async fn main() {
             debug!("UNORDERED: Before any sending");
 
             let requests = vec![
-                msg::send_bytes_and_wait_for_reply(unsafe { DEMO_ASYNC }, "START", 0),
-                msg::send_bytes_and_wait_for_reply(unsafe { DEMO_PING }, "PING", 0),
+                msg::send_bytes_and_wait_for_reply(unsafe { DEMO_ASYNC }, "START", 0).unwrap(),
+                msg::send_bytes_and_wait_for_reply(unsafe { DEMO_PING }, "PING", 0).unwrap(),
             ];
 
             let mut unordered: FuturesUnordered<_> = requests.into_iter().collect();
@@ -49,7 +49,8 @@ async fn main() {
                 source,
                 first.expect("Can't fail").expect("Exit code is 0"),
                 0,
-            );
+            )
+            .unwrap();
             debug!("First (from demo_ping) done");
 
             let second = unordered.next().await;
@@ -57,7 +58,8 @@ async fn main() {
                 source,
                 second.expect("Can't fail").expect("Exit code is 0"),
                 0,
-            );
+            )
+            .unwrap();
             debug!("Second (from demo_async) done");
 
             msg::reply_bytes("DONE", 0);
@@ -67,13 +69,13 @@ async fn main() {
             debug!("SELECT: Before any sending");
 
             select_biased! {
-                res = msg::send_bytes_and_wait_for_reply(unsafe { DEMO_ASYNC }, "START", 0) => {
+                res = msg::send_bytes_and_wait_for_reply(unsafe { DEMO_ASYNC }, "START", 0).unwrap() => {
                     debug!("Recieved msg from demo_async");
-                    msg::send_bytes(source, res.expect("Exit code is 0"), 0);
+                    msg::send_bytes(source, res.expect("Exit code is 0"), 0).unwrap();
                 },
-                res = msg::send_bytes_and_wait_for_reply(unsafe { DEMO_PING }, "PING", 0) => {
+                res = msg::send_bytes_and_wait_for_reply(unsafe { DEMO_PING }, "PING", 0).unwrap() => {
                     debug!("Recieved msg from demo_ping");
-                    msg::send_bytes(source, res.expect("Exit code is 0"), 0);
+                    msg::send_bytes(source, res.expect("Exit code is 0"), 0).unwrap();
                 },
             };
 
@@ -86,8 +88,8 @@ async fn main() {
             debug!("JOIN: Before any sending");
 
             let res = join!(
-                msg::send_bytes_and_wait_for_reply(unsafe { DEMO_ASYNC }, "START", 0),
-                msg::send_bytes_and_wait_for_reply(unsafe { DEMO_PING }, "PING", 0)
+                msg::send_bytes_and_wait_for_reply(unsafe { DEMO_ASYNC }, "START", 0).unwrap(),
+                msg::send_bytes_and_wait_for_reply(unsafe { DEMO_PING }, "PING", 0).unwrap()
             );
 
             debug!("Finish after join");
@@ -103,7 +105,7 @@ async fn main() {
                     .expect("Unable to decode string"),
             );
 
-            msg::send_bytes(source, result, 0);
+            msg::send_bytes(source, result, 0).unwrap();
             msg::reply_bytes("DONE", 0);
         }
         _ => {

--- a/examples/futures-unordered/src/lib.rs
+++ b/examples/futures-unordered/src/lib.rs
@@ -62,7 +62,7 @@ async fn main() {
             .unwrap();
             debug!("Second (from demo_async) done");
 
-            msg::reply_bytes("DONE", 0);
+            msg::reply_bytes("DONE", 0).unwrap();
         }
         // using select! macro to wait for first future done
         "select" => {
@@ -81,7 +81,7 @@ async fn main() {
 
             debug!("Finish after select");
 
-            msg::reply_bytes("DONE", 0);
+            msg::reply_bytes("DONE", 0).unwrap();
         }
         // using join! macros to wait all features done
         "join" => {
@@ -106,7 +106,7 @@ async fn main() {
             );
 
             msg::send_bytes(source, result, 0).unwrap();
-            msg::reply_bytes("DONE", 0);
+            msg::reply_bytes("DONE", 0).unwrap();
         }
         _ => {
             panic!("Unknown option");

--- a/examples/guestbook/src/lib.rs
+++ b/examples/guestbook/src/lib.rs
@@ -34,7 +34,7 @@ pub unsafe extern "C" fn handle() {
             MESSAGES.push(message);
         }
         Action::ViewMessages => {
-            msg::reply(&MESSAGES, 0);
+            msg::reply(&MESSAGES, 0).unwrap();
         }
     }
 }

--- a/examples/gui-test/src/lib.rs
+++ b/examples/gui-test/src/lib.rs
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn init() {
         }
     };
 
-    msg::reply(outgoing, 555);
+    msg::reply(outgoing, 555).unwrap();
 }
 
 type HandleIncoming = (BTreeMap<String, u8>, Option<(Option<u8>, u128, [u8; 3])>);
@@ -80,5 +80,5 @@ pub unsafe extern "C" fn handle() {
         }
     };
 
-    msg::reply(outgoing, 555);
+    msg::reply(outgoing, 555).unwrap();
 }

--- a/examples/incomplete_async_payloads/src/lib.rs
+++ b/examples/incomplete_async_payloads/src/lib.rs
@@ -30,7 +30,7 @@ async fn main() {
         "reply store" => {
             debug!("stored reply processing");
 
-            msg::reply_push(b"STORED ");
+            msg::reply_push(b"STORED ").unwrap();
 
             let _ = msg::send_bytes_and_wait_for_reply(unsafe { DEMO_PING }, b"PING", 0)
                 .unwrap()
@@ -39,9 +39,9 @@ async fn main() {
 
             debug!("stored reply processing awaken");
 
-            msg::reply_push(b"REPLY");
+            msg::reply_push(b"REPLY").unwrap();
 
-            msg::reply_commit(0);
+            msg::reply_commit(0).unwrap();
         }
         "handle" => {
             debug!("ok common processing");
@@ -51,13 +51,13 @@ async fn main() {
         }
         "reply" => {
             debug!("ok reply processing");
-            msg::reply_push(b"OK REPLY");
-            msg::reply_commit(0);
+            msg::reply_push(b"OK REPLY").unwrap();
+            msg::reply_commit(0).unwrap();
         }
         "reply twice" => {
             debug!("reply twice processing");
 
-            msg::reply_bytes("FIRST", 0);
+            msg::reply_bytes("FIRST", 0).unwrap();
 
             let _ = msg::send_bytes_and_wait_for_reply(unsafe { DEMO_PING }, b"PING", 0)
                 .unwrap()
@@ -68,7 +68,7 @@ async fn main() {
 
             // Won't be sent, because one
             // execution allows only one reply
-            msg::reply_bytes("SECOND", 0);
+            msg::reply_bytes("SECOND", 0).unwrap();
         }
         _ => {}
     }

--- a/examples/incomplete_async_payloads/src/lib.rs
+++ b/examples/incomplete_async_payloads/src/lib.rs
@@ -13,18 +13,19 @@ async fn main() {
         "handle store" => {
             debug!("stored common processing");
 
-            let handle = msg::send_init();
-            handle.push(b"STORED ");
+            let handle = msg::send_init().unwrap();
+            handle.push(b"STORED ").unwrap();
 
             let _ = msg::send_bytes_and_wait_for_reply(unsafe { DEMO_PING }, b"PING", 0)
+                .unwrap()
                 .await
                 .expect("Error in async message processing");
 
             debug!("stored common processing awaken");
 
-            handle.push("COMMON");
+            handle.push("COMMON").unwrap();
 
-            handle.commit(msg::source(), 0);
+            handle.commit(msg::source(), 0).unwrap();
         }
         "reply store" => {
             debug!("stored reply processing");
@@ -32,6 +33,7 @@ async fn main() {
             msg::reply_push(b"STORED ");
 
             let _ = msg::send_bytes_and_wait_for_reply(unsafe { DEMO_PING }, b"PING", 0)
+                .unwrap()
                 .await
                 .expect("Error in async message processing");
 
@@ -43,9 +45,9 @@ async fn main() {
         }
         "handle" => {
             debug!("ok common processing");
-            let handle = msg::send_init();
-            handle.push(b"OK PING");
-            handle.commit(msg::source(), 0);
+            let handle = msg::send_init().unwrap();
+            handle.push(b"OK PING").unwrap();
+            handle.commit(msg::source(), 0).unwrap();
         }
         "reply" => {
             debug!("ok reply processing");
@@ -58,6 +60,7 @@ async fn main() {
             msg::reply_bytes("FIRST", 0);
 
             let _ = msg::send_bytes_and_wait_for_reply(unsafe { DEMO_PING }, b"PING", 0)
+                .unwrap()
                 .await
                 .expect("Error in async message processing");
 

--- a/examples/mem/src/lib.rs
+++ b/examples/mem/src/lib.rs
@@ -6,6 +6,6 @@ use gstd::prelude::*;
 #[no_mangle]
 pub unsafe extern "C" fn handle() {
     let data = vec![0u8; 32768];
-    msg::reply(&data, 0);
+    msg::reply(&data, 0).unwrap();
     panic!()
 }

--- a/examples/meta/src/lib.rs
+++ b/examples/meta/src/lib.rs
@@ -120,7 +120,7 @@ pub unsafe extern "C" fn handle() {
     let message_in: MessageIn = msg::load().unwrap();
     let message_out: MessageOut = message_in.into();
 
-    msg::reply(message_out, 0);
+    msg::reply(message_out, 0).unwrap();
 }
 
 #[no_mangle]
@@ -149,7 +149,7 @@ pub unsafe extern "C" fn init() {
     let message_init_in: MessageInitIn = msg::load().unwrap();
     let message_init_out: MessageInitOut = message_init_in.into();
 
-    msg::reply(message_init_out, 0);
+    msg::reply(message_init_out, 0).unwrap();
 }
 
 #[no_mangle]

--- a/examples/minimal/src/lib.rs
+++ b/examples/minimal/src/lib.rs
@@ -4,5 +4,5 @@ use gstd::msg;
 
 #[no_mangle]
 pub unsafe extern "C" fn handle() {
-    msg::reply(b"Hello world!", 0);
+    msg::reply(b"Hello world!", 0).unwrap();
 }

--- a/examples/multiping/src/lib.rs
+++ b/examples/multiping/src/lib.rs
@@ -17,11 +17,11 @@ pub unsafe extern "C" fn handle() {
     }
 
     if new_msg == "PING PING PING" && COUNTER > 0 {
-        let handle = msg::send_init();
-        msg::send_push(&handle, b"PONG1");
-        msg::send_push(&handle, b"PONG2");
-        msg::send_push(&handle, b"PONG3");
-        msg::send_commit(handle, msg::source(), 0);
+        let handle = msg::send_init().unwrap();
+        msg::send_push(&handle, b"PONG1").unwrap();
+        msg::send_push(&handle, b"PONG2").unwrap();
+        msg::send_push(&handle, b"PONG3").unwrap();
+        msg::send_commit(handle, msg::source(), 0).unwrap();
     }
 
     COUNTER += 1;

--- a/examples/multiping/src/lib.rs
+++ b/examples/multiping/src/lib.rs
@@ -11,9 +11,9 @@ pub unsafe extern "C" fn handle() {
         String::from_utf8(gstd::msg::load_bytes()).expect("Invalid message: should be utf-8");
 
     if new_msg == "PING" {
-        msg::reply_push(b"PO");
-        msg::reply_push(b"NG");
-        msg::reply_commit(0);
+        msg::reply_push(b"PO").unwrap();
+        msg::reply_push(b"NG").unwrap();
+        msg::reply_commit(0).unwrap();
     }
 
     if new_msg == "PING PING PING" && COUNTER > 0 {

--- a/examples/mutex/src/lib.rs
+++ b/examples/mutex/src/lib.rs
@@ -35,9 +35,9 @@ async fn main() {
             .expect("Error in async message processing");
 
         if reply == b"PONG" {
-            msg::reply(b"SUCCESS", 0);
+            msg::reply(b"SUCCESS", 0).unwrap();
         } else {
-            msg::reply(b"FAIL", 0);
+            msg::reply(b"FAIL", 0).unwrap();
         }
     }
 }

--- a/examples/mutex/src/lib.rs
+++ b/examples/mutex/src/lib.rs
@@ -30,6 +30,7 @@ async fn main() {
         let _val = MUTEX.lock().await;
 
         let reply = msg::send_bytes_and_wait_for_reply(unsafe { PING_DEST }, b"PING", 0)
+            .unwrap()
             .await
             .expect("Error in async message processing");
 

--- a/examples/ping/src/lib.rs
+++ b/examples/ping/src/lib.rs
@@ -11,7 +11,7 @@ pub unsafe extern "C" fn handle() {
     let new_msg = String::from_utf8(msg::load_bytes()).expect("Invalid message");
 
     if new_msg == "PING" {
-        msg::reply_bytes("PONG", 0);
+        msg::reply_bytes("PONG", 0).unwrap();
     }
 
     MESSAGE_LOG.push(new_msg);

--- a/examples/program-id/src/lib.rs
+++ b/examples/program-id/src/lib.rs
@@ -7,5 +7,5 @@ pub unsafe extern "C" fn handle() {
     debug!("Starting program id");
     let program_id = exec::program_id();
     debug!("My program id: {:?}", program_id);
-    msg::reply(b"program_id", 0);
+    msg::reply(b"program_id", 0).unwrap();
 }

--- a/examples/rwlock/src/lib.rs
+++ b/examples/rwlock/src/lib.rs
@@ -33,6 +33,7 @@ async fn main() {
         }
         "ping&get" => {
             let _ = msg::send_bytes_and_wait_for_reply(unsafe { PING_DEST }, b"PING", 0)
+                .unwrap()
                 .await
                 .expect("Error in async message processing");
             msg::reply(*RWLOCK.read().await, 0);
@@ -41,12 +42,14 @@ async fn main() {
             let mut val = RWLOCK.write().await;
             *val += 1;
             let _ = msg::send_bytes_and_wait_for_reply(unsafe { PING_DEST }, b"PING", 0)
+                .unwrap()
                 .await
                 .expect("Error in async message processing");
         }
         "get&ping" => {
             let val = RWLOCK.read().await;
             let _ = msg::send_bytes_and_wait_for_reply(unsafe { PING_DEST }, b"PING", 0)
+                .unwrap()
                 .await
                 .expect("Error in async message processing");
             msg::reply(*val, 0);

--- a/examples/rwlock/src/lib.rs
+++ b/examples/rwlock/src/lib.rs
@@ -25,7 +25,7 @@ async fn main() {
 
     match message.as_ref() {
         "get" => {
-            msg::reply(*RWLOCK.read().await, 0);
+            msg::reply(*RWLOCK.read().await, 0).unwrap();
         }
         "inc" => {
             let mut val = RWLOCK.write().await;
@@ -36,7 +36,7 @@ async fn main() {
                 .unwrap()
                 .await
                 .expect("Error in async message processing");
-            msg::reply(*RWLOCK.read().await, 0);
+            msg::reply(*RWLOCK.read().await, 0).unwrap();
         }
         "inc&ping" => {
             let mut val = RWLOCK.write().await;
@@ -52,7 +52,7 @@ async fn main() {
                 .unwrap()
                 .await
                 .expect("Error in async message processing");
-            msg::reply(*val, 0);
+            msg::reply(*val, 0).unwrap();
         }
         "check readers" => {
             let mut storage = Vec::new();
@@ -96,7 +96,7 @@ async fn main() {
 
             let val = another_future.await;
 
-            msg::reply(*val, 0);
+            msg::reply(*val, 0).unwrap();
         }
         _ => {
             let _write = RWLOCK.write().await;

--- a/examples/rwlock_write/src/lib.rs
+++ b/examples/rwlock_write/src/lib.rs
@@ -30,6 +30,7 @@ async fn main() {
         let _val = RWLOCK.write().await;
 
         let reply = msg::send_bytes_and_wait_for_reply(unsafe { PING_DEST }, b"PING", 0)
+            .unwrap()
             .await
             .expect("Error in async message processing");
 

--- a/examples/rwlock_write/src/lib.rs
+++ b/examples/rwlock_write/src/lib.rs
@@ -35,9 +35,9 @@ async fn main() {
             .expect("Error in async message processing");
 
         if reply == b"PONG" {
-            msg::reply(b"SUCCESS", 0);
+            msg::reply(b"SUCCESS", 0).unwrap();
         } else {
-            msg::reply(b"FAIL", 0);
+            msg::reply(b"FAIL", 0).unwrap();
         }
     }
 }

--- a/examples/state_rollback/src/lib.rs
+++ b/examples/state_rollback/src/lib.rs
@@ -12,7 +12,7 @@ fn value() -> String {
 pub unsafe extern "C" fn handle() {
     if let Ok(message) = String::from_utf8(msg::load_bytes()) {
         // prev value
-        msg::send_bytes(msg::source(), value(), 0);
+        msg::send_bytes(msg::source(), value(), 0).unwrap();
 
         MESSAGE = Some(message.clone());
 

--- a/examples/state_rollback/src/lib.rs
+++ b/examples/state_rollback/src/lib.rs
@@ -17,7 +17,7 @@ pub unsafe extern "C" fn handle() {
         MESSAGE = Some(message.clone());
 
         // new value
-        msg::reply_bytes(value(), 0);
+        msg::reply_bytes(value(), 0).unwrap();
 
         if message == "panic" {
             panic!();

--- a/examples/sum/src/lib.rs
+++ b/examples/sum/src/lib.rs
@@ -35,7 +35,7 @@ pub unsafe extern "C" fn handle() {
     MESSAGE_LOG.push(format!("(sum) New msg: {:?}", new_msg));
     debug!("sum gas_available: {}", exec::gas_available());
 
-    msg::send(STATE.send_to(), new_msg + new_msg, 0);
+    msg::send(STATE.send_to(), new_msg + new_msg, 0).unwrap();
 
     debug!("{:?} total message(s) stored: ", MESSAGE_LOG.len());
 

--- a/examples/sync_duplicate/src/lib.rs
+++ b/examples/sync_duplicate/src/lib.rs
@@ -23,7 +23,7 @@ async fn main() {
             .await
             .expect("Error in async message processing");
 
-        msg::reply(unsafe { COUNTER } as i32, 0);
+        msg::reply(unsafe { COUNTER } as i32, 0).unwrap();
 
         unsafe {
             COUNTER = 0;

--- a/examples/sync_duplicate/src/lib.rs
+++ b/examples/sync_duplicate/src/lib.rs
@@ -19,6 +19,7 @@ async fn main() {
         unsafe { COUNTER += 1 };
 
         let _ = msg::send_bytes_and_wait_for_reply(unsafe { DEST }, "PING", 0)
+            .unwrap()
             .await
             .expect("Error in async message processing");
 

--- a/examples/token-vendor/src/lib.rs
+++ b/examples/token-vendor/src/lib.rs
@@ -150,7 +150,7 @@ async fn main() {
                 panic!("Failed to update State: {}", e);
             }
 
-            msg::reply("Config updated", 0);
+            msg::reply("Config updated", 0).unwrap();
         }
         Action::ActorId(hex) => {
             if unsafe { !STATE.members.contains(&source) } {
@@ -192,7 +192,7 @@ async fn main() {
                         member_id, source
                     );
 
-                    msg::reply("Success", unsafe { STATE.reward });
+                    msg::reply("Success", unsafe { STATE.reward }).unwrap();
 
                     unsafe { STATE.members.remove(&member_id) };
                 }
@@ -212,5 +212,5 @@ pub unsafe extern "C" fn init() {
     }
 
     debug!("Initialized");
-    msg::reply("Initialized", 0);
+    msg::reply("Initialized", 0).unwrap();
 }

--- a/examples/token-vendor/src/lib.rs
+++ b/examples/token-vendor/src/lib.rs
@@ -162,6 +162,7 @@ async fn main() {
 
             let response =
                 msg::send_bytes_and_wait_for_reply(id, &String::from("ping").encode(), 0)
+                    .unwrap()
                     .await
                     .expect("Error in async message processing");
 
@@ -173,6 +174,7 @@ async fn main() {
             if ping.to_lowercase() == "pong" {
                 let response =
                     msg::send_bytes_and_wait_for_reply(id, &String::from("success").encode(), 0)
+                        .unwrap()
                         .await
                         .expect("Error in async message processing");
 

--- a/examples/token-vendor/workshop-example/src/lib.rs
+++ b/examples/token-vendor/workshop-example/src/lib.rs
@@ -43,9 +43,9 @@ pub unsafe extern "C" fn handle() {
     debug!("CONTRACT: Got payload: '{}'", payload);
 
     if payload == "success" {
-        msg::reply(STATE.get_hex_id(), 0);
+        msg::reply(STATE.get_hex_id(), 0).unwrap();
     } else if payload == "ping" {
-        msg::reply("pong", 0);
+        msg::reply("pong", 0).unwrap();
     } else {
         // Do nothing
     }

--- a/examples/vec/src/lib.rs
+++ b/examples/vec/src/lib.rs
@@ -16,7 +16,7 @@ pub unsafe extern "C" fn handle() {
         &v[new_msg as usize - 1],
         v[new_msg as usize - 1]
     );
-    msg::send(msg::source(), v.len() as i32, 0);
+    msg::send(msg::source(), v.len() as i32, 0).unwrap();
     debug!("{:?} total message(s) stored: ", MESSAGE_LOG.len());
 
     // The test idea is to allocate two wasm pages and check this allocation,

--- a/examples/wait/src/lib.rs
+++ b/examples/wait/src/lib.rs
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn handle() {
             exec::wake(MSG_ID_2);
         }
         _ => {
-            msg::send(msg::source(), b"WAITED", 0);
+            msg::send(msg::source(), b"WAITED", 0).unwrap();
         }
     }
 }

--- a/gcore/src/exec.rs
+++ b/gcore/src/exec.rs
@@ -52,7 +52,7 @@ mod sys {
 /// // Send a reply after the block height reaches the number 1000
 /// pub unsafe extern "C" fn handle() {
 ///     if exec::block_height() >= 1000 {
-///         msg::reply(b"Block #1000 reached", 0);
+///         msg::reply(b"Block #1000 reached", 0).unwrap();
 ///     }
 /// }
 /// ```
@@ -72,7 +72,7 @@ pub fn block_height() -> u32 {
 /// // Send a reply after the block timestamp reaches the February 22, 2022
 /// pub unsafe extern "C" fn handle() {
 ///     if exec::block_timestamp() >= 1645488000000 {
-///         msg::reply(b"The current block is generated after February 22, 2022", 0);
+///         msg::reply(b"The current block is generated after February 22, 2022", 0).unwrap();
 ///     }
 /// }
 /// ```

--- a/gcore/src/msg.rs
+++ b/gcore/src/msg.rs
@@ -81,6 +81,7 @@ mod sys {
     }
 }
 
+#[must_use]
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ErrorCode(i32);
@@ -504,7 +505,7 @@ pub fn send_commit_with_gas(
     program: ActorId,
     gas_limit: u64,
     value: u128,
-) -> MessageId {
+) -> Result<MessageId, SendError> {
     unsafe {
         let mut message_id = MessageId::default();
         sys::gr_send_commit_wgas(
@@ -513,8 +514,9 @@ pub fn send_commit_with_gas(
             program.as_slice().as_ptr(),
             gas_limit,
             value.to_le_bytes().as_ptr(),
-        );
-        message_id
+        )
+        .into_send_error()?;
+        Ok(message_id)
     }
 }
 

--- a/gcore/src/msg.rs
+++ b/gcore/src/msg.rs
@@ -104,11 +104,11 @@ impl ErrorCode {
 }
 
 /// An error occurred during sending a message
-#[derive(Debug, Clone, PartialEq, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct SendError(());
 
 /// An error occurred during replying to a message
-#[derive(Debug, Clone, PartialEq, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct ReplyError(());
 
 /// Get the exit code of the message being processed.

--- a/gcore/src/msg.rs
+++ b/gcore/src/msg.rs
@@ -82,7 +82,7 @@ mod sys {
 }
 
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ErrorCode(i32);
 
 impl ErrorCode {
@@ -104,11 +104,11 @@ impl ErrorCode {
 }
 
 /// An error occurred during sending a message
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialEq, Ord, PartialOrd)]
 pub struct SendError(());
 
 /// An error occurred during replying to a message
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialEq, Ord, PartialOrd)]
 pub struct ReplyError(());
 
 /// Get the exit code of the message being processed.

--- a/gcore/src/msg.rs
+++ b/gcore/src/msg.rs
@@ -435,7 +435,11 @@ pub fn send_with_gas(
 ///
 /// [`send_push`], [`send_init`] functions allows to form a message to send in
 /// parts.
-pub fn send_commit(handle: MessageHandle, program: ActorId, value: u128) -> MessageId {
+pub fn send_commit(
+    handle: MessageHandle,
+    program: ActorId,
+    value: u128,
+) -> Result<MessageId, SendError> {
     unsafe {
         let mut message_id = MessageId::default();
         sys::gr_send_commit(
@@ -443,8 +447,9 @@ pub fn send_commit(handle: MessageHandle, program: ActorId, value: u128) -> Mess
             message_id.as_mut_slice().as_mut_ptr(),
             program.as_slice().as_ptr(),
             value.to_le_bytes().as_ptr(),
-        );
-        message_id
+        )
+        .into_send_error()?;
+        Ok(message_id)
     }
 }
 

--- a/gcore/src/prog.rs
+++ b/gcore/src/prog.rs
@@ -99,7 +99,7 @@ mod sys {
 ///     # let mut salt = vec![0u8; msg::size()];
 ///     # msg::load(&mut salt[..]);
 ///     let new_program_id = prog::create_program_with_gas(submitted_code, &salt, b"", 10_000, 0);
-///     msg::send_with_gas(new_program_id, b"payload for a new program", 10_000, 0);
+///     msg::send_with_gas(new_program_id, b"payload for a new program", 10_000, 0).unwrap();
 /// }
 /// ```
 pub fn create_program_with_gas(

--- a/gcore/tests/smoke.rs
+++ b/gcore/tests/smoke.rs
@@ -65,12 +65,14 @@ mod sys {
         gas_limit: u64,
         value_ptr: *const u8,
         _message_id_ptr: *mut u8,
-    ) {
+    ) -> i32 {
         ptr::copy(program, PROGRAM.0.as_mut_ptr(), 32);
         MESSAGE_LEN = data_len as _;
         ptr::copy(data_ptr, MESSAGE.as_mut_ptr(), data_len as _);
         GAS_LIMIT = gas_limit;
         VALUE = *(value_ptr as *const u128);
+
+        0
     }
 
     #[no_mangle]
@@ -99,7 +101,7 @@ fn messages() {
         id[i] = i as u8;
     }
 
-    msg::send_with_gas(ActorId(id), b"HELLO", 1000, 12345678);
+    msg::send_with_gas(ActorId(id), b"HELLO", 1000, 12345678).unwrap();
 
     let msg_source = msg::source();
     assert_eq!(msg_source, ActorId(id));

--- a/gstd/src/common/errors.rs
+++ b/gstd/src/common/errors.rs
@@ -22,7 +22,7 @@
 //! errors.
 
 use core::fmt;
-use gcore::msg::SendError;
+use gcore::msg::{ReplyError, SendError};
 
 pub type Result<T> = core::result::Result<T, ContractError>;
 
@@ -33,6 +33,7 @@ pub enum ContractError {
     ExitCode(i32),
     Internal(&'static str),
     Send(SendError),
+    Reply(ReplyError),
 }
 
 impl fmt::Display for ContractError {
@@ -44,6 +45,8 @@ impl fmt::Display for ContractError {
             ContractError::Internal(e) => write!(f, "Internal error: {:?}", e),
             // TODO: print error when it will contain actual information
             ContractError::Send(_) => write!(f, "Send error"),
+            // TODO: print error when it will contain actual information
+            ContractError::Reply(_) => write!(f, "Reply error"),
         }
     }
 }
@@ -51,5 +54,11 @@ impl fmt::Display for ContractError {
 impl From<SendError> for ContractError {
     fn from(err: SendError) -> Self {
         Self::Send(err)
+    }
+}
+
+impl From<ReplyError> for ContractError {
+    fn from(err: ReplyError) -> Self {
+        Self::Reply(err)
     }
 }

--- a/gstd/src/common/errors.rs
+++ b/gstd/src/common/errors.rs
@@ -22,6 +22,7 @@
 //! errors.
 
 use core::fmt;
+use gcore::msg::SendError;
 
 pub type Result<T> = core::result::Result<T, ContractError>;
 
@@ -31,6 +32,7 @@ pub enum ContractError {
     Decode(codec::Error),
     ExitCode(i32),
     Internal(&'static str),
+    Send(SendError),
 }
 
 impl fmt::Display for ContractError {
@@ -40,6 +42,14 @@ impl fmt::Display for ContractError {
             ContractError::Decode(e) => write!(f, "Decoding codec bytes error: {}", e),
             ContractError::ExitCode(e) => write!(f, "Reply returned exit code {}", e),
             ContractError::Internal(e) => write!(f, "Internal error: {:?}", e),
+            // TODO: print error when it will contain actual information
+            ContractError::Send(_) => write!(f, "Send error"),
         }
+    }
+}
+
+impl From<SendError> for ContractError {
+    fn from(err: SendError) -> Self {
+        Self::Send(err)
     }
 }

--- a/gstd/src/common/errors.rs
+++ b/gstd/src/common/errors.rs
@@ -32,7 +32,7 @@ pub enum ContractError {
     Decode(codec::Error),
     ExitCode(i32),
     Internal(&'static str),
-    Send(SendError),
+    Sending(SendError),
     Reply(ReplyError),
 }
 
@@ -44,7 +44,7 @@ impl fmt::Display for ContractError {
             ContractError::ExitCode(e) => write!(f, "Reply returned exit code {}", e),
             ContractError::Internal(e) => write!(f, "Internal error: {:?}", e),
             // TODO: print error when it will contain actual information
-            ContractError::Send(_) => write!(f, "Send error"),
+            ContractError::Sending(_) => write!(f, "Send error"),
             // TODO: print error when it will contain actual information
             ContractError::Reply(_) => write!(f, "Reply error"),
         }
@@ -53,7 +53,7 @@ impl fmt::Display for ContractError {
 
 impl From<SendError> for ContractError {
     fn from(err: SendError) -> Self {
-        Self::Send(err)
+        Self::Sending(err)
     }
 }
 

--- a/gstd/src/exec.rs
+++ b/gstd/src/exec.rs
@@ -45,7 +45,7 @@
 //! // Send a reply after the block height reaches the number 1000
 //! pub unsafe extern "C" fn handle() {
 //!     if exec::block_height() >= 1000 {
-//!         msg::reply(b"Block #1000 reached", 0);
+//!         msg::reply(b"Block #1000 reached", 0).unwrap();
 //!     }
 //! }
 //! ```
@@ -55,7 +55,7 @@
 //! // Send a reply after the block timestamp reaches the February 22, 2022
 //! pub unsafe extern "C" fn handle() {
 //!     if exec::block_timestamp() >= 1645488000000 {
-//!         msg::reply(b"The current block is generated after February 22, 2022", 0);
+//!         msg::reply(b"The current block is generated after February 22, 2022", 0).unwrap();
 //!     }
 //! }
 //! ```

--- a/gstd/src/msg/async.rs
+++ b/gstd/src/msg/async.rs
@@ -121,14 +121,14 @@ pub fn send_and_wait_for_reply<D: Decode, E: Encode>(
     program: ActorId,
     payload: E,
     value: u128,
-) -> CodecMessageFuture<D> {
-    let waiting_reply_to = crate::msg::send(program, payload, value);
+) -> Result<CodecMessageFuture<D>> {
+    let waiting_reply_to = crate::msg::send(program, payload, value)?;
     signals().register_signal(waiting_reply_to);
 
-    CodecMessageFuture::<D> {
+    Ok(CodecMessageFuture::<D> {
         waiting_reply_to,
         phantom: PhantomData,
-    }
+    })
 }
 
 /// Send a message and wait for reply.
@@ -141,9 +141,9 @@ pub fn send_bytes_and_wait_for_reply<T: AsRef<[u8]>>(
     program: ActorId,
     payload: T,
     value: u128,
-) -> MessageFuture {
-    let waiting_reply_to = crate::msg::send_bytes(program, payload, value);
+) -> Result<MessageFuture> {
+    let waiting_reply_to = crate::msg::send_bytes(program, payload, value)?;
     signals().register_signal(waiting_reply_to);
 
-    MessageFuture { waiting_reply_to }
+    Ok(MessageFuture { waiting_reply_to })
 }

--- a/gstd/src/msg/basic.rs
+++ b/gstd/src/msg/basic.rs
@@ -186,15 +186,17 @@ pub fn load_bytes() -> Vec<u8> {
 ///
 /// pub unsafe extern "C" fn handle() {
 ///     // ...
-///     msg::reply_bytes(b"PONG", 0);
+///     msg::reply_bytes(b"PONG", 0).unwrap();
 /// }
 /// ```
 ///
 /// # See also
 ///
 /// [`reply_push`] function allows to form a reply message in parts.
-pub fn reply_bytes<T: AsRef<[u8]>>(payload: T, value: u128) -> MessageId {
-    gcore::msg::reply(payload.as_ref(), value).into()
+pub fn reply_bytes<T: AsRef<[u8]>>(payload: T, value: u128) -> Result<MessageId> {
+    gcore::msg::reply(payload.as_ref(), value)
+        .map(Into::into)
+        .map_err(Into::into)
 }
 
 /// Finalize and send a current reply message.
@@ -216,19 +218,21 @@ pub fn reply_bytes<T: AsRef<[u8]>>(payload: T, value: u128) -> MessageId {
 ///
 /// pub unsafe extern "C" fn handle() {
 ///     // ...
-///     msg::reply_push(b"Part 1");
+///     msg::reply_push(b"Part 1").unwrap();
 ///     // ...
-///     msg::reply_push(b"Part 2");
+///     msg::reply_push(b"Part 2").unwrap();
 ///     // ...
-///     msg::reply_commit(42);
+///     msg::reply_commit(42).unwrap();
 /// }
 /// ```
 ///
 /// # See also
 ///
 /// [`reply_push`] function allows to form a reply message in parts.
-pub fn reply_commit(value: u128) -> MessageId {
-    gcore::msg::reply_commit(value).into()
+pub fn reply_commit(value: u128) -> Result<MessageId> {
+    gcore::msg::reply_commit(value)
+        .map(Into::into)
+        .map_err(Into::into)
 }
 
 /// Push a payload part to the current reply message.
@@ -248,13 +252,13 @@ pub fn reply_commit(value: u128) -> MessageId {
 ///
 /// pub unsafe extern "C" fn handle() {
 ///     // ...
-///     msg::reply_push(b"Part 1");
+///     msg::reply_push(b"Part 1").unwrap();
 ///     // ...
-///     msg::reply_push(b"Part 2");
+///     msg::reply_push(b"Part 2").unwrap();
 /// }
 /// ```
-pub fn reply_push<T: AsRef<[u8]>>(payload: T) {
-    gcore::msg::reply_push(payload.as_ref());
+pub fn reply_push<T: AsRef<[u8]>>(payload: T) -> Result<()> {
+    gcore::msg::reply_push(payload.as_ref()).map_err(Into::into)
 }
 
 /// Get an identifier of the initial message which the current handle_reply

--- a/gstd/src/msg/basic.rs
+++ b/gstd/src/msg/basic.rs
@@ -72,7 +72,7 @@ impl MessageHandle {
         send_push(self, payload)
     }
 
-    pub fn commit(self, program: ActorId, value: u128) -> MessageId {
+    pub fn commit(self, program: ActorId, value: u128) -> Result<MessageId> {
         send_commit(self, program, value)
     }
 
@@ -393,8 +393,10 @@ pub fn send_bytes_with_gas<T: AsRef<[u8]>>(
 ///
 /// [`send_push`], [`send_init`] functions allows to form a message to send in
 /// parts.
-pub fn send_commit(handle: MessageHandle, program: ActorId, value: u128) -> MessageId {
-    gcore::msg::send_commit(handle.into(), program.into(), value).into()
+pub fn send_commit(handle: MessageHandle, program: ActorId, value: u128) -> Result<MessageId> {
+    gcore::msg::send_commit(handle.into(), program.into(), value)
+        .map(Into::into)
+        .map_err(Into::into)
 }
 
 /// Finalize and send message formed in parts, with gas_limit.

--- a/gstd/src/msg/encoded.rs
+++ b/gstd/src/msg/encoded.rs
@@ -44,8 +44,8 @@ pub fn reply<E: Encode>(payload: E, value: u128) -> MessageId {
     super::reply_bytes(payload.encode(), value)
 }
 
-pub fn send<E: Encode>(program: ActorId, payload: E, value: u128) -> MessageId {
-    super::send_bytes(program, payload.encode(), value)
+pub fn send<E: Encode>(program: ActorId, payload: E, value: u128) -> Result<MessageId> {
+    super::send_bytes(program, payload.encode(), value).map_err(Into::into)
 }
 
 pub fn send_with_gas<E: Encode>(
@@ -53,6 +53,6 @@ pub fn send_with_gas<E: Encode>(
     payload: E,
     gas_limit: u64,
     value: u128,
-) -> MessageId {
-    super::send_bytes_with_gas(program, payload.encode(), gas_limit, value)
+) -> Result<MessageId> {
+    super::send_bytes_with_gas(program, payload.encode(), gas_limit, value).map_err(Into::into)
 }

--- a/gstd/src/msg/encoded.rs
+++ b/gstd/src/msg/encoded.rs
@@ -40,7 +40,7 @@ pub fn load<D: Decode>() -> Result<D> {
     D::decode(&mut super::load_bytes().as_ref()).map_err(ContractError::Decode)
 }
 
-pub fn reply<E: Encode>(payload: E, value: u128) -> MessageId {
+pub fn reply<E: Encode>(payload: E, value: u128) -> Result<MessageId> {
     super::reply_bytes(payload.encode(), value)
 }
 

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -422,7 +422,7 @@ fn block_gas_limit_works() {
     // Same as `ProgramCodeKind::OutgoingWithValueInHandle`, but without value sending
     let wat1 = r#"
     (module
-        (import "env" "gr_send_wgas" (func $send (param i32 i32 i32 i64 i32 i32)))
+        (import "env" "gr_send_wgas" (func $send (param i32) (param i32) (param i32) (param i64) (param i32) (param i32) (result i32)))
         (import "env" "gr_source" (func $gr_source (param i32)))
         (import "env" "memory" (memory 1))
         (export "handle" (func $handle))
@@ -440,6 +440,7 @@ fn block_gas_limit_works() {
                 (i32.const 0)
             )
             (call $send (i32.const 2) (i32.const 0) (i32.const 32) (i64.const 10000000) (i32.const 10) (i32.const 40000))
+            drop
         )
         (func $handle_reply)
         (func $init)
@@ -905,7 +906,7 @@ fn send_reply_failure_to_claim_from_mailbox() {
             panic!("Program is terminated!");
         };
 
-        populate_mailbox_from_program(prog_id, USER_1, 2, 20_000_000, 0);
+        populate_mailbox_from_program(prog_id, USER_1, 2, 10_000, 0);
 
         // Program didn't have enough balance, so it's message produces trap
         // (and following system reply with error to USER_1 mailbox)
@@ -2723,7 +2724,7 @@ mod utils {
                     // [warning] - program payload data is inaccurate, don't make assumptions about it!
                     r#"
                     (module
-                        (import "env" "gr_send_wgas" (func $send (param i32 i32 i32 i64 i32 i32)))
+                        (import "env" "gr_send_wgas" (func $send (param i32 i32 i32 i64 i32 i32) (result i32)))
                         (import "env" "gr_source" (func $gr_source (param i32)))
                         (import "env" "memory" (memory 1))
                         (export "handle" (func $handle))
@@ -2741,6 +2742,7 @@ mod utils {
                                 (i32.const 1000)
                             )
                             (call $send (i32.const 2) (i32.const 0) (i32.const 32) (i64.const 10000000) (i32.const 10) (i32.const 40000))
+                            drop
                         )
                         (func $handle_reply)
                         (func $init)

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -492,7 +492,10 @@ fn block_gas_limit_works() {
                 (i32.const 0)
             )
             (call $send (i32.const 2) (i32.const 0) (i32.const 32) (i64.const 10000000) (i32.const 10) (i32.const 40000))
-            drop
+            (if
+                (then unreachable)
+                (else)
+            )
         )
         (func $handle_reply)
         (func $init)
@@ -968,7 +971,7 @@ fn send_reply_failure_to_claim_from_mailbox() {
             panic!("Program is terminated!");
         };
 
-        populate_mailbox_from_program(prog_id, USER_1, 2, 10_000, 0);
+        populate_mailbox_from_program(prog_id, USER_1, 2, 20_000_000, 0);
 
         // Program didn't have enough balance, so it's message produces trap
         // (and following system reply with error to USER_1 mailbox)
@@ -2773,7 +2776,10 @@ mod utils {
                                 (i32.const 1000)
                             )
                             (call $send (i32.const 2) (i32.const 0) (i32.const 32) (i64.const 10000000) (i32.const 10) (i32.const 40000))
-                            drop
+                            (if
+                                (then unreachable)
+                                (else)
+                            )
                         )
                         (func $handle_reply)
                         (func $init)

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -422,7 +422,7 @@ fn block_gas_limit_works() {
     // Same as `ProgramCodeKind::OutgoingWithValueInHandle`, but without value sending
     let wat1 = r#"
     (module
-        (import "env" "gr_send_wgas" (func $send (param i32) (param i32) (param i32) (param i64) (param i32) (param i32) (result i32)))
+        (import "env" "gr_send_wgas" (func $send (param i32 i32 i32 i64 i32 i32) (result i32)))
         (import "env" "gr_source" (func $gr_source (param i32)))
         (import "env" "memory" (memory 1))
         (export "handle" (func $handle))

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 520,
+    spec_version: 530,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 510,
+    spec_version: 520,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -349,6 +349,7 @@ impl pallet_gear::Config for Runtime {
     type GasPrice = GasConverter;
     type GasHandler = Gas;
     type WeightInfo = pallet_gear::weights::GearWeight<Runtime>;
+    type Schedule = ();
     type BlockGasLimit = BlockGasLimit;
     type WaitListFeePerBlock = WaitListFeePerBlock;
     type DebugInfo = DebugInfo;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 500,
+    spec_version: 510,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -341,7 +341,6 @@ parameter_types! {
     pub const ExpirationDuration: u64 = MILLISECS_PER_BLOCK.saturating_mul(WaitListTraversalInterval::get() as u64);
     pub const ExternalSubmitterRewardFraction: Perbill = Perbill::from_percent(10);
     pub const WaitListFeePerBlock: u64 = 1_000;
-    pub Schedule: pallet_gear::Schedule<Runtime> = Default::default();
 }
 
 impl pallet_gear::Config for Runtime {
@@ -350,7 +349,6 @@ impl pallet_gear::Config for Runtime {
     type GasPrice = GasConverter;
     type GasHandler = Gas;
     type WeightInfo = pallet_gear::weights::GearWeight<Runtime>;
-    type Schedule = Schedule;
     type BlockGasLimit = BlockGasLimit;
     type WaitListFeePerBlock = WaitListFeePerBlock;
     type DebugInfo = DebugInfo;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 550,
+    spec_version: 560,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/utils/wasm-builder/test-program/src/lib.rs
+++ b/utils/wasm-builder/test-program/src/lib.rs
@@ -5,7 +5,7 @@ use gstd::{debug, msg};
 #[no_mangle]
 pub unsafe extern "C" fn handle() {
     debug!("handle()");
-    msg::reply_bytes("Hello world!", 0);
+    msg::reply_bytes("Hello world!", 0).unwrap();
 }
 
 #[no_mangle]
@@ -15,23 +15,28 @@ pub unsafe extern "C" fn init() {
 
 #[cfg(test)]
 mod gtest_tests {
-   extern crate std;
+    extern crate std;
 
-   use gtest::{Program, System, Log};
+    use gtest::{Log, Program, System};
 
-   #[test]
-   fn init_self() {
-       let system = System::new();
-       system.init_logger();
+    #[test]
+    fn init_self() {
+        let system = System::new();
+        system.init_logger();
 
-       let this_program = Program::current(&system);
+        let this_program = Program::current(&system);
 
-       let res = this_program.send_bytes(123, "INIT");
-       assert!(res.log().is_empty());
+        let res = this_program.send_bytes(123, "INIT");
+        assert!(res.log().is_empty());
 
-       let res = this_program.send_bytes(123, "Hi");
-       assert!(res.contains(&Log::builder().source(1).dest(123).payload_bytes("Hello world!")));
-   }
+        let res = this_program.send_bytes(123, "Hi");
+        assert!(res.contains(
+            &Log::builder()
+                .source(1)
+                .dest(123)
+                .payload_bytes("Hello world!")
+        ));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Resolves #409

Release notes:
1. Make `gr_send*` and `gr_reply*` syscalls return error code
2. Make `msg::send*` and `msg::reply*` functions return `Result`