### PR TITLE
Address new clippy warnings

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -239,7 +239,7 @@ pub trait ValueTree {
 
 type ConsumeOutput<Imbalance, External> = Option<(Imbalance, External)>;
 
-#[derive(Clone, Debug, Decode, Encode, PartialEq, TypeInfo)]
+#[derive(Clone, Debug, Decode, Encode, PartialEq, Eq, TypeInfo)]
 pub enum Program {
     Active(ActiveProgram),
     Terminated,
@@ -293,7 +293,7 @@ impl core::convert::TryFrom<Program> for ActiveProgram {
     }
 }
 
-#[derive(Clone, Debug, Decode, Encode, PartialEq, TypeInfo)]
+#[derive(Clone, Debug, Decode, Encode, PartialEq, Eq, TypeInfo)]
 pub struct ActiveProgram {
     /// Set of wasm pages numbers, which is allocated by the program.
     pub allocations: BTreeSet<WasmPageNumber>,
@@ -304,7 +304,7 @@ pub struct ActiveProgram {
 }
 
 /// Enumeration contains variants for program state.
-#[derive(Clone, Debug, Decode, Encode, PartialEq, TypeInfo)]
+#[derive(Clone, Debug, Decode, Encode, PartialEq, Eq, TypeInfo)]
 pub enum ProgramState {
     /// `init` method of a program has not yet finished its execution so
     /// the program is not considered as initialized. All messages to such a
@@ -315,7 +315,7 @@ pub enum ProgramState {
     Initialized,
 }
 
-#[derive(Clone, Debug, Decode, Encode, PartialEq, TypeInfo)]
+#[derive(Clone, Debug, Decode, Encode, PartialEq, Eq, TypeInfo)]
 pub struct CodeMetadata {
     pub author: H256,
     #[codec(compact)]

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -270,7 +270,7 @@ mod tests {
     }
 
     /// Struct with internal value to interact with ExtCarrier
-    #[derive(Debug, PartialEq, Clone, Copy)]
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     struct ExtImplementedStruct(u8);
 
     /// Empty Ext implementation for test struct

--- a/core/src/gas.rs
+++ b/core/src/gas.rs
@@ -36,7 +36,7 @@ pub trait Token: Copy + Clone {
 }
 
 /// The result of charging gas.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChargeResult {
     /// There was enough gas and it has been charged.
     Enough,

--- a/examples/binaries/btree/src/lib.rs
+++ b/examples/binaries/btree/src/lib.rs
@@ -32,7 +32,7 @@ extern crate alloc;
 use codec::{Decode, Encode};
 use gstd::prelude::*;
 
-#[derive(Encode, Debug, Decode, PartialEq)]
+#[derive(Encode, Debug, Decode, PartialEq, Eq)]
 pub enum Request {
     Insert(u32, u32),
     Remove(u32),
@@ -40,7 +40,7 @@ pub enum Request {
     Clear,
 }
 
-#[derive(Encode, Debug, Decode, PartialEq)]
+#[derive(Encode, Debug, Decode, PartialEq, Eq)]
 pub enum Reply {
     Error,
     None,

--- a/examples/binaries/distributor/src/lib.rs
+++ b/examples/binaries/distributor/src/lib.rs
@@ -32,14 +32,14 @@ mod code {
 #[cfg(feature = "std")]
 pub use code::WASM_BINARY_OPT as WASM_BINARY;
 
-#[derive(Encode, Debug, Decode, PartialEq)]
+#[derive(Encode, Debug, Decode, PartialEq, Eq)]
 pub enum Request {
     Receive(u64),
     Join(u64),
     Report,
 }
 
-#[derive(Encode, Debug, Decode, PartialEq)]
+#[derive(Encode, Debug, Decode, PartialEq, Eq)]
 pub enum Reply {
     Success,
     Failure,

--- a/examples/binaries/node/src/lib.rs
+++ b/examples/binaries/node/src/lib.rs
@@ -31,17 +31,17 @@ mod code {
     include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 }
 
-#[derive(Encode, Debug, Decode, PartialEq)]
+#[derive(Encode, Debug, Decode, PartialEq, Eq)]
 pub struct Operation {
     to_status: u32,
 }
 
-#[derive(Encode, Debug, Decode, PartialEq)]
+#[derive(Encode, Debug, Decode, PartialEq, Eq)]
 pub struct Initialization {
     status: u32,
 }
 
-#[derive(Encode, Debug, Decode, PartialEq)]
+#[derive(Encode, Debug, Decode, PartialEq, Eq)]
 pub enum Request {
     IsReady,
     Begin(Operation),
@@ -49,7 +49,7 @@ pub enum Request {
     Add(u64),
 }
 
-#[derive(Encode, Debug, Decode, PartialEq)]
+#[derive(Encode, Debug, Decode, PartialEq, Eq)]
 pub enum Reply {
     Yes,
     No,

--- a/examples/binaries/wait_wake/src/lib.rs
+++ b/examples/binaries/wait_wake/src/lib.rs
@@ -32,7 +32,7 @@ mod code {
 #[cfg(feature = "std")]
 pub use code::WASM_BINARY_OPT as WASM_BINARY;
 
-#[derive(Encode, Debug, Decode, PartialEq)]
+#[derive(Encode, Debug, Decode, PartialEq, Eq)]
 pub enum Request {
     EchoWait(u32),
     Wake(MessageId),

--- a/examples/meta/src/lib.rs
+++ b/examples/meta/src/lib.rs
@@ -56,7 +56,7 @@ impl From<MessageIn> for MessageOut {
 }
 
 // Additional to primary types
-#[derive(TypeInfo, Decode, Encode, Debug, PartialEq, Clone)]
+#[derive(TypeInfo, Decode, Encode, Debug, PartialEq, Eq, Clone)]
 pub struct Id {
     pub decimal: u64,
     pub hex: Vec<u8>,

--- a/examples/token-vendor/src/lib.rs
+++ b/examples/token-vendor/src/lib.rs
@@ -29,9 +29,7 @@ fn hex_to_id(hex: String) -> Result<ActorId, u8> {
 fn address_to_id(address: String) -> Result<ActorId, u8> {
     bs58::decode(address)
         .into_vec()
-        .map(|v| {
-            ActorId::from_slice(&v[1..v.len() - 2].to_vec()).expect("Unable to create ActorId")
-        })
+        .map(|v| ActorId::from_slice(&v[1..v.len() - 2]).expect("Unable to create ActorId"))
         .map_err(|_| 1)
 }
 

--- a/gear-test/src/address.rs
+++ b/gear-test/src/address.rs
@@ -43,7 +43,7 @@ static ACCOUNTS: Lazy<HashMap<&'static str, H256>> = Lazy::new(|| {
     accounts
 });
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(tag = "kind", content = "value")]
 pub enum Address {
     #[serde(rename = "account")]

--- a/gear-test/src/js/mod.rs
+++ b/gear-test/src/js/mod.rs
@@ -185,13 +185,13 @@ mod tests {
     use parity_scale_codec::{Decode, Encode};
     use serde_json::Value;
 
-    #[derive(Decode, Debug, PartialEq, Encode)]
+    #[derive(Decode, Debug, PartialEq, Eq, Encode)]
     pub enum Action {
         AddMessage(MessageIn),
         ViewMessages,
     }
 
-    #[derive(Decode, Debug, PartialEq, Encode)]
+    #[derive(Decode, Debug, PartialEq, Eq, Encode)]
     pub struct MessageIn {
         author: String,
         msg: String,

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -48,6 +48,7 @@ fn de_bytes<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Er
 /// Program being tested and it's initialization data.
 ///
 /// In test nested structure *program* is one the highest fields. The other one is *fixture*.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Program {
     /// Path to program's wasm blob.
@@ -70,26 +71,27 @@ pub struct Program {
 }
 
 /// Code saved in the persistent layer before fixtures are run
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct Code {
     /// Path to program's wasm blob.
     pub path: String,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct ChainProgram {
     #[serde(flatten)]
     pub address: ChainAddress,
     pub terminated: Option<bool>,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct Programs {
     pub only: Option<bool>,
     pub ids: Vec<ChainProgram>,
 }
 
 /// Expected data after running messages, defined in the fixture.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Expectation {
     /// Step number.
@@ -119,6 +121,7 @@ pub struct Expectation {
 /// 1) the set of messages sent to programs defined in the test;
 /// 2) expected results of message processing.
 /// Tests can have multiple `Fixtures`, which means we can define specialized "messages & expectation" block sets, each with its own `title`.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Fixture {
     /// Fixture title
@@ -130,6 +133,7 @@ pub struct Fixture {
 }
 
 /// Payload data types being used in messages.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(tag = "kind", content = "value")]
 pub enum PayloadVariant {
@@ -178,7 +182,7 @@ impl PayloadVariant {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct BytesAt {
     /// Program's id.
     #[serde(deserialize_with = "address::deserialize")]
@@ -190,7 +194,7 @@ pub struct BytesAt {
     pub bytes: Vec<u8>,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct Allocations {
     /// Program's id.
     #[serde(deserialize_with = "address::deserialize")]
@@ -200,7 +204,7 @@ pub struct Allocations {
     pub kind: AllocationExpectationKind,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AllocationExpectationKind {
     PageCount(u64),
@@ -208,13 +212,14 @@ pub enum AllocationExpectationKind {
     ContainsPages(Vec<u32>),
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AllocationFilter {
     Static,
     Dynamic,
 }
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Message {
     pub source: Option<ChainAddress>,
@@ -229,6 +234,7 @@ pub struct Message {
 }
 
 /// Main model describing test structure
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Test {
     /// Code that are needed to be submitted for tests

--- a/gstd/src/common/primitives.rs
+++ b/gstd/src/common/primitives.rs
@@ -64,7 +64,7 @@ impl ActorId {
     pub fn from_bs58(address: String) -> Result<Self> {
         bs58::decode(address)
             .into_vec()
-            .map(|v| Self::from_slice(&v[1..v.len() - 2].to_vec()))
+            .map(|v| Self::from_slice(&v[1..v.len() - 2]))
             .map_err(|_| ContractError::Convert("Unable to decode bs58 address"))?
     }
 

--- a/pallets/gear-debug/src/lib.rs
+++ b/pallets/gear-debug/src/lib.rs
@@ -86,7 +86,7 @@ pub mod pallet {
     /// Program debug info.
     // TODO: unfortunatelly we cannot store pages data in [PageBuf],
     // because polkadot-js api can not support this type.
-    #[derive(Encode, Decode, Clone, Default, PartialEq, TypeInfo)]
+    #[derive(Encode, Decode, Clone, Default, PartialEq, Eq, TypeInfo)]
     pub struct ProgramInfo {
         pub static_pages: WasmPageNumber,
         pub persistent_pages: BTreeMap<PageNumber, Vec<u8>>,
@@ -106,19 +106,19 @@ pub mod pallet {
         }
     }
 
-    #[derive(Encode, Decode, Clone, PartialEq, TypeInfo, Debug)]
+    #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo, Debug)]
     pub enum ProgramState {
         Active(ProgramInfo),
         Terminated,
     }
 
-    #[derive(Encode, Decode, Clone, PartialEq, TypeInfo, Debug)]
+    #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo, Debug)]
     pub struct ProgramDetails {
         pub id: H256,
         pub state: ProgramState,
     }
 
-    #[derive(Debug, Encode, Decode, Clone, Default, PartialEq, TypeInfo)]
+    #[derive(Debug, Encode, Decode, Clone, Default, PartialEq, Eq, TypeInfo)]
     pub struct DebugData {
         pub dispatch_queue: Vec<StoredDispatch>,
         pub programs: Vec<ProgramDetails>,

--- a/pallets/gear-program/src/pause.rs
+++ b/pallets/gear-program/src/pause.rs
@@ -26,7 +26,7 @@ use gear_core::{
 };
 use scale_info::TypeInfo;
 
-#[derive(Clone, Debug, PartialEq, Decode, Encode, TypeInfo)]
+#[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, TypeInfo)]
 pub(super) struct PausedProgram {
     program_id: H256,
     program: common::ActiveProgram,
@@ -47,7 +47,7 @@ fn wait_list_hash(wait_list: &BTreeMap<H256, StoredDispatch>) -> H256 {
     wait_list.using_encoded(sp_io::hashing::blake2_256).into()
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PauseError {
     ProgramNotFound,
     ProgramTerminated,

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -246,26 +246,26 @@ pub mod pallet {
         MessagesStorageCorrupted,
     }
 
-    #[derive(Debug, Encode, Decode, Clone, PartialEq, TypeInfo)]
+    #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]
     pub enum Reason {
         Error,
         ValueTransfer,
         Dispatch(Vec<u8>),
     }
 
-    #[derive(Debug, Encode, Decode, Clone, PartialEq, TypeInfo)]
+    #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]
     pub enum ExecutionResult {
         Success,
         Failure(Vec<u8>),
     }
 
-    #[derive(Debug, Encode, Decode, Clone, PartialEq, TypeInfo)]
+    #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]
     pub struct DispatchOutcome {
         pub message_id: H256,
         pub outcome: ExecutionResult,
     }
 
-    #[derive(Debug, Encode, Decode, Clone, PartialEq, TypeInfo)]
+    #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]
     pub struct MessageInfo {
         pub message_id: H256,
         pub program_id: H256,

--- a/pallets/usage/src/offchain.rs
+++ b/pallets/usage/src/offchain.rs
@@ -90,7 +90,7 @@ pub const STORAGE_LAST_KEY: &[u8] = b"g::ocw::last::key";
 pub const STORAGE_OCW_LOCK: &[u8] = b"g::ocw::lock";
 pub const STORAGE_ROUND_STARTED_AT: &[u8] = b"g::ocw::new::round";
 
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum OffchainError {
     FailedToGetValueFromStorage,
     SubmitTransaction,
@@ -107,7 +107,7 @@ impl sp_std::fmt::Debug for OffchainError {
     }
 }
 
-#[derive(Encode, Decode, Clone, PartialEq, scale_info::TypeInfo)]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, scale_info::TypeInfo)]
 pub struct PayeeInfo {
     pub program_id: H256,
     pub message_id: H256,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 830,
+    spec_version: 840,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
The new Rust compiler version introduced new clippy warnings.

- https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq
- https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_to_owned

@gear-tech/dev 
