### PR TITLE
Improve programs' panic handling

### DIFF
--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -424,6 +424,9 @@ impl EnvExt for Ext {
     fn debug(&mut self, data: &str) -> Result<(), &'static str> {
         self.charge_gas_runtime(RuntimeCosts::Debug)?;
 
+        if data.starts_with("panic occurred") {
+            self.error_explanation = Some("Panic occurred");
+        }
         log::debug!(target: "gwasm", "DEBUG: {}", data);
 
         Ok(())

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -21,6 +21,10 @@
 
 #![no_std]
 #![cfg_attr(target_arch = "wasm32", feature(alloc_error_handler))]
+#![cfg_attr(
+    all(target_arch = "wasm32", feature = "debug"),
+    feature(panic_info_message)
+)]
 #![cfg_attr(feature = "strict", deny(warnings))]
 #![doc(html_logo_url = "https://docs.gear.rs/logo.svg")]
 

--- a/gstd/src/macros/debug.rs
+++ b/gstd/src/macros/debug.rs
@@ -23,13 +23,13 @@
 #[macro_export]
 macro_rules! debug {
     ($arg:literal) => {
-        $crate::ext::debug(&$crate::prelude::format!("{}", $arg));
+        $crate::ext::debug(&$crate::prelude::format!("{}", $arg))
     };
     ($arg:expr) => {
-        $crate::ext::debug(&$crate::prelude::format!("{:?}", $arg));
+        $crate::ext::debug(&$crate::prelude::format!("{:?}", $arg))
     };
     ($fmt:literal, $($args:tt)+) => {
-        $crate::ext::debug(&$crate::prelude::format!($fmt, $($args)+));
+        $crate::ext::debug(&$crate::prelude::format!($fmt, $($args)+))
     };
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -127,7 +127,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 640,
+    spec_version: 650,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
- Refactor the panic handler for programs compiled with the `debug` feature to have fewer allocations.
- Propagate `Panic occurred` as an error explanation.

@gear-tech/dev 
