### PR TITLE
Introduce gear payment pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2268,6 +2268,7 @@ dependencies = [
  "pallet-gear",
  "pallet-gear-debug",
  "pallet-gear-messenger",
+ "pallet-gear-payment",
  "pallet-gear-program",
  "pallet-gear-rpc-runtime-api",
  "pallet-grandpa",
@@ -4728,6 +4729,35 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+]
+
+[[package]]
+name = "pallet-gear-payment"
+version = "0.1.0"
+dependencies = [
+ "env_logger",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "gear-common",
+ "gear-core",
+ "log",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-gas",
+ "pallet-gear",
+ "pallet-gear-program",
+ "pallet-timestamp",
+ "pallet-transaction-payment",
+ "parity-scale-codec",
+ "parity-wasm 0.42.2",
+ "primitive-types",
+ "scale-info",
+ "serde",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "wabt",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4746,6 +4746,7 @@ dependencies = [
  "pallet-balances",
  "pallet-gas",
  "pallet-gear",
+ "pallet-gear-messenger",
  "pallet-gear-program",
  "pallet-timestamp",
  "pallet-transaction-payment",

--- a/common/src/storage/deque.rs
+++ b/common/src/storage/deque.rs
@@ -14,6 +14,8 @@ pub enum DequeError {
     TailWasNotRemoved,
 }
 
+pub type LengthOf<T> = <<T as StorageDeque>::Length as StorageCounter>::Value;
+
 pub trait NextKey<V> {
     fn first(target: &V) -> Self;
     fn next(&self, target: &V) -> Self;
@@ -213,6 +215,10 @@ pub trait StorageDeque: Sized {
             (Some(_), None) => Err(DequeError::TailWasEmptyWhileHeadNot.into()),
             (None, Some(_)) => Err(DequeError::HeadWasEmptyWhileTailNot.into()),
         }
+    }
+
+    fn len() -> LengthOf<Self> {
+        Self::Length::get()
     }
 }
 

--- a/common/src/storage/deque.rs
+++ b/common/src/storage/deque.rs
@@ -14,8 +14,6 @@ pub enum DequeError {
     TailWasNotRemoved,
 }
 
-pub type LengthOf<T> = <<T as StorageDeque>::Length as StorageCounter>::Value;
-
 pub trait NextKey<V> {
     fn first(target: &V) -> Self;
     fn next(&self, target: &V) -> Self;
@@ -217,10 +215,6 @@ pub trait StorageDeque: Sized {
             (Some(_), None) => Err(DequeError::TailWasEmptyWhileHeadNot.into()),
             (None, Some(_)) => Err(DequeError::HeadWasEmptyWhileTailNot.into()),
         }
-    }
-
-    fn len() -> LengthOf<Self> {
-        Self::Length::get()
     }
 }
 

--- a/common/src/storage/deque.rs
+++ b/common/src/storage/deque.rs
@@ -182,6 +182,8 @@ pub trait StorageDeque: Sized {
             }
         }
 
+        Self::Length::clear();
+
         Ok(())
     }
 

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -516,7 +516,7 @@ impl<E: Ext + 'static> FuncsHandler<E> {
             })?;
 
         if let Some((message_id, _)) = maybe_message_id {
-            let _ = wto(&mut ctx.memory, dest, message_id.as_ref()).map_err(|err| {
+            wto(&mut ctx.memory, dest, message_id.as_ref()).map_err(|err| {
                 ctx.trap = Some(err);
                 HostError
             })?;

--- a/gear-test/src/proc.rs
+++ b/gear-test/src/proc.rs
@@ -177,7 +177,7 @@ where
         let message_id = MessageId::from(nonce);
         let id = program.id.to_program_id();
 
-        let _ = init_program::<E, JH>(
+        init_program::<E, JH>(
             InitMessage {
                 id,
                 code,

--- a/pallets/payment/Cargo.toml
+++ b/pallets/payment/Cargo.toml
@@ -37,7 +37,7 @@ serde = "1.0.132"
 env_logger = "0.9"
 wabt = "0.10"
 gear-core = { path = "../../core" }
-sp-io = { version = "6.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false }
+sp-io = { version = "6.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 pallet-gear = { path = "../gear" }
 pallet-gas = { path = "../gas" }

--- a/pallets/payment/Cargo.toml
+++ b/pallets/payment/Cargo.toml
@@ -36,12 +36,12 @@ pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, 
 serde = "1.0.132"
 env_logger = "0.9"
 wabt = "0.10"
-common = { package = "gear-common", path = "../../common" }
 gear-core = { path = "../../core" }
 sp-io = { version = "6.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false }
 pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 pallet-gear = { path = "../gear" }
 pallet-gas = { path = "../gas" }
+pallet-gear-messenger = { path = "../gear-messenger" }
 pallet-gear-program = { path = "../gear-program" }
 
 [features]

--- a/pallets/payment/Cargo.toml
+++ b/pallets/payment/Cargo.toml
@@ -1,0 +1,67 @@
+[package]
+name = "pallet-gear-payment"
+version = "0.1.0"
+authors = ['Gear Technologies']
+edition = '2018'
+license = "GPL-3.0"
+homepage = "https://gear-tech.io"
+repository = "https://github.com/gear-tech/gear"
+description = "Gear main pallet"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive", "max-encoded-len"] }
+scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
+log = { version = "0.4.16", default-features = false }
+parity-wasm = { version = "0.42.2", default-features = false, optional = true }
+primitive-types = { version = "0.11.1", default-features = false, features = ["scale-info"] }
+
+# Internal dependencies
+common = { package = "gear-common", path = "../../common", default-features = false }
+
+# Substrate deps
+frame-support = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false }
+frame-system = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false }
+frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false, optional = true }
+sp-std = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false }
+sp-runtime = { version = "6.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false }
+pallet-authorship = { version = "4.0.0-dev", default-features = false, git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+
+[dev-dependencies]
+serde = "1.0.132"
+env_logger = "0.9"
+wabt = "0.10"
+common = { package = "gear-common", path = "../../common" }
+gear-core = { path = "../../core" }
+sp-io = { version = "6.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false }
+pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+pallet-gear = { path = "../gear" }
+pallet-gas = { path = "../gas" }
+pallet-gear-program = { path = "../gear-program" }
+
+[features]
+default = ['std']
+std = [
+	"codec/std",
+	"log/std",
+	"frame-support/std",
+	"frame-system/std",
+	"scale-info/std",
+	"sp-std/std",
+	"sp-runtime/std",
+	"pallet-balances/std",
+	"pallet-transaction-payment/std",
+	"pallet-authorship/std",
+	"primitive-types/std",
+]
+runtime-benchmarks = [
+	"frame-benchmarking",
+	"frame-system/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
+	"parity-wasm",
+]

--- a/pallets/payment/README.md
+++ b/pallets/payment/README.md
@@ -1,0 +1,10 @@
+# Implementation of custom transaction fees
+
+Gear-specific implementation of traits defined by the Substrate's transaction payment pallet to be used with the said pallet in place of default implementations.
+
+## Interface
+
+### Dispatchable Functions
+The pallet doesn't define any extrinsics to be called by external users.
+
+License: Unlicense

--- a/pallets/payment/src/lib.rs
+++ b/pallets/payment/src/lib.rs
@@ -1,0 +1,349 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::{
+    pallet_prelude::*,
+    traits::Contains,
+    weights::{DispatchInfo, GetDispatchInfo, PostDispatchInfo},
+};
+use pallet_transaction_payment::{
+    ChargeTransactionPayment, FeeDetails, Multiplier, MultiplierUpdate, OnChargeTransaction,
+    RuntimeDispatchInfo,
+};
+use sp_runtime::{
+    generic::{CheckedExtrinsic, UncheckedExtrinsic},
+    traits::{Bounded, Convert, DispatchInfoOf, Dispatchable, PostDispatchInfoOf, SignedExtension},
+    transaction_validity::TransactionValidityError,
+    FixedPointNumber, FixedPointOperand, Perquintill,
+};
+use sp_std::borrow::Cow;
+
+pub use pallet::*;
+
+type BalanceOf<T> =
+    <<T as pallet_transaction_payment::Config>::OnChargeTransaction as OnChargeTransaction<T>>::Balance;
+type CallOf<T> = <T as frame_system::Config>::Call;
+
+pub type TransactionPayment<T> = pallet_transaction_payment::Pallet<T>;
+
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+/// A wrapper around the `pallet_transaction_payment::ChargeTransactionPayment`.
+/// Adjusts `DispatchInfo` to reflect custom fee add-ons.
+#[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
+pub struct CustomChargeTransactionPayment<T: Config>(ChargeTransactionPayment<T>);
+
+impl<T: Config> CustomChargeTransactionPayment<T>
+where
+    BalanceOf<T>: Send + Sync + FixedPointOperand,
+    CallOf<T>: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
+{
+    pub fn from(tip: BalanceOf<T>) -> Self {
+        Self(ChargeTransactionPayment::<T>::from(tip))
+    }
+}
+
+impl<T: Config> sp_std::fmt::Debug for CustomChargeTransactionPayment<T> {
+    #[cfg(feature = "std")]
+    fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+        write!(f, "CustomChargeTransactionPayment({:?})", self.0)
+    }
+    #[cfg(not(feature = "std"))]
+    fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+        Ok(())
+    }
+}
+
+// Follow pallet-transaction-payment implementation
+impl<T: Config> SignedExtension for CustomChargeTransactionPayment<T>
+where
+    T: TypeInfo,
+    BalanceOf<T>: Send + Sync + From<u64> + FixedPointOperand,
+    CallOf<T>: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
+{
+    const IDENTIFIER: &'static str = <ChargeTransactionPayment<T> as SignedExtension>::IDENTIFIER;
+    type AccountId = <ChargeTransactionPayment<T> as SignedExtension>::AccountId;
+    type Call = CallOf<T>;
+    type AdditionalSigned = <ChargeTransactionPayment<T> as SignedExtension>::AdditionalSigned;
+    type Pre = <ChargeTransactionPayment<T> as SignedExtension>::Pre;
+    fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
+        self.0.additional_signed()
+    }
+
+    fn validate(
+        &self,
+        who: &Self::AccountId,
+        call: &Self::Call,
+        info: &DispatchInfoOf<Self::Call>,
+        len: usize,
+    ) -> TransactionValidity {
+        // Override DispatchInfo struct for call variants exempted from weight fee multiplication
+        let info = Self::pre_dispatch_info(call, info);
+        self.0.validate(who, call, &*info, len)
+    }
+
+    fn pre_dispatch(
+        self,
+        who: &Self::AccountId,
+        call: &Self::Call,
+        info: &DispatchInfoOf<Self::Call>,
+        len: usize,
+    ) -> Result<Self::Pre, TransactionValidityError> {
+        // Override DispatchInfo struct for call variants exempted from weight fee multiplication
+        let info = Self::pre_dispatch_info(call, info);
+        self.0.pre_dispatch(who, call, &*info, len)
+    }
+
+    fn post_dispatch(
+        maybe_pre: Option<Self::Pre>,
+        info: &DispatchInfoOf<Self::Call>,
+        post_info: &PostDispatchInfoOf<Self::Call>,
+        len: usize,
+        result: &sp_runtime::DispatchResult,
+    ) -> Result<(), TransactionValidityError> {
+        // There is no easy way to modify the original `DispatchInfo` struct similarly
+        // it's done in `pre_dispatch()` because a call is not supplied.
+        // However, we can just leave it as is and yet get the correct fee refund if any:
+        //   - if `None` is returned as the actual weight (i.e. worst case) nothing is supposed
+        //   to be refunded anyway and saturating subtraction guarantees we don't have overflow;
+        //   - if `post_info` has `Some(actual_weight)`, the minimum of it and `info.weight` will
+        //   be used to calculate the correct fee so it is just our responsibility to do
+        //   weight normalization before returning it from the extrinsic.
+        //
+        // TODO: still think of a more robust way to deal with fee refunds
+        <ChargeTransactionPayment<T> as SignedExtension>::post_dispatch(
+            maybe_pre, info, post_info, len, result,
+        )
+    }
+}
+
+impl<T: Config> CustomChargeTransactionPayment<T>
+where
+    CallOf<T>: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
+{
+    fn pre_dispatch_info<'a>(
+        call: &'a <T as frame_system::Config>::Call,
+        info: &'a DispatchInfoOf<<T as frame_system::Config>::Call>,
+    ) -> Cow<'a, DispatchInfoOf<<T as frame_system::Config>::Call>> {
+        // If the call is not subject to fee multiplication, divide weight by fee multiplier.
+        // This action will effectively be cancelled out at the time the fee is calculated.
+        //
+        // TODO: consider reimplementing.
+        // This procedure does introduce a rounding error 𝞮 =  w - ⎣w / m⎦⋅m
+        // However, we argue that such error is negligible:
+        // - the rounding error can never exceed `m` (multiplier). Order of `w` (weight) is
+        // usually not less than 10^8 while the fee multiplier should not be greater than 10^3.
+        // Therefore the rounding error shouln't exceed 0.001% in the worst case.
+        // Note: this only applies to calls that do not affect message queue, that is are
+        // relatively rare. Still, a better solution can be found.
+        if !T::ExtraFeeCallFilter::contains(call) {
+            let multiplier = TransactionPayment::<T>::next_fee_multiplier();
+            if multiplier > Multiplier::saturating_from_integer(1) {
+                let mut info: DispatchInfo = *info;
+                info.weight = multiplier
+                    .reciprocal() // take inverse
+                    .unwrap_or_else(Multiplier::max_value)
+                    .saturating_mul_int(info.weight);
+                Cow::Owned(info)
+            } else {
+                Cow::Borrowed(info)
+            }
+        } else {
+            Cow::Borrowed(info)
+        }
+    }
+}
+
+/// Custom fee multiplier which looks at the message queue size to increase weight fee
+pub struct GearFeeMultiplier<S>(sp_std::marker::PhantomData<S>);
+
+impl<S> Convert<Multiplier, Multiplier> for GearFeeMultiplier<S>
+where
+    S: Get<u64>,
+{
+    fn convert(_previous: Multiplier) -> Multiplier {
+        let len_step = S::get().max(1); // Avoiding division by 0.
+
+        let pow = common::dispatch_queue_len().saturating_div(len_step);
+        Multiplier::saturating_from_integer(1 << pow)
+    }
+}
+
+impl<S> MultiplierUpdate for GearFeeMultiplier<S>
+where
+    S: Get<u64>,
+{
+    fn min() -> Multiplier {
+        Default::default()
+    }
+    fn target() -> Perquintill {
+        Default::default()
+    }
+    fn variability() -> Multiplier {
+        Default::default()
+    }
+}
+
+/// A trait whose purpose is to extract the `Call` variant of an extrinsic
+pub trait ExtractCall<Call> {
+    fn extract_call(&self) -> Call;
+}
+
+/// Implementation for unchecked extrinsic.
+impl<Address, Call, Signature, Extra> ExtractCall<Call>
+    for UncheckedExtrinsic<Address, Call, Signature, Extra>
+where
+    Call: Dispatchable + Clone,
+    Extra: SignedExtension,
+{
+    fn extract_call(&self) -> Call {
+        self.function.clone()
+    }
+}
+
+/// Implementation for checked extrinsic.
+impl<Address, Call, Extra> ExtractCall<Call> for CheckedExtrinsic<Address, Call, Extra>
+where
+    Call: Dispatchable + Clone,
+{
+    fn extract_call(&self) -> Call {
+        self.function.clone()
+    }
+}
+
+impl<T: Config> Pallet<T> {
+    /// Modification of the `pallet_transaction_payment::Pallet<T>::query_info()`
+    /// that is aware of the transaction fee customization based on a specific call
+    pub fn query_info<
+        Extrinsic: sp_runtime::traits::Extrinsic + GetDispatchInfo + ExtractCall<CallOf<T>>,
+    >(
+        unchecked_extrinsic: Extrinsic,
+        len: u32,
+    ) -> RuntimeDispatchInfo<BalanceOf<T>>
+    where
+        CallOf<T>: Dispatchable<Info = DispatchInfo>,
+        BalanceOf<T>: FixedPointOperand,
+    {
+        let DispatchInfo {
+            weight,
+            class,
+            pays_fee,
+        } = <Extrinsic as GetDispatchInfo>::get_dispatch_info(&unchecked_extrinsic);
+
+        let partial_fee = if unchecked_extrinsic.is_signed().unwrap_or(false) {
+            let call: CallOf<T> =
+                <Extrinsic as ExtractCall<CallOf<T>>>::extract_call(&unchecked_extrinsic);
+            // If call is exempted from weight multiplication pre-divide it with the fee multiplier
+            let adjusted_weight = if !T::ExtraFeeCallFilter::contains(&call) {
+                TransactionPayment::<T>::next_fee_multiplier()
+                    .reciprocal()
+                    .unwrap_or_else(Multiplier::max_value)
+                    .saturating_mul_int(weight)
+            } else {
+                weight
+            };
+            TransactionPayment::<T>::compute_fee(
+                len,
+                &DispatchInfo {
+                    weight: adjusted_weight,
+                    class,
+                    pays_fee,
+                },
+                0u32.into(),
+            )
+        } else {
+            // Unsigned extrinsics have no partial fee.
+            0u32.into()
+        };
+
+        RuntimeDispatchInfo {
+            weight,
+            class,
+            partial_fee,
+        }
+    }
+
+    /// Modification of the `pallet_transaction_payment::Pallet<T>::query_fee_details()`
+    pub fn query_fee_details<
+        Extrinsic: sp_runtime::traits::Extrinsic + GetDispatchInfo + ExtractCall<CallOf<T>>,
+    >(
+        unchecked_extrinsic: Extrinsic,
+        len: u32,
+    ) -> FeeDetails<BalanceOf<T>>
+    where
+        CallOf<T>: Dispatchable<Info = DispatchInfo>,
+        BalanceOf<T>: FixedPointOperand,
+    {
+        let DispatchInfo {
+            weight,
+            class,
+            pays_fee,
+        } = <Extrinsic as GetDispatchInfo>::get_dispatch_info(&unchecked_extrinsic);
+
+        let tip = 0u32.into();
+
+        if unchecked_extrinsic.is_signed().unwrap_or(false) {
+            let call: CallOf<T> =
+                <Extrinsic as ExtractCall<CallOf<T>>>::extract_call(&unchecked_extrinsic);
+            let adjusted_weight = if !T::ExtraFeeCallFilter::contains(&call) {
+                TransactionPayment::<T>::next_fee_multiplier()
+                    .reciprocal()
+                    .unwrap_or_else(Multiplier::max_value)
+                    .saturating_mul_int(weight)
+            } else {
+                weight
+            };
+            TransactionPayment::<T>::compute_fee_details(
+                len,
+                &DispatchInfo {
+                    weight: adjusted_weight,
+                    class,
+                    pays_fee,
+                },
+                tip,
+            )
+        } else {
+            // Unsigned extrinsics have no inclusion fee.
+            FeeDetails {
+                inclusion_fee: None,
+                tip,
+            }
+        }
+    }
+}
+
+#[frame_support::pallet]
+pub mod pallet {
+    use super::*;
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config + pallet_transaction_payment::Config {
+        /// Filter for calls subbject for extra fees
+        type ExtraFeeCallFilter: Contains<CallOf<Self>>;
+    }
+
+    #[pallet::pallet]
+    #[pallet::without_storage_info]
+    pub struct Pallet<T>(_);
+}

--- a/pallets/payment/src/lib.rs
+++ b/pallets/payment/src/lib.rs
@@ -18,7 +18,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use common::storage::{StorageCounter, StorageDeque};
+use common::storage::StorageCounter;
 use frame_support::{
     pallet_prelude::*,
     traits::Contains,
@@ -44,7 +44,7 @@ pub use pallet::*;
 type BalanceOf<T> =
     <<T as pallet_transaction_payment::Config>::OnChargeTransaction as OnChargeTransaction<T>>::Balance;
 type CallOf<T> = <T as frame_system::Config>::Call;
-type LengthOf<T> = <<<T as Config>::MessageQueue as StorageDeque>::Length as StorageCounter>::Value;
+type LengthOf<T> = <<T as Config>::MessageQueueLength as StorageCounter>::Value;
 
 pub type TransactionPayment<T> = pallet_transaction_payment::Pallet<T>;
 
@@ -192,7 +192,7 @@ where
     fn convert(_previous: Multiplier) -> Multiplier {
         let len_step = S::get().max(1); // Avoiding division by 0.
 
-        let queue_len: u128 = <T as Config>::MessageQueue::len().saturated_into();
+        let queue_len: u128 = <T as Config>::MessageQueueLength::get().saturated_into();
         let pow = queue_len.saturating_div(len_step);
         Multiplier::saturating_from_integer(1 << pow)
     }
@@ -353,7 +353,7 @@ pub mod pallet {
         type ExtraFeeCallFilter: Contains<CallOf<Self>>;
 
         /// Type representing message queue
-        type MessageQueue: StorageDeque;
+        type MessageQueueLength: StorageCounter;
     }
 
     #[pallet::pallet]

--- a/pallets/payment/src/mock.rs
+++ b/pallets/payment/src/mock.rs
@@ -1,0 +1,249 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate as pallet_gear_payment;
+use frame_support::{
+    construct_runtime, parameter_types,
+    traits::{ConstU8, Contains, Currency, FindAuthor, OnFinalize, OnInitialize, OnUnbalanced},
+    weights::IdentityFee,
+};
+use frame_system as system;
+use pallet_transaction_payment::CurrencyAdapter;
+use primitive_types::H256;
+use sp_runtime::{
+    testing::{Header, TestXt},
+    traits::{BlakeTwo256, IdentityLookup},
+};
+use sp_std::convert::{TryFrom, TryInto};
+use sp_std::prelude::*;
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+pub const ALICE: u64 = 1;
+pub const BLOCK_AUTHOR: u64 = 255;
+
+// Configure a mock runtime to test the pallet.
+construct_runtime!(
+    pub enum Test where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        System: system::{Pallet, Call, Config, Storage, Event<T>},
+        Gear: pallet_gear::{Pallet, Call, Storage, Event<T>},
+        Gas: pallet_gas::{Pallet, Storage},
+        Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+        Authorship: pallet_authorship::{Pallet, Storage},
+        TransactionPayment: pallet_transaction_payment::{Pallet, Storage},
+        Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
+        GearPayment: pallet_gear_payment::{Pallet, Storage},
+        GearProgram: pallet_gear_program::{Pallet, Storage, Event<T>},
+    }
+);
+
+impl pallet_balances::Config for Test {
+    type MaxLocks = ();
+    type MaxReserves = ();
+    type ReserveIdentifier = [u8; 8];
+    type Balance = u128;
+    type DustRemoval = ();
+    type Event = Event;
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = System;
+    type WeightInfo = ();
+}
+
+pub struct FixedBlockAuthor;
+
+impl FindAuthor<u64> for FixedBlockAuthor {
+    fn find_author<'a, I>(_digests: I) -> Option<u64>
+    where
+        I: 'a + IntoIterator<Item = (sp_runtime::ConsensusEngineId, &'a [u8])>,
+    {
+        Some(BLOCK_AUTHOR)
+    }
+}
+
+impl pallet_authorship::Config for Test {
+    type FindAuthor = FixedBlockAuthor;
+    type UncleGenerations = ();
+    type FilterUncle = ();
+    type EventHandler = ();
+}
+
+parameter_types! {
+    pub const MinimumPeriod: u64 = 500;
+}
+
+impl pallet_timestamp::Config for Test {
+    type Moment = u64;
+    type OnTimestampSet = ();
+    type MinimumPeriod = MinimumPeriod;
+    type WeightInfo = ();
+}
+
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub const SS58Prefix: u8 = 42;
+    pub const ExistentialDeposit: u64 = 1;
+    pub BlockWeights: frame_system::limits::BlockWeights =
+        frame_system::limits::BlockWeights::simple_max(1_000_000_000);
+}
+
+impl system::Config for Test {
+    type BaseCallFilter = frame_support::traits::Everything;
+    type BlockWeights = BlockWeights;
+    type BlockLength = ();
+    type DbWeight = ();
+    type Origin = Origin;
+    type Call = Call;
+    type Index = u64;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = u64;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = Event;
+    type BlockHashCount = BlockHashCount;
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = pallet_balances::AccountData<u128>;
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = SS58Prefix;
+    type OnSetCode = ();
+    type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+parameter_types! {
+    pub const TransactionByteFee: u128 = 1;
+    pub const QueueLengthStep: u64 = 5;
+}
+
+impl pallet_transaction_payment::Config for Test {
+    type OnChargeTransaction = CurrencyAdapter<Balances, DealWithFees>;
+    type TransactionByteFee = TransactionByteFee;
+    type OperationalFeeMultiplier = ConstU8<5>;
+    type WeightToFee = IdentityFee<u128>;
+    type FeeMultiplierUpdate = pallet_gear_payment::GearFeeMultiplier<QueueLengthStep>;
+}
+
+pub struct GasConverter;
+impl common::GasPrice for GasConverter {
+    type Balance = u128;
+}
+
+parameter_types! {
+    pub const BlockGasLimit: u64 = 500_000;
+    pub const OutgoingLimit: u32 = 1024;
+    pub const WaitListFeePerBlock: u64 = 1_000;
+    pub MySchedule: pallet_gear::Schedule<Test> = <pallet_gear::Schedule<Test>>::default();
+}
+
+impl pallet_gear::Config for Test {
+    type Event = Event;
+    type Currency = Balances;
+    type GasPrice = GasConverter;
+    type GasHandler = Gas;
+    type WeightInfo = ();
+    type Schedule = MySchedule;
+    type BlockGasLimit = BlockGasLimit;
+    type OutgoingLimit = OutgoingLimit;
+    type DebugInfo = ();
+    type WaitListFeePerBlock = WaitListFeePerBlock;
+    type CodeStorage = GearProgram;
+}
+
+impl pallet_gear_program::Config for Test {
+    type Event = Event;
+    type WeightInfo = ();
+    type Currency = Balances;
+}
+
+impl pallet_gas::Config for Test {}
+
+type NegativeImbalance = <Balances as Currency<u64>>::NegativeImbalance;
+
+pub struct DealWithFees;
+impl OnUnbalanced<NegativeImbalance> for DealWithFees {
+    fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance>) {
+        if let Some(fees) = fees_then_tips.next() {
+            if let Some(author) = Authorship::author() {
+                Balances::resolve_creating(&author, fees);
+            }
+            if let Some(tips) = fees_then_tips.next() {
+                if let Some(author) = Authorship::author() {
+                    Balances::resolve_creating(&author, tips);
+                }
+            }
+        }
+    }
+}
+
+pub struct ExtraFeeFilter;
+impl Contains<Call> for ExtraFeeFilter {
+    fn contains(call: &Call) -> bool {
+        // Calls that affect message queue and are subject to extra fee
+        matches!(
+            call,
+            Call::Gear(pallet_gear::Call::submit_program { .. })
+                | Call::Gear(pallet_gear::Call::send_message { .. })
+                | Call::Gear(pallet_gear::Call::send_reply { .. })
+        )
+    }
+}
+
+impl pallet_gear_payment::Config for Test {
+    type ExtraFeeCallFilter = ExtraFeeFilter;
+}
+
+// Build genesis storage according to the mock runtime.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+    let mut t = system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap();
+
+    pallet_balances::GenesisConfig::<Test> {
+        balances: vec![(ALICE, 1_000_000_000_u128), (BLOCK_AUTHOR, 1_000_u128)],
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+
+    let mut ext = sp_io::TestExternalities::new(t);
+    ext.execute_with(|| System::set_block_number(1));
+    ext
+}
+
+pub fn run_to_block(n: u64) {
+    let now = System::block_number();
+    for i in now + 1..=n {
+        System::on_finalize(i - 1);
+        System::set_block_number(i);
+        System::on_initialize(i);
+        TransactionPayment::on_finalize(i);
+    }
+}
+
+impl crate::ExtractCall<Call> for TestXt<Call, ()> {
+    fn extract_call(&self) -> Call {
+        self.call.clone()
+    }
+}

--- a/pallets/payment/src/mock.rs
+++ b/pallets/payment/src/mock.rs
@@ -52,6 +52,7 @@ construct_runtime!(
         Authorship: pallet_authorship::{Pallet, Storage},
         TransactionPayment: pallet_transaction_payment::{Pallet, Storage},
         Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
+        GearMessenger: pallet_gear_messenger::{Pallet, Storage, Event<T>},
         GearPayment: pallet_gear_payment::{Pallet, Storage},
         GearProgram: pallet_gear_program::{Pallet, Storage, Event<T>},
     }
@@ -143,7 +144,7 @@ impl pallet_transaction_payment::Config for Test {
     type TransactionByteFee = TransactionByteFee;
     type OperationalFeeMultiplier = ConstU8<5>;
     type WeightToFee = IdentityFee<u128>;
-    type FeeMultiplierUpdate = pallet_gear_payment::GearFeeMultiplier<QueueLengthStep>;
+    type FeeMultiplierUpdate = pallet_gear_payment::GearFeeMultiplier<Test, QueueLengthStep>;
 }
 
 pub struct GasConverter;
@@ -165,7 +166,6 @@ impl pallet_gear::Config for Test {
     type GasHandler = Gas;
     type WeightInfo = ();
     type Schedule = MySchedule;
-    type BlockGasLimit = BlockGasLimit;
     type OutgoingLimit = OutgoingLimit;
     type DebugInfo = ();
     type WaitListFeePerBlock = WaitListFeePerBlock;
@@ -178,7 +178,13 @@ impl pallet_gear_program::Config for Test {
     type Currency = Balances;
 }
 
-impl pallet_gas::Config for Test {}
+impl pallet_gas::Config for Test {
+    type BlockGasLimit = BlockGasLimit;
+}
+
+impl pallet_gear_messenger::Config for Test {
+    type Event = Event;
+}
 
 type NegativeImbalance = <Balances as Currency<u64>>::NegativeImbalance;
 
@@ -213,6 +219,7 @@ impl Contains<Call> for ExtraFeeFilter {
 
 impl pallet_gear_payment::Config for Test {
     type ExtraFeeCallFilter = ExtraFeeFilter;
+    type MessageQueue = pallet_gear_messenger::DequeImpl<Test>;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/payment/src/mock.rs
+++ b/pallets/payment/src/mock.rs
@@ -217,9 +217,12 @@ impl Contains<Call> for ExtraFeeFilter {
     }
 }
 
+type QueueLength =
+    <<GearMessenger as common::storage::Messenger>::Queue as common::storage::StorageDeque>::Length;
+
 impl pallet_gear_payment::Config for Test {
     type ExtraFeeCallFilter = ExtraFeeFilter;
-    type MessageQueue = pallet_gear_messenger::DequeImpl<Test>;
+    type MessageQueueLength = QueueLength;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/payment/src/tests.rs
+++ b/pallets/payment/src/tests.rs
@@ -376,6 +376,7 @@ fn mq_size_not_affecting_fee_works() {
 }
 
 #[test]
+#[allow(clippy::let_unit_value)]
 fn query_info_and_fee_details_work() {
     let program_id = H256::random();
     let call_affecting_mq = Call::Gear(pallet_gear::Call::send_message {

--- a/pallets/payment/src/tests.rs
+++ b/pallets/payment/src/tests.rs
@@ -85,7 +85,8 @@ where
 
         let dispatch = dispatch.into_stored();
 
-        assert_ok!(<T as Config>::MessageQueue::push_back(dispatch.into()).map_err(|_| "Error pushing back stored dispatch"));
+        assert_ok!(<T as Config>::MessageQueue::push_back(dispatch.into())
+            .map_err(|_| "Error pushing back stored dispatch"));
     }
 }
 

--- a/pallets/payment/src/tests.rs
+++ b/pallets/payment/src/tests.rs
@@ -1,0 +1,531 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#![allow(clippy::identity_op)]
+
+use crate::{mock::*, CustomChargeTransactionPayment};
+
+use gear_core::message::{Dispatch, DispatchKind, Message};
+
+use codec::Encode;
+use frame_support::{
+    assert_ok,
+    weights::{DispatchInfo, GetDispatchInfo, PostDispatchInfo, Weight},
+};
+use pallet_transaction_payment::{FeeDetails, InclusionFee, Multiplier, RuntimeDispatchInfo};
+use primitive_types::H256;
+use sp_runtime::{testing::TestXt, traits::SignedExtension, FixedPointNumber};
+
+macro_rules! assert_approx_eq {
+    ($left:expr, $right:expr, $tol:expr) => {{
+        assert!(
+            $left < $right + $tol && $right < $left + $tol,
+            "{} != {} with tolerance {}",
+            $left,
+            $right,
+            $tol
+        );
+    }};
+}
+
+fn info_from_weight(w: Weight) -> DispatchInfo {
+    // DispatchInfo { weight: w, class: DispatchClass::Normal, pays_fee: Pays::Yes }
+    DispatchInfo {
+        weight: w,
+        ..Default::default()
+    }
+}
+
+fn default_post_info() -> PostDispatchInfo {
+    PostDispatchInfo {
+        actual_weight: None,
+        ..Default::default()
+    }
+}
+
+fn populate_message_queue(n: u64) {
+    common::clear_dispatch_queue();
+    for i in 0_u64..n {
+        let prog_id = (i + 1).into();
+        let msg_id = (100_u64 * n + i + 1).into();
+        let user_id = (10_000_u64 * n + i + 1).into();
+        let gas_limit = Some(10_000_u64);
+        let dispatch = Dispatch::new(
+            DispatchKind::Handle,
+            Message::new(
+                msg_id,
+                user_id,
+                prog_id,
+                Default::default(),
+                gas_limit,
+                0,
+                None,
+            ),
+        );
+
+        let dispatch = dispatch.into_stored();
+
+        common::queue_dispatch(dispatch);
+    }
+}
+
+#[test]
+fn custom_fee_multiplier_updated_per_block() {
+    new_test_ext().execute_with(|| {
+        // Send n extrinsics and run to next block
+        populate_message_queue(10);
+        run_to_block(2);
+
+        // CustomFeeMultiplier is 2^(10 / 5) == 4
+        assert_eq!(
+            TransactionPayment::next_fee_multiplier(),
+            Multiplier::saturating_from_integer(4)
+        );
+
+        populate_message_queue(33);
+        run_to_block(3);
+
+        // CustomFeeMultiplier is 2^(33 / 5) == 64
+        assert_eq!(
+            TransactionPayment::next_fee_multiplier(),
+            Multiplier::saturating_from_integer(64)
+        );
+    });
+}
+
+#[test]
+fn fee_rounding_error_bounded_by_multiplier() {
+    new_test_ext().execute_with(|| {
+        // Test various combinations:
+        // - large weight, small multiplier
+        // - large weight, large (relatively) multiplier
+        // - relatively small weight, small multiplier
+        // - relatively small weight, relatively large multiplier
+
+        let test_case =
+            |call: &<Test as frame_system::Config>::Call, weights: Vec<u64>, mult: u64| {
+                // not charging for tx len to make rounding error more significant
+                let len = 0;
+
+                for w in weights {
+                    let alice_initial_balance = Balances::free_balance(ALICE);
+                    let author_initial_balance = Balances::free_balance(BLOCK_AUTHOR);
+
+                    let pre = CustomChargeTransactionPayment::<Test>::from(0)
+                        .pre_dispatch(&ALICE, call, &info_from_weight(w), len)
+                        .unwrap();
+                    assert_approx_eq!(
+                        Balances::free_balance(ALICE),
+                        alice_initial_balance - w as u128,
+                        mult as u128
+                    );
+
+                    assert_ok!(CustomChargeTransactionPayment::<Test>::post_dispatch(
+                        Some(pre),
+                        &info_from_weight(w),
+                        &default_post_info(),
+                        len,
+                        &Ok(())
+                    ));
+                    assert_approx_eq!(
+                        Balances::free_balance(BLOCK_AUTHOR),
+                        author_initial_balance + w as u128,
+                        mult as u128
+                    );
+                }
+            };
+
+        // rounding error only arises for calls that do not affect MQ
+        let call: &<Test as frame_system::Config>::Call =
+            &Call::Gear(pallet_gear::Call::claim_value_from_mailbox {
+                message_id: H256::from_low_u64_le(1),
+            });
+
+        let weights: Vec<u64> = vec![1000, 100_000, 100_000_000];
+
+        // MQ is empty => multiplier is 1. No rounding error expected
+        test_case(call, weights.clone(), 1);
+
+        // Now populate message queue with 20 => multiplier == 16
+        populate_message_queue(20);
+        run_to_block(2);
+        test_case(call, weights.clone(), 16);
+
+        // Populate message queue with 60 => multiplier == 4096
+        populate_message_queue(60);
+        run_to_block(3);
+        test_case(call, weights, 4096);
+    });
+}
+
+#[test]
+fn mq_size_affecting_fee_works() {
+    new_test_ext().execute_with(|| {
+        // Scenario:
+        //
+        // - clear dispatch queue
+        // - submit transaction of known weight and len that affects MQ
+        // - ensure the fee is "standard": `len_fee` + `unadjsted_weight_fee`
+
+        // Populate MQ
+        // In the next block re-submit the transaction from before and check that
+        // - the fee factors in an additional custom multiplier that affects weight_fee part,
+        // - balances add up.
+
+        let alice_initial_balance = Balances::free_balance(ALICE);
+        let author_initial_balance = Balances::free_balance(BLOCK_AUTHOR);
+
+        let program_id = H256::random();
+
+        let call: &<Test as frame_system::Config>::Call =
+            &Call::Gear(pallet_gear::Call::send_message {
+                destination: program_id,
+                payload: Default::default(),
+                gas_limit: 100_000,
+                value: 0,
+            });
+
+        let len = 100_usize;
+        let per_byte_fee = <Test as pallet_transaction_payment::Config>::TransactionByteFee::get();
+        let len_fee = per_byte_fee.saturating_mul(len as u128);
+
+        let weight = 1000_u64;
+
+        let pre = CustomChargeTransactionPayment::<Test>::from(0)
+            .pre_dispatch(&ALICE, call, &info_from_weight(weight), len)
+            .unwrap();
+        // Can use strict equality for calls that do not introduce ronding error
+        assert_eq!(
+            Balances::free_balance(ALICE),
+            alice_initial_balance - weight as u128 - len_fee
+        );
+
+        assert_ok!(CustomChargeTransactionPayment::<Test>::post_dispatch(
+            Some(pre),
+            &info_from_weight(1_000),
+            &default_post_info(),
+            len,
+            &Ok(())
+        ));
+        assert_eq!(
+            Balances::free_balance(ALICE),
+            alice_initial_balance - weight as u128 - len_fee
+        );
+        assert_eq!(
+            Balances::free_balance(BLOCK_AUTHOR),
+            author_initial_balance + weight as u128 + len_fee
+        );
+
+        // Now populate message queue
+        populate_message_queue(20);
+
+        run_to_block(2);
+
+        let alice_initial_balance = Balances::free_balance(ALICE);
+        let author_initial_balance = Balances::free_balance(BLOCK_AUTHOR);
+
+        // Fee multiplier should have been set to 16
+        let pre = CustomChargeTransactionPayment::<Test>::from(0)
+            .pre_dispatch(&ALICE, call, &info_from_weight(weight), len)
+            .unwrap();
+
+        assert_eq!(
+            Balances::free_balance(ALICE),
+            alice_initial_balance - (weight as u128 * 16 + len_fee)
+        );
+
+        assert_ok!(CustomChargeTransactionPayment::<Test>::post_dispatch(
+            Some(pre),
+            &info_from_weight(1_000),
+            &default_post_info(),
+            len,
+            &Ok(())
+        ));
+        assert_eq!(
+            Balances::free_balance(ALICE),
+            alice_initial_balance - (weight as u128 * 16 + len_fee)
+        );
+        assert_eq!(
+            Balances::free_balance(BLOCK_AUTHOR),
+            author_initial_balance + (weight as u128 * 16 + len_fee)
+        );
+    });
+}
+
+#[test]
+fn mq_size_not_affecting_fee_works() {
+    new_test_ext().execute_with(|| {
+        // Scenario:
+        //
+        // - clear dispatch queue
+        // - submit transaction of known weight and len that does not affect MQ
+        // - ensure the fee is "standard": `len_fee` + `unadjsted_weight_fee`
+
+        // Populate MQ
+        // In the next block re-submit the transaction from before and check that
+        // - the fee remains unchanged,
+        // - balances add up.
+
+        let alice_initial_balance = Balances::free_balance(ALICE);
+        let author_initial_balance = Balances::free_balance(BLOCK_AUTHOR);
+
+        let call: &<Test as frame_system::Config>::Call =
+            &Call::Gear(pallet_gear::Call::claim_value_from_mailbox {
+                message_id: H256::from_low_u64_le(1),
+            });
+
+        let len = 100_usize;
+        let per_byte_fee = <Test as pallet_transaction_payment::Config>::TransactionByteFee::get();
+        let len_fee = per_byte_fee.saturating_mul(len as u128);
+
+        let weight = 1000_u64;
+
+        let pre = CustomChargeTransactionPayment::<Test>::from(0)
+            .pre_dispatch(&ALICE, call, &info_from_weight(weight), len)
+            .unwrap();
+        assert_approx_eq!(
+            Balances::free_balance(ALICE),
+            alice_initial_balance - weight as u128 - len_fee,
+            1
+        );
+
+        assert_ok!(CustomChargeTransactionPayment::<Test>::post_dispatch(
+            Some(pre),
+            &info_from_weight(weight),
+            &default_post_info(),
+            len,
+            &Ok(())
+        ));
+        assert_eq!(
+            Balances::free_balance(ALICE),
+            alice_initial_balance - weight as u128 - len_fee
+        );
+        assert_approx_eq!(
+            Balances::free_balance(ALICE),
+            alice_initial_balance - weight as u128 - len_fee,
+            1
+        );
+        assert_approx_eq!(
+            Balances::free_balance(BLOCK_AUTHOR),
+            author_initial_balance + weight as u128 + len_fee,
+            1
+        );
+
+        // Now populate message queue
+        populate_message_queue(20);
+
+        run_to_block(2);
+
+        let alice_initial_balance = Balances::free_balance(ALICE);
+        let author_initial_balance = Balances::free_balance(BLOCK_AUTHOR);
+
+        // Fee multiplier should have been set to 16
+        let pre = CustomChargeTransactionPayment::<Test>::from(0)
+            .pre_dispatch(&ALICE, call, &info_from_weight(weight), len)
+            .unwrap();
+
+        // Now we may have some rounding error somewhere at the least significant digits
+        assert_approx_eq!(
+            Balances::free_balance(ALICE),
+            alice_initial_balance - weight as u128 - len_fee,
+            16
+        );
+
+        assert_ok!(CustomChargeTransactionPayment::<Test>::post_dispatch(
+            Some(pre),
+            &info_from_weight(weight),
+            &default_post_info(),
+            len,
+            &Ok(())
+        ));
+        assert_approx_eq!(
+            Balances::free_balance(ALICE),
+            alice_initial_balance - weight as u128 - len_fee,
+            16
+        );
+        assert_approx_eq!(
+            Balances::free_balance(BLOCK_AUTHOR),
+            author_initial_balance + weight as u128 + len_fee,
+            16
+        );
+    });
+}
+
+#[test]
+fn query_info_and_fee_details_work() {
+    let program_id = H256::random();
+    let call_affecting_mq = Call::Gear(pallet_gear::Call::send_message {
+        destination: program_id,
+        payload: Default::default(),
+        gas_limit: 100_000,
+        value: 0,
+    });
+    let call_not_affecting_mq = Call::Gear(pallet_gear::Call::claim_value_from_mailbox {
+        message_id: H256::from_low_u64_le(1),
+    });
+    let extra = ();
+
+    let xt_affecting_mq = TestXt::new(call_affecting_mq.clone(), Some((ALICE, extra)));
+    let info_affecting_mq = xt_affecting_mq.get_dispatch_info();
+    let ext_affecting_mq = xt_affecting_mq.encode();
+    let len_affecting_mq = ext_affecting_mq.len() as u32;
+
+    let xt_not_affecting_mq = TestXt::new(call_not_affecting_mq, Some((ALICE, extra)));
+    let info_not_affecting_mq = xt_not_affecting_mq.get_dispatch_info();
+    let ext_not_affecting_mq = xt_not_affecting_mq.encode();
+    let len_not_affecting_mq = ext_not_affecting_mq.len() as u32;
+
+    let unsigned_xt = TestXt::<_, ()>::new(call_affecting_mq, None);
+    let unsigned_xt_info = unsigned_xt.get_dispatch_info();
+
+    new_test_ext().execute_with(|| {
+        // Empty Message queue => extra fee is not applied
+        assert_eq!(
+            GearPayment::query_info(xt_affecting_mq.clone(), len_affecting_mq),
+            RuntimeDispatchInfo {
+                weight: info_affecting_mq.weight,
+                class: info_affecting_mq.class,
+                partial_fee: 0 /* base_fee */
+                    + len_affecting_mq as u128  /* len * 1 */
+                    + info_affecting_mq.weight as u128 /* weight */
+            },
+        );
+
+        assert_eq!(
+            GearPayment::query_info(xt_not_affecting_mq.clone(), len_not_affecting_mq),
+            RuntimeDispatchInfo {
+                weight: info_not_affecting_mq.weight,
+                class: info_not_affecting_mq.class,
+                partial_fee: 0 /* base_fee */
+                    + len_not_affecting_mq as u128  /* len * 1 */
+                    + info_not_affecting_mq.weight as u128 /* weight */
+            },
+        );
+
+        assert_eq!(
+            GearPayment::query_info(unsigned_xt.clone(), len_affecting_mq),
+            RuntimeDispatchInfo {
+                weight: unsigned_xt_info.weight,
+                class: unsigned_xt_info.class,
+                partial_fee: 0,
+            },
+        );
+
+        assert_eq!(
+            GearPayment::query_fee_details(xt_affecting_mq.clone(), len_affecting_mq),
+            FeeDetails {
+                inclusion_fee: Some(InclusionFee {
+                    base_fee: 0,
+                    len_fee: len_affecting_mq as u128,
+                    adjusted_weight_fee: info_affecting_mq.weight as u128
+                }),
+                tip: 0,
+            },
+        );
+
+        assert_eq!(
+            GearPayment::query_fee_details(xt_not_affecting_mq.clone(), len_not_affecting_mq),
+            FeeDetails {
+                inclusion_fee: Some(InclusionFee {
+                    base_fee: 0,
+                    len_fee: len_not_affecting_mq as u128,
+                    adjusted_weight_fee: info_not_affecting_mq.weight as u128
+                }),
+                tip: 0,
+            },
+        );
+
+        assert_eq!(
+            GearPayment::query_fee_details(unsigned_xt.clone(), len_affecting_mq),
+            FeeDetails {
+                inclusion_fee: None,
+                tip: 0
+            },
+        );
+
+        // Now populate message queue
+        populate_message_queue(20);
+        run_to_block(2);
+
+        // Extra fee multiplier is now 2^(20 / 5) == 16
+        assert_eq!(
+            GearPayment::query_info(xt_affecting_mq.clone(), len_affecting_mq),
+            RuntimeDispatchInfo {
+                weight: info_affecting_mq.weight,
+                class: info_affecting_mq.class,
+                partial_fee: 0 /* base_fee */
+                    + len_affecting_mq as u128  /* len * 1 */
+                    + (info_affecting_mq.weight as u128) * 16_u128 /* weight * 16 */
+            },
+        );
+
+        // Extra fee not applicable => fee should be exactly what it was for empty MQ
+        // However, we must account for the rounding error in this case
+        assert_eq!(
+            GearPayment::query_info(xt_not_affecting_mq.clone(), len_not_affecting_mq),
+            RuntimeDispatchInfo {
+                weight: info_not_affecting_mq.weight,
+                class: info_not_affecting_mq.class,
+                partial_fee: 0 /* base_fee */
+                    + len_not_affecting_mq as u128  /* len * 1 */
+                    + (info_not_affecting_mq.weight as u128 / 16) * 16 /* weight, with potential small rounding error */
+            },
+        );
+
+        assert_eq!(
+            GearPayment::query_info(unsigned_xt.clone(), len_affecting_mq),
+            RuntimeDispatchInfo {
+                weight: unsigned_xt_info.weight,
+                class: unsigned_xt_info.class,
+                partial_fee: 0,
+            },
+        );
+
+        assert_eq!(
+            GearPayment::query_fee_details(xt_affecting_mq, len_affecting_mq),
+            FeeDetails {
+                inclusion_fee: Some(InclusionFee {
+                    base_fee: 0,
+                    len_fee: len_affecting_mq as u128,
+                    adjusted_weight_fee: (info_affecting_mq.weight as u128) * 16_u128
+                }),
+                tip: 0,
+            },
+        );
+
+        assert_eq!(
+            GearPayment::query_fee_details(xt_not_affecting_mq, len_not_affecting_mq),
+            FeeDetails {
+                inclusion_fee: Some(InclusionFee {
+                    base_fee: 0,
+                    len_fee: len_not_affecting_mq as u128,
+                    adjusted_weight_fee: (info_not_affecting_mq.weight as u128 / 16) * 16_u128
+                }),
+                tip: 0,
+            },
+        );
+
+        assert_eq!(
+            GearPayment::query_fee_details(unsigned_xt, len_affecting_mq),
+            FeeDetails {
+                inclusion_fee: None,
+                tip: 0
+            },
+        );
+    });
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -81,6 +81,7 @@ std = [
 	"pallet-gear-debug/std",
 	"pallet-usage/std",
 	"pallet-gas/std",
+	"pallet-gear-payment/std",
 	"pallet-gear-rpc-runtime-api/std",
 	"gear-common/std",
 	"pallet-grandpa/std",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -57,6 +57,7 @@ pallet-gear = { version = "2.0.0", default-features = false, path = "../pallets/
 pallet-gear-debug = { version = "2.0.0", default-features = false, path = "../pallets/gear-debug", optional = true }
 pallet-usage = { version = "2.0.0", default-features = false, path = "../pallets/usage" }
 pallet-gas = { version = "2.0.0", default-features = false, path = "../pallets/gas" }
+pallet-gear-payment = { version = "0.1.0", default-features = false, path = "../pallets/payment" }
 pallet-gear-rpc-runtime-api = { version = "2.0.0", default-features = false, path = "../pallets/gear/rpc/runtime-api" }
 gear-common = { version = "0.1.0", default-features = false, path = "../common" }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -125,7 +125,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 720,
+    spec_version: 730,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -416,9 +416,12 @@ impl OnUnbalanced<NegativeImbalance> for DealWithFees {
     }
 }
 
+type QueueLength =
+    <<GearMessenger as gear_common::storage::Messenger>::Queue as gear_common::storage::StorageDeque>::Length;
+
 impl pallet_gear_payment::Config for Runtime {
     type ExtraFeeCallFilter = ExtraFeeFilter;
-    type MessageQueue = pallet_gear_messenger::DequeImpl<Runtime>;
+    type MessageQueueLength = QueueLength;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -27,17 +27,15 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 use pallet_grandpa::{
     fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
 };
-pub use pallet_transaction_payment::{Multiplier, MultiplierUpdate};
+pub use pallet_transaction_payment::{CurrencyAdapter, Multiplier};
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata, H256};
 use sp_runtime::{
     create_runtime_str, generic, impl_opaque_keys,
-    traits::{
-        AccountIdLookup, BlakeTwo256, Block as BlockT, Convert, IdentifyAccount, NumberFor, Verify,
-    },
+    traits::{AccountIdLookup, BlakeTwo256, Block as BlockT, IdentifyAccount, NumberFor, Verify},
     transaction_validity::{TransactionSource, TransactionValidity},
-    ApplyExtrinsicResult, FixedPointNumber, MultiSignature, Perbill, Percent, Perquintill,
+    ApplyExtrinsicResult, MultiSignature, Perbill, Percent,
 };
 use sp_std::convert::{TryFrom, TryInto};
 use sp_std::prelude::*;
@@ -51,8 +49,8 @@ pub use pallet_gear::manager::{ExtManager, HandleKind};
 pub use frame_support::{
     construct_runtime, parameter_types,
     traits::{
-        ConstU128, ConstU32, ConstU64, ConstU8, FindAuthor, KeyOwnerProofSystem, Randomness,
-        StorageInfo,
+        ConstU128, ConstU32, ConstU64, ConstU8, Contains, Currency, FindAuthor,
+        KeyOwnerProofSystem, OnUnbalanced, Randomness, StorageInfo,
     },
     weights::{
         constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
@@ -62,13 +60,13 @@ pub use frame_support::{
 };
 pub use pallet_balances::Call as BalancesCall;
 pub use pallet_timestamp::Call as TimestampCall;
-use pallet_transaction_payment::CurrencyAdapter;
+
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 
 #[cfg(feature = "debug-mode")]
 pub use pallet_gear_debug;
-pub use {pallet_gas, pallet_gear, pallet_usage};
+pub use {pallet_gas, pallet_gear, pallet_gear_payment, pallet_usage};
 
 /// An index to a block.
 pub type BlockNumber = u32;
@@ -304,44 +302,15 @@ impl pallet_balances::Config for Runtime {
 
 parameter_types! {
     pub const TransactionByteFee: Balance = 1;
-    pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_integer(1);
-}
-
-/// Custom fee multiplier which remains constant regardless the network congestion
-/// TODO: consider using Substrate's built-in `pallet_transaction_payment::TargetedFeeAdjustment`
-/// to allow elastic fees based on network conditions (if that's more appropriate)
-pub struct ConstantFeeMultiplier<M>(sp_std::marker::PhantomData<M>);
-
-impl<M> MultiplierUpdate for ConstantFeeMultiplier<M>
-where
-    M: frame_support::traits::Get<Multiplier>,
-{
-    fn min() -> Multiplier {
-        M::get()
-    }
-    fn target() -> Perquintill {
-        Default::default()
-    }
-    fn variability() -> Multiplier {
-        Default::default()
-    }
-}
-impl<M> Convert<Multiplier, Multiplier> for ConstantFeeMultiplier<M>
-where
-    M: frame_support::traits::Get<Multiplier>,
-{
-    fn convert(previous: Multiplier) -> Multiplier {
-        let min_multiplier = M::get();
-        previous.max(min_multiplier)
-    }
+    pub const QueueLengthStep: u64 = 10;
 }
 
 impl pallet_transaction_payment::Config for Runtime {
-    type OnChargeTransaction = CurrencyAdapter<Balances, ()>;
+    type OnChargeTransaction = CurrencyAdapter<Balances, DealWithFees>;
     type TransactionByteFee = TransactionByteFee;
     type OperationalFeeMultiplier = ConstU8<5>;
     type WeightToFee = IdentityFee<Balance>;
-    type FeeMultiplierUpdate = ConstantFeeMultiplier<MinimumMultiplier>;
+    type FeeMultiplierUpdate = pallet_gear_payment::GearFeeMultiplier<QueueLengthStep>;
 }
 
 impl pallet_sudo::Config for Runtime {
@@ -416,6 +385,41 @@ impl pallet_gear_messenger::Config for Runtime {
     type Event = Event;
 }
 
+pub struct ExtraFeeFilter;
+impl Contains<Call> for ExtraFeeFilter {
+    fn contains(call: &Call) -> bool {
+        // Calls that affect message queue and are subject to extra fee
+        matches!(
+            call,
+            Call::Gear(pallet_gear::Call::submit_program { .. })
+                | Call::Gear(pallet_gear::Call::send_message { .. })
+                | Call::Gear(pallet_gear::Call::send_reply { .. })
+        )
+    }
+}
+
+type NegativeImbalance = <Balances as Currency<AccountId>>::NegativeImbalance;
+
+pub struct DealWithFees;
+impl OnUnbalanced<NegativeImbalance> for DealWithFees {
+    fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance>) {
+        if let Some(fees) = fees_then_tips.next() {
+            if let Some(author) = Authorship::author() {
+                Balances::resolve_creating(&author, fees);
+            }
+            if let Some(tips) = fees_then_tips.next() {
+                if let Some(author) = Authorship::author() {
+                    Balances::resolve_creating(&author, tips);
+                }
+            }
+        }
+    }
+}
+
+impl pallet_gear_payment::Config for Runtime {
+    type ExtraFeeCallFilter = ExtraFeeFilter;
+}
+
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime
 where
     Call: From<C>,
@@ -447,6 +451,7 @@ construct_runtime!(
         Gear: pallet_gear,
         Usage: pallet_usage,
         Gas: pallet_gas,
+        GearPayment: pallet_gear_payment,
 
         // Only available with "debug-mode" feature on
         GearDebug: pallet_gear_debug,
@@ -475,6 +480,7 @@ construct_runtime!(
         Gear: pallet_gear,
         Usage: pallet_usage,
         Gas: pallet_gas,
+        GearPayment: pallet_gear_payment,
     }
 );
 
@@ -493,7 +499,7 @@ pub type SignedExtra = (
     frame_system::CheckEra<Runtime>,
     frame_system::CheckNonce<Runtime>,
     frame_system::CheckWeight<Runtime>,
-    pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+    pallet_gear_payment::CustomChargeTransactionPayment<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;
@@ -632,13 +638,13 @@ impl_runtime_apis! {
             uxt: <Block as BlockT>::Extrinsic,
             len: u32,
         ) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-            TransactionPayment::query_info(uxt, len)
+            GearPayment::query_info(uxt, len)
         }
         fn query_fee_details(
             uxt: <Block as BlockT>::Extrinsic,
             len: u32,
         ) -> pallet_transaction_payment::FeeDetails<Balance> {
-            TransactionPayment::query_fee_details(uxt, len)
+            GearPayment::query_fee_details(uxt, len)
         }
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -302,7 +302,7 @@ impl pallet_balances::Config for Runtime {
 
 parameter_types! {
     pub const TransactionByteFee: Balance = 1;
-    pub const QueueLengthStep: u64 = 10;
+    pub const QueueLengthStep: u128 = 10;
 }
 
 impl pallet_transaction_payment::Config for Runtime {
@@ -310,7 +310,7 @@ impl pallet_transaction_payment::Config for Runtime {
     type TransactionByteFee = TransactionByteFee;
     type OperationalFeeMultiplier = ConstU8<5>;
     type WeightToFee = IdentityFee<Balance>;
-    type FeeMultiplierUpdate = pallet_gear_payment::GearFeeMultiplier<QueueLengthStep>;
+    type FeeMultiplierUpdate = pallet_gear_payment::GearFeeMultiplier<Runtime, QueueLengthStep>;
 }
 
 impl pallet_sudo::Config for Runtime {
@@ -418,6 +418,7 @@ impl OnUnbalanced<NegativeImbalance> for DealWithFees {
 
 impl pallet_gear_payment::Config for Runtime {
     type ExtraFeeCallFilter = ExtraFeeFilter;
+    type MessageQueue = pallet_gear_messenger::DequeImpl<Runtime>;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime


### PR DESCRIPTION
Implements one of the measures in order to resolve [this issue](https://github.com/gear-tech/core-audit/issues/2).

Briefly, a solution is to increase transaction fees if the message queue inflates and reduce them back once it's shrunk down. This would raise a barrier for transactions to enter the system and relieve the pressure on the processing engine.
This is a modification of the standard approach taken in Substrate to adjust fees based on the overall network congestion level.

Generally, it is reasonable to charge transactions that affect the Message Queue based on the gas_limit they declare:

`Fee = base_fee + P⋅tx.len +  𝛂⋅F(tx.weight) + 𝛃⋅G(tx.gas_limit)`, 

where `P` - per byte cost, `F(.)` - weight to fee conversion function, `G(.)` - gas-to-fee conversion function (`gas_price`),`𝛂 ≥ 1` - fee multiplier reflecting the tx pool state, `𝛃 ≥ 1` - fee multiplier reflecting the message queue congestion level.

The problem is that the actual amount of gas spent is not known by the time the extrinsic has been dispatched so we can't yet calculate the gas leftover that needs to be refunded.

Hence the following simplification:

`Fee = base_fee + P⋅tx.len +  𝞬⋅F(tx.weight)`, where `𝞬 ≥ 1` is some empirical coefficient depending on the number of messages in the queue by the end of the previous block. If a transaction does not affect the message queue (like `set_code`, for instance), `𝞬` is set to 1.

This is essentially the formula Substrate uses for transaction fee calculation in its own `transaction-payment` pallet, only that the multiplier is calculated differently, and can vary depending on the concrete call.