### PR TITLE
Bugfix: gas nodes are not properly consumed in some circumstances

### DIFF
--- a/pallets/usage/src/lib.rs
+++ b/pallets/usage/src/lib.rs
@@ -340,30 +340,35 @@ pub mod pallet {
                     let new_msg_gas_balance = msg_gas_balance.saturating_sub(fee);
                     if new_msg_gas_balance <= T::TrapReplyExistentialGasLimit::get() {
                         if common::get_program(program_id.into_origin()).is_some() {
-                                // TODO: generate system signal for program (#647)
+                            // TODO: generate system signal for program (#647)
 
-                                // Generate trap reply
-                                let trap_message_id = MessageId::generate_reply(msg_id, core_processor::ERR_EXIT_CODE);
-                                let packet = ReplyPacket::system(core_processor::ERR_EXIT_CODE);
-                                let message = ReplyMessage::from_packet(trap_message_id, packet);
-                                let dispatch = message.into_stored_dispatch(program_id, dispatch.source(), msg_id);
+                            // Generate trap reply
+                            let trap_message_id = MessageId::generate_reply(msg_id, core_processor::ERR_EXIT_CODE);
+                            let packet = ReplyPacket::system(core_processor::ERR_EXIT_CODE);
+                            let message = ReplyMessage::from_packet(trap_message_id, packet);
+                            let dispatch = message.into_stored_dispatch(program_id, dispatch.source(), msg_id);
 
-                                // Enqueue the trap reply message
-                                let _ = <T as pallet_gear::Config>::GasHandler::split_with_value(
-                                    msg_id.into_origin(),
-                                    trap_message_id.into_origin(),
-                                    new_msg_gas_balance
-                                );
-                                common::queue_dispatch(dispatch);
+                            // Enqueue the trap reply message
+                            let _ = <T as pallet_gear::Config>::GasHandler::split_with_value(
+                                msg_id.into_origin(),
+                                trap_message_id.into_origin(),
+                                new_msg_gas_balance
+                            );
+                            common::queue_dispatch(dispatch);
+
+                            // Consume the corresponding node
+                            let _ = <T as pallet_gear::Config>::GasHandler::consume(
+                                msg_id.into_origin(),
+                            );
                         } else {
-                                // Wait init messages can't reach that, because if program init failed,
-                                // then all waiting messages are moved to queue deleted.
-                                log::debug!(
-                                    target: "essential",
-                                    "Program {:?} isn't in storage, but message with that dest is in WL",
-                                    program_id,
-                                )
-                            }
+                            // Wait init messages can't reach that, because if program init failed,
+                            // then all waiting messages are moved to queue deleted.
+                            log::debug!(
+                                target: "essential",
+                                "Program {:?} isn't in storage, but message with that dest is in WL",
+                                program_id,
+                            )
+                        }
                     } else {
                         // Message still got enough gas limit and may keep waiting.
                         // Updating gas limit value and re-inserting the message into wait list.

--- a/pallets/usage/src/lib.rs
+++ b/pallets/usage/src/lib.rs
@@ -349,10 +349,9 @@ pub mod pallet {
                             let dispatch = message.into_stored_dispatch(program_id, dispatch.source(), msg_id);
 
                             // Enqueue the trap reply message
-                            let _ = <T as pallet_gear::Config>::GasHandler::split_with_value(
+                            let _ = <T as pallet_gear::Config>::GasHandler::split(
                                 msg_id.into_origin(),
                                 trap_message_id.into_origin(),
-                                new_msg_gas_balance
                             );
                             common::queue_dispatch(dispatch);
 

--- a/pallets/usage/src/mock.rs
+++ b/pallets/usage/src/mock.rs
@@ -19,7 +19,7 @@
 use crate as pallet_usage;
 use codec::Decode;
 use common::Origin as _;
-use frame_support::traits::{ConstU64, FindAuthor, OffchainWorker, OnInitialize};
+use frame_support::traits::{ConstU64, FindAuthor, OffchainWorker, OnIdle, OnInitialize};
 use frame_support::{construct_runtime, parameter_types};
 use frame_system as system;
 use gear_core::{ids::CodeId, program::Program};
@@ -231,8 +231,10 @@ pub fn with_offchain_ext() -> (sp_io::TestExternalities, Arc<RwLock<PoolState>>)
 pub(crate) fn run_to_block(n: u64) {
     let now = System::block_number();
     for i in now + 1..=n {
+        log::debug!("📦 Processing block {}", i);
         System::set_block_number(i);
         Usage::on_initialize(i);
+        Gear::on_idle(i, 1_000_000_000);
     }
 }
 

--- a/pallets/usage/src/tests.rs
+++ b/pallets/usage/src/tests.rs
@@ -24,6 +24,7 @@ use core::convert::TryInto;
 use frame_support::{assert_ok, traits::ReservableCurrency};
 use gear_core::{
     code::CheckedCode,
+    ids::MessageId,
     message::{DispatchKind, StoredDispatch, StoredMessage},
 };
 use hex_literal::hex;
@@ -58,6 +59,36 @@ fn populate_wait_list(n: u64, bn: u32, num_users: u64, gas_limits: Vec<u64>) {
             msg_id.into_origin(),
             gas_limit,
         );
+    }
+}
+
+fn populate_wait_list_with_split(n: u64, bn: u32, num_users: u64, gas_limit: u64) {
+    let mut last_msg_id: Option<MessageId> = None;
+    for i in 0_u64..n {
+        let prog_id = (i + 1).into();
+        let msg_id = (100_u64 * n + i + 1).into();
+        let blk_num = i % (bn as u64) + 1;
+        let user_id = (i % num_users + 1).into();
+        let message = StoredMessage::new(msg_id, user_id, prog_id, Default::default(), 0, None);
+        common::insert_waiting_message(
+            prog_id.into_origin(),
+            msg_id.into_origin(),
+            StoredDispatch::new(DispatchKind::Handle, message, None),
+            blk_num.try_into().unwrap(),
+        );
+        if last_msg_id.is_none() {
+            let _ = <Test as pallet_gear::Config>::GasHandler::create(
+                user_id.into_origin(),
+                msg_id.into_origin(),
+                gas_limit,
+            );
+        } else {
+            let _ = <Test as pallet_gear::Config>::GasHandler::split(
+                last_msg_id.expect("Guaranteed to have value").into_origin(),
+                msg_id.into_origin(),
+            );
+        }
+        last_msg_id = Some(msg_id);
     }
 }
 
@@ -628,5 +659,79 @@ fn dust_discarded_with_noop() {
         // The amount destined to the tx submitter is below `ExistentialDeposit`
         // It should have been removed as dust, no change in the beneficiary free balance
         assert_eq!(Balances::free_balance(&11), 0);
+    });
+}
+
+#[test]
+fn gas_properly_handled_for_trap_replies() {
+    init_logger();
+    new_test_ext().execute_with(|| {
+        // 1st user has just above `T::TrapReplyExistentialGasLimit` reserved
+        assert_ok!(<Balances as ReservableCurrency<_>>::reserve(&1, 1_100));
+        // 2nd user already has less than `T::TrapReplyExistentialGasLimit` reserved
+        assert_ok!(<Balances as ReservableCurrency<_>>::reserve(&2, 500));
+
+        run_to_block(10);
+
+        // Populate wait list with 2 messages
+        populate_wait_list_with_split(2, 10, 2, 1_100);
+
+        let wl = wait_list_contents()
+            .into_iter()
+            .map(|(d, n)| (d.message().clone(), n))
+            .collect::<Vec<_>>();
+        assert_eq!(wl.len(), 2);
+
+        // Insert respective programs to the program storage
+        let program_1 = gear_core::program::Program::new(
+            1.into(),
+            CheckedCode::try_new(
+                hex!("0061736d01000000020f0103656e76066d656d6f7279020001").to_vec(),
+            )
+            .unwrap(),
+        );
+        crate::mock::set_program(program_1);
+
+        let program_2 = gear_core::program::Program::new(
+            2.into(),
+            CheckedCode::try_new(
+                hex!["0061736d01000000020f0103656e76066d656d6f7279020001"].to_vec(),
+            )
+            .unwrap(),
+        );
+        crate::mock::set_program(program_2);
+
+        run_to_block(15);
+
+        // Calling the unsigned version of the extrinsic
+        assert_ok!(Usage::collect_waitlist_rent(
+            Origin::none(),
+            vec![
+                PayeeInfo {
+                    program_id: 1.into_origin(),
+                    message_id: 201.into_origin()
+                },
+                PayeeInfo {
+                    program_id: 2.into_origin(),
+                    message_id: 202.into_origin()
+                },
+            ],
+        ));
+
+        // Both messages should have been removed from wait list
+        assert_eq!(wait_list_contents().len(), 0);
+
+        // 100 gas spent for rent payment by 1st message => total_issuance = 1000 + 500
+        assert_eq!(
+            <Test as pallet_gear::Config>::GasHandler::total_issuance(),
+            1000
+        );
+
+        // Upon queue processing in the following block all the gas must be consumed or spent
+        run_to_block(16);
+        assert_eq!(
+            <Test as pallet_gear::Config>::GasHandler::total_issuance(),
+            0
+        );
     });
 }

--- a/pallets/usage/src/tests.rs
+++ b/pallets/usage/src/tests.rs
@@ -721,7 +721,7 @@ fn gas_properly_handled_for_trap_replies() {
         // Both messages should have been removed from wait list
         assert_eq!(wait_list_contents().len(), 0);
 
-        // 100 gas spent for rent payment by 1st message => total_issuance = 1000 + 500
+        // 100 gas spent for rent payment by 1st message => total_issuance = 1000
         assert_eq!(
             <Test as pallet_gear::Config>::GasHandler::total_issuance(),
             1000

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 480,
+    spec_version: 490,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
When a message is removed from the wait list due to inability to pay rent (run out of free gas), a trap reply is generated with a new gas node split from the one corresponding to the expelled message. This must be followed by explicit consumption of that node.