### PR TITLE
Remove redundant testing from `CI` and `pre-commit`

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -147,9 +147,6 @@ jobs:
       - name: "Test: Gear workspace"
         run: ./scripts/gear.sh test gear --release
 
-      - name: "Test: Gear pallet" # Temporary feature to test sandbox backend
-        run: ./scripts/gear.sh test pallet --release
-
       - name: "Test: JS metadata"
         run: ./scripts/gear.sh test js
 

--- a/Makefile
+++ b/Makefile
@@ -201,10 +201,10 @@ purge-dev-chain-release:
 
 # Test section
 .PHONY: test
-test: test-gear test-pallet test-js gtest
+test: test-gear test-js gtest
 
 .PHONY: test-release
-test-release: test-gear-release test-pallet-release test-js gtest rtest
+test-release: test-gear-release test-js gtest rtest
 
 .PHONY: test-gear
 test-gear: init-js examples


### PR DESCRIPTION
These checks seems unused nowadays, so deleting them a bit decreases test time.

@gear-tech/dev 
