### PR TITLE
update PageBuf and remove allowance_exceed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,6 +2306,7 @@ version = "0.1.0"
 dependencies = [
  "blake2-rfc",
  "derive_more",
+ "env_logger",
  "gear-core-errors",
  "hex",
  "log",

--- a/common/src/benchmarking.rs
+++ b/common/src/benchmarking.rs
@@ -18,7 +18,7 @@
 
 use super::*;
 
-use gear_core::memory::{PageNumber, WasmPageNumber, new_zeroed_page_buf};
+use gear_core::memory::{new_zeroed_page_buf, PageNumber, WasmPageNumber};
 use parity_wasm::elements::*;
 use sp_io::hashing::blake2_256;
 use sp_std::borrow::ToOwned;

--- a/common/src/benchmarking.rs
+++ b/common/src/benchmarking.rs
@@ -18,7 +18,7 @@
 
 use super::*;
 
-use gear_core::memory::{PageNumber, WasmPageNumber};
+use gear_core::memory::{PageNumber, WasmPageNumber, new_zeroed_page_buf};
 use parity_wasm::elements::*;
 use sp_io::hashing::blake2_256;
 use sp_std::borrow::ToOwned;
@@ -135,10 +135,10 @@ pub fn generate_wasm3(payload: Vec<u8>) -> Result<Vec<u8>, &'static str> {
 pub fn set_program(program_id: H256, code: Vec<u8>, static_pages: WasmPageNumber) {
     let code_id = CodeId::generate(&code).into_origin();
     let allocations = (0..static_pages.0).map(WasmPageNumber);
-    let persistent_pages_data: BTreeMap<PageNumber, Vec<u8>> = allocations
+    let persistent_pages_data: BTreeMap<PageNumber, PageBuf> = allocations
         .clone()
         .flat_map(|p| p.to_gear_pages_iter())
-        .map(|p| (p, vec![0u8; PageNumber::size()]))
+        .map(|p| (p, new_zeroed_page_buf()))
         .collect();
     super::set_program_and_pages_data(
         program_id,

--- a/common/src/benchmarking.rs
+++ b/common/src/benchmarking.rs
@@ -18,7 +18,7 @@
 
 use super::*;
 
-use gear_core::memory::{new_zeroed_page_buf, PageNumber, WasmPageNumber};
+use gear_core::memory::{PageNumber, WasmPageNumber};
 use parity_wasm::elements::*;
 use sp_io::hashing::blake2_256;
 use sp_std::borrow::ToOwned;
@@ -138,7 +138,7 @@ pub fn set_program(program_id: H256, code: Vec<u8>, static_pages: WasmPageNumber
     let persistent_pages_data: BTreeMap<PageNumber, PageBuf> = allocations
         .clone()
         .flat_map(|p| p.to_gear_pages_iter())
-        .map(|p| (p, new_zeroed_page_buf()))
+        .map(|p| (p, PageBuf::new_zeroed()))
         .collect();
     super::set_program_and_pages_data(
         program_id,

--- a/common/src/lazy_pages.rs
+++ b/common/src/lazy_pages.rs
@@ -19,8 +19,8 @@
 //! Lazy pages support runtime functions
 
 use crate::Origin;
-use gear_core::{ids::ProgramId, memory::PageBuf};
 use gear_core::memory::PageNumber;
+use gear_core::{ids::ProgramId, memory::PageBuf};
 use gear_runtime_interface::{gear_ri, GetReleasedPageError, MprotectError};
 use sp_std::{
     collections::{btree_map::BTreeMap, btree_set::BTreeSet},

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -36,7 +36,7 @@ use frame_support::{
 };
 use gear_core::{
     ids::{CodeId, MessageId, ProgramId},
-    memory::{page_buf_from_vec_u8, Error as MemoryError, PageBuf, PageNumber, WasmPageNumber},
+    memory::{Error as MemoryError, PageBuf, PageNumber, WasmPageNumber},
     message::StoredDispatch,
 };
 use gear_runtime_interface as gear_ri;
@@ -403,7 +403,7 @@ pub fn get_program_page_data(
 ) -> Option<Result<PageBuf, MemoryError>> {
     let key = page_key(id, page_idx);
     let data = sp_io::storage::get(&key)?;
-    Some(page_buf_from_vec_u8(data))
+    Some(PageBuf::new_from_vec(data))
 }
 
 /// Save page data key in storage
@@ -429,7 +429,7 @@ pub fn get_program_data_for_pages<'a>(
         let key = page_key(id, *page);
         let data = sp_io::storage::get(&key);
         if let Some(data) = data {
-            let page_buf = page_buf_from_vec_u8(data)?;
+            let page_buf = PageBuf::new_from_vec(data)?;
             pages_data.insert(*page, page_buf);
         }
     }
@@ -464,7 +464,7 @@ pub fn set_program_and_pages_data(
             return Err(PageIsNotAllocatedErr(page_num));
         }
         let key = page_key(id, page_num);
-        sp_io::storage::set(&key, page_buf.as_slice());
+        sp_io::storage::set(&key, page_buf.0.as_slice());
     }
     set_program(id, program);
     Ok(())
@@ -483,7 +483,7 @@ pub fn set_program_allocations(id: H256, allocations: BTreeSet<WasmPageNumber>) 
 
 pub fn set_program_page_data(program_id: H256, page: PageNumber, page_buf: PageBuf) {
     let page_key = page_key(program_id, page);
-    sp_io::storage::set(&page_key, page_buf.as_slice());
+    sp_io::storage::set(&page_key, page_buf.0.as_slice());
 }
 
 pub fn remove_program_page_data(program_id: H256, page_num: PageNumber) {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -36,7 +36,7 @@ use frame_support::{
 };
 use gear_core::{
     ids::{CodeId, MessageId, ProgramId},
-    memory::{PageNumber, WasmPageNumber, PageBuf, Error as MemoryError, page_buf_from_vec_u8},
+    memory::{page_buf_from_vec_u8, Error as MemoryError, PageBuf, PageNumber, WasmPageNumber},
     message::StoredDispatch,
 };
 use gear_runtime_interface as gear_ri;
@@ -397,7 +397,10 @@ pub fn get_program(id: H256) -> Option<Program> {
 }
 
 /// Returns mem page data from storage for program `id` and `page_idx`
-pub fn get_program_page_data(id: H256, page_idx: PageNumber) -> Option<Result<PageBuf, MemoryError>> {
+pub fn get_program_page_data(
+    id: H256,
+    page_idx: PageNumber,
+) -> Option<Result<PageBuf, MemoryError>> {
     let key = page_key(id, page_idx);
     let data = sp_io::storage::get(&key)?;
     Some(page_buf_from_vec_u8(data))
@@ -409,7 +412,10 @@ pub fn save_page_lazy_info(id: H256, page_num: PageNumber) {
     gear_ri::gear_ri::save_page_lazy_info(page_num.0, &key);
 }
 
-pub fn get_program_pages_data(id: H256, program: &ActiveProgram) -> Result<BTreeMap<PageNumber, PageBuf>, MemoryError> {
+pub fn get_program_pages_data(
+    id: H256,
+    program: &ActiveProgram,
+) -> Result<BTreeMap<PageNumber, PageBuf>, MemoryError> {
     get_program_data_for_pages(id, program.pages_with_data.iter())
 }
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -464,7 +464,7 @@ pub fn set_program_and_pages_data(
             return Err(PageIsNotAllocatedErr(page_num));
         }
         let key = page_key(id, page_num);
-        sp_io::storage::set(&key, page_buf.0.as_slice());
+        sp_io::storage::set(&key, page_buf.as_slice());
     }
     set_program(id, program);
     Ok(())
@@ -483,7 +483,7 @@ pub fn set_program_allocations(id: H256, allocations: BTreeSet<WasmPageNumber>) 
 
 pub fn set_program_page_data(program_id: H256, page: PageNumber, page_buf: PageBuf) {
     let page_key = page_key(program_id, page);
-    sp_io::storage::set(&page_key, page_buf.0.as_slice());
+    sp_io::storage::set(&page_key, page_buf.as_slice());
 }
 
 pub fn remove_program_page_data(program_id: H256, page_num: PageNumber) {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -36,7 +36,7 @@ use frame_support::{
 };
 use gear_core::{
     ids::{CodeId, MessageId, ProgramId},
-    memory::{PageNumber, WasmPageNumber},
+    memory::{PageNumber, WasmPageNumber, PageBuf, Error as MemoryError, page_buf_from_vec_u8},
     message::StoredDispatch,
 };
 use gear_runtime_interface as gear_ri;
@@ -397,9 +397,10 @@ pub fn get_program(id: H256) -> Option<Program> {
 }
 
 /// Returns mem page data from storage for program `id` and `page_idx`
-pub fn get_program_page_data(id: H256, page_idx: PageNumber) -> Option<Vec<u8>> {
+pub fn get_program_page_data(id: H256, page_idx: PageNumber) -> Option<Result<PageBuf, MemoryError>> {
     let key = page_key(id, page_idx);
-    sp_io::storage::get(&key)
+    let data = sp_io::storage::get(&key)?;
+    Some(page_buf_from_vec_u8(data))
 }
 
 /// Save page data key in storage
@@ -408,7 +409,7 @@ pub fn save_page_lazy_info(id: H256, page_num: PageNumber) {
     gear_ri::gear_ri::save_page_lazy_info(page_num.0, &key);
 }
 
-pub fn get_program_pages_data(id: H256, program: &ActiveProgram) -> BTreeMap<PageNumber, Vec<u8>> {
+pub fn get_program_pages_data(id: H256, program: &ActiveProgram) -> Result<BTreeMap<PageNumber, PageBuf>, MemoryError> {
     get_program_data_for_pages(id, program.pages_with_data.iter())
 }
 
@@ -416,14 +417,17 @@ pub fn get_program_pages_data(id: H256, program: &ActiveProgram) -> BTreeMap<Pag
 pub fn get_program_data_for_pages<'a>(
     id: H256,
     pages: impl Iterator<Item = &'a PageNumber>,
-) -> BTreeMap<PageNumber, Vec<u8>> {
-    pages
-        .map(|p| {
-            let key = page_key(id, *p);
-            (*p, sp_io::storage::get(&key))
-        })
-        .filter_map(|(page, data)| data.map(|data| (page, data)))
-        .collect()
+) -> Result<BTreeMap<PageNumber, PageBuf>, MemoryError> {
+    let mut pages_data = BTreeMap::new();
+    for page in pages {
+        let key = page_key(id, *page);
+        let data = sp_io::storage::get(&key);
+        if let Some(data) = data {
+            let page_buf = page_buf_from_vec_u8(data)?;
+            pages_data.insert(*page, page_buf);
+        }
+    }
+    Ok(pages_data)
 }
 
 pub fn set_program(id: H256, program: ActiveProgram) {
@@ -447,14 +451,14 @@ impl fmt::Display for PageIsNotAllocatedErr {
 pub fn set_program_and_pages_data(
     id: H256,
     program: ActiveProgram,
-    persistent_pages: BTreeMap<PageNumber, Vec<u8>>,
+    persistent_pages: BTreeMap<PageNumber, PageBuf>,
 ) -> Result<(), PageIsNotAllocatedErr> {
     for (page_num, page_buf) in persistent_pages {
         if !program.allocations.contains(&page_num.to_wasm_page()) {
             return Err(PageIsNotAllocatedErr(page_num));
         }
         let key = page_key(id, page_num);
-        sp_io::storage::set(&key, &page_buf);
+        sp_io::storage::set(&key, page_buf.as_slice());
     }
     set_program(id, program);
     Ok(())
@@ -471,9 +475,9 @@ pub fn set_program_allocations(id: H256, allocations: BTreeSet<WasmPageNumber>) 
     }
 }
 
-pub fn set_program_page_data(program_id: H256, page: PageNumber, page_buf: Vec<u8>) {
+pub fn set_program_page_data(program_id: H256, page: PageNumber, page_buf: PageBuf) {
     let page_key = page_key(program_id, page);
-    sp_io::storage::set(&page_key, &page_buf);
+    sp_io::storage::set(&page_key, page_buf.as_slice());
 }
 
 pub fn remove_program_page_data(program_id: H256, page_num: PageNumber) {

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -34,7 +34,7 @@ use gear_core::{
     env::Ext,
     gas::GasAmount,
     ids::{CodeId, MessageId, ProgramId},
-    memory::{PageNumber, WasmPageNumber, PageBuf},
+    memory::{PageBuf, PageNumber, WasmPageNumber},
     message::{ContextStore, Dispatch},
 };
 use gear_core_errors::ExtError;

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -34,7 +34,7 @@ use gear_core::{
     env::Ext,
     gas::GasAmount,
     ids::{CodeId, MessageId, ProgramId},
-    memory::{PageNumber, WasmPageNumber},
+    memory::{PageNumber, WasmPageNumber, PageBuf},
     message::{ContextStore, Dispatch},
 };
 use gear_core_errors::ExtError;
@@ -57,7 +57,7 @@ pub enum TerminationReason {
 pub struct ExtInfo {
     pub gas_amount: GasAmount,
     pub allocations: BTreeSet<WasmPageNumber>,
-    pub pages_data: BTreeMap<PageNumber, Vec<u8>>,
+    pub pages_data: BTreeMap<PageNumber, PageBuf>,
     pub generated_dispatches: Vec<Dispatch>,
     pub awakening: Vec<MessageId>,
     pub program_candidates_data: BTreeMap<CodeId, Vec<(ProgramId, MessageId)>>,
@@ -110,7 +110,7 @@ pub trait Environment<E: Ext + IntoExtInfo + 'static>: Sized {
     fn new(
         ext: E,
         binary: &[u8],
-        memory_pages: &BTreeMap<PageNumber, Vec<u8>>,
+        memory_pages: &BTreeMap<PageNumber, PageBuf>,
         mem_size: WasmPageNumber,
     ) -> Result<Self, BackendError<Self::Error>>;
 

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -26,7 +26,6 @@ pub mod funcs;
 
 use alloc::{
     borrow::Cow,
-    boxed::Box,
     collections::{BTreeMap, BTreeSet},
     vec::Vec,
 };
@@ -35,7 +34,7 @@ use gear_core::{
     env::Ext,
     gas::GasAmount,
     ids::{CodeId, MessageId, ProgramId},
-    memory::{PageBuf, PageNumber, WasmPageNumber},
+    memory::{PageNumber, WasmPageNumber},
     message::{ContextStore, Dispatch},
 };
 use gear_core_errors::ExtError;
@@ -111,7 +110,7 @@ pub trait Environment<E: Ext + IntoExtInfo + 'static>: Sized {
     fn new(
         ext: E,
         binary: &[u8],
-        memory_pages: &BTreeMap<PageNumber, Box<PageBuf>>,
+        memory_pages: &BTreeMap<PageNumber, Vec<u8>>,
         mem_size: WasmPageNumber,
     ) -> Result<Self, BackendError<Self::Error>>;
 

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -28,7 +28,7 @@ use gear_backend_common::{
 use gear_core::{
     env::{Ext, ExtCarrier},
     gas::GasAmount,
-    memory::{Memory, PageNumber, WasmPageNumber, PageBuf},
+    memory::{Memory, PageBuf, PageNumber, WasmPageNumber},
 };
 use gear_core_errors::TerminationReason as CoreTerminationReason;
 use gear_core_errors::{CoreError, MemoryError};

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -28,7 +28,7 @@ use gear_backend_common::{
 use gear_core::{
     env::{Ext, ExtCarrier},
     gas::GasAmount,
-    memory::{Memory, PageNumber, WasmPageNumber},
+    memory::{Memory, PageNumber, WasmPageNumber, PageBuf},
 };
 use gear_core_errors::TerminationReason as CoreTerminationReason;
 use gear_core_errors::{CoreError, MemoryError};
@@ -79,7 +79,7 @@ fn get_module_exports(binary: &[u8]) -> Result<Vec<String>, String> {
 
 fn set_pages(
     memory: &mut impl Memory,
-    pages: &BTreeMap<PageNumber, Vec<u8>>,
+    pages: &BTreeMap<PageNumber, PageBuf>,
 ) -> Result<(), String> {
     let memory_size = memory.size();
     for (page, buf) in pages {
@@ -87,13 +87,6 @@ fn set_pages(
             return Err(format!(
                 "{:?} is out of memory size: {:?}",
                 page, memory_size
-            ));
-        }
-        if buf.len() != PageNumber::size() {
-            return Err(format!(
-                "Data for page must be {:#x} bytes, but revieved {:#x}",
-                PageNumber::size(),
-                buf.len()
             ));
         }
         memory
@@ -109,7 +102,7 @@ impl<E: Ext + IntoExtInfo + 'static> Environment<E> for SandboxEnvironment<E> {
     fn new(
         ext: E,
         binary: &[u8],
-        memory_pages: &BTreeMap<PageNumber, Vec<u8>>,
+        memory_pages: &BTreeMap<PageNumber, PageBuf>,
         mem_size: WasmPageNumber,
     ) -> Result<Self, BackendError<Self::Error>> {
         let ext_carrier = ExtCarrier::new(ext);

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -90,7 +90,7 @@ fn set_pages(
             ));
         }
         memory
-            .write(page.offset(), &buf[..])
+            .write(page.offset(), &buf.0[..])
             .map_err(|e| format!("Cannot write mem to {:?}: {:?}", page, e))?;
     }
     Ok(())

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -90,7 +90,7 @@ fn set_pages(
             ));
         }
         memory
-            .write(page.offset(), &buf.0[..])
+            .write(page.offset(), &buf[..])
             .map_err(|e| format!("Cannot write mem to {:?}: {:?}", page, e))?;
     }
     Ok(())

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -87,7 +87,7 @@ fn set_pages<T: Ext>(
             ));
         }
         memory
-            .write(&mut store, page.offset(), &buf[..])
+            .write(&mut store, page.offset(), &buf.0[..])
             .map_err(|e| format!("Cannot write to {:?}: {:?}", page, e))?;
     }
     Ok(())

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -32,7 +32,7 @@ use gear_backend_common::{
 use gear_core::{
     env::{ClonedExtCarrier, Ext, ExtCarrier},
     gas::GasAmount,
-    memory::{PageNumber, WasmPageNumber, PageBuf},
+    memory::{PageBuf, PageNumber, WasmPageNumber},
 };
 use wasmtime::{
     Engine, Extern, Func, Instance, Memory as WasmtimeMemory, MemoryAccessError, MemoryType,

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -87,7 +87,7 @@ fn set_pages<T: Ext>(
             ));
         }
         memory
-            .write(&mut store, page.offset(), &buf.0[..])
+            .write(&mut store, page.offset(), &buf[..])
             .map_err(|e| format!("Cannot write to {:?}: {:?}", page, e))?;
     }
     Ok(())

--- a/core-errors/src/lib.rs
+++ b/core-errors/src/lib.rs
@@ -103,8 +103,8 @@ pub enum MemoryError {
     MemoryAccessError,
 
     /// There is wasm page, which has not all gear pages in the begin
-    #[display(fmt = "There is wasm page, which has not all gear pages in the begin")]
-    NotAllPagesInBegin,
+    #[display(fmt = "Page data has wrong size: {:#x}", _0)]
+    InvalidPageDataSize(usize),
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -268,9 +268,7 @@ pub struct ExecutionError {
     /// Gas amount of the execution.
     pub gas_amount: GasAmount,
     /// Error text.
-    pub reason: Option<ExecutionErrorReason>,
-    /// Triggered by gas allowance exceed.
-    pub allowance_exceed: bool,
+    pub reason: ExecutionErrorReason,
 }
 
 /// Reason of execution error
@@ -318,6 +316,9 @@ pub enum ExecutionErrorReason {
     /// Ext works with lazy pages, but lazy pages env is not enabled
     #[display(fmt = "Ext works with lazy pages, but lazy pages env is not enabled")]
     LazyPagesInconsistentState,
+    /// Page with data is not allocated for program
+    #[display(fmt = "Page with data is not allocated for program: {:?}", _0)]
+    PageIsNotAllocated(PageNumber),
 }
 
 /// Executable actor.

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -25,6 +25,7 @@ use alloc::{
     vec::Vec,
 };
 use codec::{Decode, Encode};
+use gear_core::memory::PageBuf;
 use gear_core::{
     gas::GasAmount,
     ids::{CodeId, MessageId, ProgramId},
@@ -68,7 +69,7 @@ pub struct DispatchResult {
     /// Gas amount after execution.
     pub gas_amount: GasAmount,
     /// Page updates.
-    pub page_update: BTreeMap<PageNumber, Vec<u8>>,
+    pub page_update: BTreeMap<PageNumber, PageBuf>,
     /// New allocations set for program if it has been changed.
     pub allocations: Option<BTreeSet<WasmPageNumber>>,
 }
@@ -182,7 +183,7 @@ pub enum JournalNote {
         /// Number of the page.
         page_number: PageNumber,
         /// New data of the page.
-        data: Vec<u8>,
+        data: PageBuf,
     },
     /// Update allocations set note.
     /// And also removes data for pages which is not in allocations set now.
@@ -244,7 +245,7 @@ pub trait JournalHandler {
     fn update_pages_data(
         &mut self,
         program_id: ProgramId,
-        pages_data: BTreeMap<PageNumber, Vec<u8>>,
+        pages_data: BTreeMap<PageNumber, PageBuf>,
     );
     /// Process [JournalNote::UpdateAllocations].
     fn update_allocations(&mut self, program_id: ProgramId, allocations: BTreeSet<WasmPageNumber>);
@@ -329,7 +330,7 @@ pub struct ExecutableActor {
     /// Program value balance.
     pub balance: u128,
     /// Data which some program allocated pages may have.
-    pub pages_data: BTreeMap<PageNumber, Vec<u8>>,
+    pub pages_data: BTreeMap<PageNumber, PageBuf>,
 }
 
 /// Execution context.

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -317,7 +317,7 @@ pub enum ExecutionErrorReason {
     #[display(fmt = "Ext works with lazy pages, but lazy pages env is not enabled")]
     LazyPagesInconsistentState,
     /// Page with data is not allocated for program
-    #[display(fmt = "Page with data is not allocated for program: {:?}", _0)]
+    #[display(fmt = "{:?} is not allocated for program", _0)]
     PageIsNotAllocated(PageNumber),
 }
 

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -305,7 +305,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
         }
 
         if let Some(initial_data) = pages_data.get(&page) {
-            if !new_data.eq(initial_data) {
+            if !new_data.0.eq(&initial_data.0) {
                 page_update.insert(page, new_data);
                 log::trace!(
                     "Page {} is new or changed - will be updated in storage",

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -305,7 +305,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
         }
 
         if let Some(initial_data) = pages_data.get(&page) {
-            if !new_data.0.eq(&initial_data.0) {
+            if new_data != *initial_data {
                 page_update.insert(page, new_data);
                 log::trace!(
                     "Page {} is new or changed - will be updated in storage",

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -18,7 +18,6 @@
 
 use crate::configs::{AllocationsConfig, BlockInfo};
 use alloc::{
-    boxed::Box,
     collections::{BTreeMap, BTreeSet},
     vec::Vec,
 };
@@ -30,7 +29,7 @@ use gear_core::{
     env::Ext as EnvExt,
     gas::{ChargeResult, GasAllowanceCounter, GasAmount, GasCounter, ValueCounter},
     ids::{CodeId, MessageId, ProgramId},
-    memory::{AllocationsContext, Memory, PageBuf, PageNumber, WasmPageNumber},
+    memory::{AllocationsContext, Memory, PageNumber, WasmPageNumber},
     message::{HandlePacket, InitPacket, MessageContext, ReplyPacket},
 };
 use gear_core_errors::{ExtError, TerminationReason};
@@ -75,7 +74,7 @@ pub trait ProcessorExt {
 
     /// Lazy pages contract post execution actions
     fn lazy_pages_post_execution_actions(
-        memory_pages: &mut BTreeMap<PageNumber, Box<PageBuf>>,
+        memory_pages: &mut BTreeMap<PageNumber, Vec<u8>>,
         wasm_mem_begin_addr: u64,
     ) -> Result<(), Self::Error>;
 }
@@ -167,7 +166,7 @@ impl ProcessorExt for Ext {
     }
 
     fn lazy_pages_post_execution_actions(
-        _memory_pages: &mut BTreeMap<PageNumber, Box<PageBuf>>,
+        _memory_pages: &mut BTreeMap<PageNumber, Vec<u8>>,
         _wasm_mem_begin_addr: u64,
     ) -> Result<(), Self::Error> {
         unreachable!()

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -182,7 +182,7 @@ impl IntoExtInfo for Ext {
         let mut pages_data = BTreeMap::new();
         for page in wasm_pages.iter().flat_map(|p| p.to_gear_pages_iter()) {
             let mut buf = PageBuf::new_zeroed();
-            if let Err(err) = get_page_data(page.offset(), buf.0.as_mut_slice()) {
+            if let Err(err) = get_page_data(page.offset(), buf.as_mut_slice()) {
                 return Err((err, self.gas_counter.into()));
             }
             pages_data.insert(page, buf);

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -29,9 +29,7 @@ use gear_core::{
     env::Ext as EnvExt,
     gas::{ChargeResult, GasAllowanceCounter, GasAmount, GasCounter, ValueCounter},
     ids::{CodeId, MessageId, ProgramId},
-    memory::{
-        new_zeroed_page_buf, AllocationsContext, Memory, PageBuf, PageNumber, WasmPageNumber,
-    },
+    memory::{AllocationsContext, Memory, PageBuf, PageNumber, WasmPageNumber},
     message::{HandlePacket, InitPacket, MessageContext, ReplyPacket},
 };
 use gear_core_errors::{ExtError, TerminationReason};
@@ -183,8 +181,8 @@ impl IntoExtInfo for Ext {
         let wasm_pages = self.allocations_context.allocations().clone();
         let mut pages_data = BTreeMap::new();
         for page in wasm_pages.iter().flat_map(|p| p.to_gear_pages_iter()) {
-            let mut buf = new_zeroed_page_buf();
-            if let Err(err) = get_page_data(page.offset(), buf.as_mut_slice()) {
+            let mut buf = PageBuf::new_zeroed();
+            if let Err(err) = get_page_data(page.offset(), buf.0.as_mut_slice()) {
                 return Err((err, self.gas_counter.into()));
             }
             pages_data.insert(page, buf);

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -29,7 +29,9 @@ use gear_core::{
     env::Ext as EnvExt,
     gas::{ChargeResult, GasAllowanceCounter, GasAmount, GasCounter, ValueCounter},
     ids::{CodeId, MessageId, ProgramId},
-    memory::{AllocationsContext, Memory, PageNumber, WasmPageNumber, PageBuf, new_zeroed_page_buf},
+    memory::{
+        new_zeroed_page_buf, AllocationsContext, Memory, PageBuf, PageNumber, WasmPageNumber,
+    },
     message::{HandlePacket, InitPacket, MessageContext, ReplyPacket},
 };
 use gear_core_errors::{ExtError, TerminationReason};

--- a/core-processor/src/processor.rs
+++ b/core-processor/src/processor.rs
@@ -310,13 +310,14 @@ pub fn process_executable<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: E
                 process_allowance_exceed(dispatch, program_id, res.gas_amount.burned())
             }
         },
-        Err(e) => {
-            if e.allowance_exceed {
+        Err(e) => match e.reason {
+            ExecutionErrorReason::InitialMemoryBlockGasExceeded
+            | ExecutionErrorReason::GrowMemoryBlockGasExceeded
+            | ExecutionErrorReason::LoadMemoryBlockGasExceeded => {
                 process_allowance_exceed(dispatch, program_id, e.gas_amount.burned())
-            } else {
-                process_error(dispatch, program_id, e.gas_amount.burned(), e.reason)
             }
-        }
+            _ => process_error(dispatch, program_id, e.gas_amount.burned(), Some(e.reason)),
+        },
     }
 }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,6 +21,7 @@ hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 wabt = "0.10.0"
+env_logger = "0.9"
 
 [features]
 strict = []

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -54,7 +54,7 @@ impl PageBuf {
     pub fn new_from_vec(v: Vec<u8>) -> Result<Self, Error> {
         Box::<[u8; GEAR_PAGE_SIZE]>::try_from(v.into_boxed_slice())
             .map_err(|data| Error::InvalidPageDataSize(data.len()))
-            .map(|data| Self(data))
+            .map(Self)
     }
 
     /// Returns new page buffer with zeroed data.

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -43,24 +43,29 @@ const GEAR_PAGE_SIZE: usize = 0x1000;
 const GEAR_PAGES_IN_ONE_WASM: u32 = (WASM_PAGE_SIZE / GEAR_PAGE_SIZE) as u32;
 
 /// Buffer for gear page data.
-pub type PageBuf = Box<[u8; GEAR_PAGE_SIZE]>;
+/// TODO: impl self debug
+#[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
+pub struct PageBuf(pub Box<[u8; GEAR_PAGE_SIZE]>);
 
-/// Tries to transform vec<u8> into page buffer.
-/// Makes it without any rellocations or memcpy: vector's buffer becames PageBuf without any changes,
-/// except vector's buffer capacity, which is removed.
-pub fn page_buf_from_vec_u8(v: Vec<u8>) -> Result<PageBuf, Error> {
-    Box::<[u8; GEAR_PAGE_SIZE]>::try_from(v.into_boxed_slice())
-        .map_err(|data| Error::InvalidPageDataSize(data.len()))
-}
+impl PageBuf {
+    /// Tries to transform vec<u8> into page buffer.
+    /// Makes it without any rellocations or memcpy: vector's buffer becames PageBuf without any changes,
+    /// except vector's buffer capacity, which is removed.
+    pub fn new_from_vec(v: Vec<u8>) -> Result<Self, Error> {
+        Box::<[u8; GEAR_PAGE_SIZE]>::try_from(v.into_boxed_slice())
+            .map_err(|data| Error::InvalidPageDataSize(data.len()))
+            .map(|data| Self(data))
+    }
 
-/// Returns new page buffer with zeroed data.
-pub fn new_zeroed_page_buf() -> PageBuf {
-    PageBuf::new([0u8; GEAR_PAGE_SIZE])
-}
+    /// Returns new page buffer with zeroed data.
+    pub fn new_zeroed() -> PageBuf {
+        Self(Box::<[u8; GEAR_PAGE_SIZE]>::new([0u8; GEAR_PAGE_SIZE]))
+    }
 
-/// Convert page buffer into vector without rellocations.
-pub fn page_buf_into_vec_u8(buf: PageBuf) -> Vec<u8> {
-    (buf as Box<[_]>).into_vec()
+    /// Convert page buffer into vector without rellocations.
+    pub fn into_vec(self) -> Vec<u8> {
+        (self.0 as Box<[_]>).into_vec()
+    }
 }
 
 /// Tries to convert vector data map to page buffer data map.
@@ -70,7 +75,7 @@ pub fn vec_page_data_map_to_page_buf_map(
 ) -> Result<BTreeMap<PageNumber, PageBuf>, Error> {
     let mut pages_data_res = BTreeMap::new();
     for (page, data) in pages_data {
-        let data = page_buf_from_vec_u8(data)?;
+        let data = PageBuf::new_from_vec(data)?;
         pages_data_res.insert(page, data);
     }
     Ok(pages_data_res)

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -420,11 +420,13 @@ mod tests {
 
     #[test]
     fn page_buf() {
-        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("gear_core=debug"))
-            .format_module_path(false)
-            .format_level(true)
-            .try_init()
-            .expect("cannot init logger");
+        env_logger::Builder::from_env(
+            env_logger::Env::default().default_filter_or("gear_core=debug"),
+        )
+        .format_module_path(false)
+        .format_level(true)
+        .try_init()
+        .expect("cannot init logger");
         let mut data = vec![199u8; PageNumber::size()];
         data[1] = 2;
         let page_buf = PageBuf::new_from_vec(data).unwrap();

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -18,7 +18,10 @@
 
 //! Module for memory and allocations context.
 
-use core::convert::TryFrom;
+use core::{
+    convert::TryFrom,
+    ops::{Deref, DerefMut},
+};
 
 use alloc::{
     boxed::Box,
@@ -26,6 +29,7 @@ use alloc::{
     vec::Vec,
 };
 use codec::{Decode, Encode};
+use core::fmt;
 use scale_info::TypeInfo;
 
 /// A WebAssembly page has a constant size of 64KiB.
@@ -43,9 +47,32 @@ const GEAR_PAGE_SIZE: usize = 0x1000;
 const GEAR_PAGES_IN_ONE_WASM: u32 = (WASM_PAGE_SIZE / GEAR_PAGE_SIZE) as u32;
 
 /// Buffer for gear page data.
-/// TODO: impl self debug
-#[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
-pub struct PageBuf(pub Box<[u8; GEAR_PAGE_SIZE]>);
+#[derive(Clone, Encode, Decode, PartialEq, Eq)]
+pub struct PageBuf(Box<[u8; GEAR_PAGE_SIZE]>);
+
+impl fmt::Debug for PageBuf {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "PageBuf({:?}..{:?})",
+            &self.0[0..10],
+            &self.0[GEAR_PAGE_SIZE - 10..GEAR_PAGE_SIZE]
+        )
+    }
+}
+
+impl Deref for PageBuf {
+    type Target = Box<[u8; GEAR_PAGE_SIZE]>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for PageBuf {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
 
 impl PageBuf {
     /// Tries to transform vec<u8> into page buffer.

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -38,9 +38,6 @@ const GEAR_PAGES_IN_ONE_WASM: u32 = (WASM_PAGE_SIZE / GEAR_PAGE_SIZE) as u32;
 
 pub use gear_core_errors::MemoryError as Error;
 
-/// Page buffer.
-pub type PageBuf = [u8; GEAR_PAGE_SIZE];
-
 /// Page number.
 #[derive(
     Clone,

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -360,8 +360,8 @@ impl AllocationsContext {
 #[cfg(test)]
 /// This module contains tests of PageNumber struct
 mod tests {
-    use super::{PageNumber, WasmPageNumber};
-    use alloc::vec::Vec;
+    use super::{PageBuf, PageNumber, WasmPageNumber};
+    use alloc::{vec, vec::Vec};
 
     #[test]
     /// Test that PageNumbers add up correctly
@@ -416,5 +416,18 @@ mod tests {
         ];
 
         assert!(gear_pages.eq(&expectation));
+    }
+
+    #[test]
+    fn page_buf() {
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("gear_core=debug"))
+            .format_module_path(false)
+            .format_level(true)
+            .try_init()
+            .expect("cannot init logger");
+        let mut data = vec![199u8; PageNumber::size()];
+        data[1] = 2;
+        let page_buf = PageBuf::new_from_vec(data).unwrap();
+        log::debug!("page buff = {:?}", page_buf);
     }
 }

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -18,24 +18,9 @@
 
 //! Module for programs.
 
-use crate::{
-    code::InstrumentedCode,
-    ids::ProgramId,
-    memory::{PageBuf, PageNumber, WasmPageNumber},
-};
-use alloc::{boxed::Box, collections::BTreeMap, collections::BTreeSet};
+use crate::{code::InstrumentedCode, ids::ProgramId, memory::WasmPageNumber};
+use alloc::collections::BTreeSet;
 use codec::{Decode, Encode};
-use core::array::TryFromSliceError;
-
-/// A program error
-#[derive(Debug, Clone, Copy)]
-pub enum Error {
-    /// Failed to convert PageBuf from slice
-    TryFromSlice(TryFromSliceError),
-}
-
-/// Type alias for map of persistent pages.
-pub type PersistentPageMap = BTreeMap<PageNumber, Option<Box<PageBuf>>>;
 
 /// Program.
 #[derive(Clone, Debug, Decode, Encode)]
@@ -153,7 +138,7 @@ mod tests {
     }
 
     #[test]
-    /// Test that Program constructor fails when pages can't be converted into PageBuf.
+    /// Test static pages.
     fn program_memory() {
         let wat = r#"
             (module
@@ -181,8 +166,5 @@ mod tests {
 
         // 2 static pages
         assert_eq!(program.static_pages(), 2.into());
-
-        // no allocations because we do not set them in new
-        assert_eq!(program.get_allocations().len(), 0);
     }
 }

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -166,5 +166,8 @@ mod tests {
 
         // 2 static pages
         assert_eq!(program.static_pages(), 2.into());
+
+        // Has no allocations because we do not set them in new
+        assert_eq!(program.get_allocations().len(), 0);
     }
 }

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -422,7 +422,7 @@ pub fn check_memory(
                 if let Some(page_buf) = actor.pages_data.get(&page) {
                     let begin_byte = case.address - page.offset();
                     let end_byte = begin_byte + case.bytes.len();
-                    if page_buf[begin_byte..end_byte] != case.bytes {
+                    if page_buf.0[begin_byte..end_byte] != case.bytes {
                         errors.push("Expectation error (Static memory doesn't match)".to_string());
                     }
                 } else {

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -422,7 +422,7 @@ pub fn check_memory(
                 if let Some(page_buf) = actor.pages_data.get(&page) {
                     let begin_byte = case.address - page.offset();
                     let end_byte = begin_byte + case.bytes.len();
-                    if page_buf.0[begin_byte..end_byte] != case.bytes {
+                    if page_buf[begin_byte..end_byte] != case.bytes {
                         errors.push("Expectation error (Static memory doesn't match)".to_string());
                     }
                 } else {

--- a/gear-test/src/manager.rs
+++ b/gear-test/src/manager.rs
@@ -21,7 +21,7 @@ use core_processor::common::*;
 use gear_core::{
     code::{Code, CodeAndId, InstrumentedCodeAndId},
     ids::{CodeId, MessageId, ProgramId},
-    memory::{PageNumber, WasmPageNumber},
+    memory::{PageNumber, WasmPageNumber, PageBuf},
     message::{Dispatch, DispatchKind, StoredDispatch, StoredMessage},
     program::Program,
 };
@@ -198,7 +198,7 @@ impl JournalHandler for InMemoryExtManager {
     fn update_pages_data(
         &mut self,
         program_id: ProgramId,
-        mut pages_data: BTreeMap<PageNumber, Vec<u8>>,
+        mut pages_data: BTreeMap<PageNumber, PageBuf>,
     ) {
         if let Some(actor) = self
             .actors

--- a/gear-test/src/manager.rs
+++ b/gear-test/src/manager.rs
@@ -21,7 +21,7 @@ use core_processor::common::*;
 use gear_core::{
     code::{Code, CodeAndId, InstrumentedCodeAndId},
     ids::{CodeId, MessageId, ProgramId},
-    memory::{PageNumber, WasmPageNumber, PageBuf},
+    memory::{PageBuf, PageNumber, WasmPageNumber},
     message::{Dispatch, DispatchKind, StoredDispatch, StoredMessage},
     program::Program,
 };

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -25,7 +25,7 @@ use gear_backend_wasmtime::WasmtimeEnvironment;
 use gear_core::{
     code::{Code, CodeAndId, InstrumentedCodeAndId},
     ids::{CodeId, MessageId, ProgramId},
-    memory::{PageNumber, WasmPageNumber, PageBuf},
+    memory::{PageBuf, PageNumber, WasmPageNumber},
     message::{Dispatch, DispatchKind, ReplyMessage, ReplyPacket, StoredDispatch, StoredMessage},
     program::Program as CoreProgram,
 };

--- a/lazy-pages/src/unix.rs
+++ b/lazy-pages/src/unix.rs
@@ -68,9 +68,10 @@ extern "C" fn handle_sigsegv(_x: i32, info: *mut siginfo_t, _z: *mut c_void) {
 
         let accessed_page = PageNumber::from(((mem as usize - wasm_mem_begin) / gear_ps) as u32);
         log::debug!(
-            "mem={:?} accessed={:?} pages={:?} page_native_addr={:#x}",
+            "mem={:?} accessed={:?},{:?} pages={:?} page_native_addr={:#x}",
             mem,
             accessed_page,
+            accessed_page.to_wasm_page(),
             res.0 .0..res.0 .0 + res.1 as u32,
             res.2
         );

--- a/lazy-pages/src/unix.rs
+++ b/lazy-pages/src/unix.rs
@@ -18,7 +18,7 @@
 
 //! Lazy pages support in unix.
 
-use gear_core::memory::{PageNumber, WasmPageNumber, page_buf_from_vec_u8};
+use gear_core::memory::{page_buf_from_vec_u8, PageNumber, WasmPageNumber};
 use libc::{c_void, siginfo_t};
 use nix::sys::signal;
 
@@ -125,9 +125,10 @@ extern "C" fn handle_sigsegv(_x: i32, info: *mut siginfo_t, _z: *mut c_void) {
             // Some pages can be released many times, when page has been free and then allocated.
             // We save here the most fresh data for these pages, in order to identify wether
             // page had been changed after last page allocation or after execution start.
-            let _ = released_pages
-                .borrow_mut()
-                .insert(page, Some(page_buf_from_vec_u8(buffer_as_slice.to_vec()).unwrap()));
+            let _ = released_pages.borrow_mut().insert(
+                page,
+                Some(page_buf_from_vec_u8(buffer_as_slice.to_vec()).unwrap()),
+            );
         });
     }
 }

--- a/lazy-pages/src/unix.rs
+++ b/lazy-pages/src/unix.rs
@@ -18,7 +18,7 @@
 
 //! Lazy pages support in unix.
 
-use gear_core::memory::{PageNumber, WasmPageNumber};
+use gear_core::memory::{PageNumber, WasmPageNumber, page_buf_from_vec_u8};
 use libc::{c_void, siginfo_t};
 use nix::sys::signal;
 
@@ -127,7 +127,7 @@ extern "C" fn handle_sigsegv(_x: i32, info: *mut siginfo_t, _z: *mut c_void) {
             // page had been changed after last page allocation or after execution start.
             let _ = released_pages
                 .borrow_mut()
-                .insert(page, buffer_as_slice.to_vec());
+                .insert(page, Some(page_buf_from_vec_u8(buffer_as_slice.to_vec()).unwrap()));
         });
     }
 }

--- a/lazy-pages/src/unix.rs
+++ b/lazy-pages/src/unix.rs
@@ -18,7 +18,7 @@
 
 //! Lazy pages support in unix.
 
-use gear_core::memory::{page_buf_from_vec_u8, PageNumber, WasmPageNumber};
+use gear_core::memory::{PageBuf, PageNumber, WasmPageNumber};
 use libc::{c_void, siginfo_t};
 use nix::sys::signal;
 
@@ -125,10 +125,9 @@ extern "C" fn handle_sigsegv(_x: i32, info: *mut siginfo_t, _z: *mut c_void) {
             // Some pages can be released many times, when page has been free and then allocated.
             // We save here the most fresh data for these pages, in order to identify wether
             // page had been changed after last page allocation or after execution start.
-            let _ = released_pages.borrow_mut().insert(
-                page,
-                Some(page_buf_from_vec_u8(buffer_as_slice.to_vec()).unwrap()),
-            );
+            let page_buf = PageBuf::new_from_vec(buffer_as_slice.to_vec())
+                .expect("Cannot panic because we create slice with PageBuf size");
+            let _ = released_pages.borrow_mut().insert(page, Some(page_buf));
         });
     }
 }

--- a/pallets/gear-debug/src/lib.rs
+++ b/pallets/gear-debug/src/lib.rs
@@ -84,8 +84,8 @@ pub mod pallet {
     pub enum Error<T> {}
 
     /// Program debug info.
-    /// TODO: unfortunatelly we cannot store pages data in [PageBuf],
-    /// because polkadot-js api can not support this type.
+    // TODO: unfortunatelly we cannot store pages data in [PageBuf],
+    // because polkadot-js api can not support this type.
     #[derive(Encode, Decode, Clone, Default, PartialEq, TypeInfo)]
     pub struct ProgramInfo {
         pub static_pages: WasmPageNumber,

--- a/pallets/gear-debug/src/lib.rs
+++ b/pallets/gear-debug/src/lib.rs
@@ -44,7 +44,7 @@ pub mod pallet {
     use frame_system::pallet_prelude::*;
     use gear_core::{
         ids::{CodeId, ProgramId},
-        memory::{PageNumber, WasmPageNumber},
+        memory::{PageNumber, WasmPageNumber, PageBuf},
         message::{StoredDispatch, StoredMessage},
     };
     use pallet_gear_messenger::Pallet as MessengerPallet;
@@ -86,7 +86,7 @@ pub mod pallet {
     #[derive(Encode, Decode, Clone, Default, PartialEq, TypeInfo)]
     pub struct ProgramInfo {
         pub static_pages: WasmPageNumber,
-        pub persistent_pages: BTreeMap<PageNumber, Vec<u8>>,
+        pub persistent_pages: BTreeMap<PageNumber, PageBuf>,
         pub code_hash: H256,
     }
 
@@ -211,12 +211,13 @@ pub mod pallet {
                     Some(code) => code.static_pages(),
                     None => WasmPageNumber(0),
                 };
+                let persistent_pages = common::get_program_pages_data(id, &active).unwrap();
                 ProgramDetails {
                     id,
                     state: {
                         ProgramState::Active(ProgramInfo {
                             static_pages,
-                            persistent_pages: common::get_program_pages_data(id, &active),
+                            persistent_pages,
                             code_hash: active.code_hash,
                         })
                     },

--- a/pallets/gear-debug/src/lib.rs
+++ b/pallets/gear-debug/src/lib.rs
@@ -44,7 +44,7 @@ pub mod pallet {
     use frame_system::pallet_prelude::*;
     use gear_core::{
         ids::{CodeId, ProgramId},
-        memory::{PageNumber, WasmPageNumber, PageBuf},
+        memory::{PageBuf, PageNumber, WasmPageNumber},
         message::{StoredDispatch, StoredMessage},
     };
     use pallet_gear_messenger::Pallet as MessengerPallet;

--- a/pallets/gear-debug/src/lib.rs
+++ b/pallets/gear-debug/src/lib.rs
@@ -44,7 +44,7 @@ pub mod pallet {
     use frame_system::pallet_prelude::*;
     use gear_core::{
         ids::{CodeId, ProgramId},
-        memory::{page_buf_into_vec_u8, PageNumber, WasmPageNumber},
+        memory::{PageNumber, WasmPageNumber},
         message::{StoredDispatch, StoredMessage},
     };
     use pallet_gear_messenger::Pallet as MessengerPallet;
@@ -217,7 +217,7 @@ pub mod pallet {
                 let persistent_pages = common::get_program_pages_data(id, &active)
                     .unwrap()
                     .into_iter()
-                    .map(|(page, data)| (page, page_buf_into_vec_u8(data)))
+                    .map(|(page, data)| (page, data.into_vec()))
                     .collect();
                 ProgramDetails {
                     id,

--- a/pallets/gear-program/src/benchmarking.rs
+++ b/pallets/gear-program/src/benchmarking.rs
@@ -43,7 +43,7 @@ benchmarks! {
 
         let wasm_pages = (0..q).map(WasmPageNumber).collect::<Vec<WasmPageNumber>>();
         let pages: Vec<PageNumber> = wasm_pages.iter().flat_map(|p| p.to_gear_pages_iter()).collect();
-        let memory_pages = common::get_program_data_for_pages(program_id, pages.iter());
+        let memory_pages = common::get_program_data_for_pages(program_id, pages.iter()).unwrap();
 
         crate::Pallet::<T>::pause_program(program_id).unwrap();
     }: _(RawOrigin::Signed(caller), program_id, memory_pages, Default::default(), 10_000u32.into())

--- a/pallets/gear-program/src/benchmarking.rs
+++ b/pallets/gear-program/src/benchmarking.rs
@@ -43,7 +43,7 @@ benchmarks! {
 
         let wasm_pages = (0..q).map(WasmPageNumber).collect::<Vec<WasmPageNumber>>();
         let pages: Vec<PageNumber> = wasm_pages.iter().flat_map(|p| p.to_gear_pages_iter()).collect();
-        let memory_pages = common::get_program_data_for_pages(program_id, pages.iter()).unwrap();
+        let memory_pages = common::get_program_data_for_pages(program_id, pages.iter()).unwrap().into_iter().map(|(page, data)| (page, data.into_vec())).collect();
 
         crate::Pallet::<T>::pause_program(program_id).unwrap();
     }: _(RawOrigin::Signed(caller), program_id, memory_pages, Default::default(), 10_000u32.into())

--- a/pallets/gear-program/src/lib.rs
+++ b/pallets/gear-program/src/lib.rs
@@ -61,7 +61,7 @@ pub mod pallet {
         },
     };
     use frame_system::pallet_prelude::*;
-    use gear_core::memory::{PageNumber, PageBuf};
+    use gear_core::memory::{PageBuf, PageNumber};
     use sp_runtime::traits::{UniqueSaturatedInto, Zero};
     use weights::WeightInfo;
 

--- a/pallets/gear-program/src/lib.rs
+++ b/pallets/gear-program/src/lib.rs
@@ -61,7 +61,7 @@ pub mod pallet {
         },
     };
     use frame_system::pallet_prelude::*;
-    use gear_core::memory::PageNumber;
+    use gear_core::memory::{PageNumber, PageBuf};
     use sp_runtime::traits::{UniqueSaturatedInto, Zero};
     use weights::WeightInfo;
 
@@ -102,6 +102,7 @@ pub mod pallet {
         NotAllocatedPageWithData,
         ResumeProgramNotEnoughValue,
         WrongWaitList,
+        InvalidPageDataSize,
     }
 
     #[pallet::storage]
@@ -144,7 +145,7 @@ pub mod pallet {
         pub fn resume_program(
             origin: OriginFor<T>,
             program_id: H256,
-            memory_pages: BTreeMap<PageNumber, Vec<u8>>,
+            memory_pages: BTreeMap<PageNumber, PageBuf>,
             wait_list: BTreeMap<H256, gear_core::message::StoredDispatch>,
             value: BalanceOf<T>,
         ) -> DispatchResultWithPostInfo {

--- a/pallets/gear-program/src/lib.rs
+++ b/pallets/gear-program/src/lib.rs
@@ -129,6 +129,8 @@ pub mod pallet {
     where
         T::AccountId: common::Origin,
     {
+        // TODO: unfortunatelly we cannot pass pages data in [PageBuf],
+        // because polkadot-js api can not support this type.
         /// Resumes a previously paused program
         ///
         /// The origin must be Signed and the sender must have sufficient funds to
@@ -141,8 +143,6 @@ pub mod pallet {
         ///
         /// - `ProgramResumed(H256)` in the case of success.
         ///
-        /// TODO: unfortunatelly we cannot pass pages data in [PageBuf],
-        /// because polkadot-js api can not support this type.
         #[frame_support::transactional]
         #[pallet::weight(<T as Config>::WeightInfo::resume_program(memory_pages.values().map(|p| p.len() as u32).sum()))]
         pub fn resume_program(

--- a/pallets/gear-program/src/pause.rs
+++ b/pallets/gear-program/src/pause.rs
@@ -20,7 +20,10 @@ use super::*;
 use codec::{Decode, Encode};
 use common::Origin as _;
 use frame_support::{dispatch::DispatchResult, storage::PrefixIterator};
-use gear_core::{memory::{PageNumber, PageBuf}, message::StoredDispatch};
+use gear_core::{
+    memory::{PageBuf, PageNumber},
+    message::StoredDispatch,
+};
 use scale_info::TypeInfo;
 
 #[derive(Clone, Debug, PartialEq, Decode, Encode, TypeInfo)]

--- a/pallets/gear-program/src/tests.rs
+++ b/pallets/gear-program/src/tests.rs
@@ -21,7 +21,7 @@ use frame_support::{assert_noop, assert_ok};
 use gear_core::{
     code::{Code, CodeAndId},
     ids::{CodeId, MessageId, ProgramId},
-    memory::{new_zeroed_page_buf, PageNumber, WasmPageNumber},
+    memory::{PageBuf, PageNumber, WasmPageNumber},
     message::{DispatchKind, StoredDispatch, StoredMessage},
 };
 use hex_literal::hex;
@@ -50,13 +50,13 @@ fn pause_program_works() {
         let memory_pages = {
             let mut pages = BTreeMap::new();
             for page in wasm_static_pages.to_gear_pages_iter() {
-                pages.insert(page, new_zeroed_page_buf());
+                pages.insert(page, PageBuf::new_zeroed());
             }
             for page in (wasm_static_pages + 2.into()).to_gear_pages_iter() {
-                pages.insert(page, new_zeroed_page_buf());
+                pages.insert(page, PageBuf::new_zeroed());
             }
             for i in 0..wasm_static_pages.to_gear_page().0 {
-                pages.insert(i.into(), new_zeroed_page_buf());
+                pages.insert(i.into(), PageBuf::new_zeroed());
             }
 
             pages
@@ -449,13 +449,13 @@ mod utils {
         let memory_pages = {
             let mut pages = BTreeMap::new();
             for page in wasm_static_pages.to_gear_pages_iter() {
-                pages.insert(page, new_zeroed_page_buf());
+                pages.insert(page, PageBuf::new_zeroed());
             }
             for page in (wasm_static_pages + 2.into()).to_gear_pages_iter() {
-                pages.insert(page, new_zeroed_page_buf());
+                pages.insert(page, PageBuf::new_zeroed());
             }
             for i in 0..wasm_static_pages.to_gear_page().0 {
-                pages.insert(i.into(), new_zeroed_page_buf());
+                pages.insert(i.into(), PageBuf::new_zeroed());
             }
 
             pages

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -30,11 +30,11 @@ use gear_core::{
     env::Ext as EnvExt,
     gas::{GasAllowanceCounter, GasAmount, GasCounter, ValueCounter},
     ids::{CodeId, MessageId, ProgramId},
-    memory::{AllocationsContext, Memory, PageBuf, PageNumber, WasmPageNumber},
+    memory::{AllocationsContext, Memory, PageNumber, WasmPageNumber},
     message::{HandlePacket, MessageContext, ReplyPacket},
 };
 use gear_core_errors::{CoreError, ExtError, TerminationReason};
-use sp_std::{boxed::Box, collections::btree_map::BTreeMap, vec, vec::Vec};
+use sp_std::{collections::btree_map::BTreeMap, vec, vec::Vec};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
@@ -186,7 +186,7 @@ impl ProcessorExt for LazyPagesExt {
     }
 
     fn lazy_pages_post_execution_actions(
-        memory_pages: &mut BTreeMap<PageNumber, Box<PageBuf>>,
+        memory_pages: &mut BTreeMap<PageNumber, Vec<u8>>,
         wasm_mem_begin_addr: u64,
     ) -> Result<(), Self::Error> {
         lazy_pages::post_execution_actions(memory_pages, wasm_mem_begin_addr)

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -30,7 +30,9 @@ use gear_core::{
     env::Ext as EnvExt,
     gas::{GasAllowanceCounter, GasAmount, GasCounter, ValueCounter},
     ids::{CodeId, MessageId, ProgramId},
-    memory::{AllocationsContext, Memory, PageNumber, WasmPageNumber, new_zeroed_page_buf, PageBuf},
+    memory::{
+        new_zeroed_page_buf, AllocationsContext, Memory, PageBuf, PageNumber, WasmPageNumber,
+    },
     message::{HandlePacket, MessageContext, ReplyPacket},
 };
 use gear_core_errors::{CoreError, ExtError, TerminationReason};

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -30,9 +30,7 @@ use gear_core::{
     env::Ext as EnvExt,
     gas::{GasAllowanceCounter, GasAmount, GasCounter, ValueCounter},
     ids::{CodeId, MessageId, ProgramId},
-    memory::{
-        new_zeroed_page_buf, AllocationsContext, Memory, PageBuf, PageNumber, WasmPageNumber,
-    },
+    memory::{AllocationsContext, Memory, PageBuf, PageNumber, WasmPageNumber},
     message::{HandlePacket, MessageContext, ReplyPacket},
 };
 use gear_core_errors::{CoreError, ExtError, TerminationReason};
@@ -103,8 +101,8 @@ impl IntoExtInfo for LazyPagesExt {
 
         let mut accessed_pages_data = BTreeMap::new();
         for page in accessed_pages {
-            let mut buf = new_zeroed_page_buf();
-            if let Err(err) = get_page_data(page.offset(), buf.as_mut_slice()) {
+            let mut buf = PageBuf::new_zeroed();
+            if let Err(err) = get_page_data(page.offset(), buf.0.as_mut_slice()) {
                 return Err((err, self.into_gas_amount()));
             }
             accessed_pages_data.insert(page, buf);

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -102,7 +102,7 @@ impl IntoExtInfo for LazyPagesExt {
         let mut accessed_pages_data = BTreeMap::new();
         for page in accessed_pages {
             let mut buf = PageBuf::new_zeroed();
-            if let Err(err) = get_page_data(page.offset(), buf.0.as_mut_slice()) {
+            if let Err(err) = get_page_data(page.offset(), buf.as_mut_slice()) {
                 return Err((err, self.into_gas_amount()));
             }
             accessed_pages_data.insert(page, buf);

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -766,6 +766,11 @@ pub mod pallet {
                                     code
                                 } else {
                                     // todo: mark code as unable for instrument to skip next time
+                                    log::debug!(
+                                        "Can not instrument code '{:?}' for program '{:?}'",
+                                        code_id,
+                                        program_id
+                                    );
                                     continue;
                                 }
                             } else {
@@ -811,10 +816,19 @@ pub mod pallet {
                             let pages_data = if lazy_pages_enabled {
                                 Default::default()
                             } else {
-                                common::get_program_data_for_pages(
+                                match common::get_program_data_for_pages(
                                     program_id.into_origin(),
                                     prog.pages_with_data.iter(),
-                                )
+                                ) {
+                                    Ok(data) => data,
+                                    Err(err) => {
+                                        log::error!(
+                                            "Page data in storage is in invalid state: {}",
+                                            err
+                                        );
+                                        continue;
+                                    }
+                                }
                             };
 
                             Some(ExecutableActor {

--- a/pallets/gear/src/manager.rs
+++ b/pallets/gear/src/manager.rs
@@ -33,7 +33,7 @@ use frame_support::traits::{
 };
 use gear_core::{
     ids::{CodeId, MessageId, ProgramId},
-    memory::PageNumber,
+    memory::{PageNumber, PageBuf},
     message::{Dispatch, ExitCode, StoredDispatch},
     program::Program as NativeProgram,
 };
@@ -94,7 +94,7 @@ where
             <T as Config>::Currency::free_balance(&<T::AccountId as Origin>::from_origin(id))
                 .unique_saturated_into();
         let pages_data = if with_pages {
-            common::get_program_data_for_pages(id, active.pages_with_data.iter())
+            common::get_program_data_for_pages(id, active.pages_with_data.iter()).ok()?
         } else {
             Default::default()
         };
@@ -479,7 +479,7 @@ where
     fn update_pages_data(
         &mut self,
         program_id: ProgramId,
-        pages_data: BTreeMap<PageNumber, Vec<u8>>,
+        pages_data: BTreeMap<PageNumber, PageBuf>,
     ) {
         let program_id = program_id.into_origin();
         let program = common::get_program(program_id)

--- a/pallets/gear/src/manager.rs
+++ b/pallets/gear/src/manager.rs
@@ -33,7 +33,7 @@ use frame_support::traits::{
 };
 use gear_core::{
     ids::{CodeId, MessageId, ProgramId},
-    memory::{PageNumber, PageBuf},
+    memory::{PageBuf, PageNumber},
     message::{Dispatch, ExitCode, StoredDispatch},
     program::Program as NativeProgram,
 };

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -2421,7 +2421,7 @@ fn resume_program_works() {
             common::Program::Active(p) => p,
             _ => unreachable!(),
         };
-        let memory_pages = common::get_program_pages_data(program_id, &program);
+        let memory_pages = common::get_program_pages_data(program_id, &program).unwrap();
 
         assert_ok!(GearProgram::pause_program(program_id));
 

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -24,7 +24,7 @@ use demo_mul_by_const::WASM_BINARY as MUL_CONST_WASM_BINARY;
 use demo_program_factory::{CreateProgram, WASM_BINARY as PROGRAM_FACTORY_WASM_BINARY};
 use frame_support::{assert_noop, assert_ok};
 use frame_system::Pallet as SystemPallet;
-use gear_core::{code::Code, ids::CodeId, memory::PageBuf};
+use gear_core::{code::Code, ids::CodeId};
 use pallet_balances::{self, Pallet as BalancesPallet};
 
 use super::{

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -24,7 +24,7 @@ use demo_mul_by_const::WASM_BINARY as MUL_CONST_WASM_BINARY;
 use demo_program_factory::{CreateProgram, WASM_BINARY as PROGRAM_FACTORY_WASM_BINARY};
 use frame_support::{assert_noop, assert_ok};
 use frame_system::Pallet as SystemPallet;
-use gear_core::{code::Code, ids::CodeId, memory::page_buf_into_vec_u8};
+use gear_core::{code::Code, ids::CodeId, memory::PageBuf};
 use pallet_balances::{self, Pallet as BalancesPallet};
 
 use super::{
@@ -2425,7 +2425,7 @@ fn resume_program_works() {
         let memory_pages = common::get_program_pages_data(program_id, &program)
             .unwrap()
             .into_iter()
-            .map(|(page, data)| (page, page_buf_into_vec_u8(data)))
+            .map(|(page, data)| (page, data.into_vec()))
             .collect();
 
         assert_ok!(GearProgram::pause_program(program_id));

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -24,7 +24,7 @@ use demo_mul_by_const::WASM_BINARY as MUL_CONST_WASM_BINARY;
 use demo_program_factory::{CreateProgram, WASM_BINARY as PROGRAM_FACTORY_WASM_BINARY};
 use frame_support::{assert_noop, assert_ok};
 use frame_system::Pallet as SystemPallet;
-use gear_core::{code::Code, ids::CodeId};
+use gear_core::{code::Code, ids::CodeId, memory::page_buf_into_vec_u8};
 use pallet_balances::{self, Pallet as BalancesPallet};
 
 use super::{
@@ -2421,7 +2421,12 @@ fn resume_program_works() {
             common::Program::Active(p) => p,
             _ => unreachable!(),
         };
-        let memory_pages = common::get_program_pages_data(program_id, &program).unwrap();
+
+        let memory_pages = common::get_program_pages_data(program_id, &program)
+            .unwrap()
+            .into_iter()
+            .map(|(page, data)| (page, page_buf_into_vec_u8(data)))
+            .collect();
 
         assert_ok!(GearProgram::pause_program(program_id));
 

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -21,7 +21,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};
-use gear_core::memory::{PageBuf, page_buf_from_vec_u8};
+use gear_core::memory::{page_buf_from_vec_u8, PageBuf};
 use sp_runtime_interface::runtime_interface;
 
 #[cfg(feature = "std")]
@@ -259,7 +259,8 @@ pub trait GearRI {
 
     #[version(3)]
     fn get_released_page_old_data(page: u32) -> Result<PageBuf, GetReleasedPageError> {
-        let data = gear_lazy_pages::get_released_page_old_data(page).map_err(|_| GetReleasedPageError)?;
+        let data =
+            gear_lazy_pages::get_released_page_old_data(page).map_err(|_| GetReleasedPageError)?;
         Ok(page_buf_from_vec_u8(data).unwrap())
     }
 

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -21,7 +21,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};
-use gear_core::memory::{page_buf_from_vec_u8, PageBuf};
+use gear_core::memory::PageBuf;
 use sp_runtime_interface::runtime_interface;
 
 #[cfg(feature = "std")]
@@ -248,20 +248,20 @@ pub trait GearRI {
         gear_lazy_pages::get_released_pages()
     }
 
+    /// TODO: remove before release
     fn get_released_page_old_data(page: u32) -> Vec<u8> {
-        gear_lazy_pages::get_released_page_old_data(page).expect("Must have data for released page")
+        gear_lazy_pages::get_released_page_old_data(page).expect("Must have data for released page").to_vec()
     }
 
+    /// TODO: remove before release
     #[version(2)]
     fn get_released_page_old_data(page: u32) -> Result<Vec<u8>, GetReleasedPageError> {
-        gear_lazy_pages::get_released_page_old_data(page).map_err(|_| GetReleasedPageError)
+        gear_lazy_pages::get_released_page_old_data(page).map_err(|_| GetReleasedPageError).map(|data| data.to_vec())
     }
 
     #[version(3)]
     fn get_released_page_old_data(page: u32) -> Result<PageBuf, GetReleasedPageError> {
-        let data =
-            gear_lazy_pages::get_released_page_old_data(page).map_err(|_| GetReleasedPageError)?;
-        Ok(page_buf_from_vec_u8(data).unwrap())
+        gear_lazy_pages::get_released_page_old_data(page).map_err(|_| GetReleasedPageError)
     }
 
     fn print_hello() {

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -21,6 +21,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};
+use gear_core::memory::{PageBuf, page_buf_from_vec_u8};
 use sp_runtime_interface::runtime_interface;
 
 #[cfg(feature = "std")]
@@ -254,6 +255,12 @@ pub trait GearRI {
     #[version(2)]
     fn get_released_page_old_data(page: u32) -> Result<Vec<u8>, GetReleasedPageError> {
         gear_lazy_pages::get_released_page_old_data(page).map_err(|_| GetReleasedPageError)
+    }
+
+    #[version(3)]
+    fn get_released_page_old_data(page: u32) -> Result<PageBuf, GetReleasedPageError> {
+        let data = gear_lazy_pages::get_released_page_old_data(page).map_err(|_| GetReleasedPageError)?;
+        Ok(page_buf_from_vec_u8(data).unwrap())
     }
 
     fn print_hello() {

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -250,13 +250,17 @@ pub trait GearRI {
 
     /// TODO: remove before release
     fn get_released_page_old_data(page: u32) -> Vec<u8> {
-        gear_lazy_pages::get_released_page_old_data(page).expect("Must have data for released page").to_vec()
+        gear_lazy_pages::get_released_page_old_data(page)
+            .expect("Must have data for released page")
+            .to_vec()
     }
 
     /// TODO: remove before release
     #[version(2)]
     fn get_released_page_old_data(page: u32) -> Result<Vec<u8>, GetReleasedPageError> {
-        gear_lazy_pages::get_released_page_old_data(page).map_err(|_| GetReleasedPageError).map(|data| data.to_vec())
+        gear_lazy_pages::get_released_page_old_data(page)
+            .map_err(|_| GetReleasedPageError)
+            .map(|data| data.to_vec())
     }
 
     #[version(3)]

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -252,6 +252,7 @@ pub trait GearRI {
     fn get_released_page_old_data(page: u32) -> Vec<u8> {
         gear_lazy_pages::get_released_page_old_data(page)
             .expect("Must have data for released page")
+            .0
             .to_vec()
     }
 
@@ -260,7 +261,7 @@ pub trait GearRI {
     fn get_released_page_old_data(page: u32) -> Result<Vec<u8>, GetReleasedPageError> {
         gear_lazy_pages::get_released_page_old_data(page)
             .map_err(|_| GetReleasedPageError)
-            .map(|data| data.to_vec())
+            .map(|data| data.0.to_vec())
     }
 
     #[version(3)]

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -252,7 +252,6 @@ pub trait GearRI {
     fn get_released_page_old_data(page: u32) -> Vec<u8> {
         gear_lazy_pages::get_released_page_old_data(page)
             .expect("Must have data for released page")
-            .0
             .to_vec()
     }
 
@@ -261,7 +260,7 @@ pub trait GearRI {
     fn get_released_page_old_data(page: u32) -> Result<Vec<u8>, GetReleasedPageError> {
         gear_lazy_pages::get_released_page_old_data(page)
             .map_err(|_| GetReleasedPageError)
-            .map(|data| data.0.to_vec())
+            .map(|data| data.to_vec())
     }
 
     #[version(3)]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -125,7 +125,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 800,
+    spec_version: 810,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/utils/gear-runtime-test-cli/src/command.rs
+++ b/utils/gear-runtime-test-cli/src/command.rs
@@ -29,6 +29,7 @@ use gear_common::{
 };
 use gear_core::{
     ids::{CodeId, MessageId, ProgramId},
+    memory::vec_page_data_map_to_page_buf_map,
     message::{DispatchKind, GasLimit, StoredDispatch, StoredMessage},
     program::Program as CoreProgram,
 };
@@ -396,7 +397,10 @@ fn run_fixture(test: &'_ sample::Test, fixture: &sample::Fixture) -> ColoredStri
                         Some(ExecutableActor {
                             program,
                             balance: 0,
-                            pages_data: info.persistent_pages.clone(),
+                            pages_data: vec_page_data_map_to_page_buf_map(
+                                info.persistent_pages.clone(),
+                            )
+                            .unwrap(),
                         })
                     } else {
                         None


### PR DESCRIPTION
Resolves #881  .

1) Uses now PageBuf everywhere for page data representation. I have found a way (thanks to @ark0f) to transform vec to PageBuf without any relocations, so now it's almost for free. Using PageBuf is more profitable for compiler, which can apply more optimisations in case it knows buffer size in compile time.
2) Remove allowance_exceed and use error reason instead.

