### PR TITLE
Configurable page size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,6 +2276,7 @@ dependencies = [
  "gear-lazy-pages",
  "libc",
  "log",
+ "page_size",
  "parity-scale-codec",
  "sp-runtime-interface",
  "sp-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4612,6 +4612,7 @@ dependencies = [
  "gear-core-processor",
  "gear-runtime-interface",
  "log",
+ "page_size",
  "pallet-authorship",
  "pallet-balances",
  "pallet-gas",

--- a/common/src/lazy_pages.rs
+++ b/common/src/lazy_pages.rs
@@ -68,7 +68,7 @@ pub fn protect_pages_and_init_info(
     let lazy_pages = memory_pages
         .iter()
         .filter(|(_num, buf)| buf.is_none())
-        .map(|(num, _buf)| num)
+        .map(|(num, _buf)| *num)
         .collect::<Vec<_>>();
     let prog_id_hash = prog_id.into_origin();
 
@@ -77,7 +77,7 @@ pub fn protect_pages_and_init_info(
     gear_ri::set_wasm_mem_begin_addr(wasm_mem_begin_addr);
 
     lazy_pages.iter().for_each(|p| {
-        crate::save_page_lazy_info(prog_id_hash, **p);
+        crate::save_page_lazy_info(prog_id_hash, *p);
     });
 
     mprotect_lazy_pages(wasm_mem_begin_addr, true)
@@ -99,8 +99,6 @@ pub fn post_execution_actions(
     }
 
     // Removes protections from lazy pages
-    let lazy_pages = gear_ri::get_wasm_lazy_pages_numbers();
-    log::debug!("lazy pages after = {:?}", lazy_pages);
     mprotect_lazy_pages(wasm_mem_begin_addr, false)
 }
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -46,6 +46,7 @@ use gear_core::{
     ids::{CodeId, MessageId, ProgramId},
     message::StoredDispatch,
     program::Program as NativeProgram,
+    memory::WasmPageNumber,
 };
 
 pub use storage_queue::Iterator;
@@ -303,8 +304,7 @@ impl core::convert::TryFrom<Program> for ActiveProgram {
 
 #[derive(Clone, Debug, Decode, Encode, PartialEq, TypeInfo)]
 pub struct ActiveProgram {
-    #[codec(compact)]
-    pub static_pages: u32,
+    pub static_pages: WasmPageNumber,
     pub persistent_pages: BTreeSet<u32>,
     pub code_hash: H256,
     pub state: ProgramState,
@@ -629,7 +629,7 @@ mod tests {
 
             let program_id = H256::from_low_u64_be(1);
             let program = ActiveProgram {
-                static_pages: 256,
+                static_pages: 256.into(),
                 persistent_pages: Default::default(),
                 code_hash: code_id,
                 state: ProgramState::Initialized,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -44,9 +44,9 @@ use sp_std::{
 use gear_core::{
     code::Code,
     ids::{CodeId, MessageId, ProgramId},
+    memory::{PageNumber, WasmPageNumber},
     message::StoredDispatch,
     program::Program as NativeProgram,
-    memory::WasmPageNumber,
 };
 
 pub use storage_queue::Iterator;
@@ -305,7 +305,7 @@ impl core::convert::TryFrom<Program> for ActiveProgram {
 #[derive(Clone, Debug, Decode, Encode, PartialEq, TypeInfo)]
 pub struct ActiveProgram {
     pub static_pages: WasmPageNumber,
-    pub persistent_pages: BTreeSet<u32>,
+    pub persistent_pages: BTreeSet<PageNumber>,
     pub code_hash: H256,
     pub state: ProgramState,
 }
@@ -377,10 +377,10 @@ pub fn pages_prefix(program_id: H256) -> Vec<u8> {
     key
 }
 
-fn page_key(id: H256, page: u32) -> Vec<u8> {
+fn page_key(id: H256, page: PageNumber) -> Vec<u8> {
     let mut key = pages_prefix(id);
     key.extend(b"::");
-    page.encode_to(&mut key);
+    page.raw().encode_to(&mut key);
     key
 }
 
@@ -460,18 +460,21 @@ pub fn get_program(id: H256) -> Option<Program> {
 }
 
 /// Returns mem page data from storage for program `id` and `page_idx`
-pub fn get_program_page_data(id: H256, page_idx: u32) -> Option<Vec<u8>> {
+pub fn get_program_page_data(id: H256, page_idx: PageNumber) -> Option<Vec<u8>> {
     let key = page_key(id, page_idx);
     sp_io::storage::get(&key)
 }
 
 /// Save page data key in storage
-pub fn save_page_lazy_info(id: H256, page_num: u32) {
+pub fn save_page_lazy_info(id: H256, page_num: PageNumber) {
     let key = page_key(id, page_num);
-    gear_ri::gear_ri::save_page_lazy_info(page_num, &key);
+    gear_ri::gear_ri::save_page_lazy_info(page_num.raw(), &key);
 }
 
-pub fn get_program_pages(id: H256, pages: BTreeSet<u32>) -> Option<BTreeMap<u32, Vec<u8>>> {
+pub fn get_program_pages(
+    id: H256,
+    pages: BTreeSet<PageNumber>,
+) -> Option<BTreeMap<PageNumber, Vec<u8>>> {
     let mut persistent_pages = BTreeMap::new();
     for page_num in pages {
         let key = page_key(id, page_num);
@@ -481,7 +484,11 @@ pub fn get_program_pages(id: H256, pages: BTreeSet<u32>) -> Option<BTreeMap<u32,
     Some(persistent_pages)
 }
 
-pub fn set_program(id: H256, program: ActiveProgram, persistent_pages: BTreeMap<u32, Vec<u8>>) {
+pub fn set_program(
+    id: H256,
+    program: ActiveProgram,
+    persistent_pages: BTreeMap<PageNumber, Vec<u8>>,
+) {
     for (page_num, page_buf) in persistent_pages {
         let key = page_key(id, page_num);
         sp_io::storage::set(&key, &page_buf);
@@ -518,20 +525,20 @@ pub fn dispatch_iter() -> Iterator<StoredDispatch> {
     StorageQueue::get(STORAGE_MESSAGE_PREFIX).into_iter()
 }
 
-pub fn set_program_persistent_pages(id: H256, persistent_pages: BTreeSet<u32>) {
+pub fn set_program_persistent_pages(id: H256, persistent_pages: BTreeSet<PageNumber>) {
     if let Some(Program::Active(mut prog)) = get_program(id) {
         prog.persistent_pages = persistent_pages;
         sp_io::storage::set(&program_key(id), &Program::Active(prog).encode())
     }
 }
 
-pub fn set_program_page(program_id: H256, page_num: u32, page_buf: Vec<u8>) {
+pub fn set_program_page(program_id: H256, page_num: PageNumber, page_buf: Vec<u8>) {
     let page_key = page_key(program_id, page_num);
 
     sp_io::storage::set(&page_key, &page_buf);
 }
 
-pub fn remove_program_page(program_id: H256, page_num: u32) {
+pub fn remove_program_page(program_id: H256, page_num: PageNumber) {
     let page_key = page_key(program_id, page_num);
 
     sp_io::storage::clear(&page_key);

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -380,7 +380,7 @@ pub fn pages_prefix(program_id: H256) -> Vec<u8> {
 fn page_key(id: H256, page: PageNumber) -> Vec<u8> {
     let mut key = pages_prefix(id);
     key.extend(b"::");
-    page.raw().encode_to(&mut key);
+    page.0.encode_to(&mut key);
     key
 }
 
@@ -468,7 +468,7 @@ pub fn get_program_page_data(id: H256, page_idx: PageNumber) -> Option<Vec<u8>> 
 /// Save page data key in storage
 pub fn save_page_lazy_info(id: H256, page_num: PageNumber) {
     let key = page_key(id, page_num);
-    gear_ri::gear_ri::save_page_lazy_info(page_num.raw(), &key);
+    gear_ri::gear_ri::save_page_lazy_info(page_num.0, &key);
 }
 
 pub fn get_program_pages(

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -43,6 +43,7 @@ pub const LEAVE_TRAP_STR: &str = "leave";
 pub const WAIT_TRAP_STR: &str = "wait";
 pub const GAS_ALLOWANCE_STR: &str = "allowance";
 
+#[derive(Debug)]
 pub enum TerminationReason<'a> {
     Exit(ProgramId),
     Leave,

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -101,7 +101,7 @@ pub trait Environment<E: Ext + IntoExtInfo + 'static>: Sized {
     ) -> Result<Self, BackendError<'static>>;
 
     /// Returns addr to the stack end if it can be identified
-    fn get_stack_mem_end(&mut self) -> Option<i32>;
+    fn get_stack_mem_end(&mut self) -> Option<WasmPageNumber>;
 
     /// Returns host address of wasm memory buffer. Needed for lazy-pages
     fn get_wasm_memory_begin_addr(&mut self) -> u64;

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -34,7 +34,7 @@ use gear_core::{
     env::Ext,
     gas::GasAmount,
     ids::{CodeId, MessageId, ProgramId},
-    memory::{PageBuf, PageNumber},
+    memory::{PageBuf, PageNumber, WasmPageNumber},
     message::{ContextStore, Dispatch},
 };
 
@@ -58,7 +58,7 @@ pub enum TerminationReason<'a> {
 pub struct ExtInfo {
     pub gas_amount: GasAmount,
     pub pages: BTreeSet<PageNumber>,
-    pub accessed_pages: BTreeMap<PageNumber, Vec<u8>>,
+    pub pages_data: BTreeMap<PageNumber, Vec<u8>>,
     pub generated_dispatches: Vec<Dispatch>,
     pub awakening: Vec<MessageId>,
     pub program_candidates_data: BTreeMap<CodeId, Vec<(ProgramId, MessageId)>>,
@@ -97,7 +97,7 @@ pub trait Environment<E: Ext + IntoExtInfo + 'static>: Sized {
         ext: E,
         binary: &[u8],
         memory_pages: &BTreeMap<PageNumber, Option<Box<PageBuf>>>,
-        mem_size: u32,
+        mem_size: WasmPageNumber,
     ) -> Result<Self, BackendError<'static>>;
 
     /// Returns addr to the stack end if it can be identified

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -26,7 +26,7 @@ use gear_backend_common::{
 use gear_core::{
     env::{Ext, LaterExt},
     gas::GasAmount,
-    memory::{Error, Memory, PageBuf, PageNumber, WasmPageNumber, WASM_PAGE_SIZE},
+    memory::{Memory, PageBuf, PageNumber, WasmPageNumber, WASM_PAGE_SIZE},
 };
 use sp_sandbox::{
     default_executor::{EnvironmentDefinitionBuilder, Instance, Memory as DefaultExecutorMemory},
@@ -60,12 +60,12 @@ fn get_module_exports(binary: &[u8]) -> Result<Vec<String>, String> {
 fn set_pages(
     memory: &mut dyn Memory,
     pages: &BTreeMap<PageNumber, Option<Box<PageBuf>>>,
-) -> Result<(), Error> {
+) -> Result<(), String> {
     for (num, buf) in pages {
         if let Some(buf) = buf {
             memory
                 .write(num.offset(), &buf[..])
-                .map_err(|_| Error::MemoryAccessError)?;
+                .map_err(|e| format!("Cannot write mem to {:?}: {:?}", num, e))?;
         }
     }
     Ok(())

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -26,7 +26,7 @@ use gear_backend_common::{
 use gear_core::{
     env::{Ext, LaterExt},
     gas::GasAmount,
-    memory::{Error, Memory, PageBuf, PageNumber},
+    memory::{Error, Memory, PageBuf, PageNumber, WasmPageNumber},
 };
 use sp_sandbox::{
     default_executor::{EnvironmentDefinitionBuilder, Instance, Memory as DefaultExecutorMemory},
@@ -76,13 +76,13 @@ impl<E: Ext + IntoExtInfo + 'static> Environment<E> for SandboxEnvironment<E> {
         ext: E,
         binary: &[u8],
         memory_pages: &BTreeMap<PageNumber, Option<Box<PageBuf>>>,
-        mem_size: u32,
+        mem_size: WasmPageNumber,
     ) -> Result<Self, BackendError<'static>> {
         let mut later_ext = LaterExt::default();
         later_ext.set(ext);
 
         let mem: DefaultExecutorMemory =
-            SandboxMemory::new(mem_size, None).map_err(|e| BackendError {
+            SandboxMemory::new(mem_size.0, None).map_err(|e| BackendError {
                 reason: "Create env memory fail",
                 description: Some(format!("{:?}", e).into()),
                 gas_amount: later_ext.unset().into_gas_amount(),

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -26,7 +26,7 @@ use gear_backend_common::{
 use gear_core::{
     env::{Ext, LaterExt},
     gas::GasAmount,
-    memory::{Memory, PageBuf, PageNumber, WasmPageNumber, WASM_PAGE_SIZE},
+    memory::{Memory, PageBuf, PageNumber, WasmPageNumber},
 };
 use sp_sandbox::{
     default_executor::{EnvironmentDefinitionBuilder, Instance, Memory as DefaultExecutorMemory},
@@ -164,7 +164,9 @@ impl<E: Ext + IntoExtInfo + 'static> Environment<E> for SandboxEnvironment<E> {
             if addr < 0 {
                 None
             } else {
-                Some(WasmPageNumber((addr as usize / WASM_PAGE_SIZE) as u32))
+                Some(WasmPageNumber(
+                    (addr as usize / WasmPageNumber::size()) as u32,
+                ))
             }
         })
     }

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -300,10 +300,9 @@ impl<E: Ext + 'static> FuncsHandler<E> {
         ctx.ext
             .clone()
             .with_fallible(|ext| ext.alloc(pages.into(), &mut ctx.memory))
-            .map(|v| {
-                let ptr = v.raw();
-                log::debug!("ALLOC: {} pages at {}", pages, ptr);
-                ReturnValue::Value(Value::I32(ptr as i32))
+            .map(|page| {
+                log::debug!("ALLOC: {} pages at {:?}", pages, page);
+                ReturnValue::Value(Value::I32(page.0 as i32))
             })
             .map_err(|e| {
                 ctx.trap = Some(e);

--- a/core-backend/sandbox/src/memory.rs
+++ b/core-backend/sandbox/src/memory.rs
@@ -18,7 +18,7 @@
 
 //! sp-sandbox extensions for memory.
 
-use gear_core::memory::{Error, Memory, PageNumber};
+use gear_core::memory::{Error, Memory, PageNumber, WasmPageNumber};
 use sp_sandbox::SandboxMemory;
 
 /// Wrapper for sp_sandbox::Memory.
@@ -33,14 +33,14 @@ impl MemoryWrap {
 
 /// Memory interface for the allocator.
 impl Memory for MemoryWrap {
-    fn grow(&mut self, pages: PageNumber) -> Result<PageNumber, Error> {
+    fn grow(&mut self, pages: WasmPageNumber) -> Result<PageNumber, Error> {
         self.0
-            .grow(pages.raw())
+            .grow(pages.0)
             .map(|prev| prev.into())
             .map_err(|_| Error::OutOfMemory)
     }
 
-    fn size(&self) -> PageNumber {
+    fn size(&self) -> WasmPageNumber {
         self.0.size().into()
     }
 
@@ -109,9 +109,8 @@ mod tests {
         // and now can allocate page that was freed
         assert_eq!(
             mem.alloc(1.into(), &mut mem_wrap)
-                .expect("allocation failed")
-                .raw(),
-            137
+                .expect("allocation failed"),
+            137.into()
         );
 
         // if we have 2 in a row we can allocate even 2
@@ -120,9 +119,8 @@ mod tests {
 
         assert_eq!(
             mem.alloc(2.into(), &mut mem_wrap)
-                .expect("allocation failed")
-                .raw(),
-            117
+                .expect("allocation failed"),
+            117.into()
         );
 
         // but if 2 are not in a row, bad luck

--- a/core-backend/sandbox/src/memory.rs
+++ b/core-backend/sandbox/src/memory.rs
@@ -57,7 +57,7 @@ impl Memory for MemoryWrap {
     }
 
     fn data_size(&self) -> usize {
-        (self.0.size() * 65536) as usize
+        self.0.size() as usize * WasmPageNumber::size()
     }
 
     fn get_wasm_memory_begin_addr(&self) -> u64 {

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -18,14 +18,20 @@
 
 //! Wasmtime environment for running a module.
 
-use alloc::{boxed::Box, collections::BTreeMap, format, string::ToString, vec::Vec};
+use alloc::{
+    boxed::Box,
+    collections::BTreeMap,
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
 use gear_backend_common::{
     funcs as common_funcs, BackendError, BackendReport, Environment, IntoExtInfo, TerminationReason,
 };
 use gear_core::{
     env::{Ext, LaterExt},
     gas::GasAmount,
-    memory::{Error, PageBuf, PageNumber, WasmPageNumber, WASM_PAGE_SIZE},
+    memory::{PageBuf, PageNumber, WasmPageNumber, WASM_PAGE_SIZE},
 };
 use wasmtime::{
     Engine, Extern, Func, Instance, Memory as WasmtimeMemory, MemoryType, Module, Store, Trap,
@@ -48,15 +54,16 @@ fn set_pages<T: Ext>(
     mut store: &mut Store<StoreData<T>>,
     memory: &mut WasmtimeMemory,
     pages: &BTreeMap<PageNumber, Option<Box<PageBuf>>>,
-) -> Result<(), Error> {
+) -> Result<(), String> {
+    let memory_size = WasmPageNumber(memory.size(&mut store) as u32);
     for (num, buf) in pages {
-        if memory.size(&mut store) <= num.raw() as u64 {
-            return Err(Error::MemoryAccessError);
+        if memory_size <= num.to_wasm_page() {
+            return Err(format!("Memory size {:?} less then {:?}", memory_size, num));
         }
         if let Some(buf) = buf {
             memory
                 .write(&mut store, num.offset(), &buf[..])
-                .map_err(|_| Error::MemoryAccessError)?;
+                .map_err(|e| format!("Cannot write to {:?}: {:?}", num, e))?;
         }
     }
     Ok(())
@@ -79,13 +86,11 @@ impl<E: Ext + IntoExtInfo> Environment<E> for WasmtimeEnvironment<E> {
         let mut store = Store::<StoreData<E>>::new(&engine, store_data);
 
         // Creates new wasm memory
-        let mut memory =
-            WasmtimeMemory::new(&mut store, MemoryType::new(mem_size.0, None)).map_err(|e| {
-                BackendError {
-                    reason: "Create env memory failed",
-                    description: Some(e.to_string().into()),
-                    gas_amount: later_ext.unset().into_gas_amount(),
-                }
+        let mut memory = WasmtimeMemory::new(&mut store, MemoryType::new(mem_size.0, None))
+            .map_err(|e| BackendError {
+                reason: "Create env memory failed",
+                description: Some(e.to_string().into()),
+                gas_amount: later_ext.unset().into_gas_amount(),
             })?;
 
         /// Make import funcs
@@ -203,7 +208,13 @@ impl<E: Ext + IntoExtInfo> Environment<E> for WasmtimeEnvironment<E> {
         let global = self
             .instance
             .get_global(&mut self.store, "__gear_stack_end")?;
-        global.get(&mut self.store).i32().and_then(|addr| if addr < 0 { None } else { Some(WasmPageNumber((addr as usize / WASM_PAGE_SIZE) as u32)) })
+        global.get(&mut self.store).i32().and_then(|addr| {
+            if addr < 0 {
+                None
+            } else {
+                Some(WasmPageNumber((addr as usize / WASM_PAGE_SIZE) as u32))
+            }
+        })
     }
 
     fn get_wasm_memory_begin_addr(&mut self) -> u64 {

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -31,7 +31,7 @@ use gear_backend_common::{
 use gear_core::{
     env::{Ext, LaterExt},
     gas::GasAmount,
-    memory::{PageBuf, PageNumber, WasmPageNumber, WASM_PAGE_SIZE},
+    memory::{PageBuf, PageNumber, WasmPageNumber},
 };
 use wasmtime::{
     Engine, Extern, Func, Instance, Memory as WasmtimeMemory, MemoryType, Module, Store, Trap,
@@ -212,7 +212,9 @@ impl<E: Ext + IntoExtInfo> Environment<E> for WasmtimeEnvironment<E> {
             if addr < 0 {
                 None
             } else {
-                Some(WasmPageNumber((addr as usize / WASM_PAGE_SIZE) as u32))
+                Some(WasmPageNumber(
+                    (addr as usize / WasmPageNumber::size()) as u32,
+                ))
             }
         })
     }

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -25,7 +25,7 @@ use gear_backend_common::{
 use gear_core::{
     env::{Ext, LaterExt},
     gas::GasAmount,
-    memory::{Error, PageBuf, PageNumber},
+    memory::{Error, PageBuf, PageNumber, WasmPageNumber},
 };
 use wasmtime::{
     Engine, Extern, Func, Instance, Memory as WasmtimeMemory, MemoryType, Module, Store, Trap,
@@ -67,7 +67,7 @@ impl<E: Ext + IntoExtInfo> Environment<E> for WasmtimeEnvironment<E> {
         ext: E,
         binary: &[u8],
         memory_pages: &BTreeMap<PageNumber, Option<Box<PageBuf>>>,
-        mem_size: u32,
+        mem_size: WasmPageNumber,
     ) -> Result<Self, BackendError<'static>> {
         let mut later_ext = LaterExt::default();
         later_ext.set(ext);
@@ -80,7 +80,7 @@ impl<E: Ext + IntoExtInfo> Environment<E> for WasmtimeEnvironment<E> {
 
         // Creates new wasm memory
         let mut memory =
-            WasmtimeMemory::new(&mut store, MemoryType::new(mem_size, None)).map_err(|e| {
+            WasmtimeMemory::new(&mut store, MemoryType::new(mem_size.0, None)).map_err(|e| {
                 BackendError {
                     reason: "Create env memory failed",
                     description: Some(e.to_string().into()),

--- a/core-backend/wasmtime/src/funcs.rs
+++ b/core-backend/wasmtime/src/funcs.rs
@@ -61,13 +61,13 @@ impl<E: Ext + 'static> FuncsHandler<E> {
         let func = move |mut caller: Caller<'_, StoreData<E>>, pages: i32| {
             let ext = caller.data().ext.clone();
             let pages = pages as u32;
-            let ptr = ext
+            let page = ext
                 .with_fallible(|ext| {
                     ext.alloc(pages.into(), &mut get_caller_memory(&mut caller, &mem))
                 })
                 .map_err(Trap::new)?;
-            log::debug!("ALLOC PAGES: {} pages at {}", pages, ptr.raw());
-            Ok(ptr.raw())
+            log::debug!("ALLOC PAGES: {} pages at {:?}", pages, page);
+            Ok(page.0)
         };
         Func::wrap(store, func)
     }

--- a/core-backend/wasmtime/src/memory.rs
+++ b/core-backend/wasmtime/src/memory.rs
@@ -20,7 +20,7 @@
 
 use crate::env::StoreData;
 use gear_core::env::Ext;
-use gear_core::memory::{Error, Memory, PageNumber};
+use gear_core::memory::{Error, Memory, PageNumber, WasmPageNumber};
 use wasmtime::StoreContextMut;
 
 /// Wrapper for wasmtime memory.
@@ -31,14 +31,14 @@ pub struct MemoryWrap<'a, E: Ext> {
 
 /// Memory interface for the allocator.
 impl<'a, E: Ext> Memory for MemoryWrap<'a, E> {
-    fn grow(&mut self, pages: PageNumber) -> Result<PageNumber, Error> {
+    fn grow(&mut self, pages: WasmPageNumber) -> Result<PageNumber, Error> {
         self.mem
-            .grow(&mut self.store, pages.raw() as u64)
+            .grow(&mut self.store, pages.0 as u64)
             .map(|offset| (offset as u32).into())
             .map_err(|_| Error::OutOfMemory)
     }
 
-    fn size(&self) -> PageNumber {
+    fn size(&self) -> WasmPageNumber {
         (self.mem.size(&self.store) as u32).into()
     }
 

--- a/core-processor/src/configs.rs
+++ b/core-processor/src/configs.rs
@@ -19,9 +19,9 @@
 //! Configurations.
 
 use codec::{Decode, Encode};
-use gear_core::memory::PageNumber;
+use gear_core::memory::WasmPageNumber;
 
-const MAX_PAGES: u32 = 512;
+const MAX_WASM_PAGES: u32 = 512;
 const INIT_COST: u64 = 5000;
 const ALLOC_COST: u64 = 10000;
 const MEM_GROW_COST: u64 = 10000;
@@ -40,7 +40,7 @@ pub struct BlockInfo {
 #[derive(Clone, Debug, Decode, Encode)]
 pub struct AllocationsConfig {
     /// Max amount of pages.
-    pub max_pages: PageNumber,
+    pub max_pages: WasmPageNumber,
     /// Cost of initial memory.
     pub init_cost: u64,
     /// Cost of allocating memory.
@@ -54,7 +54,7 @@ pub struct AllocationsConfig {
 impl Default for AllocationsConfig {
     fn default() -> Self {
         Self {
-            max_pages: MAX_PAGES.into(),
+            max_pages: WasmPageNumber(MAX_WASM_PAGES),
             init_cost: INIT_COST,
             alloc_cost: ALLOC_COST,
             mem_grow_cost: MEM_GROW_COST,
@@ -84,7 +84,7 @@ impl ExecutionSettings {
     }
 
     /// Max amount of pages.
-    pub fn max_pages(&self) -> PageNumber {
+    pub fn max_pages(&self) -> WasmPageNumber {
         self.config.max_pages
     }
 

--- a/core-processor/src/configs.rs
+++ b/core-processor/src/configs.rs
@@ -25,7 +25,7 @@ const MAX_WASM_PAGES: u32 = 512;
 const INIT_COST: u64 = 5000;
 const ALLOC_COST: u64 = 10000;
 const MEM_GROW_COST: u64 = 10000;
-const LOAD_PAGE_COST: u64 = 3000;
+const LOAD_PAGE_COST: u64 = 200;
 
 /// Contextual block information.
 #[derive(Clone, Copy, Debug, Encode, Decode, Default)]
@@ -103,7 +103,7 @@ impl ExecutionSettings {
         self.config.mem_grow_cost
     }
 
-    /// Load page cost.
+    /// Load gear page cost.
     pub fn load_page_cost(&self) -> u64 {
         self.config.load_page_cost
     }

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -31,7 +31,7 @@ use gear_backend_common::{BackendReport, Environment, IntoExtInfo, TerminationRe
 use gear_core::{
     env::Ext as EnvExt,
     gas::{ChargeResult, GasAllowanceCounter, GasCounter, ValueCounter},
-    memory::{pages_set_to_wasm_pages_set, AllocationsContext, WasmPageNumber},
+    memory::{pages_to_wasm_pages_set, AllocationsContext, PageNumber, WasmPageNumber},
     message::{IncomingDispatch, MessageContext},
 };
 
@@ -63,7 +63,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
     let code = program.raw_code().to_vec();
 
     let mem_size = if let Some((max_page, _)) = program.get_pages().iter().next_back() {
-        if (max_page.0 + 1) % GEAR_PAGES_IN_ONE_WASM != 0 {
+        if (max_page.0 + 1) % PageNumber::num_in_one_wasm_page() != 0 {
             log::error!(
                 "Program's max page is not last page in wasm page: {}",
                 max_page.0
@@ -334,10 +334,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
             }
         } else {
             page_update.insert(page, Some(new_data));
-            log::trace!(
-                "Page {} is a new page - will be upload to storage",
-                page.0
-            );
+            log::trace!("Page {} is a new page - will be upload to storage", page.0);
         };
     }
 

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -263,6 +263,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
             })
         }
     };
+    log::debug!("trem reason = {:?}", termination);
 
     if lazy_pages_enabled {
         // accessed lazy pages old data will be added to `initial_pages`
@@ -331,8 +332,6 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
             );
         };
     }
-
-    // log::trace!("pages to update: {:?}", page_update);
 
     // freed pages will be removed from storage
     let current_pages = &info.pages;

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -272,7 +272,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
         }
     };
 
-    log::trace!("trem reason = {:?}", termination);
+    log::trace!("term reason = {:?}", termination);
 
     if lazy_pages_enabled {
         // accessed lazy pages old data will be added to `initial_pages`

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -166,7 +166,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
 
     // Getting wasm pages allocations.
     let allocations: BTreeSet<WasmPageNumber> = if !initial_pages.is_empty() {
-        let res = pages_set_to_wasm_pages_set(&initial_pages.keys().cloned().collect());
+        let res = pages_to_wasm_pages_set(initial_pages.keys());
         if let Err(e) = res {
             return Err(ExecutionError {
                 program_id,

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -100,8 +100,8 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
         };
 
         // Charging gas for mem size
-        let amount =
-            settings.mem_grow_cost() * (max_wasm_page.0 as u64 + 1 - program.static_pages().0 as u64);
+        let amount = settings.mem_grow_cost()
+            * (max_wasm_page.0 as u64 + 1 - program.static_pages().0 as u64);
 
         if gas_allowance_counter.charge(amount) != ChargeResult::Enough {
             return Err(ExecutionError {

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -31,7 +31,7 @@ use gear_backend_common::{BackendReport, Environment, IntoExtInfo, TerminationRe
 use gear_core::{
     env::Ext as EnvExt,
     gas::{ChargeResult, GasAllowanceCounter, GasCounter, ValueCounter},
-    memory::{AllocationsContext, PageNumber, PAGE_SIZE},
+    memory::{AllocationsContext, PageNumber},
     message::{IncomingDispatch, MessageContext},
 };
 
@@ -226,7 +226,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
     // Page which is right after stack last page
     let stack_end_page = env
         .get_stack_mem_end()
-        .map(|addr| addr as u32 / PAGE_SIZE as u32);
+        .map(|addr| addr as u32 / PageNumber::size() as u32);
     log::trace!("Stack end page = {:?}", stack_end_page);
 
     // Running backend.

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -63,10 +63,10 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
     let code = program.raw_code().to_vec();
 
     let mem_size = if let Some((max_page, _)) = program.get_pages().iter().next_back() {
-        if (max_page.raw() + 1) % GEAR_PAGES_IN_ONE_WASM != 0 {
+        if (max_page.0 + 1) % GEAR_PAGES_IN_ONE_WASM != 0 {
             log::error!(
                 "Program's max page is not last page in wasm page: {}",
-                max_page.raw()
+                max_page.0
             );
             return Err(ExecutionError {
                 program_id,
@@ -237,7 +237,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
         "init memory pages = {:?}",
         initial_pages
             .iter()
-            .map(|(a, _b)| a.raw())
+            .map(|(a, _b)| a.0)
             .collect::<Vec<u32>>()
     );
 
@@ -313,7 +313,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
         // we ignore stack pages update, because they are unused after execution is ended,
         // and for next program execution old data in stack it's just garbage.
         if let Some(stack_end_page) = stack_end_page {
-            if page.raw() < stack_end_page.to_gear_pages().raw() {
+            if page.0 < stack_end_page.to_gear_pages().0 {
                 continue;
             }
         }
@@ -329,14 +329,14 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
                 page_update.insert(page, Some(new_data));
                 log::trace!(
                     "Page {} has been changed - will be updated in storage",
-                    page.raw()
+                    page.0
                 );
             }
         } else {
             page_update.insert(page, Some(new_data));
             log::trace!(
                 "Page {} is a new page - will be upload to storage",
-                page.raw()
+                page.0
             );
         };
     }

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -191,6 +191,7 @@ impl IntoExtInfo for Ext {
         mut get_page_data: F,
     ) -> Result<ExtInfo, (&'static str, GasAmount)> {
         let pages = wasm_pages_to_pages_set(self.allocations_context.allocations());
+        log::trace!("allocations = {:?}, pages = {:?}", self.allocations_context.allocations(), pages);
         let mut pages_data = BTreeMap::new();
         for page in pages.iter() {
             let mut buf = alloc::vec![0u8; PageNumber::size()];

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -23,7 +23,7 @@ use gear_core::{
     env::Ext as EnvExt,
     gas::{ChargeResult, GasAllowanceCounter, GasAmount, GasCounter, ValueCounter},
     ids::{CodeId, MessageId, ProgramId},
-    memory::{AllocationsContext, Memory, PageBuf, PageNumber},
+    memory::{AllocationsContext, Memory, PageBuf, PageNumber, WasmPageNumber, wasm_pages_to_pages_set},
     message::{ExitCode, HandlePacket, InitPacket, MessageContext, ReplyPacket},
 };
 
@@ -190,14 +190,14 @@ impl IntoExtInfo for Ext {
         self,
         mut get_page_data: F,
     ) -> Result<ExtInfo, (&'static str, GasAmount)> {
-        let accessed_pages_numbers = self.allocations_context.allocations().clone();
-        let mut accessed_pages = BTreeMap::new();
-        for page in accessed_pages_numbers {
+        let pages = wasm_pages_to_pages_set(self.allocations_context.allocations());
+        let mut pages_data = BTreeMap::new();
+        for page in pages.iter() {
             let mut buf = alloc::vec![0u8; PageNumber::size()];
             if let Err(err) = get_page_data(page.offset(), &mut buf) {
                 return Err((err, self.gas_counter.into()));
             }
-            accessed_pages.insert(page, buf);
+            pages_data.insert(*page, buf);
         }
 
         let (outcome, context_store) = self.message_context.drain();
@@ -205,8 +205,8 @@ impl IntoExtInfo for Ext {
 
         Ok(ExtInfo {
             gas_amount: self.gas_counter.into(),
-            pages: self.allocations_context.allocations().clone(),
-            accessed_pages,
+            pages,
+            pages_data,
             generated_dispatches,
             awakening,
             context_store,
@@ -237,15 +237,15 @@ impl Ext {
 impl EnvExt for Ext {
     fn alloc(
         &mut self,
-        pages_num: PageNumber,
+        pages_num: WasmPageNumber,
         mem: &mut dyn Memory,
-    ) -> Result<PageNumber, &'static str> {
+    ) -> Result<WasmPageNumber, &'static str> {
         // Greedily charge gas for allocations
-        self.charge_gas(pages_num.raw() * self.config.alloc_cost as u32)?;
+        self.charge_gas(pages_num.0 * self.config.alloc_cost as u32)?;
         // Greedily charge gas for grow
-        self.charge_gas(pages_num.raw() * self.config.mem_grow_cost as u32)?;
+        self.charge_gas(pages_num.0 * self.config.mem_grow_cost as u32)?;
 
-        let old_mem_size = mem.size().raw();
+        let old_mem_size = mem.size();
 
         let result = self
             .allocations_context
@@ -255,22 +255,22 @@ impl EnvExt for Ext {
         let page_number = self.return_and_store_err(result)?;
 
         // Returns back greedily used gas for grow
-        let new_mem_size = mem.size().raw();
+        let new_mem_size = mem.size();
         let grow_pages_num = new_mem_size - old_mem_size;
         let mut gas_to_return_back =
-            self.config.mem_grow_cost * (pages_num.raw() - grow_pages_num) as u64;
+            self.config.mem_grow_cost * (pages_num - grow_pages_num).0 as u64;
 
         // Returns back greedily used gas for allocations
-        let first_page = page_number.raw();
-        let last_page = first_page + pages_num.raw() - 1;
+        let first_page = page_number;
+        let last_page = first_page + pages_num - 1.into();
         let mut new_alloced_pages_num = 0;
-        for page in first_page..=last_page {
+        for page in first_page.0..=last_page.0 {
             if !self.allocations_context.is_init_page(page.into()) {
                 new_alloced_pages_num += 1;
             }
         }
         gas_to_return_back +=
-            self.config.alloc_cost * (pages_num.raw() - new_alloced_pages_num) as u64;
+            self.config.alloc_cost * (pages_num.0 - new_alloced_pages_num) as u64;
 
         self.refund_gas(gas_to_return_back as u32)?;
 
@@ -384,14 +384,14 @@ impl EnvExt for Ext {
         self.program_id
     }
 
-    fn free(&mut self, ptr: PageNumber) -> Result<(), &'static str> {
+    fn free(&mut self, page: WasmPageNumber) -> Result<(), &'static str> {
         let result = self
             .allocations_context
-            .free(ptr)
+            .free(page)
             .map_err(|_e| "Free error");
 
         // Returns back gas for allocated page if it's new
-        if !self.allocations_context.is_init_page(ptr) {
+        if !self.allocations_context.is_init_page(page) {
             self.refund_gas(self.config.alloc_cost as u32)?;
         }
 

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -186,11 +186,6 @@ impl IntoExtInfo for Ext {
         mut get_page_data: F,
     ) -> Result<ExtInfo, (&'static str, GasAmount)> {
         let pages = wasm_pages_to_pages_set(self.allocations_context.allocations().iter());
-        log::trace!(
-            "allocations = {:?}, pages = {:?}",
-            self.allocations_context.allocations(),
-            pages
-        );
         let mut pages_data = BTreeMap::new();
         for page in pages.iter() {
             let mut buf = alloc::vec![0u8; PageNumber::size()];

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -185,7 +185,7 @@ impl IntoExtInfo for Ext {
         self,
         mut get_page_data: F,
     ) -> Result<ExtInfo, (&'static str, GasAmount)> {
-        let pages = wasm_pages_to_pages_set(self.allocations_context.allocations());
+        let pages = wasm_pages_to_pages_set(self.allocations_context.allocations().iter());
         log::trace!(
             "allocations = {:?}, pages = {:?}",
             self.allocations_context.allocations(),

--- a/core-processor/src/handler.rs
+++ b/core-processor/src/handler.rs
@@ -28,7 +28,6 @@ pub fn handle_journal(
     let mut exit_list = vec![];
 
     for note in journal.into_iter() {
-        log::debug!("note = {:?}", note);
         match note {
             JournalNote::MessageDispatched(outcome) => handler.message_dispatched(outcome),
             JournalNote::GasBurned { message_id, amount } => handler.gas_burned(message_id, amount),

--- a/core-processor/src/handler.rs
+++ b/core-processor/src/handler.rs
@@ -28,6 +28,7 @@ pub fn handle_journal(
     let mut exit_list = vec![];
 
     for note in journal.into_iter() {
+        log::debug!("note = {:?}", note);
         match note {
             JournalNote::MessageDispatched(outcome) => handler.message_dispatched(outcome),
             JournalNote::GasBurned { message_id, amount } => handler.gas_burned(message_id, amount),

--- a/core/src/code.rs
+++ b/core/src/code.rs
@@ -99,7 +99,7 @@ impl Code {
                     }
                     _ => None,
                 })
-                .ok_or(CodeError::CheckError)?
+                .ok_or(CodeError::CheckError)?,
         );
 
         let instrumented_module = wasm_instrument::gas_metering::inject(module, &gas_rules, "env")

--- a/core/src/code.rs
+++ b/core/src/code.rs
@@ -48,6 +48,8 @@ pub enum CodeError {
     Encode,
 }
 
+use crate::memory::WasmPageNumber;
+
 /// Contains instrumented binary code of a program and initial memory size from memory import.
 #[derive(Clone, Debug, Decode, Encode, PartialEq, Eq)]
 pub struct Code {
@@ -66,8 +68,7 @@ pub struct Code {
     /// when loading the code from storage.
     #[codec(skip)]
     code_hash: CodeId,
-    #[codec(compact)]
-    static_pages: u32,
+    static_pages: WasmPageNumber,
     #[codec(compact)]
     instruction_weights_version: u32,
 }
@@ -86,7 +87,7 @@ impl Code {
         );
 
         // get initial memory size from memory import.
-        let static_pages: u32 = {
+        let static_pages = WasmPageNumber(
             module
                 .import_section()
                 .ok_or(CodeError::CheckError)?
@@ -99,7 +100,7 @@ impl Code {
                     _ => None,
                 })
                 .ok_or(CodeError::CheckError)?
-        };
+        );
 
         let instrumented_module = wasm_instrument::gas_metering::inject(module, &gas_rules, "env")
             .map_err(|_| CodeError::GasInjection)?;
@@ -144,7 +145,7 @@ impl Code {
     }
 
     /// Returns initial memory size from memory import.
-    pub fn static_pages(&self) -> u32 {
+    pub fn static_pages(&self) -> WasmPageNumber {
         self.static_pages
     }
 }

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -18,10 +18,9 @@
 
 //! Environment for running a module.
 
-use crate::memory::Memory;
+use crate::memory::{Memory, WasmPageNumber};
 use crate::{
     ids::{MessageId, ProgramId},
-    memory::PageNumber,
     message::{ExitCode, HandlePacket, InitPacket, ReplyPacket},
 };
 use alloc::rc::Rc;
@@ -47,9 +46,9 @@ pub trait Ext {
     /// The resulting page number should point to `pages` consecutives memory pages.
     fn alloc(
         &mut self,
-        pages: PageNumber,
+        pages: WasmPageNumber,
         mem: &mut dyn Memory,
-    ) -> Result<PageNumber, &'static str>;
+    ) -> Result<WasmPageNumber, &'static str>;
 
     /// Get the current block height.
     fn block_height(&self) -> u32;
@@ -106,7 +105,7 @@ pub trait Ext {
     ///
     /// Unlike traditional allocator, if multiple pages allocated via `alloc`, all pages
     /// should be `free`-d separately.
-    fn free(&mut self, ptr: PageNumber) -> Result<(), &'static str>;
+    fn free(&mut self, page: WasmPageNumber) -> Result<(), &'static str>;
 
     /// Send debug message.
     ///
@@ -214,9 +213,9 @@ mod tests {
     impl Ext for ExtImplementedStruct {
         fn alloc(
             &mut self,
-            _pages: PageNumber,
+            _pages: WasmPageNumber,
             _mem: &mut dyn Memory,
-        ) -> Result<PageNumber, &'static str> {
+        ) -> Result<WasmPageNumber, &'static str> {
             Err("")
         }
         fn block_height(&self) -> u32 {
@@ -262,7 +261,7 @@ mod tests {
         fn program_id(&self) -> ProgramId {
             0.into()
         }
-        fn free(&mut self, _ptr: PageNumber) -> Result<(), &'static str> {
+        fn free(&mut self, _page: WasmPageNumber) -> Result<(), &'static str> {
             Ok(())
         }
         fn debug(&mut self, _data: &str) -> Result<(), &'static str> {

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -21,8 +21,11 @@
 use alloc::collections::BTreeSet;
 use codec::{Decode, Encode};
 
-/// A WebAssembly page has a constant size of 65,536 bytes, i.e., 64KiB.
-pub const PAGE_SIZE: usize = 65536;
+/// A WebAssembly page has a constant size of 64KiB.
+pub const WASM_PAGE_SIZE: usize = 0x10000;
+
+/// A gear page size - part of wasm page size.
+const GEAR_PAGE_SIZE: usize = 0x10000;
 
 /// Memory error.
 #[derive(Clone, Debug)]
@@ -50,7 +53,7 @@ pub enum Error {
 }
 
 /// Page buffer.
-pub type PageBuf = [u8; PAGE_SIZE];
+pub type PageBuf = [u8; GEAR_PAGE_SIZE];
 
 /// Page number.
 #[derive(
@@ -66,12 +69,12 @@ impl PageNumber {
 
     /// Return page offset.
     pub fn offset(&self) -> usize {
-        (self.0 as usize) * PAGE_SIZE
+        (self.0 as usize) * PageNumber::size()
     }
 
     /// Return page size in bytes.
     pub fn size() -> usize {
-        PAGE_SIZE
+        GEAR_PAGE_SIZE
     }
 }
 

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -152,7 +152,8 @@ pub fn pages_set_to_wasm_pages_set(pages: &BTreeSet<PageNumber>) -> Result<BTree
 pub fn wasm_pages_to_pages_set(wasm_pages: &BTreeSet<WasmPageNumber>) -> BTreeSet<PageNumber> {
     let mut pages = BTreeSet::<PageNumber>::new();
     for page in wasm_pages {
-        pages.extend((page.0..page.0 + GEAR_PAGES_IN_ONE_WASM).map(|p| PageNumber::from(p)));
+        let gear_page = page.to_gear_pages().0;
+        pages.extend((gear_page..gear_page + GEAR_PAGES_IN_ONE_WASM).map(|p| PageNumber::from(p)));
     }
     pages
 }

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -19,7 +19,7 @@
 //! Module for memory and allocations context.
 
 use alloc::collections::BTreeSet;
-use codec::{Decode, Encode, HasCompact};
+use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 
 /// A WebAssembly page has a constant size of 64KiB.

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -76,11 +76,6 @@ pub type PageBuf = [u8; GEAR_PAGE_SIZE];
 pub struct PageNumber(pub u32);
 
 impl PageNumber {
-    /// Return raw 32-bit page address.
-    pub fn raw(&self) -> u32 {
-        self.0
-    }
-
     /// Return page offset.
     pub fn offset(&self) -> usize {
         (self.0 as usize) * PageNumber::size()
@@ -172,10 +167,10 @@ pub fn pages_to_wasm_pages_set<'a>(
 ) -> Result<BTreeSet<WasmPageNumber>, &'static str> {
     let mut wasm_pages = BTreeSet::<WasmPageNumber>::new();
     while let Some(page) = pages_iter.next() {
-        if page.raw() % GEAR_PAGES_IN_ONE_WASM != 0 {
+        if page.0 % GEAR_PAGES_IN_ONE_WASM != 0 {
             return Err("There is wasm page, which has not all gear pages in the begin");
         }
-        let wasm_page_num = WasmPageNumber(page.raw() / GEAR_PAGES_IN_ONE_WASM);
+        let wasm_page_num = WasmPageNumber(page.0 / GEAR_PAGES_IN_ONE_WASM);
         wasm_pages.insert(wasm_page_num);
         for _ in 0..(WASM_PAGE_SIZE / PageNumber::size() - 1) {
             pages_iter

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -167,19 +167,19 @@ impl core::ops::Sub for WasmPageNumber {
 }
 
 /// TODO
-pub fn pages_set_to_wasm_pages_set(
-    pages: &BTreeSet<PageNumber>,
+pub fn pages_to_wasm_pages_set<'a>(
+    mut pages_iter: impl Iterator<Item = &'a PageNumber>,
 ) -> Result<BTreeSet<WasmPageNumber>, &'static str> {
     let mut wasm_pages = BTreeSet::<WasmPageNumber>::new();
-    let mut iter = pages.iter();
-    while let Some(page) = iter.next() {
+    while let Some(page) = pages_iter.next() {
         if page.raw() % GEAR_PAGES_IN_ONE_WASM != 0 {
             return Err("There is wasm page, which has not all gear pages in the begin");
         }
         let wasm_page_num = WasmPageNumber(page.raw() / GEAR_PAGES_IN_ONE_WASM);
         wasm_pages.insert(wasm_page_num);
         for _ in 0..(WASM_PAGE_SIZE / PageNumber::size() - 1) {
-            iter.next()
+            pages_iter
+                .next()
                 .expect("There is wasm page, which has not all gear pages in the end");
         }
     }
@@ -187,9 +187,11 @@ pub fn pages_set_to_wasm_pages_set(
 }
 
 /// TODO
-pub fn wasm_pages_to_pages_set(wasm_pages: &BTreeSet<WasmPageNumber>) -> BTreeSet<PageNumber> {
+pub fn wasm_pages_to_pages_set<'a>(
+    wasm_pages_iter: impl Iterator<Item = &'a WasmPageNumber>,
+) -> BTreeSet<PageNumber> {
     let mut pages = BTreeSet::<PageNumber>::new();
-    for page in wasm_pages {
+    for page in wasm_pages_iter {
         let gear_page = page.to_gear_pages().0;
         pages.extend((gear_page..gear_page + GEAR_PAGES_IN_ONE_WASM).map(PageNumber));
     }

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -21,7 +21,7 @@
 use crate::{
     code::Code,
     ids::ProgramId,
-    memory::{PageBuf, PageNumber},
+    memory::{PageBuf, PageNumber, WasmPageNumber},
 };
 use alloc::{boxed::Box, collections::BTreeMap, collections::BTreeSet, vec::Vec};
 use anyhow::Result;
@@ -84,7 +84,7 @@ impl Program {
     }
 
     /// Get initial memory size for this program.
-    pub fn static_pages(&self) -> u32 {
+    pub fn static_pages(&self) -> WasmPageNumber {
         self.code.static_pages()
     }
 
@@ -227,7 +227,7 @@ mod tests {
         let mut program = Program::new(ProgramId::from(1), code);
 
         // 2 static pages
-        assert_eq!(program.static_pages(), 2);
+        assert_eq!(program.static_pages(), 2.into());
 
         assert!(program.set_page(1.into(), &[0; 123]).is_err());
 

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -54,7 +54,7 @@ impl Program {
     pub fn from_parts(
         id: ProgramId,
         code: Code,
-        persistent_pages_numbers: BTreeSet<u32>,
+        persistent_pages_numbers: BTreeSet<PageNumber>,
         is_initialized: bool,
     ) -> Self {
         Self {
@@ -62,7 +62,7 @@ impl Program {
             code,
             persistent_pages: persistent_pages_numbers
                 .into_iter()
-                .map(|k| (k.into(), None))
+                .map(|k| (k, None))
                 .collect(),
             is_initialized,
         }
@@ -173,6 +173,7 @@ mod tests {
     use super::Program;
     use crate::code::Code;
     use crate::ids::ProgramId;
+    use crate::memory::PageNumber;
     use alloc::{vec, vec::Vec};
 
     fn parse_wat(source: &str) -> Vec<u8> {
@@ -231,7 +232,9 @@ mod tests {
 
         assert!(program.set_page(1.into(), &[0; 123]).is_err());
 
-        assert!(program.set_page(1.into(), &vec![0; 65536]).is_ok());
+        assert!(program
+            .set_page(1.into(), &vec![0; PageNumber::size()])
+            .is_ok());
         assert_eq!(program.get_pages().len(), 1);
     }
 }

--- a/examples/binaries/program-factory/src/lib.rs
+++ b/examples/binaries/program-factory/src/lib.rs
@@ -123,6 +123,7 @@ mod tests {
     #[test]
     fn test_simple() {
         let sys = System::new();
+        sys.init_logger();
         let factory = prepare_factory(&sys);
 
         let child_id_expected = calculate_program_id(CHILD_CODE_HASH.into(), &0i32.to_le_bytes());

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -66,7 +66,9 @@ pub struct FixtureLogger {
 impl FixtureLogger {
     fn new(map: Arc<RwLock<HashMap<ThreadId, Vec<String>>>>) -> FixtureLogger {
         let mut builder = Builder::from_env(FILTER_ENV);
-        builder.parse("gear_test=debug,gear_core=debug,gear_backend_common=debug,gwasm=debug");
+        builder.parse(
+            "gear_test=debug,gear_core=debug,gear_backend_common=debug,gear_backend_wasmtime=debug,gear_backend_sandbox=debug,gear_core_processor=debug,gwasm=debug",
+        );
 
         FixtureLogger {
             inner: builder.build(),

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -343,8 +343,8 @@ pub fn check_allocations(
                 .get_pages()
                 .iter()
                 .filter(|(page, _buf)| match exp.filter {
-                    Some(AllocationFilter::Static) => page.raw() < program.static_pages(),
-                    Some(AllocationFilter::Dynamic) => page.raw() >= program.static_pages(),
+                    Some(AllocationFilter::Static) => **page < program.static_pages().to_gear_pages(),
+                    Some(AllocationFilter::Dynamic) => **page >= program.static_pages().to_gear_pages(),
                     None => true,
                 })
                 .collect::<Vec<_>>();

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -30,7 +30,7 @@ use env_logger::filter::{Builder, Filter};
 use gear_backend_common::Environment;
 use gear_core::code::Code;
 use gear_core::ids::CodeId;
-use gear_core::memory::{PageNumber, pages_set_to_wasm_pages_set};
+use gear_core::memory::{pages_set_to_wasm_pages_set, PageNumber};
 use gear_core::{
     ids::{MessageId, ProgramId},
     message::*,
@@ -66,9 +66,7 @@ pub struct FixtureLogger {
 impl FixtureLogger {
     fn new(map: Arc<RwLock<HashMap<ThreadId, Vec<String>>>>) -> FixtureLogger {
         let mut builder = Builder::from_env(FILTER_ENV);
-        builder.parse(
-            "gear_test=debug,gear_core=debug,gear_backend_common=debug,gwasm=debug",
-        );
+        builder.parse("gear_test=debug,gear_core=debug,gear_backend_common=debug,gwasm=debug");
 
         FixtureLogger {
             inner: builder.build(),
@@ -343,14 +341,19 @@ pub fn check_allocations(
                 .get_pages()
                 .iter()
                 .filter(|(page, _buf)| match exp.filter {
-                    Some(AllocationFilter::Static) => **page < program.static_pages().to_gear_pages(),
-                    Some(AllocationFilter::Dynamic) => **page >= program.static_pages().to_gear_pages(),
+                    Some(AllocationFilter::Static) => {
+                        **page < program.static_pages().to_gear_pages()
+                    }
+                    Some(AllocationFilter::Dynamic) => {
+                        **page >= program.static_pages().to_gear_pages()
+                    }
                     None => true,
                 })
                 .map(|(page, _buf)| *page)
                 .collect::<BTreeSet<_>>();
 
-            let actual_pages = pages_set_to_wasm_pages_set(&actual_pages).expect("unexpected pages");
+            let actual_pages =
+                pages_set_to_wasm_pages_set(&actual_pages).expect("unexpected pages");
 
             match exp.kind {
                 AllocationExpectationKind::PageCount(expected_page_count) => {
@@ -364,10 +367,8 @@ pub fn check_allocations(
                     }
                 }
                 AllocationExpectationKind::ExactPages(ref expected_pages) => {
-                    let mut actual_pages = actual_pages
-                        .iter()
-                        .map(|page| page.0)
-                        .collect::<Vec<_>>();
+                    let mut actual_pages =
+                        actual_pages.iter().map(|page| page.0).collect::<Vec<_>>();
                     let mut expected_pages = expected_pages.clone();
 
                     actual_pages.sort_unstable();

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -30,9 +30,9 @@ use env_logger::filter::{Builder, Filter};
 use gear_backend_common::Environment;
 use gear_core::code::Code;
 use gear_core::ids::CodeId;
+use gear_core::memory::PageNumber;
 use gear_core::{
     ids::{MessageId, ProgramId},
-    memory::PAGE_SIZE,
     message::*,
     program::Program,
 };
@@ -418,12 +418,11 @@ pub fn check_memory(
     for case in expected_memory {
         for p in &mut *program_storage {
             if p.id() == case.id.to_program_id() {
-                let page = case.address / PAGE_SIZE;
+                let page = case.address / PageNumber::size();
                 if let Some(page_buf) = p.get_page_data((page as u32).into()) {
-                    if page_buf[case.address - page * PAGE_SIZE
-                        ..(case.address - page * PAGE_SIZE) + case.bytes.len()]
-                        != case.bytes
-                    {
+                    let begin_byte = case.address - page * PageNumber::size();
+                    let end_byte = begin_byte + case.bytes.len();
+                    if page_buf[begin_byte..end_byte] != case.bytes {
                         errors.push("Expectation error (Static memory doesn't match)".to_string());
                     }
                 } else {

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -30,7 +30,7 @@ use env_logger::filter::{Builder, Filter};
 use gear_backend_common::Environment;
 use gear_core::code::Code;
 use gear_core::ids::CodeId;
-use gear_core::memory::{pages_set_to_wasm_pages_set, PageNumber};
+use gear_core::memory::{pages_to_wasm_pages_set, PageNumber};
 use gear_core::{
     ids::{MessageId, ProgramId},
     message::*,
@@ -353,7 +353,7 @@ pub fn check_allocations(
                 .collect::<BTreeSet<_>>();
 
             let actual_pages =
-                pages_set_to_wasm_pages_set(&actual_pages).expect("unexpected pages");
+                pages_to_wasm_pages_set(actual_pages.iter()).expect("unexpected pages");
 
             match exp.kind {
                 AllocationExpectationKind::PageCount(expected_page_count) => {

--- a/gear-test/src/proc.rs
+++ b/gear-test/src/proc.rs
@@ -91,7 +91,7 @@ where
     )
     .map_err(|e| anyhow::anyhow!("Error initialisation: {:?}", &e))?;
 
-    if code.static_pages() > AllocationsConfig::default().max_pages.raw() {
+    if code.static_pages() > AllocationsConfig::default().max_pages {
         return Err(anyhow::anyhow!(
             "Error initialisation: memory limit exceeded"
         ));

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -272,7 +272,6 @@ impl ExtManager {
     }
 
     fn mark_failed(&mut self, msg_id: MessageId) {
-        // panic!("LOL");
         if self.msg_id == msg_id {
             self.main_failed = true;
         } else {

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -272,6 +272,7 @@ impl ExtManager {
     }
 
     fn mark_failed(&mut self, msg_id: MessageId) {
+        // panic!("LOL");
         if self.msg_id == msg_id {
             self.main_failed = true;
         } else {

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -49,13 +49,13 @@ thread_local! {
 }
 
 /// Save page key in storage
-pub fn save_page_lazy_info(wasm_page: u32, key: &[u8]) {
+pub fn save_page_lazy_info(page: u32, key: &[u8]) {
     LAZY_PAGES_INFO
-        .with(|lazy_pages_info| lazy_pages_info.borrow_mut().insert(wasm_page, key.to_vec()));
+        .with(|lazy_pages_info| lazy_pages_info.borrow_mut().insert(page, key.to_vec()));
 }
 
 /// Returns vec of not-accessed wasm lazy pages
-pub fn get_wasm_lazy_pages_numbers() -> Vec<u32> {
+pub fn get_lazy_pages_numbers() -> Vec<u32> {
     LAZY_PAGES_INFO.with(|lazy_pages_info| lazy_pages_info.borrow().iter().map(|x| *x.0).collect())
 }
 

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -50,8 +50,7 @@ thread_local! {
 
 /// Save page key in storage
 pub fn save_page_lazy_info(page: u32, key: &[u8]) {
-    LAZY_PAGES_INFO
-        .with(|lazy_pages_info| lazy_pages_info.borrow_mut().insert(page, key.to_vec()));
+    LAZY_PAGES_INFO.with(|lazy_pages_info| lazy_pages_info.borrow_mut().insert(page, key.to_vec()));
 }
 
 /// Returns vec of not-accessed wasm lazy pages

--- a/lazy-pages/src/unix.rs
+++ b/lazy-pages/src/unix.rs
@@ -66,7 +66,7 @@ extern "C" fn handle_sigsegv(_x: i32, info: *mut siginfo_t, _z: *mut c_void) {
             (gear_page, 1usize, wasm_mem_begin + gear_page.offset())
         };
 
-        log::debug!(target: "gear_node::sig_handler", "mem={:?} gear_page={} pages_num={} page_addr={:#x}", mem, res.0.raw(), res.1, res.2);
+        log::debug!(target: "gear_node::sig_handler", "mem={:?} gear_page={} pages_num={} page_addr={:#x}", mem, res.0.0, res.1, res.2);
 
         res
     };
@@ -87,7 +87,7 @@ extern "C" fn handle_sigsegv(_x: i32, info: *mut siginfo_t, _z: *mut c_void) {
     );
 
     for idx in 0..gear_pages_num as u32 {
-        let page = gear_page.raw() + idx;
+        let page = gear_page.0 + idx;
 
         let hash_key_in_storage = LAZY_PAGES_INFO
             .with(|info| info.borrow_mut().remove(&page))

--- a/lazy-pages/src/unix.rs
+++ b/lazy-pages/src/unix.rs
@@ -18,7 +18,7 @@
 
 //! Lazy pages support in unix.
 
-use gear_core::memory::{PageNumber, WASM_PAGE_SIZE};
+use gear_core::memory::{PageNumber, WasmPageNumber};
 use libc::{c_void, siginfo_t};
 use nix::sys::signal;
 
@@ -142,8 +142,8 @@ pub unsafe fn init_lazy_pages() -> bool {
     }
 
     let ps = page_size::get();
-    if ps > WASM_PAGE_SIZE
-        || WASM_PAGE_SIZE % ps != 0
+    if ps > WasmPageNumber::size()
+        || WasmPageNumber::size() % ps != 0
         || (ps > PageNumber::size() && ps % PageNumber::size() != 0)
         || (ps < PageNumber::size() && PageNumber::size() % ps != 0)
     {

--- a/lazy-pages/src/unix.rs
+++ b/lazy-pages/src/unix.rs
@@ -108,9 +108,7 @@ extern "C" fn handle_sigsegv(_x: i32, info: *mut siginfo_t, _z: *mut c_void) {
         );
 
         RELEASED_LAZY_PAGES.with(|rpages| {
-            let res = rpages
-                .borrow_mut()
-                .insert(page, buffer_as_slice.to_vec());
+            let res = rpages.borrow_mut().insert(page, buffer_as_slice.to_vec());
             assert!(res.is_none(), "Any page cannot be released twice");
         });
     }

--- a/pallets/gear-debug/src/lib.rs
+++ b/pallets/gear-debug/src/lib.rs
@@ -45,6 +45,7 @@ pub mod pallet {
     use frame_system::pallet_prelude::*;
     use gear_core::{
         ids::ProgramId,
+        memory::{PageNumber, WasmPageNumber},
         message::{StoredDispatch, StoredMessage},
     };
     use primitive_types::H256;
@@ -81,8 +82,8 @@ pub mod pallet {
 
     #[derive(Encode, Decode, Clone, Default, PartialEq, TypeInfo)]
     pub struct ProgramInfo {
-        pub static_pages: u32,
-        pub persistent_pages: BTreeMap<u32, Vec<u8>>,
+        pub static_pages: WasmPageNumber,
+        pub persistent_pages: BTreeMap<PageNumber, Vec<u8>>,
         pub code_hash: H256,
     }
 
@@ -92,7 +93,7 @@ pub mod pallet {
                 .field("static_pages", &self.static_pages)
                 .field(
                     "persistent_pages",
-                    &self.persistent_pages.keys().cloned().collect::<Vec<u32>>(),
+                    &self.persistent_pages.keys().cloned().collect::<Vec<_>>(),
                 )
                 .field("code_hash", &self.code_hash)
                 .finish()

--- a/pallets/gear-debug/src/tests.rs
+++ b/pallets/gear-debug/src/tests.rs
@@ -24,6 +24,7 @@ use common::{self, Origin as _};
 use frame_system::Pallet as SystemPallet;
 use gear_core::{
     ids::{CodeId, MessageId, ProgramId},
+    memory::{PageNumber, WasmPageNumber},
     message::{DispatchKind, StoredDispatch, StoredMessage},
 };
 use pallet_gear::DebugInfo;
@@ -103,14 +104,17 @@ fn debug_mode_works() {
 
         Pallet::<Test>::do_snapshot();
 
+        let static_pages = WasmPageNumber(16);
         System::assert_last_event(
             crate::Event::DebugDataSnapshot(DebugData {
                 dispatch_queue: vec![],
                 programs: vec![crate::ProgramDetails {
                     id: program_id_1,
                     state: crate::ProgramState::Active(crate::ProgramInfo {
-                        static_pages: 16,
-                        persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
+                        static_pages,
+                        persistent_pages: (0..static_pages.to_gear_pages().0)
+                            .map(|v| (PageNumber(v), vec![0; PageNumber::size()]))
+                            .collect(),
                         code_hash: generate_code_hash(&code_1),
                     }),
                 }],
@@ -139,16 +143,20 @@ fn debug_mode_works() {
                     crate::ProgramDetails {
                         id: program_id_2,
                         state: crate::ProgramState::Active(crate::ProgramInfo {
-                            static_pages: 16,
-                            persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
+                            static_pages,
+                            persistent_pages: (0..static_pages.to_gear_pages().0)
+                            .map(|v| (PageNumber(v), vec![0; PageNumber::size()]))
+                            .collect(),
                             code_hash: generate_code_hash(&code_2),
                         }),
                     },
                     crate::ProgramDetails {
                         id: program_id_1,
                         state: crate::ProgramState::Active(crate::ProgramInfo {
-                            static_pages: 16,
-                            persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
+                            static_pages,
+                            persistent_pages: (0..static_pages.to_gear_pages().0)
+                            .map(|v| (PageNumber(v), vec![0; PageNumber::size()]))
+                            .collect(),
                             code_hash: generate_code_hash(&code_1),
                         }),
                     },
@@ -215,16 +223,20 @@ fn debug_mode_works() {
                     crate::ProgramDetails {
                         id: program_id_2,
                         state: crate::ProgramState::Active(crate::ProgramInfo {
-                            static_pages: 16,
-                            persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
+                            static_pages,
+                            persistent_pages: (0..static_pages.to_gear_pages().0)
+                            .map(|v| (PageNumber(v), vec![0; PageNumber::size()]))
+                            .collect(),
                             code_hash: generate_code_hash(&code_2),
                         }),
                     },
                     crate::ProgramDetails {
                         id: program_id_1,
                         state: crate::ProgramState::Active(crate::ProgramInfo {
-                            static_pages: 16,
-                            persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
+                            static_pages,
+                            persistent_pages: (0..static_pages.to_gear_pages().0)
+                            .map(|v| (PageNumber(v), vec![0; PageNumber::size()]))
+                            .collect(),
                             code_hash: generate_code_hash(&code_1),
                         }),
                     },
@@ -244,16 +256,20 @@ fn debug_mode_works() {
                     crate::ProgramDetails {
                         id: program_id_2,
                         state: crate::ProgramState::Active(crate::ProgramInfo {
-                            static_pages: 16,
-                            persistent_pages: (0..20).map(|v| (v, vec![0; 65536])).collect(),
+                            static_pages,
+                            persistent_pages: (0..WasmPageNumber(20).to_gear_pages().0)
+                                .map(|v| (PageNumber(v), vec![0; PageNumber::size()]))
+                                .collect(),
                             code_hash: generate_code_hash(&code_2),
                         }),
                     },
                     crate::ProgramDetails {
                         id: program_id_1,
                         state: crate::ProgramState::Active(crate::ProgramInfo {
-                            static_pages: 16,
-                            persistent_pages: (0..16).map(|v| (v, vec![0; 65536])).collect(),
+                            static_pages,
+                            persistent_pages: (0..static_pages.to_gear_pages().0)
+                                .map(|v| (PageNumber(v), vec![0; PageNumber::size()]))
+                                .collect(),
                             code_hash: generate_code_hash(&code_1),
                         }),
                     },

--- a/pallets/gear-debug/src/tests.rs
+++ b/pallets/gear-debug/src/tests.rs
@@ -145,8 +145,8 @@ fn debug_mode_works() {
                         state: crate::ProgramState::Active(crate::ProgramInfo {
                             static_pages,
                             persistent_pages: (0..static_pages.to_gear_pages().0)
-                            .map(|v| (PageNumber(v), vec![0; PageNumber::size()]))
-                            .collect(),
+                                .map(|v| (PageNumber(v), vec![0; PageNumber::size()]))
+                                .collect(),
                             code_hash: generate_code_hash(&code_2),
                         }),
                     },
@@ -155,8 +155,8 @@ fn debug_mode_works() {
                         state: crate::ProgramState::Active(crate::ProgramInfo {
                             static_pages,
                             persistent_pages: (0..static_pages.to_gear_pages().0)
-                            .map(|v| (PageNumber(v), vec![0; PageNumber::size()]))
-                            .collect(),
+                                .map(|v| (PageNumber(v), vec![0; PageNumber::size()]))
+                                .collect(),
                             code_hash: generate_code_hash(&code_1),
                         }),
                     },
@@ -225,8 +225,8 @@ fn debug_mode_works() {
                         state: crate::ProgramState::Active(crate::ProgramInfo {
                             static_pages,
                             persistent_pages: (0..static_pages.to_gear_pages().0)
-                            .map(|v| (PageNumber(v), vec![0; PageNumber::size()]))
-                            .collect(),
+                                .map(|v| (PageNumber(v), vec![0; PageNumber::size()]))
+                                .collect(),
                             code_hash: generate_code_hash(&code_2),
                         }),
                     },
@@ -235,8 +235,8 @@ fn debug_mode_works() {
                         state: crate::ProgramState::Active(crate::ProgramInfo {
                             static_pages,
                             persistent_pages: (0..static_pages.to_gear_pages().0)
-                            .map(|v| (PageNumber(v), vec![0; PageNumber::size()]))
-                            .collect(),
+                                .map(|v| (PageNumber(v), vec![0; PageNumber::size()]))
+                                .collect(),
                             code_hash: generate_code_hash(&code_1),
                         }),
                     },

--- a/pallets/gear-program/src/lib.rs
+++ b/pallets/gear-program/src/lib.rs
@@ -50,6 +50,7 @@ pub mod pallet {
         },
     };
     use frame_system::pallet_prelude::*;
+    use gear_core::memory::PageNumber;
     use sp_runtime::traits::{UniqueSaturatedInto, Zero};
     use weights::WeightInfo;
 
@@ -118,7 +119,7 @@ pub mod pallet {
         pub fn resume_program(
             origin: OriginFor<T>,
             program_id: H256,
-            memory_pages: BTreeMap<u32, Vec<u8>>,
+            memory_pages: BTreeMap<PageNumber, Vec<u8>>,
             wait_list: BTreeMap<H256, gear_core::message::StoredDispatch>,
             value: BalanceOf<T>,
         ) -> DispatchResultWithPostInfo {

--- a/pallets/gear-program/src/pause.rs
+++ b/pallets/gear-program/src/pause.rs
@@ -20,7 +20,7 @@ use super::*;
 use codec::{Decode, Encode};
 use common::Origin as _;
 use frame_support::{dispatch::DispatchResult, storage::PrefixIterator};
-use gear_core::message::StoredDispatch;
+use gear_core::{memory::PageNumber, message::StoredDispatch};
 use scale_info::TypeInfo;
 
 #[derive(Clone, Debug, PartialEq, Decode, Encode, TypeInfo)]
@@ -36,7 +36,7 @@ fn decode_dispatch_tuple(_key: &[u8], value: &[u8]) -> Result<(StoredDispatch, u
     <(StoredDispatch, u32)>::decode(&mut &*value)
 }
 
-fn memory_pages_hash(pages: &BTreeMap<u32, Vec<u8>>) -> H256 {
+fn memory_pages_hash(pages: &BTreeMap<PageNumber, Vec<u8>>) -> H256 {
     pages.using_encoded(sp_io::hashing::blake2_256).into()
 }
 
@@ -94,7 +94,7 @@ impl<T: Config> pallet::Pallet<T> {
 
     pub(super) fn resume_program_impl(
         program_id: H256,
-        memory_pages: BTreeMap<u32, Vec<u8>>,
+        memory_pages: BTreeMap<PageNumber, Vec<u8>>,
         wait_list: BTreeMap<H256, StoredDispatch>,
         block_number: u32,
     ) -> DispatchResult {

--- a/pallets/gear-program/src/tests.rs
+++ b/pallets/gear-program/src/tests.rs
@@ -21,6 +21,7 @@ use frame_support::{assert_noop, assert_ok};
 use gear_core::{
     code::Code,
     ids::{CodeId, MessageId, ProgramId},
+    memory::{PageNumber, WasmPageNumber},
     message::{DispatchKind, StoredDispatch, StoredMessage},
 };
 use hex_literal::hex;
@@ -47,13 +48,22 @@ fn pause_program_works() {
 
         common::set_code(code_hash, &code);
 
-        let static_pages: u32 = 16;
+        let wasm_static_pages = WasmPageNumber(16);
+        let static_pages = wasm_static_pages.to_gear_pages();
         let memory_pages = {
             let mut pages = BTreeMap::new();
-            pages.insert(static_pages, vec![static_pages as u8]);
-            pages.insert(static_pages + 2, vec![static_pages as u8 + 2]);
-            for i in 0..static_pages {
-                pages.insert(i, vec![i as u8]);
+            for i in 0..PageNumber::num_in_one_wasm_page() {
+                pages.insert(
+                    static_pages + PageNumber(i),
+                    vec![wasm_static_pages.0 as u8],
+                );
+                pages.insert(
+                    static_pages + PageNumber(i + 2 * PageNumber::num_in_one_wasm_page()),
+                    vec![wasm_static_pages.0 as u8 + 2],
+                );
+            }
+            for i in 0..static_pages.0 {
+                pages.insert(i.into(), vec![i as u8]);
             }
 
             pages
@@ -64,7 +74,7 @@ fn pause_program_works() {
         common::set_program(
             program_id,
             ActiveProgram {
-                static_pages: static_pages.into(),
+                static_pages: static_pages.to_wasm_page(),
                 persistent_pages: memory_pages.clone().into_keys().collect(),
                 code_hash,
                 state: ProgramState::Initialized,
@@ -210,7 +220,7 @@ fn pause_terminated_program_fails() {
 #[test]
 fn pause_uninitialized_program_works() {
     new_test_ext().execute_with(|| {
-        let static_pages = 16;
+        let static_pages = WasmPageNumber(16);
         let CreateProgramResult {
             program_id,
             code_hash,
@@ -246,7 +256,7 @@ fn pause_uninitialized_program_works() {
 #[test]
 fn resume_uninitialized_program_works() {
     new_test_ext().execute_with(|| {
-        let static_pages = 16;
+        let static_pages = WasmPageNumber(16);
         let CreateProgramResult {
             program_id,
             init_msg,
@@ -307,7 +317,7 @@ fn resume_uninitialized_program_works() {
 #[test]
 fn resume_program_twice_fails() {
     new_test_ext().execute_with(|| {
-        let static_pages = 16;
+        let static_pages = WasmPageNumber(16);
         let CreateProgramResult {
             program_id,
             memory_pages,
@@ -342,7 +352,7 @@ fn resume_program_twice_fails() {
 #[test]
 fn resume_program_wrong_memory_fails() {
     new_test_ext().execute_with(|| {
-        let static_pages = 16;
+        let static_pages = WasmPageNumber(16);
         let CreateProgramResult {
             program_id,
             mut memory_pages,
@@ -357,7 +367,7 @@ fn resume_program_wrong_memory_fails() {
         assert_ok!(GearProgram::pause_program(program_id));
 
         let block_number = 100;
-        memory_pages.remove(&0);
+        memory_pages.remove(&0.into());
         assert_noop!(
             GearProgram::resume_program_impl(
                 program_id,
@@ -375,7 +385,7 @@ fn resume_program_wrong_memory_fails() {
 #[test]
 fn resume_program_wrong_list_fails() {
     new_test_ext().execute_with(|| {
-        let static_pages = 16;
+        let static_pages = WasmPageNumber(16);
         let CreateProgramResult {
             program_id,
             memory_pages,
@@ -429,10 +439,12 @@ mod utils {
         pub init_msg: StoredDispatch,
         pub msg_1: StoredDispatch,
         pub msg_2: StoredDispatch,
-        pub memory_pages: BTreeMap<u32, Vec<u8>>,
+        pub memory_pages: BTreeMap<PageNumber, Vec<u8>>,
     }
 
-    pub fn create_uninitialized_program_messages(static_pages: u32) -> CreateProgramResult {
+    pub fn create_uninitialized_program_messages(
+        wasm_static_pages: WasmPageNumber,
+    ) -> CreateProgramResult {
         let code = hex!("0061736d01000000020f0103656e76066d656d6f7279020001").to_vec();
         let code_hash: H256 = CodeId::generate(&code).into_origin();
 
@@ -446,12 +458,21 @@ mod utils {
 
         common::set_code(code_hash, &code);
 
+        let static_pages = wasm_static_pages.to_gear_pages();
         let memory_pages = {
-            let mut pages = BTreeMap::<u32, Vec<u8>>::new();
-            pages.insert(static_pages, vec![static_pages as u8]);
-            pages.insert(static_pages + 2, vec![static_pages as u8 + 2]);
-            for i in 0..static_pages {
-                pages.insert(i, vec![i as u8]);
+            let mut pages = BTreeMap::new();
+            for i in 0..PageNumber::num_in_one_wasm_page() {
+                pages.insert(
+                    static_pages + PageNumber(i),
+                    vec![wasm_static_pages.0 as u8],
+                );
+                pages.insert(
+                    static_pages + PageNumber(i + 2 * PageNumber::num_in_one_wasm_page()),
+                    vec![wasm_static_pages.0 as u8 + 2],
+                );
+            }
+            for i in 0..static_pages.0 {
+                pages.insert(i.into(), vec![i as u8]);
             }
 
             pages
@@ -462,7 +483,7 @@ mod utils {
         common::set_program(
             program_id,
             ActiveProgram {
-                static_pages: static_pages.into(),
+                static_pages: wasm_static_pages,
                 persistent_pages: memory_pages.clone().into_keys().collect(),
                 code_hash,
                 state: ProgramState::Uninitialized {

--- a/pallets/gear-program/src/tests.rs
+++ b/pallets/gear-program/src/tests.rs
@@ -64,7 +64,7 @@ fn pause_program_works() {
         common::set_program(
             program_id,
             ActiveProgram {
-                static_pages,
+                static_pages: static_pages.into(),
                 persistent_pages: memory_pages.clone().into_keys().collect(),
                 code_hash,
                 state: ProgramState::Initialized,
@@ -149,7 +149,7 @@ fn pause_program_twice_fails() {
         common::set_program(
             program_id,
             ActiveProgram {
-                static_pages,
+                static_pages: static_pages.into(),
                 persistent_pages: Default::default(),
                 code_hash,
                 state: ProgramState::Initialized,
@@ -188,7 +188,7 @@ fn pause_terminated_program_fails() {
         common::set_program(
             program_id,
             ActiveProgram {
-                static_pages,
+                static_pages: static_pages.into(),
                 persistent_pages: Default::default(),
                 code_hash,
                 state: ProgramState::Initialized,
@@ -462,7 +462,7 @@ mod utils {
         common::set_program(
             program_id,
             ActiveProgram {
-                static_pages,
+                static_pages: static_pages.into(),
                 persistent_pages: memory_pages.clone().into_keys().collect(),
                 code_hash,
                 state: ProgramState::Uninitialized {

--- a/pallets/gear/Cargo.toml
+++ b/pallets/gear/Cargo.toml
@@ -57,6 +57,7 @@ demo-exit-init = { path = "../../examples/binaries/exit-init" }
 demo-exit-handle = { path = "../../examples/binaries/exit-handle" }
 demo-program-factory = { path = "../../examples/binaries/program-factory" }
 demo-proxy = { path = "../../examples/binaries/proxy" }
+page_size = "0.4.2"
 
 [features]
 default = ['std']

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -66,7 +66,7 @@ benchmarks! {
         let c in 0 .. MAX_CODE_LEN;
         let caller: T::AccountId = benchmarking::account("caller", 0, 0);
         let code = benchmarking::generate_wasm3(vec![0u8; c as usize]).unwrap();
-        let code_hash: H256 =     CodeId::generate(&code).into_origin();
+        let code_hash: H256 = CodeId::generate(&code).into_origin();
     }: _(RawOrigin::Signed(caller), code)
     verify {
         assert!(common::code_exists(code_hash));
@@ -92,8 +92,8 @@ benchmarks! {
         let caller = benchmarking::account("caller", 0, 0);
         <T as pallet::Config>::Currency::deposit_creating(&caller, 100_000_000_000_000_u128.unique_saturated_into());
         let program_id = benchmarking::account::<T::AccountId>("program", 0, 100).into_origin();
-        let code = benchmarking::generate_wasm2(16_i32).unwrap();
-        benchmarking::set_program(program_id, code, 1_u32);
+        let code = benchmarking::generate_wasm2(16.into()).unwrap();
+        benchmarking::set_program(program_id, code, 1.into());
         let payload = vec![0_u8; p as usize];
     }: _(RawOrigin::Signed(caller), program_id, payload, 100_000_000_u64, 10_000_u32.into())
     verify {
@@ -105,8 +105,8 @@ benchmarks! {
         let caller = benchmarking::account("caller", 0, 0);
         <T as pallet::Config>::Currency::deposit_creating(&caller, 100_000_000_000_000_u128.unique_saturated_into());
         let program_id = benchmarking::account::<T::AccountId>("program", 0, 100).into_origin();
-        let code = benchmarking::generate_wasm2(16_i32).unwrap();
-        benchmarking::set_program(program_id, code, 1_u32);
+        let code = benchmarking::generate_wasm2(16.into()).unwrap();
+        benchmarking::set_program(program_id, code, 1.into());
         let original_message_id = benchmarking::account::<T::AccountId>("message", 0, 100).into_origin();
         Gear::<T>::insert_to_mailbox(
             caller.clone().into_origin(),
@@ -129,7 +129,7 @@ benchmarks! {
         let q in 1 .. MAX_PAGES;
         let caller: T::AccountId = benchmarking::account("caller", 0, 0);
         <T as pallet::Config>::Currency::deposit_creating(&caller, (1u128 << 60).unique_saturated_into());
-        let code = benchmarking::generate_wasm(q).unwrap();
+        let code = benchmarking::generate_wasm(q.into()).unwrap();
         let salt = vec![255u8; 32];
     }: {
         let _ = crate::Pallet::<T>::submit_program(RawOrigin::Signed(caller).into(), code, salt, vec![], 100_000_000u64, 0u32.into());
@@ -143,7 +143,7 @@ benchmarks! {
         let q in 0 .. MAX_PAGES;
         let caller: T::AccountId = benchmarking::account("caller", 0, 0);
         <T as pallet::Config>::Currency::deposit_creating(&caller, (1_u128 << 60).unique_saturated_into());
-        let code = benchmarking::generate_wasm2(q as i32).unwrap();
+        let code = benchmarking::generate_wasm2(q.into()).unwrap();
         let salt = vec![255u8; 32];
     }: {
         let _ = crate::Pallet::<T>::submit_program(RawOrigin::Signed(caller).into(), code, salt, vec![], 100_000_000u64, 0u32.into());

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -26,7 +26,9 @@ use gear_core::{
     env::Ext as EnvExt,
     gas::{GasAllowanceCounter, GasAmount, GasCounter, ValueCounter},
     ids::{CodeId, MessageId, ProgramId},
-    memory::{AllocationsContext, Memory, PageBuf, PageNumber, wasm_pages_to_pages_set, WasmPageNumber},
+    memory::{
+        wasm_pages_to_pages_set, AllocationsContext, Memory, PageBuf, PageNumber, WasmPageNumber,
+    },
     message::{HandlePacket, MessageContext, ReplyPacket},
 };
 use sp_std::{boxed::Box, collections::btree_map::BTreeMap, vec, vec::Vec};
@@ -48,7 +50,7 @@ impl IntoExtInfo for LazyPagesExt {
         if self.lazy_pages_enabled {
             let lazy_pages_numbers = lazy_pages::get_lazy_pages_numbers();
             lazy_pages_numbers.into_iter().for_each(|p| {
-                accessed_pages.remove(&p.into());
+                accessed_pages.remove(&p);
             });
         }
 
@@ -153,10 +155,6 @@ impl ProcessorExt for LazyPagesExt {
         new_mem_addr: u64,
     ) -> Result<(), &'static str> {
         lazy_pages::protect_lazy_pages_and_update_wasm_mem_addr(old_mem_addr, new_mem_addr)
-    }
-
-    fn get_lazy_pages_numbers() -> Vec<u32> {
-        lazy_pages::get_lazy_pages_numbers()
     }
 }
 

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -45,7 +45,7 @@ impl IntoExtInfo for LazyPagesExt {
         mut get_page_data: F,
     ) -> Result<ExtInfo, (&'static str, GasAmount)> {
         // accessed pages are all pages except current lazy pages
-        let pages = wasm_pages_to_pages_set(self.inner.allocations_context.allocations());
+        let pages = wasm_pages_to_pages_set(self.inner.allocations_context.allocations().iter());
         let mut accessed_pages = pages.clone();
         if self.lazy_pages_enabled {
             let lazy_pages_numbers = lazy_pages::get_lazy_pages_numbers();

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -27,7 +27,6 @@ use gear_core::{
     gas::{GasAllowanceCounter, GasAmount, GasCounter, ValueCounter},
     ids::{CodeId, MessageId, ProgramId},
     memory::{AllocationsContext, Memory, PageBuf, PageNumber, wasm_pages_to_pages_set, WasmPageNumber},
-    memory::{AllocationsContext, Memory, PageBuf, PageNumber},
     message::{HandlePacket, MessageContext, ReplyPacket},
 };
 use sp_std::{boxed::Box, collections::btree_map::BTreeMap, vec, vec::Vec};

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -26,6 +26,7 @@ use gear_core::{
     env::Ext as EnvExt,
     gas::{GasAllowanceCounter, GasAmount, GasCounter, ValueCounter},
     ids::{CodeId, MessageId, ProgramId},
+    memory::{AllocationsContext, Memory, PageBuf, PageNumber, wasm_pages_to_pages_set, WasmPageNumber},
     memory::{AllocationsContext, Memory, PageBuf, PageNumber},
     message::{HandlePacket, MessageContext, ReplyPacket},
 };
@@ -42,25 +43,24 @@ impl IntoExtInfo for LazyPagesExt {
         self,
         mut get_page_data: F,
     ) -> Result<ExtInfo, (&'static str, GasAmount)> {
-        let mut accessed_pages_numbers = self.inner.allocations_context.allocations().clone();
-
         // accessed pages are all pages except current lazy pages
+        let mut accessed_pages = wasm_pages_to_pages_set(self.inner.allocations_context.allocations());
         if self.lazy_pages_enabled {
             let lazy_pages_numbers = lazy_pages::get_lazy_pages_numbers();
             lazy_pages_numbers.into_iter().for_each(|p| {
-                accessed_pages_numbers.remove(&p.into());
+                accessed_pages.remove(&p.into());
             });
         }
 
-        log::debug!("pages numbers = {:?}", accessed_pages_numbers);
+        log::trace!("accessed pages numbers = {:?}", accessed_pages);
 
-        let mut accessed_pages = BTreeMap::new();
-        for page in accessed_pages_numbers {
+        let mut accessed_pages_data = BTreeMap::new();
+        for page in accessed_pages.iter() {
             let mut buf = vec![0u8; PageNumber::size()];
             if let Err(err) = get_page_data(page.offset(), &mut buf) {
                 return Err((err, self.into_gas_amount()));
             }
-            accessed_pages.insert(page, buf);
+            accessed_pages_data.insert(*page, buf);
         }
 
         let (outcome, context_store) = self.inner.message_context.drain();
@@ -68,8 +68,8 @@ impl IntoExtInfo for LazyPagesExt {
 
         Ok(ExtInfo {
             gas_amount: self.inner.gas_counter.into(),
-            pages: self.inner.allocations_context.allocations().clone(),
-            accessed_pages,
+            pages: accessed_pages,
+            pages_data: accessed_pages_data,
             generated_dispatches,
             awakening,
             context_store,
@@ -163,15 +163,15 @@ impl ProcessorExt for LazyPagesExt {
 impl EnvExt for LazyPagesExt {
     fn alloc(
         &mut self,
-        pages_num: PageNumber,
+        pages_num: WasmPageNumber,
         mem: &mut dyn Memory,
-    ) -> Result<PageNumber, &'static str> {
+    ) -> Result<WasmPageNumber, &'static str> {
         // Greedily charge gas for allocations
-        self.charge_gas(pages_num.raw() * self.inner.config.alloc_cost as u32)?;
+        self.charge_gas(pages_num.0 * self.inner.config.alloc_cost as u32)?;
         // Greedily charge gas for grow
-        self.charge_gas(pages_num.raw() * self.inner.config.mem_grow_cost as u32)?;
+        self.charge_gas(pages_num.0 * self.inner.config.mem_grow_cost as u32)?;
 
-        let old_mem_size = mem.size().raw();
+        let old_mem_size = mem.size();
 
         // New pages allocation may change wasm memory buffer location.
         // So, if lazy-pages are enabled we remove protections from lazy-pages
@@ -199,22 +199,22 @@ impl EnvExt for LazyPagesExt {
         }
 
         // Returns back greedily used gas for grow
-        let new_mem_size = mem.size().raw();
+        let new_mem_size = mem.size();
         let grow_pages_num = new_mem_size - old_mem_size;
         let mut gas_to_return_back =
-            self.inner.config.mem_grow_cost * (pages_num.raw() - grow_pages_num) as u64;
+            self.inner.config.mem_grow_cost * (pages_num - grow_pages_num).0 as u64;
 
         // Returns back greedily used gas for allocations
-        let first_page = page_number.raw();
-        let last_page = first_page + pages_num.raw() - 1;
-        let mut new_alloced_pages_num = 0;
-        for page in first_page..=last_page {
+        let first_page = page_number;
+        let last_page = first_page + pages_num - 1.into();
+        let mut new_alloced_pages_num = WasmPageNumber(0);
+        for page in first_page.0..=last_page.0 {
             if !self.inner.allocations_context.is_init_page(page.into()) {
-                new_alloced_pages_num += 1;
+                new_alloced_pages_num = new_alloced_pages_num + 1.into();
             }
         }
         gas_to_return_back +=
-            self.inner.config.alloc_cost * (pages_num.raw() - new_alloced_pages_num) as u64;
+            self.inner.config.alloc_cost * (pages_num - new_alloced_pages_num).0 as u64;
 
         self.refund_gas(gas_to_return_back as u32)?;
 
@@ -273,8 +273,8 @@ impl EnvExt for LazyPagesExt {
         self.inner.program_id()
     }
 
-    fn free(&mut self, ptr: PageNumber) -> Result<(), &'static str> {
-        self.inner.free(ptr)
+    fn free(&mut self, page: WasmPageNumber) -> Result<(), &'static str> {
+        self.inner.free(page)
     }
 
     fn debug(&mut self, data: &str) -> Result<(), &'static str> {

--- a/pallets/gear/src/manager.rs
+++ b/pallets/gear/src/manager.rs
@@ -432,7 +432,6 @@ where
         data: Option<Vec<u8>>,
     ) {
         let program_id = program_id.into_origin();
-        let page_number = page_number.raw();
 
         let program = common::get_program(program_id)
             .expect("page update guaranteed to be called only for existing and active program");

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -476,7 +476,7 @@ fn lazy_pages() {
         // checks not accessed pages
         [1, 3, 4, 6, 7].iter().for_each(|p| {
             let wasm_page = WasmPageNumber(*p);
-            let expected = wasm_pages_to_pages_set(&[wasm_page].iter().map(|p| *p).collect());
+            let expected = wasm_pages_to_pages_set([wasm_page].iter());
             assert!(
                 lazy_pages.is_superset(&expected),
                 "Must contains all gear pages from wasm page which has not been accessed"
@@ -490,7 +490,7 @@ fn lazy_pages() {
         // checks accessed pages
         [0, 2, 5, 8, 9].iter().for_each(|p| {
             let wasm_page = WasmPageNumber(*p);
-            let expected = wasm_pages_to_pages_set(&[wasm_page].iter().map(|p| *p).collect());
+            let expected = wasm_pages_to_pages_set([wasm_page].iter());
             assert!(
                 !lazy_pages.is_superset(&expected),
                 "Some gear pages from wasm released page must be not lazy now"

--- a/pallets/usage/src/mock.rs
+++ b/pallets/usage/src/mock.rs
@@ -272,11 +272,7 @@ pub(crate) fn set_program(program: Program) {
         H256::from_slice(program.id().as_ref()),
         common::ActiveProgram {
             static_pages: program.static_pages(),
-            persistent_pages: program
-                .get_pages()
-                .iter()
-                .map(|(num, _)| num.raw())
-                .collect(),
+            persistent_pages: program.get_pages().iter().map(|(num, _)| *num).collect(),
             code_hash,
             state: common::ProgramState::Initialized,
         },
@@ -287,7 +283,7 @@ pub(crate) fn set_program(program: Program) {
                 let buf = buf
                     .as_ref()
                     .expect("When set program, each page must have data");
-                (num.raw(), buf.to_vec())
+                (*num, buf.to_vec())
             })
             .collect(),
     );

--- a/runtime-interface/Cargo.toml
+++ b/runtime-interface/Cargo.toml
@@ -18,6 +18,7 @@ sp-std = { version = "4.0.0", git = "https://github.com/gear-tech/substrate.git"
 gear-lazy-pages = { path = "../lazy-pages", optional = true }
 errno = { version = "0.2.8", optional = true }
 codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false }
+page_size = { version = "0.4.2", optional = true }
 
 [features]
 default = ["std"]
@@ -27,4 +28,5 @@ std = [
 	"log",
 	"gear-lazy-pages",
 	"errno",
+	"page_size",
 ]

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -24,7 +24,7 @@ use codec::{Decode, Encode};
 use sp_runtime_interface::runtime_interface;
 
 #[cfg(feature = "std")]
-use gear_core::memory::{WASM_PAGE_SIZE, PageNumber};
+use gear_core::memory::{PageNumber, WASM_PAGE_SIZE};
 
 pub use sp_std::{result::Result, vec::Vec};
 
@@ -174,7 +174,8 @@ pub trait GearRI {
                 size_in_pages += 1;
             } else {
                 if size_in_pages != 0 {
-                    let addr = wasm_mem_addr + ((prev_page + 1 - size_in_pages) as usize * PageNumber::size()) as u64;
+                    let addr = wasm_mem_addr
+                        + ((prev_page + 1 - size_in_pages) as usize * PageNumber::size()) as u64;
                     let size = size_in_pages as usize * PageNumber::size();
                     if protect {
                         unsafe { sys_mprotect_interval(addr, size, false, false, false)? };

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -37,6 +37,7 @@ pub enum MprotectError {
 #[derive(Debug, Encode, Decode)]
 pub struct GetReleasedPageError;
 
+/// TODO: deprecated remove before release
 #[cfg(feature = "std")]
 #[cfg(unix)]
 unsafe fn sys_mprotect_wasm_pages(
@@ -85,6 +86,8 @@ unsafe fn sys_mprotect_wasm_pages(
     Err(MprotectError::OsError)
 }
 
+/// Mprotect native memory interval [`addr`, `addr` + `size`].
+/// Protection mask is set according to protection argumetns.
 #[cfg(feature = "std")]
 #[cfg(unix)]
 unsafe fn sys_mprotect_interval(
@@ -136,7 +139,7 @@ unsafe fn sys_mprotect_interval(
 /// !!! Note: Will be expanded as gear_ri
 #[runtime_interface]
 pub trait GearRI {
-    /// old interface
+    /// TODO: deprecated remove before release
     fn mprotect_wasm_pages(
         from_ptr: u64,
         pages_nums: &[u32],
@@ -149,6 +152,7 @@ pub trait GearRI {
         }
     }
 
+    /// TODO: deprecated remove before release
     /// Apply mprotect syscall for given list of wasm pages.
     #[version(2)]
     fn mprotect_wasm_pages(
@@ -161,14 +165,20 @@ pub trait GearRI {
         unsafe { sys_mprotect_wasm_pages(from_ptr, pages_nums, prot_read, prot_write, prot_exec) }
     }
 
+    /// Mprotect all lazy pages.
+    /// If `protect` argument is true then restrict all accesses to page,
+    /// else allows read and write accesses.
     fn mprotect_lazy_pages(wasm_mem_addr: u64, protect: bool) -> Result<(), MprotectError> {
         let mut prev_page = 0u32;
         let mut size_in_pages = 0u32;
         let mut lazy_pages = gear_lazy_pages::get_lazy_pages_numbers();
 
-        // TODO
+        // We add this page num to lazy pages in order to be able correctly
+        // break loop execution.
         lazy_pages.push(u32::MAX);
 
+        // Collects continuous intervals of memory from lazy pages to protect them.
+        // TODO: make more simple and safe solution
         for page in lazy_pages {
             if prev_page + 1 == page {
                 size_in_pages += 1;
@@ -194,7 +204,7 @@ pub trait GearRI {
         gear_lazy_pages::save_page_lazy_info(page, key);
     }
 
-    /// old interface
+    /// TODO: deprecated remove before release
     fn get_wasm_lazy_pages_numbers() -> Vec<u32> {
         gear_lazy_pages::get_lazy_pages_numbers()
     }

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -24,7 +24,7 @@ use codec::{Decode, Encode};
 use sp_runtime_interface::runtime_interface;
 
 #[cfg(feature = "std")]
-use gear_core::memory::PAGE_SIZE;
+use gear_core::memory::WASM_PAGE_SIZE;
 
 pub use sp_std::{result::Result, vec::Vec};
 
@@ -57,8 +57,8 @@ unsafe fn sys_mprotect_wasm_pages(
         prot_mask |= libc::PROT_EXEC;
     }
     for page in pages_nums {
-        let addr = from_ptr as usize + *page as usize * PAGE_SIZE;
-        let res = libc::mprotect(addr as *mut libc::c_void, PAGE_SIZE, prot_mask);
+        let addr = from_ptr as usize + *page as usize * WASM_PAGE_SIZE;
+        let res = libc::mprotect(addr as *mut libc::c_void, WASM_PAGE_SIZE, prot_mask);
         if res != 0 {
             log::error!(
                 "Cannot set page protection for {:#x}: {}",

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -173,12 +173,19 @@ pub trait GearRI {
         let mut size_in_pages = 0u32;
         let mut lazy_pages = gear_lazy_pages::get_lazy_pages_numbers();
 
+        if let Some(page) = lazy_pages.last() {
+            // This case is impossible in real live, so just returns err and does nothing.
+            if *page == u32::MAX || *page == u32::MAX - 1 {
+                return Err(MprotectError::PageError);
+            }
+        }
+
         // We add this page num to lazy pages in order to be able correctly
-        // break loop execution.
+        // finish lazy pages handling in loop. This last page won't be
+        // handled.
         lazy_pages.push(u32::MAX);
 
         // Collects continuous intervals of memory from lazy pages to protect them.
-        // TODO: make more simple and safe solution
         for page in lazy_pages {
             if prev_page + 1 == page {
                 size_in_pages += 1;

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -81,13 +81,14 @@ unsafe fn sys_mprotect_wasm_pages(
     prot_write: bool,
     prot_exec: bool,
 ) -> Result<(), MprotectError> {
-    log::error!("unsupported OS for pages protectections");
+    log::error!("unsupported OS for pages protectection");
     Err(MprotectError::OsError)
 }
 
 /// !!! Note: Will be expanded as gear_ri
 #[runtime_interface]
 pub trait GearRI {
+    /// old interface
     fn mprotect_wasm_pages(
         from_ptr: u64,
         pages_nums: &[u32],
@@ -112,12 +113,17 @@ pub trait GearRI {
         unsafe { sys_mprotect_wasm_pages(from_ptr, pages_nums, prot_read, prot_write, prot_exec) }
     }
 
-    fn save_page_lazy_info(wasm_page: u32, key: &[u8]) {
-        gear_lazy_pages::save_page_lazy_info(wasm_page, key);
+    fn save_page_lazy_info(page: u32, key: &[u8]) {
+        gear_lazy_pages::save_page_lazy_info(page, key);
     }
 
+    /// old interface
     fn get_wasm_lazy_pages_numbers() -> Vec<u32> {
-        gear_lazy_pages::get_wasm_lazy_pages_numbers()
+        gear_lazy_pages::get_lazy_pages_numbers()
+    }
+
+    fn get_lazy_pages_numbers() -> Vec<u32> {
+        gear_lazy_pages::get_lazy_pages_numbers()
     }
 
     fn init_lazy_pages() -> bool {

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -24,7 +24,7 @@ use codec::{Decode, Encode};
 use sp_runtime_interface::runtime_interface;
 
 #[cfg(feature = "std")]
-use gear_core::memory::{PageNumber, WASM_PAGE_SIZE};
+use gear_core::memory::{PageNumber, WasmPageNumber};
 
 pub use sp_std::{result::Result, vec::Vec};
 
@@ -57,8 +57,8 @@ unsafe fn sys_mprotect_wasm_pages(
         prot_mask |= libc::PROT_EXEC;
     }
     for page in pages_nums {
-        let addr = from_ptr as usize + *page as usize * WASM_PAGE_SIZE;
-        let res = libc::mprotect(addr as *mut libc::c_void, WASM_PAGE_SIZE, prot_mask);
+        let addr = from_ptr as usize + *page as usize * WasmPageNumber::size();
+        let res = libc::mprotect(addr as *mut libc::c_void, WasmPageNumber::size(), prot_mask);
         if res != 0 {
             log::error!(
                 "Cannot set page protection for {:#x}: {}",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 540,
+    spec_version: 550,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/utils/gear-runtime-test-cli/src/command.rs
+++ b/utils/gear-runtime-test-cli/src/command.rs
@@ -194,7 +194,7 @@ fn run_fixture(test: &'_ sample::Test, fixture: &sample::Fixture) -> ColoredStri
     // Fill the key in the storage with a fake Program ID so that messages to this program get into the message queue
     for id in programs_map.keys() {
         let program = gear_common::ActiveProgram {
-            static_pages: 0,
+            static_pages: 0.into(),
             persistent_pages: Default::default(),
             code_hash: H256::default(),
             state: gear_common::ProgramState::Initialized,


### PR DESCRIPTION
Resolves #799 .

1) Reduce size of code pages in storage: 4kB now. Fixes to work correct in LazyPages, Common, CoreBackend, CoreProcessor.
2) new type: `WasmPageNumber` - which represents `wasm` pages
3) Fixes in tests to pass them.

### Changes in storage:
common/src/lib.rs: struct ActiveProgram
core/src/code.rs: struct Code
size of data for each page in storage is reduced and now equal to 0x1000 bytes (old = 0x10000)

### IMPORTANT:
after this PR is committed we must rebuild nodes in test-net and reset storage 