### PR TITLE
Make `codecov/patch` informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,9 @@ coverage:
   status:
     project:
       default:
-        # basic
         target: auto
-        threshold: 5%
-        if_ci_failed: error #success, failure, error, ignore
+        threshold: 10%
+        if_ci_failed: error
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
This will calm codecov for concrete PR's changes to prevent CI useless fails.
Threshold for whole repo also increased twice.
