### PR TITLE
Fix build on Linux

### DIFF
--- a/examples/binaries/btree/src/lib.rs
+++ b/examples/binaries/btree/src/lib.rs
@@ -29,9 +29,8 @@ pub use code::WASM_BINARY_OPT as WASM_BINARY;
 
 extern crate alloc;
 
-use alloc::collections::BTreeMap;
 use codec::{Decode, Encode};
-use gstd::{debug, msg, prelude::*};
+use gstd::prelude::*;
 
 #[derive(Encode, Debug, Decode, PartialEq)]
 pub enum Request {
@@ -49,43 +48,51 @@ pub enum Reply {
     List(Vec<(u32, u32)>),
 }
 
-static mut STATE: Option<BTreeMap<u32, u32>> = None;
+#[cfg(not(feature = "std"))]
+mod wasm {
+    use super::*;
 
-#[no_mangle]
-pub unsafe extern "C" fn handle() {
-    let reply = match msg::load() {
-        Ok(request) => process(request),
-        Err(e) => {
-            debug!("Error processing request: {:?}", e);
-            Reply::Error
-        }
-    };
+    use alloc::collections::BTreeMap;
+    use gstd::{debug, msg};
 
-    msg::reply(reply, 0);
-}
+    static mut STATE: Option<BTreeMap<u32, u32>> = None;
 
-fn state() -> &'static mut BTreeMap<u32, u32> {
-    unsafe { STATE.as_mut().unwrap() }
-}
+    #[no_mangle]
+    pub unsafe extern "C" fn handle() {
+        let reply = match msg::load() {
+            Ok(request) => process(request),
+            Err(e) => {
+                debug!("Error processing request: {:?}", e);
+                Reply::Error
+            }
+        };
 
-fn process(request: Request) -> Reply {
-    use Request::*;
+        msg::reply(reply, 0);
+    }
 
-    match request {
-        Insert(key, value) => Reply::Value(state().insert(key, value)),
-        Remove(key) => Reply::Value(state().remove(&key)),
-        List => Reply::List(state().iter().map(|(k, v)| (*k, *v)).collect()),
-        Clear => {
-            state().clear();
-            Reply::None
+    fn state() -> &'static mut BTreeMap<u32, u32> {
+        unsafe { STATE.as_mut().unwrap() }
+    }
+
+    fn process(request: Request) -> Reply {
+        use Request::*;
+
+        match request {
+            Insert(key, value) => Reply::Value(state().insert(key, value)),
+            Remove(key) => Reply::Value(state().remove(&key)),
+            List => Reply::List(state().iter().map(|(k, v)| (*k, *v)).collect()),
+            Clear => {
+                state().clear();
+                Reply::None
+            }
         }
     }
-}
 
-#[no_mangle]
-pub unsafe extern "C" fn init() {
-    STATE = Some(BTreeMap::new());
-    msg::reply((), 0);
+    #[no_mangle]
+    pub unsafe extern "C" fn init() {
+        STATE = Some(BTreeMap::new());
+        msg::reply((), 0);
+    }
 }
 
 #[cfg(test)]

--- a/examples/binaries/distributor/src/lib.rs
+++ b/examples/binaries/distributor/src/lib.rs
@@ -21,11 +21,8 @@
 
 extern crate alloc;
 
-use alloc::collections::BTreeSet;
 use codec::{Decode, Encode};
-use core::future::Future;
-use gstd::lock::mutex::Mutex;
-use gstd::{debug, msg, prelude::*, ActorId};
+use gstd::{prelude::*, ActorId};
 
 #[cfg(feature = "std")]
 mod code {
@@ -55,164 +52,173 @@ struct Program {
     handle: ActorId,
 }
 
-struct ProgramState {
-    nodes: Mutex<BTreeSet<Program>>,
-    amount: u64,
-}
+#[cfg(not(feature = "std"))]
+mod wasm {
+    use super::*;
 
-impl Default for ProgramState {
-    fn default() -> Self {
-        Self {
-            nodes: Mutex::new(BTreeSet::default()),
-            amount: 0,
-        }
-    }
-}
+    use alloc::collections::BTreeSet;
+    use core::future::Future;
+    use gstd::{debug, lock::mutex::Mutex, msg};
 
-static mut STATE: Option<ProgramState> = None;
+    static mut STATE: Option<ProgramState> = None;
 
-impl Program {
-    fn new(handle: impl Into<ActorId>) -> Self {
-        Self {
-            handle: handle.into(),
-        }
+    struct ProgramState {
+        nodes: Mutex<BTreeSet<Program>>,
+        amount: u64,
     }
 
-    fn do_request<Req: Encode, Rep: Decode>(
-        &self,
-        request: Req,
-    ) -> impl Future<Output = Result<Rep, &'static str>> {
-        let encoded_request: Vec<u8> = request.encode();
-
-        let program_handle = self.handle;
-        async move {
-            let reply_bytes =
-                msg::send_bytes_and_wait_for_reply(program_handle, &encoded_request[..], 0)
-                    .await
-                    .expect("Error in async message processing");
-
-            Rep::decode(&mut &reply_bytes[..]).map_err(|_| "Failed to decode reply")
-        }
-    }
-
-    async fn do_send(&self, amount: u64) -> Result<(), &'static str> {
-        match self.do_request(Request::Receive(amount)).await? {
-            Reply::Success => Ok(()),
-            _ => Err("Unexpected send reply"),
-        }
-    }
-
-    async fn do_report(&self) -> Result<u64, &'static str> {
-        match self.do_request(Request::Report).await? {
-            Reply::Amount(amount) => Ok(amount),
-            _ => Err("Unexpected send reply"),
-        }
-    }
-
-    fn nodes() -> &'static Mutex<BTreeSet<Program>> {
-        unsafe { &mut STATE.as_mut().expect("STATE UNITIALIZED!").nodes }
-    }
-
-    fn amount() -> &'static mut u64 {
-        unsafe { &mut STATE.as_mut().expect("STATE UNITIALIZED!").amount }
-    }
-
-    async fn handle_request() {
-        let reply = match msg::load::<Request>() {
-            Ok(request) => match request {
-                Request::Receive(amount) => Self::handle_receive(amount).await,
-                Request::Join(program_id) => Self::handle_join(program_id).await,
-                Request::Report => Self::handle_report().await,
-            },
-            Err(e) => {
-                debug!("Error processing request: {:?}", e);
-                Reply::Failure
+    impl Default for ProgramState {
+        fn default() -> Self {
+            Self {
+                nodes: Mutex::new(BTreeSet::default()),
+                amount: 0,
             }
-        };
-
-        debug!("Handle request finished");
-        msg::reply(reply, 0);
+        }
     }
 
-    async fn handle_receive(amount: u64) -> Reply {
-        debug!("Handling receive {}", amount);
+    impl Program {
+        fn new(handle: impl Into<ActorId>) -> Self {
+            Self {
+                handle: handle.into(),
+            }
+        }
 
-        let nodes = Program::nodes().lock().await;
-        let subnodes_count = nodes.as_ref().len() as u64;
+        fn do_request<Req: Encode, Rep: Decode>(
+            &self,
+            request: Req,
+        ) -> impl Future<Output = Result<Rep, &'static str>> {
+            let encoded_request: Vec<u8> = request.encode();
 
-        if subnodes_count > 0 {
-            let distributed_per_node = amount / subnodes_count;
-            let distributed_total = distributed_per_node * subnodes_count;
-            let mut left_over = amount - distributed_total;
+            let program_handle = self.handle;
+            async move {
+                let reply_bytes =
+                    msg::send_bytes_and_wait_for_reply(program_handle, &encoded_request[..], 0)
+                        .await
+                        .expect("Error in async message processing");
 
-            if distributed_per_node > 0 {
-                for program in nodes.as_ref().iter() {
-                    if program.do_send(distributed_per_node).await.is_err() {
-                        // reclaiming amount from nodes that fail!
-                        left_over += distributed_per_node;
+                Rep::decode(&mut &reply_bytes[..]).map_err(|_| "Failed to decode reply")
+            }
+        }
+
+        async fn do_send(&self, amount: u64) -> Result<(), &'static str> {
+            match self.do_request(Request::Receive(amount)).await? {
+                Reply::Success => Ok(()),
+                _ => Err("Unexpected send reply"),
+            }
+        }
+
+        async fn do_report(&self) -> Result<u64, &'static str> {
+            match self.do_request(Request::Report).await? {
+                Reply::Amount(amount) => Ok(amount),
+                _ => Err("Unexpected send reply"),
+            }
+        }
+
+        fn nodes() -> &'static Mutex<BTreeSet<Program>> {
+            unsafe { &mut STATE.as_mut().expect("STATE UNITIALIZED!").nodes }
+        }
+
+        fn amount() -> &'static mut u64 {
+            unsafe { &mut STATE.as_mut().expect("STATE UNITIALIZED!").amount }
+        }
+
+        async fn handle_request() {
+            let reply = match msg::load::<Request>() {
+                Ok(request) => match request {
+                    Request::Receive(amount) => Self::handle_receive(amount).await,
+                    Request::Join(program_id) => Self::handle_join(program_id).await,
+                    Request::Report => Self::handle_report().await,
+                },
+                Err(e) => {
+                    debug!("Error processing request: {:?}", e);
+                    Reply::Failure
+                }
+            };
+
+            debug!("Handle request finished");
+            msg::reply(reply, 0);
+        }
+
+        async fn handle_receive(amount: u64) -> Reply {
+            debug!("Handling receive {}", amount);
+
+            let nodes = Program::nodes().lock().await;
+            let subnodes_count = nodes.as_ref().len() as u64;
+
+            if subnodes_count > 0 {
+                let distributed_per_node = amount / subnodes_count;
+                let distributed_total = distributed_per_node * subnodes_count;
+                let mut left_over = amount - distributed_total;
+
+                if distributed_per_node > 0 {
+                    for program in nodes.as_ref().iter() {
+                        if program.do_send(distributed_per_node).await.is_err() {
+                            // reclaiming amount from nodes that fail!
+                            left_over += distributed_per_node;
+                        }
+                    }
+                }
+
+                debug!("Set own amount to: {}", left_over);
+                *Self::amount() = *Self::amount() + left_over;
+            } else {
+                debug!("Set own amount to: {}", amount);
+                *Self::amount() = *Self::amount() + amount;
+            }
+
+            Reply::Success
+        }
+
+        async fn handle_join(program_id: u64) -> Reply {
+            let mut nodes = Self::nodes().lock().await;
+            debug!("Inserting into nodes");
+            nodes.as_mut().insert(Program::new(program_id));
+            Reply::Success
+        }
+
+        async fn handle_report() -> Reply {
+            let mut amount = *Program::amount();
+            debug!("Own amount: {}", amount);
+
+            let nodes = Program::nodes().lock().await;
+
+            for program in nodes.as_ref().iter() {
+                debug!("Querying next node");
+                amount += match program.do_report().await {
+                    Ok(amount) => {
+                        debug!("Sub-node result: {}", amount);
+                        amount
+                    }
+                    Err(_) => {
+                        // skipping erroneous sub-nodes!
+                        debug!("Skipping errorneous node");
+                        0
                     }
                 }
             }
 
-            debug!("Set own amount to: {}", left_over);
-            *Self::amount() = *Self::amount() + left_over;
-        } else {
-            debug!("Set own amount to: {}", amount);
-            *Self::amount() = *Self::amount() + amount;
+            Reply::Amount(amount)
         }
-
-        Reply::Success
     }
 
-    async fn handle_join(program_id: u64) -> Reply {
-        let mut nodes = Self::nodes().lock().await;
-        debug!("Inserting into nodes");
-        nodes.as_mut().insert(Program::new(program_id));
-        Reply::Success
+    #[no_mangle]
+    pub unsafe extern "C" fn handle() {
+        debug!("Handling sequence started");
+        gstd::message_loop(Program::handle_request());
+        debug!("Handling sequence terminated");
     }
 
-    async fn handle_report() -> Reply {
-        let mut amount = *Program::amount();
-        debug!("Own amount: {}", amount);
-
-        let nodes = Program::nodes().lock().await;
-
-        for program in nodes.as_ref().iter() {
-            debug!("Querying next node");
-            amount += match program.do_report().await {
-                Ok(amount) => {
-                    debug!("Sub-node result: {}", amount);
-                    amount
-                }
-                Err(_) => {
-                    // skipping erroneous sub-nodes!
-                    debug!("Skipping errorneous node");
-                    0
-                }
-            }
-        }
-
-        Reply::Amount(amount)
+    #[no_mangle]
+    pub unsafe extern "C" fn handle_reply() {
+        gstd::record_reply();
     }
-}
 
-#[no_mangle]
-pub unsafe extern "C" fn handle() {
-    debug!("Handling sequence started");
-    gstd::message_loop(Program::handle_request());
-    debug!("Handling sequence terminated");
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn handle_reply() {
-    gstd::record_reply();
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn init() {
-    STATE = Some(ProgramState::default());
-    msg::reply((), 0);
-    debug!("Program initialized");
+    #[no_mangle]
+    pub unsafe extern "C" fn init() {
+        STATE = Some(ProgramState::default());
+        msg::reply((), 0);
+        debug!("Program initialized");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
There are no building problems when compiling on macOS and Ubuntu 20.04 LTS (as well as CI based on it). But the build fails on Ubuntu 21.10.

The problem seems to be in the linker (`ld`) version (`v2.34` on 20.04 LTS vs `v2.37` on 21.10). The newer version seems to be more strict resulting in linker error due to `handle`/`init` symbols doubling.

The fix hides `init`/`handle`/`handle_reply` functions when building with the `std` feature. 
