### PR TITLE
Bugfix in gas pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,6 +1326,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "demo-compose"
+version = "0.1.0"
+dependencies = [
+ "gear-wasm-builder",
+ "gstd",
+ "hex",
+ "parity-scale-codec",
+]
+
+[[package]]
 name = "demo-distributor"
 version = "0.1.0"
 dependencies = [
@@ -1357,6 +1367,16 @@ version = "0.1.0"
 dependencies = [
  "gear-wasm-builder",
  "gstd",
+]
+
+[[package]]
+name = "demo-mul-by-const"
+version = "0.1.0"
+dependencies = [
+ "gear-wasm-builder",
+ "gstd",
+ "hex",
+ "parity-scale-codec",
 ]
 
 [[package]]
@@ -4805,10 +4825,12 @@ name = "pallet-gear"
 version = "2.0.0"
 dependencies = [
  "demo-btree",
+ "demo-compose",
  "demo-distributor",
  "demo-exit-handle",
  "demo-exit-init",
  "demo-init-wait",
+ "demo-mul-by-const",
  "demo-program-factory",
  "demo-proxy",
  "env_logger",

--- a/examples/binaries/compose/Cargo.toml
+++ b/examples/binaries/compose/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "demo-compose"
+version = "0.1.0"
+authors = ["Gear Technologies"]
+edition = "2018"
+license = "GPL-3.0"
+workspace = "../../../"
+
+[dependencies]
+gstd = { path = "../../../gstd", features = ["debug"] }
+codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive"] }
+hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
+
+[build-dependencies]
+gear-wasm-builder = { path = "../../../utils/wasm-builder" }
+
+[lib]
+
+[features]
+std = ["codec/std"]
+default = ["std"]

--- a/examples/binaries/compose/build.rs
+++ b/examples/binaries/compose/build.rs
@@ -1,0 +1,21 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+fn main() {
+    gear_wasm_builder::build();
+}

--- a/examples/binaries/compose/src/lib.rs
+++ b/examples/binaries/compose/src/lib.rs
@@ -1,0 +1,153 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// This contract recursively composes itself with another contract (the other contract
+// being applied to the input data first): `c(f) = (c(f) . f) x`.
+// Every call to the auto_composer contract incremets the internal `ITER` counter.
+// As soon as the counter reaches the `MAX_ITER`, the recursion stops.
+// Effectively, this procedure executes a composition of `MAX_ITER` contracts `f`
+// where the output of the previous call is fed to the input of the next call.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "std")]
+mod code {
+    include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+}
+
+#[cfg(feature = "std")]
+pub use code::WASM_BINARY_OPT as WASM_BINARY;
+
+#[cfg(not(feature = "std"))]
+mod wasm {
+    extern crate alloc;
+
+    use codec::{Decode, Encode};
+    use gstd::{debug, exec, msg, prelude::*, ActorId};
+
+    static mut STATE: State = State {
+        contract_a: Program {
+            handle: ActorId::new([0u8; 32]),
+        },
+        contract_b: Program {
+            handle: ActorId::new([0u8; 32]),
+        },
+    };
+
+    struct State {
+        contract_a: Program,
+        contract_b: Program,
+    }
+
+    impl State {
+        fn new(actor_a: impl Into<ActorId>, actor_b: impl Into<ActorId>) -> Self {
+            Self {
+                contract_a: Program::new(actor_a),
+                contract_b: Program::new(actor_b),
+            }
+        }
+
+        async fn compose(&mut self, input: Vec<u8>) -> Result<Vec<u8>, &'static str> {
+            debug!(
+                "[0x{} compose::compose] Composing programs 0x{} and 0x{} on input {:?}",
+                hex::encode(exec::program_id()),
+                hex::encode(self.contract_a.handle),
+                hex::encode(self.contract_b.handle),
+                input
+            );
+            debug!(
+                "[0x{} compose::compose] Calling contract #1 at 0x{}",
+                hex::encode(exec::program_id()),
+                hex::encode(self.contract_a.handle),
+            );
+            let output_a = self.contract_a.call(input).await?;
+            debug!(
+                "[0x{} compose::compose] Calling contract #2 at 0x{}",
+                hex::encode(exec::program_id()),
+                hex::encode(self.contract_b.handle),
+            );
+            let output = self.contract_b.call(output_a).await?;
+            debug!(
+                "[0x{} compose::compose] Composition output: {:?}",
+                hex::encode(exec::program_id()),
+                output
+            );
+
+            Ok(output)
+        }
+    }
+
+    #[derive(Eq, Ord, PartialEq, PartialOrd)]
+    struct Program {
+        handle: ActorId,
+    }
+
+    impl Program {
+        fn new(handle: impl Into<ActorId>) -> Self {
+            Self {
+                handle: handle.into(),
+            }
+        }
+
+        async fn call(&self, input: Vec<u8>) -> Result<Vec<u8>, &'static str> {
+            let reply_bytes = msg::send_bytes_and_wait_for_reply(self.handle, &input[..], 0)
+                .expect("Error sending message")
+                .await
+                .map_err(|_| "Error in async message processing")?;
+            debug!(
+                "[0x{} compose::Program::call] Received reply from remote contract: {}",
+                hex::encode(exec::program_id()),
+                hex::encode(&reply_bytes),
+            );
+
+            Ok(reply_bytes)
+        }
+    }
+
+    #[gstd::async_main]
+    async fn main() {
+        let input = msg::load_bytes();
+        debug!(
+            "[0x{} compose::handle] input = {:?}, gas_available = {}",
+            hex::encode(exec::program_id()),
+            input,
+            exec::gas_available()
+        );
+
+        if let Ok(outcome) = (unsafe { STATE.compose(input) }).await {
+            debug!(
+                "[0x{} compose::handle] Composition output: {:?}",
+                hex::encode(exec::program_id()),
+                outcome
+            );
+            msg::reply(outcome, 0);
+        }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn init() {
+        let (contract_a, contract_b): (ActorId, ActorId) =
+            msg::load().expect("Expecting two contract addresses");
+        STATE = State::new(contract_a, contract_b);
+        msg::reply((), 0);
+        debug!(
+            "[0x{} compose::init] Program initialized",
+            hex::encode(exec::program_id())
+        );
+    }
+}

--- a/examples/binaries/mul-by-const/Cargo.toml
+++ b/examples/binaries/mul-by-const/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "demo-mul-by-const"
+version = "0.1.0"
+authors = ["Gear Technologies"]
+edition = "2018"
+license = "GPL-3.0"
+workspace = "../../../"
+
+[dependencies]
+gstd = { path = "../../../gstd", features = ["debug"] }
+codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive"] }
+hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
+
+[build-dependencies]
+gear-wasm-builder = { path = "../../../utils/wasm-builder" }
+
+[lib]
+
+[features]
+std = ["codec/std"]
+default = ["std"]

--- a/examples/binaries/mul-by-const/build.rs
+++ b/examples/binaries/mul-by-const/build.rs
@@ -1,0 +1,21 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+fn main() {
+    gear_wasm_builder::build();
+}

--- a/examples/binaries/mul-by-const/src/lib.rs
+++ b/examples/binaries/mul-by-const/src/lib.rs
@@ -1,0 +1,96 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// This contract recursively composes itself with another contract (the other contract
+// being applied to the input data first): `c(f) = (c(f) . f) x`.
+// Every call to the auto_composer contract incremets the internal `ITER` counter.
+// As soon as the counter reaches the `MAX_ITER`, the recursion stops.
+// Effectively, this procedure executes a composition of `MAX_ITER` contracts `f`
+// where the output of the previous call is fed to the input of the next call.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "std")]
+mod code {
+    include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+}
+
+#[cfg(feature = "std")]
+pub use code::WASM_BINARY_OPT as WASM_BINARY;
+
+#[cfg(not(feature = "std"))]
+mod wasm {
+    extern crate alloc;
+
+    use gstd::{debug, exec, msg, String};
+
+    static mut DEBUG: DebugInfo = DebugInfo { me: String::new() };
+    static mut STATE: State = State { intrinsic: 0 };
+
+    struct DebugInfo {
+        me: String,
+    }
+
+    struct State {
+        intrinsic: u64,
+    }
+
+    impl State {
+        fn new(value: u64) -> Self {
+            Self { intrinsic: value }
+        }
+
+        unsafe fn unchecked_mul(&mut self, other: u64) -> u64 {
+            let z: u64 = self
+                .intrinsic
+                .checked_mul(other)
+                .expect("Multiplication overflow");
+            debug!(
+                "[0x{} mul_by_const::unchecked_mul] Calculated {} x {} == {}",
+                DEBUG.me, self.intrinsic, other, z
+            );
+            z
+        }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn handle() {
+        let x: u64 = msg::load().expect("Expecting a u64 number");
+
+        debug!(
+            "[0x{} mul_by_const::handle] Before sending reply message, gas_available = {}",
+            DEBUG.me,
+            exec::gas_available()
+        );
+        msg::reply(STATE.unchecked_mul(x), 0);
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn init() {
+        let val: u64 = msg::load().expect("Expecting a u64 number");
+        STATE = State::new(val);
+        DEBUG = DebugInfo {
+            me: hex::encode(exec::program_id()),
+        };
+        msg::reply((), 0);
+        debug!(
+            "[0x{} mul_by_const::init] Program initialized with input {}",
+            DEBUG.me, val
+        );
+    }
+}

--- a/pallets/gas/src/lib.rs
+++ b/pallets/gas/src/lib.rs
@@ -356,13 +356,11 @@ where
                         } else {
                             parent_node.unspec_refs = parent_node.unspec_refs.saturating_sub(1);
                         }
-                    }
 
-                    if parent_node.refs() == 0 {
-                        consume_parent_node = true;
-                    }
+                        if parent_node.refs() == 0 {
+                            consume_parent_node = true;
+                        }
 
-                    if delete_current_node {
                         // Update parent node
                         GasTree::<T>::mutate(parent, |value| {
                             *value = Some(parent_node);
@@ -401,12 +399,11 @@ where
                             if let Some(inner_value) = node.inner_value_mut() {
                                 *inner_value = 0
                             };
-
-                            // Save current node
-                            GasTree::<T>::mutate(key, |value| {
-                                *value = Some(node);
-                            });
                         }
+                        // Save current node
+                        GasTree::<T>::mutate(key, |value| {
+                            *value = Some(node);
+                        });
                     }
 
                     // now check if the parent node can be consumed as well

--- a/pallets/gear/Cargo.toml
+++ b/pallets/gear/Cargo.toml
@@ -60,6 +60,8 @@ demo-exit-init = { path = "../../examples/binaries/exit-init" }
 demo-exit-handle = { path = "../../examples/binaries/exit-handle" }
 demo-program-factory = { path = "../../examples/binaries/program-factory" }
 demo-proxy = { path = "../../examples/binaries/proxy" }
+demo-mul-by-const = { path = "../../examples/binaries/mul-by-const" }
+demo-compose = { path = "../../examples/binaries/compose" }
 page_size = "0.4.2"
 
 [features]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -125,7 +125,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 760,
+    spec_version: 770,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
A node wouldn't be marked as "consumed" unless it had no unspecified refs.