### PR TITLE
Add list of forbidden syscalls to WASM executor

### DIFF
--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -47,6 +47,7 @@ pub enum TerminationReasonKind {
     Leave,
     Wait,
     GasAllowanceExceeded,
+    ForbiddenFunction,
 }
 
 #[derive(Debug, Clone)]

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -71,6 +71,8 @@ pub(crate) struct Runtime<E: Ext> {
     pub termination_reason: Option<TerminationReasonKind>,
 }
 
+// A helping wrapper for `EnvironmentDefinitionBuilder` and `forbidden_funcs`.
+// It makes adding functions to `EnvironmentDefinitionBuilder` shorter.
 struct EnvBuilder<'a, E: Ext> {
     env_def_builder: EnvironmentDefinitionBuilder<Runtime<E>>,
     forbidden_funcs: &'a BTreeSet<&'static str>,

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -18,7 +18,10 @@
 
 //! sp-sandbox environment for running a module.
 
-use crate::{funcs::FuncError, memory::MemoryWrap};
+use crate::{
+    funcs::{FuncError, FuncsHandler as Funcs},
+    memory::MemoryWrap,
+};
 use alloc::{
     collections::{BTreeMap, BTreeSet},
     format,
@@ -85,7 +88,7 @@ impl<'a, E: Ext + IntoExtInfo + 'static> EnvBuilder<'a, E> {
     {
         if self.forbidden_funcs.contains(name) {
             self.env_def_builder
-                .add_host_func("env", name, crate::funcs::FuncsHandler::forbidden);
+                .add_host_func("env", name, Funcs::forbidden);
         } else {
             self.env_def_builder.add_host_func("env", name, f);
         }
@@ -146,39 +149,38 @@ where
             forbidden_funcs: ext.forbidden_funcs(),
         };
 
-        use crate::funcs::FuncsHandler as funcs;
-        builder.add_func("gr_block_height", funcs::block_height);
-        builder.add_func("gr_block_timestamp", funcs::block_timestamp);
-        builder.add_func("gr_create_program", funcs::create_program);
-        builder.add_func("gr_create_program_wgas", funcs::create_program_wgas);
-        builder.add_func("gr_debug", funcs::debug);
-        builder.add_func("gr_error", funcs::error);
-        builder.add_func("gr_exit", funcs::exit);
-        builder.add_func("gr_exit_code", funcs::exit_code);
-        builder.add_func("gr_gas_available", funcs::gas_available);
-        builder.add_func("gr_leave", funcs::leave);
-        builder.add_func("gr_msg_id", funcs::msg_id);
-        builder.add_func("gr_origin", funcs::origin);
-        builder.add_func("gr_program_id", funcs::program_id);
-        builder.add_func("gr_read", funcs::read);
-        builder.add_func("gr_reply", funcs::reply);
-        builder.add_func("gr_reply_commit", funcs::reply_commit);
-        builder.add_func("gr_reply_commit_wgas", funcs::reply_commit_wgas);
-        builder.add_func("gr_reply_push", funcs::reply_push);
-        builder.add_func("gr_reply_to", funcs::reply_to);
-        builder.add_func("gr_reply_wgas", funcs::reply_wgas);
-        builder.add_func("gr_send", funcs::send);
-        builder.add_func("gr_send_commit", funcs::send_commit);
-        builder.add_func("gr_send_commit_wgas", funcs::send_commit_wgas);
-        builder.add_func("gr_send_init", funcs::send_init);
-        builder.add_func("gr_send_push", funcs::send_push);
-        builder.add_func("gr_send_wgas", funcs::send_wgas);
-        builder.add_func("gr_size", funcs::size);
-        builder.add_func("gr_source", funcs::source);
-        builder.add_func("gr_value", funcs::value);
-        builder.add_func("gr_value_available", funcs::value_available);
-        builder.add_func("gr_wait", funcs::wait);
-        builder.add_func("gr_wake", funcs::wake);
+        builder.add_func("gr_block_height", Funcs::block_height);
+        builder.add_func("gr_block_timestamp", Funcs::block_timestamp);
+        builder.add_func("gr_create_program", Funcs::create_program);
+        builder.add_func("gr_create_program_wgas", Funcs::create_program_wgas);
+        builder.add_func("gr_debug", Funcs::debug);
+        builder.add_func("gr_error", Funcs::error);
+        builder.add_func("gr_exit", Funcs::exit);
+        builder.add_func("gr_exit_code", Funcs::exit_code);
+        builder.add_func("gr_gas_available", Funcs::gas_available);
+        builder.add_func("gr_leave", Funcs::leave);
+        builder.add_func("gr_msg_id", Funcs::msg_id);
+        builder.add_func("gr_origin", Funcs::origin);
+        builder.add_func("gr_program_id", Funcs::program_id);
+        builder.add_func("gr_read", Funcs::read);
+        builder.add_func("gr_reply", Funcs::reply);
+        builder.add_func("gr_reply_commit", Funcs::reply_commit);
+        builder.add_func("gr_reply_commit_wgas", Funcs::reply_commit_wgas);
+        builder.add_func("gr_reply_push", Funcs::reply_push);
+        builder.add_func("gr_reply_to", Funcs::reply_to);
+        builder.add_func("gr_reply_wgas", Funcs::reply_wgas);
+        builder.add_func("gr_send", Funcs::send);
+        builder.add_func("gr_send_commit", Funcs::send_commit);
+        builder.add_func("gr_send_commit_wgas", Funcs::send_commit_wgas);
+        builder.add_func("gr_send_init", Funcs::send_init);
+        builder.add_func("gr_send_push", Funcs::send_push);
+        builder.add_func("gr_send_wgas", Funcs::send_wgas);
+        builder.add_func("gr_size", Funcs::size);
+        builder.add_func("gr_source", Funcs::source);
+        builder.add_func("gr_value", Funcs::value);
+        builder.add_func("gr_value_available", Funcs::value_available);
+        builder.add_func("gr_wait", Funcs::wait);
+        builder.add_func("gr_wake", Funcs::wake);
         let mut env_builder: EnvironmentDefinitionBuilder<_> = builder.into();
 
         let ext_carrier = ExtCarrier::new(ext);
@@ -195,9 +197,9 @@ where
         };
 
         env_builder.add_memory("env", "memory", mem.clone());
-        env_builder.add_host_func("env", "alloc", funcs::alloc);
-        env_builder.add_host_func("env", "free", funcs::free);
-        env_builder.add_host_func("env", "gas", funcs::gas);
+        env_builder.add_host_func("env", "alloc", Funcs::alloc);
+        env_builder.add_host_func("env", "free", Funcs::free);
+        env_builder.add_host_func("env", "gas", Funcs::gas);
 
         let mut runtime = Runtime {
             ext: ext_carrier,

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -98,6 +98,8 @@ pub enum FuncError<E> {
     Leave,
     #[display(fmt = "`gr_wait` has been called")]
     Wait,
+    #[display(fmt = "Unable to call a forbidden function")]
+    ForbiddenFunction,
 }
 
 impl<E> FuncError<E> {
@@ -884,5 +886,11 @@ where
             ctx.trap = Some(err);
             HostError
         })
+    }
+
+    pub fn forbidden(ctx: &mut Runtime<E>, _args: &[Value]) -> SyscallOutput {
+        ctx.termination_reason = Some(TerminationReasonKind::ForbiddenFunction);
+        ctx.trap = Some(FuncError::ForbiddenFunction);
+        Err(HostError)
     }
 }

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -108,6 +108,7 @@ where
         memory_pages: &BTreeMap<PageNumber, PageBuf>,
         mem_size: WasmPageNumber,
     ) -> Result<Self, BackendError<Self::Error>> {
+        let forbidden_funcs = ext.forbidden_funcs().clone();
         let ext_carrier = ExtCarrier::new(ext);
 
         let engine = Engine::default();
@@ -182,6 +183,10 @@ where
         funcs.insert("gr_wait", funcs::wait(&mut store));
         funcs.insert("gr_wake", funcs::wake(&mut store, memory));
         funcs.insert("gr_error", funcs::error(&mut store, memory));
+
+        for name in forbidden_funcs {
+            funcs.insert(name, funcs::forbidden(&mut store));
+        }
 
         let module = match Module::new(&engine, binary) {
             Ok(module) => module,

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -40,7 +40,7 @@ use wasmtime::{
     Engine, Extern, Func, Instance, Memory as WasmtimeMemory, MemoryType, Module, Store, Trap,
 };
 
-use crate::memory::MemoryWrapExternal;
+use crate::{funcs::FuncsHandler as Funcs, memory::MemoryWrapExternal};
 
 /// Data type in wasmtime store
 pub struct StoreData<E: Ext> {
@@ -130,62 +130,60 @@ where
             }
         };
 
-        /// Make import funcs
-        use crate::funcs::FuncsHandler as funcs;
         let mut funcs = BTreeMap::<&'static str, Func>::new();
-        funcs.insert("alloc", funcs::alloc(&mut store, memory));
-        funcs.insert("free", funcs::free(&mut store));
-        funcs.insert("gas", funcs::gas(&mut store));
-        funcs.insert("gr_block_height", funcs::block_height(&mut store));
-        funcs.insert("gr_block_timestamp", funcs::block_timestamp(&mut store));
+        funcs.insert("alloc", Funcs::alloc(&mut store, memory));
+        funcs.insert("free", Funcs::free(&mut store));
+        funcs.insert("gas", Funcs::gas(&mut store));
+        funcs.insert("gr_block_height", Funcs::block_height(&mut store));
+        funcs.insert("gr_block_timestamp", Funcs::block_timestamp(&mut store));
         funcs.insert(
             "gr_create_program",
-            funcs::create_program(&mut store, memory),
+            Funcs::create_program(&mut store, memory),
         );
         funcs.insert(
             "gr_create_program_wgas",
-            funcs::create_program_wgas(&mut store, memory),
+            Funcs::create_program_wgas(&mut store, memory),
         );
-        funcs.insert("gr_exit_code", funcs::exit_code(&mut store));
-        funcs.insert("gr_gas_available", funcs::gas_available(&mut store));
-        funcs.insert("gr_debug", funcs::debug(&mut store, memory));
-        funcs.insert("gr_exit", funcs::exit(&mut store, memory));
-        funcs.insert("gr_origin", funcs::origin(&mut store, memory));
-        funcs.insert("gr_msg_id", funcs::msg_id(&mut store, memory));
-        funcs.insert("gr_program_id", funcs::program_id(&mut store, memory));
-        funcs.insert("gr_read", funcs::read(&mut store, memory));
-        funcs.insert("gr_reply", funcs::reply(&mut store, memory));
-        funcs.insert("gr_reply_wgas", funcs::reply_wgas(&mut store, memory));
-        funcs.insert("gr_reply_commit", funcs::reply_commit(&mut store, memory));
+        funcs.insert("gr_exit_code", Funcs::exit_code(&mut store));
+        funcs.insert("gr_gas_available", Funcs::gas_available(&mut store));
+        funcs.insert("gr_debug", Funcs::debug(&mut store, memory));
+        funcs.insert("gr_exit", Funcs::exit(&mut store, memory));
+        funcs.insert("gr_origin", Funcs::origin(&mut store, memory));
+        funcs.insert("gr_msg_id", Funcs::msg_id(&mut store, memory));
+        funcs.insert("gr_program_id", Funcs::program_id(&mut store, memory));
+        funcs.insert("gr_read", Funcs::read(&mut store, memory));
+        funcs.insert("gr_reply", Funcs::reply(&mut store, memory));
+        funcs.insert("gr_reply_wgas", Funcs::reply_wgas(&mut store, memory));
+        funcs.insert("gr_reply_commit", Funcs::reply_commit(&mut store, memory));
         funcs.insert(
             "gr_reply_commit_wgas",
-            funcs::reply_commit_wgas(&mut store, memory),
+            Funcs::reply_commit_wgas(&mut store, memory),
         );
-        funcs.insert("gr_reply_push", funcs::reply_push(&mut store, memory));
-        funcs.insert("gr_reply_to", funcs::reply_to(&mut store, memory));
-        funcs.insert("gr_send_wgas", funcs::send_wgas(&mut store, memory));
-        funcs.insert("gr_send", funcs::send(&mut store, memory));
+        funcs.insert("gr_reply_push", Funcs::reply_push(&mut store, memory));
+        funcs.insert("gr_reply_to", Funcs::reply_to(&mut store, memory));
+        funcs.insert("gr_send_wgas", Funcs::send_wgas(&mut store, memory));
+        funcs.insert("gr_send", Funcs::send(&mut store, memory));
         funcs.insert(
             "gr_send_commit_wgas",
-            funcs::send_commit_wgas(&mut store, memory),
+            Funcs::send_commit_wgas(&mut store, memory),
         );
-        funcs.insert("gr_send_commit", funcs::send_commit(&mut store, memory));
-        funcs.insert("gr_send_init", funcs::send_init(&mut store, memory));
-        funcs.insert("gr_send_push", funcs::send_push(&mut store, memory));
-        funcs.insert("gr_size", funcs::size(&mut store));
-        funcs.insert("gr_source", funcs::source(&mut store, memory));
-        funcs.insert("gr_value", funcs::value(&mut store, memory));
+        funcs.insert("gr_send_commit", Funcs::send_commit(&mut store, memory));
+        funcs.insert("gr_send_init", Funcs::send_init(&mut store, memory));
+        funcs.insert("gr_send_push", Funcs::send_push(&mut store, memory));
+        funcs.insert("gr_size", Funcs::size(&mut store));
+        funcs.insert("gr_source", Funcs::source(&mut store, memory));
+        funcs.insert("gr_value", Funcs::value(&mut store, memory));
         funcs.insert(
             "gr_value_available",
-            funcs::value_available(&mut store, memory),
+            Funcs::value_available(&mut store, memory),
         );
-        funcs.insert("gr_leave", funcs::leave(&mut store));
-        funcs.insert("gr_wait", funcs::wait(&mut store));
-        funcs.insert("gr_wake", funcs::wake(&mut store, memory));
-        funcs.insert("gr_error", funcs::error(&mut store, memory));
+        funcs.insert("gr_leave", Funcs::leave(&mut store));
+        funcs.insert("gr_wait", Funcs::wait(&mut store));
+        funcs.insert("gr_wake", Funcs::wake(&mut store, memory));
+        funcs.insert("gr_error", Funcs::error(&mut store, memory));
 
         for name in forbidden_funcs {
-            funcs.insert(name, funcs::forbidden(&mut store));
+            funcs.insert(name, Funcs::forbidden(&mut store));
         }
 
         let module = match Module::new(&engine, binary) {

--- a/core-processor/src/configs.rs
+++ b/core-processor/src/configs.rs
@@ -18,6 +18,7 @@
 
 //! Configurations.
 
+use alloc::collections::BTreeSet;
 use codec::{Decode, Encode};
 use gear_core::{costs::HostFnWeights, memory::WasmPageNumber};
 
@@ -73,6 +74,8 @@ pub struct ExecutionSettings {
     pub existential_deposit: u128,
     /// Weights of host functions.
     pub host_fn_weights: HostFnWeights,
+    /// Functions forbidden to be called.
+    pub forbidden_funcs: BTreeSet<&'static str>,
 }
 
 impl ExecutionSettings {
@@ -82,12 +85,14 @@ impl ExecutionSettings {
         existential_deposit: u128,
         allocations_config: AllocationsConfig,
         host_fn_weights: HostFnWeights,
+        forbidden_funcs: BTreeSet<&'static str>,
     ) -> Self {
         Self {
             block_info,
             existential_deposit,
             allocations_config,
             host_fn_weights,
+            forbidden_funcs,
         }
     }
 

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -194,6 +194,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
         program_id,
         Default::default(),
         settings.host_fn_weights,
+        settings.forbidden_funcs,
     );
 
     let mut env = E::new(ext, program.raw_code(), &pages_data, mem_size).map_err(|err| {

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -60,6 +60,7 @@ pub trait ProcessorExt {
         program_id: ProgramId,
         program_candidates_data: BTreeMap<CodeId, Vec<(ProgramId, MessageId)>>,
         host_fn_weights: HostFnWeights,
+        forbidden_funcs: BTreeSet<&'static str>,
     ) -> Self;
 
     /// Returns whether this extension works with lazy pages
@@ -185,6 +186,8 @@ pub struct Ext {
     pub program_candidates_data: BTreeMap<CodeId, Vec<(ProgramId, MessageId)>>,
     /// Weights of host functions.
     pub host_fn_weights: HostFnWeights,
+    /// Functions forbidden to be called.
+    pub forbidden_funcs: BTreeSet<&'static str>,
 }
 
 /// Empty implementation for non-substrate (and non-lazy-pages) using
@@ -205,6 +208,7 @@ impl ProcessorExt for Ext {
         program_id: ProgramId,
         program_candidates_data: BTreeMap<CodeId, Vec<(ProgramId, MessageId)>>,
         host_fn_weights: HostFnWeights,
+        forbidden_funcs: BTreeSet<&'static str>,
     ) -> Self {
         Self {
             gas_counter,
@@ -221,6 +225,7 @@ impl ProcessorExt for Ext {
             program_id,
             program_candidates_data,
             host_fn_weights,
+            forbidden_funcs,
         }
     }
 
@@ -592,5 +597,9 @@ impl EnvExt for Ext {
             });
 
         self.return_and_store_err(result)
+    }
+
+    fn forbidden_funcs(&self) -> &BTreeSet<&'static str> {
+        &self.forbidden_funcs
     }
 }

--- a/core-processor/src/processor.rs
+++ b/core-processor/src/processor.rs
@@ -25,7 +25,7 @@ use crate::{
     executor,
     ext::ProcessorExt,
 };
-use alloc::{string::ToString, vec::Vec};
+use alloc::{collections::BTreeSet, string::ToString, vec::Vec};
 use gear_backend_common::{Environment, IntoExtInfo};
 use gear_core::{
     costs::HostFnWeights,
@@ -56,6 +56,7 @@ pub fn process<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environment<
     gas_allowance: u64,
     outgoing_limit: u32,
     host_fn_weights: HostFnWeights,
+    forbidden_funcs: BTreeSet<&'static str>,
 ) -> Vec<JournalNote> {
     match check_is_executable(maybe_actor, &dispatch) {
         Err(exit_code) => process_non_executable(dispatch, program_id, exit_code),
@@ -69,6 +70,7 @@ pub fn process<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environment<
             gas_allowance,
             outgoing_limit,
             host_fn_weights,
+            forbidden_funcs,
         ),
     }
 }
@@ -281,6 +283,7 @@ pub fn process_executable<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: E
     gas_allowance: u64,
     outgoing_limit: u32,
     host_fn_weights: HostFnWeights,
+    forbidden_funcs: BTreeSet<&'static str>,
 ) -> Vec<JournalNote> {
     use SuccessfulDispatchResultKind::*;
 
@@ -289,6 +292,7 @@ pub fn process_executable<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: E
         existential_deposit,
         allocations_config,
         host_fn_weights,
+        forbidden_funcs,
     );
     let execution_context = ExecutionContext {
         origin,

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -259,13 +259,13 @@ mod tests {
     // Test function of format `Fn(&mut E: Ext) -> R`
     // to call `fn with<R>(&self, f: impl FnOnce(&mut E) -> R) -> R`.
     // For example, returns the field of ext's inner value.
-    fn converter(e: &mut ExtImplementedStruct) -> u8 {
-        e.0
+    fn converter(_e: &mut ExtImplementedStruct) -> u8 {
+        0
     }
 
     /// Struct with internal value to interact with ExtCarrier
-    #[derive(Debug, PartialEq, Eq, Clone, Default)] //, Copy)]
-    struct ExtImplementedStruct(u8, BTreeSet<&'static str>);
+    #[derive(Debug, PartialEq, Eq, Clone, Default)]
+    struct ExtImplementedStruct(BTreeSet<&'static str>);
 
     /// Empty Ext implementation for test struct
     impl Ext for ExtImplementedStruct {
@@ -364,7 +364,7 @@ mod tests {
             Ok(Default::default())
         }
         fn forbidden_funcs(&self) -> &BTreeSet<&'static str> {
-            &self.1
+            &self.0
         }
     }
 

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -24,7 +24,7 @@ use crate::{
     memory::{Memory, WasmPageNumber},
     message::{ExitCode, HandlePacket, InitPacket, ReplyPacket},
 };
-use alloc::rc::Rc;
+use alloc::{collections::BTreeSet, rc::Rc};
 use codec::{Decode, Encode};
 use core::cell::RefCell;
 use gear_core_errors::CoreError;
@@ -151,6 +151,9 @@ pub trait Ext {
 
     /// Send init message to create a new program
     fn create_program(&mut self, packet: InitPacket) -> Result<ProgramId, Self::Error>;
+
+    /// Return the set of functions that are forbidden to be called.
+    fn forbidden_funcs(&self) -> &BTreeSet<&'static str>;
 }
 
 /// An error occurred during [`ExtCarrier::with_fallible`] which should be called only when inner is set
@@ -261,8 +264,8 @@ mod tests {
     }
 
     /// Struct with internal value to interact with ExtCarrier
-    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-    struct ExtImplementedStruct(u8);
+    #[derive(Debug, PartialEq, Eq, Clone, Default)] //, Copy)]
+    struct ExtImplementedStruct(u8, BTreeSet<&'static str>);
 
     /// Empty Ext implementation for test struct
     impl Ext for ExtImplementedStruct {
@@ -360,14 +363,17 @@ mod tests {
         fn create_program(&mut self, _packet: InitPacket) -> Result<ProgramId, Self::Error> {
             Ok(Default::default())
         }
+        fn forbidden_funcs(&self) -> &BTreeSet<&'static str> {
+            &self.1
+        }
     }
 
     #[test]
     fn create_and_unwrap_ext_carrier() {
-        let ext_implementer = ExtImplementedStruct(0);
-        let ext = ExtCarrier::new(ext_implementer);
+        let ext_implementer: ExtImplementedStruct = Default::default();
+        let ext = ExtCarrier::new(ext_implementer.clone());
 
-        assert_eq!(ext.0, Rc::new(RefCell::new(Some(ext_implementer))));
+        assert_eq!(ext.0, Rc::new(RefCell::new(Some(ext_implementer.clone()))));
 
         let inner = ext.into_inner();
 
@@ -376,7 +382,7 @@ mod tests {
 
     #[test]
     fn calling_fn_within_inner_ext() {
-        let ext_implementer = ExtImplementedStruct(0);
+        let ext_implementer: ExtImplementedStruct = Default::default();
         let ext = ExtCarrier::new(ext_implementer);
         let ext_clone = ext.cloned();
 
@@ -386,7 +392,7 @@ mod tests {
 
     #[test]
     fn calling_fn_when_ext_unwrapped() {
-        let ext = ExtCarrier::new(ExtImplementedStruct(0));
+        let ext = ExtCarrier::new(ExtImplementedStruct::default());
         let ext_clone = ext.cloned();
 
         let _ = ext.into_inner();
@@ -395,7 +401,7 @@ mod tests {
 
     #[test]
     fn calling_fn_when_dropped_ext() {
-        let ext = ExtCarrier::new(ExtImplementedStruct(0));
+        let ext = ExtCarrier::new(ExtImplementedStruct::default());
         let ext_clone = ext.cloned();
 
         drop(ext);
@@ -407,8 +413,8 @@ mod tests {
     #[allow(clippy::redundant_clone)]
     /// Test that ext's clone still refers to the same inner object as the original one
     fn ext_cloning() {
-        let ext_implementer = ExtImplementedStruct(0);
-        let ext = ExtCarrier::new(ext_implementer);
+        let ext_implementer: ExtImplementedStruct = Default::default();
+        let ext = ExtCarrier::new(ext_implementer.clone());
         let ext_clone = ext.cloned();
 
         assert_eq!(ext_clone.0 .0, Rc::new(RefCell::new(Some(ext_implementer))));
@@ -416,8 +422,8 @@ mod tests {
 
     #[test]
     fn unwrap_ext_with_dropped_clones() {
-        let ext_implementer = ExtImplementedStruct(0);
-        let ext = ExtCarrier::new(ext_implementer);
+        let ext_implementer: ExtImplementedStruct = Default::default();
+        let ext = ExtCarrier::new(ext_implementer.clone());
         let ext_clone1 = ext.cloned();
         let ext_clone2 = ext_clone1.clone();
 

--- a/examples/binaries/mul-by-const/src/lib.rs
+++ b/examples/binaries/mul-by-const/src/lib.rs
@@ -72,11 +72,6 @@ mod wasm {
     pub unsafe extern "C" fn handle() {
         let x: u64 = msg::load().expect("Expecting a u64 number");
 
-        debug!(
-            "[0x{} mul_by_const::handle] Before sending reply message, gas_available = {}",
-            DEBUG.me,
-            exec::gas_available()
-        );
         msg::reply(STATE.unchecked_mul(x), 0).unwrap();
     }
 

--- a/gear-test/src/proc.rs
+++ b/gear-test/src/proc.rs
@@ -114,6 +114,7 @@ where
         u64::MAX,
         OUTGOING_LIMIT,
         Default::default(),
+        Default::default(),
     );
 
     core_processor::handle_journal(journal, journal_handler);
@@ -297,6 +298,7 @@ where
                     u64::MAX,
                     OUTGOING_LIMIT,
                     Default::default(),
+                    Default::default(),
                 );
 
                 core_processor::handle_journal(journal, journal_handler);
@@ -334,6 +336,7 @@ where
                 program_id,
                 u64::MAX,
                 OUTGOING_LIMIT,
+                Default::default(),
                 Default::default(),
             );
             counter += 1;

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -441,6 +441,7 @@ impl ExtManager {
             u64::MAX,
             OUTGOING_LIMIT,
             Default::default(),
+            Default::default(),
         );
 
         core_processor::handle_journal(journal, self);

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -449,6 +449,7 @@ benchmarks! {
                     gas_allowance,
                     outgoing_limit,
                     Default::default(),
+                    Default::default(),
                 );
     }
 
@@ -534,6 +535,7 @@ benchmarks! {
                     gas_allowance,
                     outgoing_limit,
                     Default::default(),
+                    Default::default(),
                 );
     }
 
@@ -586,6 +588,7 @@ benchmarks! {
                     gas_allowance,
                     outgoing_limit,
                     Default::default(),
+                    Default::default(),
                 );
     }
 
@@ -625,6 +628,7 @@ benchmarks! {
                     program_id,
                     gas_allowance,
                     outgoing_limit,
+                    Default::default(),
                     Default::default(),
                 );
     }
@@ -666,6 +670,7 @@ benchmarks! {
                     gas_allowance,
                     outgoing_limit,
                     Default::default(),
+                    Default::default(),
                 );
     }
 
@@ -705,6 +710,7 @@ benchmarks! {
                     program_id,
                     gas_allowance,
                     outgoing_limit,
+                    Default::default(),
                     Default::default(),
                 );
     }
@@ -748,6 +754,7 @@ benchmarks! {
                     gas_allowance,
                     outgoing_limit,
                     Default::default(),
+                    Default::default(),
                 );
     }
 
@@ -788,6 +795,7 @@ benchmarks! {
                     gas_allowance,
                     outgoing_limit,
                     Default::default(),
+                    Default::default(),
                 );
     }
 
@@ -827,6 +835,7 @@ benchmarks! {
                     program_id,
                     gas_allowance,
                     outgoing_limit,
+                    Default::default(),
                     Default::default(),
                 );
     }
@@ -879,6 +888,7 @@ benchmarks! {
                     program_id,
                     gas_allowance,
                     outgoing_limit,
+                    Default::default(),
                     Default::default(),
                 );
     }
@@ -942,6 +952,7 @@ benchmarks! {
                     program_id,
                     gas_allowance,
                     outgoing_limit,
+                    Default::default(),
                     Default::default(),
                 );
     }
@@ -1010,6 +1021,7 @@ benchmarks! {
                     gas_allowance,
                     outgoing_limit,
                     Default::default(),
+                    Default::default(),
                 );
     }
 
@@ -1061,6 +1073,7 @@ benchmarks! {
                     program_id,
                     gas_allowance,
                     outgoing_limit,
+                    Default::default(),
                     Default::default(),
                 );
     }
@@ -1114,6 +1127,7 @@ benchmarks! {
                     gas_allowance,
                     outgoing_limit,
                     Default::default(),
+                    Default::default(),
                 );
     }
 
@@ -1166,6 +1180,7 @@ benchmarks! {
                     program_id,
                     gas_allowance,
                     outgoing_limit,
+                    Default::default(),
                     Default::default(),
                 );
         core_processor::handle_journal(journal, &mut ext_manager);
@@ -1232,6 +1247,7 @@ benchmarks! {
                     gas_allowance,
                     outgoing_limit,
                     Default::default(),
+                    Default::default(),
                 );
         core_processor::handle_journal(journal, &mut ext_manager);
     }
@@ -1296,6 +1312,7 @@ benchmarks! {
                     program_id,
                     gas_allowance,
                     outgoing_limit,
+                    Default::default(),
                     Default::default(),
                 );
         core_processor::handle_journal(journal, &mut ext_manager);
@@ -1374,6 +1391,7 @@ benchmarks! {
                     gas_allowance,
                     outgoing_limit,
                     Default::default(),
+                    Default::default(),
                 );
 
         core_processor::handle_journal(journal, &mut ext_manager);
@@ -1451,6 +1469,7 @@ benchmarks! {
                     gas_allowance,
                     outgoing_limit,
                     Default::default(),
+                    Default::default(),
                 );
 
         core_processor::handle_journal(journal, &mut ext_manager);
@@ -1518,6 +1537,7 @@ benchmarks! {
                     gas_allowance,
                     outgoing_limit,
                     Default::default(),
+                    Default::default(),
                 );
 
         core_processor::handle_journal(journal, &mut ext_manager);
@@ -1583,6 +1603,7 @@ benchmarks! {
                     gas_allowance,
                     outgoing_limit,
                     Default::default(),
+                    Default::default(),
                 );
 
         core_processor::handle_journal(journal, &mut ext_manager);
@@ -1640,6 +1661,7 @@ benchmarks! {
                     gas_allowance,
                     outgoing_limit,
                     Default::default(),
+                    Default::default(),
                 );
 
         core_processor::handle_journal(journal, &mut ext_manager);
@@ -1694,6 +1716,7 @@ benchmarks! {
                     program_id,
                     gas_allowance,
                     outgoing_limit,
+                    Default::default(),
                     Default::default(),
                 );
 
@@ -1751,6 +1774,7 @@ benchmarks! {
                     program_id,
                     gas_allowance,
                     outgoing_limit,
+                    Default::default(),
                     Default::default(),
                 );
 
@@ -1816,6 +1840,7 @@ benchmarks! {
                     gas_allowance,
                     outgoing_limit,
                     Default::default(),
+                    Default::default(),
                 );
         core_processor::handle_journal(journal, &mut ext_manager);
     }
@@ -1870,6 +1895,7 @@ benchmarks! {
                     gas_allowance,
                     outgoing_limit,
                     Default::default(),
+                    Default::default(),
                 );
         core_processor::handle_journal(journal, &mut ext_manager);
     }
@@ -1923,6 +1949,7 @@ benchmarks! {
                     program_id,
                     gas_allowance,
                     outgoing_limit,
+                    Default::default(),
                     Default::default(),
                 );
         core_processor::handle_journal(journal, &mut ext_manager);
@@ -1992,6 +2019,7 @@ benchmarks! {
                     program_id,
                     gas_allowance,
                     outgoing_limit,
+                    Default::default(),
                     Default::default(),
                 );
         core_processor::handle_journal(journal, &mut ext_manager);
@@ -2079,6 +2107,7 @@ benchmarks! {
                     program_id,
                     gas_allowance,
                     outgoing_limit,
+                    Default::default(),
                     Default::default(),
                 );
         log::debug!("journal: {:?}", &journal);

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -161,6 +161,7 @@ impl ProcessorExt for LazyPagesExt {
         program_id: ProgramId,
         program_candidates_data: BTreeMap<CodeId, Vec<(ProgramId, MessageId)>>,
         host_fn_weights: HostFnWeights,
+        forbidden_funcs: BTreeSet<&'static str>,
     ) -> Self {
         assert!(cfg!(feature = "lazy-pages"));
         Self {
@@ -179,6 +180,7 @@ impl ProcessorExt for LazyPagesExt {
                 program_id,
                 program_candidates_data,
                 host_fn_weights,
+                forbidden_funcs,
             },
             fresh_allocations: Default::default(),
         }
@@ -418,5 +420,9 @@ impl EnvExt for LazyPagesExt {
         self.inner
             .charge_gas_runtime(costs)
             .map_err(Error::Processor)
+    }
+
+    fn forbidden_funcs(&self) -> &BTreeSet<&'static str> {
+        &self.inner.forbidden_funcs
     }
 }

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -653,6 +653,7 @@ pub mod pallet {
                         u64::MAX,
                         T::OutgoingLimit::get(),
                         schedule.host_fn_weights.clone().into_core(),
+                        ["gr_gas_available"].into(),
                     )
                 } else {
                     core_processor::process::<Ext, SandboxEnvironment<_>>(
@@ -666,6 +667,7 @@ pub mod pallet {
                         u64::MAX,
                         T::OutgoingLimit::get(),
                         schedule.host_fn_weights.clone().into_core(),
+                        ["gr_gas_available"].into(),
                     )
                 };
 
@@ -958,6 +960,7 @@ pub mod pallet {
                             GasPallet::<T>::gas_allowance(),
                             T::OutgoingLimit::get(),
                             schedule.host_fn_weights.into_core(),
+                            Default::default(),
                         )
                     } else {
                         core_processor::process::<Ext, SandboxEnvironment<_>>(
@@ -971,6 +974,7 @@ pub mod pallet {
                             GasPallet::<T>::gas_allowance(),
                             T::OutgoingLimit::get(),
                             schedule.host_fn_weights.into_core(),
+                            Default::default(),
                         )
                     };
 

--- a/pallets/gear/src/mock.rs
+++ b/pallets/gear/src/mock.rs
@@ -287,6 +287,7 @@ pub fn calc_handle_gas_spent(source: H256, dest: ProgramId, payload: Vec<u8>) ->
             u64::MAX,
             <Test as pallet_gear::Config>::OutgoingLimit::get(),
             schedule.host_fn_weights.into_core(),
+            ["gr_gas_available"].into(),
         )
     } else {
         core_processor::process::<Ext, SandboxEnvironment<_>>(
@@ -300,6 +301,7 @@ pub fn calc_handle_gas_spent(source: H256, dest: ProgramId, payload: Vec<u8>) ->
             u64::MAX,
             <Test as pallet_gear::Config>::OutgoingLimit::get(),
             schedule.host_fn_weights.into_core(),
+            ["gr_gas_available"].into(),
         )
     };
 
@@ -500,6 +502,7 @@ where
                 u64::MAX,
                 T::OutgoingLimit::get(),
                 schedule.host_fn_weights.clone().into_core(),
+                ["gr_gas_available"].into(),
             )
         } else {
             core_processor::process::<Ext, SandboxEnvironment<_>>(
@@ -513,6 +516,7 @@ where
                 u64::MAX,
                 T::OutgoingLimit::get(),
                 schedule.host_fn_weights.clone().into_core(),
+                ["gr_gas_available"].into(),
             )
         };
 

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -3361,7 +3361,7 @@ fn cascading_messages_with_value_do_not_overcharge() {
         )
         .expect("Failed to get gas burned");
 
-        assert!(gas_reserved > gas_to_spend);
+        assert!(gas_reserved >= gas_to_spend);
 
         run_to_block(4, None);
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1020,
+    spec_version: 1030,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Finally resolves #587.

- Add functions (aka syscalls) blacklist.
- Generate a trap when trying to call a forbidden function in a program.
- Forbid to call `gr_gas_available` when executing WASM from `get_gas_spent` function.

TODO:

- [x] Fix tests 

### Use case

Now it is possible to pass a list of forbidden syscalls when calling the `gear_core_processor::process()` function. If the WASM program contains a call to that forbidden function, the execution will return a correspondent error.

For example when we calculate the amount of gas needed for processing messages in the `get_gas_spent()` function, we forbid calling the `gr_gas_available` syscall in the program. `get_gas_spent()` will return `Program terminated with a trap: Unable to call a forbidden function` error if the program calls `exec:gas_available()` function during message processing.

Up to now, the main end-user application is that he will receive an error when trying to calculate the gas amount to be spent for handling a message by the program that uses the `exec::gas_available()` function inside.

Also, there are potential use cases in the future.

@gear-tech/dev