### PR TITLE
Remove legacy clears

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -549,10 +549,4 @@ pub fn reset_storage() {
     sp_io::storage::clear_prefix(STORAGE_PROGRAM_PREFIX, None);
     sp_io::storage::clear_prefix(STORAGE_PROGRAM_PAGES_PREFIX, None);
     sp_io::storage::clear_prefix(STORAGE_WAITLIST_PREFIX, None);
-
-    // TODO: Remove this legacy after next runtime upgrade.
-    sp_io::storage::clear_prefix(b"g::msg::", None);
-    sp_io::storage::clear_prefix(b"g::gas_tree", None);
-    sp_io::storage::clear_prefix(b"g::code::", None);
-    sp_io::storage::clear_prefix(b"g::code::orig", None);
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 880,
+    spec_version: 890,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Closes #871 

We had runtime upgrade recently, so we could remove outdated clears of `sp_io` storages.
