### PR TITLE
fix wasmtime backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ gtest: init-js examples
 	@ ./scripts/gear.sh test gtest yamls="$(yamls)"
 
 .PHONY: rtest
-rtest: init-js examples
+rtest: init-js node-release examples
 	@ ./scripts/gear.sh test rtest
 
 .PHONY: test-pallet

--- a/common/src/lazy_pages.rs
+++ b/common/src/lazy_pages.rs
@@ -21,7 +21,7 @@
 use crate::Origin;
 use gear_core::{
     ids::ProgramId,
-    memory::{PageBuf, PageNumber},
+    memory::{PageBuf, PageNumber, Memory, HostPointer},
 };
 use gear_runtime_interface::{gear_ri, GetReleasedPageError, MprotectError};
 use sp_std::{
@@ -55,8 +55,9 @@ impl From<GetReleasedPageError> for Error {
     }
 }
 
-fn mprotect_lazy_pages(addr: u64, protect: bool) -> Result<(), Error> {
-    gear_ri::mprotect_lazy_pages(addr, protect).map_err(Into::into)
+fn mprotect_lazy_pages(mem: &dyn Memory, protect: bool) -> Result<(), Error> {
+    let wasm_mem_addr = mem.get_buffer_host_addr();
+    gear_ri::mprotect_lazy_pages(wasm_mem_addr, protect).map_err(Into::into)
 }
 
 /// Try to enable and initialize lazy pages env
@@ -79,27 +80,27 @@ pub fn is_lazy_pages_enabled() -> bool {
 
 /// Protect and save storage keys for pages which has no data
 pub fn protect_pages_and_init_info(
+    mem: &dyn Memory,
     lazy_pages: &BTreeSet<PageNumber>,
     prog_id: ProgramId,
-    wasm_mem_begin_addr: u64,
 ) -> Result<(), Error> {
     let prog_id_hash = prog_id.into_origin();
 
     gear_ri::reset_lazy_pages_info();
 
-    gear_ri::set_wasm_mem_begin_addr(wasm_mem_begin_addr);
+    gear_ri::set_wasm_mem_begin_addr(mem.get_buffer_host_addr());
 
     lazy_pages.iter().for_each(|p| {
         crate::save_page_lazy_info(prog_id_hash, *p);
     });
 
-    mprotect_lazy_pages(wasm_mem_begin_addr, true)
+    mprotect_lazy_pages(mem, true)
 }
 
 /// Lazy pages contract post execution actions
 pub fn post_execution_actions(
+    mem: &dyn Memory,
     memory_pages: &mut BTreeMap<PageNumber, PageBuf>,
-    wasm_mem_begin_addr: u64,
 ) -> Result<(), Error> {
     // Loads data for released lazy pages. Data which was before execution.
     let released_pages = gear_ri::get_released_pages();
@@ -111,19 +112,20 @@ pub fn post_execution_actions(
     }
 
     // Removes protections from lazy pages
-    mprotect_lazy_pages(wasm_mem_begin_addr, false)
+    mprotect_lazy_pages(mem, false)
 }
 
 /// Remove lazy-pages protection, returns wasm memory begin addr
-pub fn remove_lazy_pages_prot(mem_addr: u64) -> Result<(), Error> {
-    mprotect_lazy_pages(mem_addr, false)
+pub fn remove_lazy_pages_prot(mem: &dyn Memory) -> Result<(), Error> {
+    mprotect_lazy_pages(mem, false)
 }
 
 /// Protect lazy-pages and set new wasm mem addr if it has been changed
 pub fn protect_lazy_pages_and_update_wasm_mem_addr(
-    old_mem_addr: u64,
-    new_mem_addr: u64,
+    mem: &dyn Memory,
+    old_mem_addr: HostPointer,
 ) -> Result<(), Error> {
+    let new_mem_addr = mem.get_buffer_host_addr();
     if new_mem_addr != old_mem_addr {
         log::debug!(
             "backend executor has changed wasm mem buff: from {:#x} to {:#x}",
@@ -132,7 +134,7 @@ pub fn protect_lazy_pages_and_update_wasm_mem_addr(
         );
         gear_ri::set_wasm_mem_begin_addr(new_mem_addr);
     }
-    mprotect_lazy_pages(new_mem_addr, true)
+    mprotect_lazy_pages(mem, true)
 }
 
 /// Returns list of current lazy pages numbers

--- a/common/src/lazy_pages.rs
+++ b/common/src/lazy_pages.rs
@@ -21,7 +21,7 @@
 use crate::Origin;
 use gear_core::{
     ids::ProgramId,
-    memory::{PageBuf, PageNumber, Memory, HostPointer},
+    memory::{HostPointer, Memory, PageBuf, PageNumber},
 };
 use gear_runtime_interface::{gear_ri, GetReleasedPageError, MprotectError};
 use sp_std::{

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -34,7 +34,7 @@ use gear_core::{
     env::Ext,
     gas::GasAmount,
     ids::{CodeId, MessageId, ProgramId},
-    memory::{PageBuf, PageNumber, WasmPageNumber, Memory},
+    memory::{Memory, PageBuf, PageNumber, WasmPageNumber},
     message::{ContextStore, Dispatch},
 };
 use gear_core_errors::{ExtError, MemoryError};
@@ -65,10 +65,7 @@ pub struct ExtInfo {
 }
 
 pub trait IntoExtInfo {
-    fn into_ext_info(
-        self,
-        memory: &dyn Memory,
-    ) -> Result<ExtInfo, (MemoryError, GasAmount)>;
+    fn into_ext_info(self, memory: &dyn Memory) -> Result<ExtInfo, (MemoryError, GasAmount)>;
     fn into_gas_amount(self) -> GasAmount;
 }
 

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -27,7 +27,7 @@ use alloc::{
 };
 use core::fmt;
 use gear_backend_common::{
-    BackendError, BackendReport, Environment, HostPointer, IntoExtInfo, TerminationReason,
+    BackendError, BackendReport, Environment, IntoExtInfo, TerminationReason,
 };
 use gear_core::{
     env::{Ext, ExtCarrier},
@@ -217,8 +217,8 @@ impl<E: Ext + IntoExtInfo + 'static> Environment<E> for SandboxEnvironment<E> {
         })
     }
 
-    fn get_wasm_memory_begin_addr(&self) -> HostPointer {
-        self.runtime.memory.get_wasm_memory_begin_addr()
+    fn get_mem(&self) -> &dyn Memory {
+        &self.runtime.memory
     }
 
     fn execute<F, T>(
@@ -227,7 +227,7 @@ impl<E: Ext + IntoExtInfo + 'static> Environment<E> for SandboxEnvironment<E> {
         post_execution_handler: F,
     ) -> Result<BackendReport, BackendError<Self::Error>>
     where
-        F: FnOnce(HostPointer) -> Result<(), T>,
+        F: FnOnce(&dyn Memory) -> Result<(), T>,
         T: fmt::Display,
     {
         let res = if self.entries.contains(&String::from(entry_point)) {
@@ -236,15 +236,13 @@ impl<E: Ext + IntoExtInfo + 'static> Environment<E> for SandboxEnvironment<E> {
             Ok(ReturnValue::Unit)
         };
 
-        let wasm_memory_addr = self.get_wasm_memory_begin_addr();
+        log::debug!("execution res = {:?}", res);
 
         let Runtime { ext, memory, trap } = self.runtime;
 
-        log::debug!("execution res = {:?}", res);
-
         let info = ext
             .into_inner()
-            .into_ext_info(|ptr, buff| memory.read(ptr, buff))
+            .into_ext_info(&memory)
             .map_err(|(reason, gas_amount)| BackendError {
                 reason: SandboxEnvironmentError::Memory(reason),
                 description: None,
@@ -276,7 +274,7 @@ impl<E: Ext + IntoExtInfo + 'static> Environment<E> for SandboxEnvironment<E> {
             TerminationReason::Success
         };
 
-        match post_execution_handler(wasm_memory_addr) {
+        match post_execution_handler(&memory) {
             Ok(_) => Ok(BackendReport { termination, info }),
             Err(e) => Err(BackendError {
                 reason: SandboxEnvironmentError::PostExecutionHandler(e.to_string()),

--- a/core-backend/sandbox/src/memory.rs
+++ b/core-backend/sandbox/src/memory.rs
@@ -60,7 +60,7 @@ impl Memory for MemoryWrap {
         self.0.size() as usize * WasmPageNumber::size()
     }
 
-    fn get_wasm_memory_begin_addr(&self) -> u64 {
+    fn get_buffer_host_addr(&self) -> u64 {
         unsafe { self.0.get_buff() }
     }
 }

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -27,17 +27,19 @@ use alloc::{
     vec::Vec,
 };
 use gear_backend_common::{
-    BackendError, BackendReport, Environment, HostPointer, IntoExtInfo, TerminationReason,
+    BackendError, BackendReport, Environment, ExtInfo, IntoExtInfo, TerminationReason,
 };
 use gear_core::{
     env::{ClonedExtCarrier, Ext, ExtCarrier},
     gas::GasAmount,
-    memory::{PageBuf, PageNumber, WasmPageNumber},
+    memory::{Memory, PageBuf, PageNumber, WasmPageNumber},
 };
+use gear_core_errors::MemoryError;
 use wasmtime::{
-    Engine, Extern, Func, Instance, Memory as WasmtimeMemory, MemoryAccessError, MemoryType,
-    Module, Store, Trap,
+    Engine, Extern, Func, Instance, Memory as WasmtimeMemory, MemoryType, Module, Store, Trap,
 };
+
+use crate::memory::MemoryWrapExternal;
 
 /// Data type in wasmtime store
 pub struct StoreData<E: Ext> {
@@ -60,16 +62,15 @@ pub enum WasmtimeEnvironmentError {
     #[display(fmt = "Failed to create env memory")]
     CreateEnvMemory,
     #[display(fmt = "{}", _0)]
-    MemoryAccess(MemoryAccessError),
+    MemoryAccess(MemoryError),
     #[display(fmt = "{}", _0)]
     PostExecutionHandler(String),
 }
 
 /// Environment to run one module at a time providing Ext.
 pub struct WasmtimeEnvironment<E: Ext + 'static> {
-    store: Store<StoreData<E>>,
     ext: ExtCarrier<E>,
-    memory: WasmtimeMemory,
+    memory_wrap: MemoryWrapExternal<E>,
     instance: Instance,
 }
 
@@ -244,10 +245,11 @@ where
             });
         }
 
+        let memory_wrap = MemoryWrapExternal { mem: memory, store };
+
         Ok(WasmtimeEnvironment {
-            store,
             ext: ext_carrier,
-            memory,
+            memory_wrap,
             instance,
         })
     }
@@ -256,20 +258,23 @@ where
         // `__gear_stack_end` export is inserted in wasm-proc or wasm-builder
         let global = self
             .instance
-            .get_global(&mut self.store, "__gear_stack_end")?;
-        global.get(&mut self.store).i32().and_then(|addr| {
-            if addr < 0 {
-                None
-            } else {
-                Some(WasmPageNumber(
-                    (addr as usize / WasmPageNumber::size()) as u32,
-                ))
-            }
-        })
+            .get_global(&mut self.memory_wrap.store, "__gear_stack_end")?;
+        global
+            .get(&mut self.memory_wrap.store)
+            .i32()
+            .and_then(|addr| {
+                if addr < 0 {
+                    None
+                } else {
+                    Some(WasmPageNumber(
+                        (addr as usize / WasmPageNumber::size()) as u32,
+                    ))
+                }
+            })
     }
 
-    fn get_wasm_memory_begin_addr(&self) -> HostPointer {
-        self.memory.data_ptr(&self.store) as HostPointer
+    fn get_mem(&self) -> &dyn gear_core::memory::Memory {
+        &self.memory_wrap
     }
 
     fn execute<F, T>(
@@ -278,36 +283,38 @@ where
         post_execution_handler: F,
     ) -> Result<BackendReport, BackendError<Self::Error>>
     where
-        F: FnOnce(HostPointer) -> Result<(), T>,
+        F: FnOnce(&dyn Memory) -> Result<(), T>,
         T: fmt::Display,
     {
-        let func = self.instance.get_func(&mut self.store, entry_point);
+        let func = self
+            .instance
+            .get_func(&mut self.memory_wrap.store, entry_point);
+
+        let prepare_info = |this: Self| -> Result<
+            (ExtInfo, MemoryWrapExternal<E>),
+            BackendError<Self::Error>,
+        > {
+            let WasmtimeEnvironment {
+                ext, memory_wrap, ..
+            } = this;
+            ext
+                .into_inner()
+                .into_ext_info(&memory_wrap)
+                .map_err(|(reason, gas_amount)| BackendError {
+                    reason: WasmtimeEnvironmentError::MemoryAccess(reason),
+                    description: None,
+                    gas_amount,
+                }).map(|info| (info, memory_wrap))
+        };
 
         let entry_func = if let Some(f) = func {
             // Entry function found
             f
         } else {
-            let wasm_memory_addr = self.get_wasm_memory_begin_addr();
-            let WasmtimeEnvironment {
-                mut store,
-                ext,
-                memory,
-                ..
-            } = self;
-            let (info, _) = ext
-                .into_inner()
-                .into_ext_info(|offset: usize, buffer: &mut [u8]| {
-                    memory.read(&mut store, offset, buffer)
-                })
-                .map_err(|(reason, gas_amount)| BackendError {
-                    reason: WasmtimeEnvironmentError::MemoryAccess(reason),
-                    description: None,
-                    gas_amount,
-                })
-                .map(|info| (info, wasm_memory_addr))?;
+            let (info, memory_wrap) = prepare_info(self)?;
 
             // Entry function not found, so we mean this as empty function
-            return match post_execution_handler(wasm_memory_addr) {
+            return match post_execution_handler(&memory_wrap) {
                 Ok(_) => Ok(BackendReport {
                     termination: TerminationReason::Success,
                     info,
@@ -320,28 +327,11 @@ where
             };
         };
 
-        let res = entry_func.call(&mut self.store, &[], &mut []);
+        let res = entry_func.call(&mut self.memory_wrap.store, &[], &mut []);
 
-        let termination_reason = self.store.data().termination_reason.clone();
+        let termination_reason = self.memory_wrap.store.data().termination_reason.clone();
 
-        let wasm_memory_addr = self.get_wasm_memory_begin_addr();
-        let WasmtimeEnvironment {
-            mut store,
-            ext,
-            memory,
-            ..
-        } = self;
-        let (info, _) = ext
-            .into_inner()
-            .into_ext_info(|offset: usize, buffer: &mut [u8]| {
-                memory.read(&mut store, offset, buffer)
-            })
-            .map_err(|(reason, gas_amount)| BackendError {
-                reason: WasmtimeEnvironmentError::MemoryAccess(reason),
-                description: None,
-                gas_amount,
-            })
-            .map(|info| (info, wasm_memory_addr))?;
+        let (info, memory_wrap) = prepare_info(self)?;
 
         let termination = if let Err(e) = &res {
             let reason = if let Some(_trap) = e.downcast_ref::<Trap>() {
@@ -362,7 +352,7 @@ where
             TerminationReason::Success
         };
 
-        match post_execution_handler(wasm_memory_addr) {
+        match post_execution_handler(&memory_wrap) {
             Ok(_) => Ok(BackendReport { termination, info }),
             Err(e) => Err(BackendError {
                 reason: WasmtimeEnvironmentError::PostExecutionHandler(e.to_string()),

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -290,22 +290,20 @@ where
             .instance
             .get_func(&mut self.memory_wrap.store, entry_point);
 
-        let prepare_info = |this: Self| -> Result<
-            (ExtInfo, MemoryWrapExternal<E>),
-            BackendError<Self::Error>,
-        > {
-            let WasmtimeEnvironment {
-                ext, memory_wrap, ..
-            } = this;
-            ext
-                .into_inner()
-                .into_ext_info(&memory_wrap)
-                .map_err(|(reason, gas_amount)| BackendError {
-                    reason: WasmtimeEnvironmentError::MemoryAccess(reason),
-                    description: None,
-                    gas_amount,
-                }).map(|info| (info, memory_wrap))
-        };
+        let prepare_info =
+            |this: Self| -> Result<(ExtInfo, MemoryWrapExternal<E>), BackendError<Self::Error>> {
+                let WasmtimeEnvironment {
+                    ext, memory_wrap, ..
+                } = this;
+                ext.into_inner()
+                    .into_ext_info(&memory_wrap)
+                    .map_err(|(reason, gas_amount)| BackendError {
+                        reason: WasmtimeEnvironmentError::MemoryAccess(reason),
+                        description: None,
+                        gas_amount,
+                    })
+                    .map(|info| (info, memory_wrap))
+            };
 
         let entry_func = if let Some(f) = func {
             // Entry function found

--- a/core-backend/wasmtime/src/memory.rs
+++ b/core-backend/wasmtime/src/memory.rs
@@ -21,9 +21,9 @@
 use crate::env::StoreData;
 use gear_core::{
     env::Ext,
-    memory::{Error, Memory, PageNumber, WasmPageNumber},
+    memory::{Error, Memory, PageNumber, WasmPageNumber, HostPointer},
 };
-use wasmtime::StoreContextMut;
+use wasmtime::{StoreContextMut, Store};
 
 /// Wrapper for wasmtime memory.
 pub struct MemoryWrap<'a, E: Ext> {
@@ -60,7 +60,45 @@ impl<'a, E: Ext> Memory for MemoryWrap<'a, E> {
         self.mem.data_size(&self.store)
     }
 
-    fn get_wasm_memory_begin_addr(&self) -> u64 {
+    fn get_buffer_host_addr(&self) -> u64 {
+        self.mem.data_ptr(&self.store) as u64
+    }
+}
+
+pub struct MemoryWrapExternal<E: Ext> {
+    pub mem: wasmtime::Memory,
+    pub store: Store<StoreData<E>>,
+}
+
+impl<'a, E: Ext> Memory for MemoryWrapExternal< E> {
+    fn grow(&mut self, pages: WasmPageNumber) -> Result<PageNumber, Error> {
+        self.mem
+            .grow(&mut self.store, pages.0 as u64)
+            .map(|offset| (offset as u32).into())
+            .map_err(|_| Error::OutOfMemory)
+    }
+
+    fn size(&self) -> WasmPageNumber {
+        (self.mem.size(&self.store) as u32).into()
+    }
+
+    fn write(&mut self, offset: usize, buffer: &[u8]) -> Result<(), Error> {
+        self.mem
+            .write(&mut self.store, offset, buffer)
+            .map_err(|_| Error::MemoryAccessError)
+    }
+
+    fn read(&self, offset: usize, buffer: &mut [u8]) -> Result<(), Error> {
+        self.mem
+            .read(&self.store, offset, buffer)
+            .map_err(|_| Error::MemoryAccessError)
+    }
+
+    fn data_size(&self) -> usize {
+        self.mem.data_size(&self.store)
+    }
+
+    fn get_buffer_host_addr(&self) -> HostPointer {
         self.mem.data_ptr(&self.store) as u64
     }
 }

--- a/core-backend/wasmtime/src/memory.rs
+++ b/core-backend/wasmtime/src/memory.rs
@@ -70,7 +70,7 @@ pub struct MemoryWrapExternal<E: Ext> {
     pub store: Store<StoreData<E>>,
 }
 
-impl<'a, E: Ext> Memory for MemoryWrapExternal<E> {
+impl<E: Ext> Memory for MemoryWrapExternal<E> {
     fn grow(&mut self, pages: WasmPageNumber) -> Result<PageNumber, Error> {
         self.mem
             .grow(&mut self.store, pages.0 as u64)

--- a/core-backend/wasmtime/src/memory.rs
+++ b/core-backend/wasmtime/src/memory.rs
@@ -21,9 +21,9 @@
 use crate::env::StoreData;
 use gear_core::{
     env::Ext,
-    memory::{Error, Memory, PageNumber, WasmPageNumber, HostPointer},
+    memory::{Error, HostPointer, Memory, PageNumber, WasmPageNumber},
 };
-use wasmtime::{StoreContextMut, Store};
+use wasmtime::{Store, StoreContextMut};
 
 /// Wrapper for wasmtime memory.
 pub struct MemoryWrap<'a, E: Ext> {
@@ -70,7 +70,7 @@ pub struct MemoryWrapExternal<E: Ext> {
     pub store: Store<StoreData<E>>,
 }
 
-impl<'a, E: Ext> Memory for MemoryWrapExternal< E> {
+impl<'a, E: Ext> Memory for MemoryWrapExternal<E> {
     fn grow(&mut self, pages: WasmPageNumber) -> Result<PageNumber, Error> {
         self.mem
             .grow(&mut self.store, pages.0 as u64)

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -218,9 +218,9 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
             .filter(|page| !pages_data.contains_key(page))
             .collect();
         if let Err(e) = A::lazy_pages_protect_and_init_info(
+            env.get_mem(),
             &lazy_pages,
             program_id,
-            env.get_wasm_memory_begin_addr(),
         ) {
             return Err(ExecutionError {
                 program_id,
@@ -238,15 +238,15 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
     let stack_end_page = env.get_stack_mem_end();
     log::trace!("Stack end page = {:?}", stack_end_page);
 
-    // Running backend.
+    // Execute program in backend env.
     let BackendReport { termination, info } =
-        match env.execute(kind.into_entry(), |wasm_memory_addr| {
+        match env.execute(kind.into_entry(), |mem| {
             // accessed lazy pages old data will be added to `initial_pages`
             // TODO: if post execution actions err is connected, with removing pages protections,
-            // then we should panic here, because protected pages may cause UB later, during err handling,
+            // then we should panic here, because protected pages may cause UB later, during signal handling,
             // if somebody will try to access this pages.
             if A::is_lazy_pages_enabled() {
-                A::lazy_pages_post_execution_actions(&mut pages_data, wasm_memory_addr)
+                A::lazy_pages_post_execution_actions(mem, &mut pages_data)
             } else {
                 Ok(())
             }

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -217,11 +217,8 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
             .flat_map(|page| page.to_gear_pages_iter())
             .filter(|page| !pages_data.contains_key(page))
             .collect();
-        if let Err(e) = A::lazy_pages_protect_and_init_info(
-            env.get_mem(),
-            &lazy_pages,
-            program_id,
-        ) {
+        if let Err(e) = A::lazy_pages_protect_and_init_info(env.get_mem(), &lazy_pages, program_id)
+        {
             return Err(ExecutionError {
                 program_id,
                 gas_amount: env.into_gas_amount(),
@@ -239,27 +236,26 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
     log::trace!("Stack end page = {:?}", stack_end_page);
 
     // Execute program in backend env.
-    let BackendReport { termination, info } =
-        match env.execute(kind.into_entry(), |mem| {
-            // accessed lazy pages old data will be added to `initial_pages`
-            // TODO: if post execution actions err is connected, with removing pages protections,
-            // then we should panic here, because protected pages may cause UB later, during signal handling,
-            // if somebody will try to access this pages.
-            if A::is_lazy_pages_enabled() {
-                A::lazy_pages_post_execution_actions(mem, &mut pages_data)
-            } else {
-                Ok(())
-            }
-        }) {
-            Ok(report) => report,
-            Err(e) => {
-                return Err(ExecutionError {
-                    program_id,
-                    gas_amount: e.gas_amount.clone(),
-                    reason: ExecutionErrorReason::Backend(e.to_string()),
-                })
-            }
-        };
+    let BackendReport { termination, info } = match env.execute(kind.into_entry(), |mem| {
+        // accessed lazy pages old data will be added to `initial_pages`
+        // TODO: if post execution actions err is connected, with removing pages protections,
+        // then we should panic here, because protected pages may cause UB later, during signal handling,
+        // if somebody will try to access this pages.
+        if A::is_lazy_pages_enabled() {
+            A::lazy_pages_post_execution_actions(mem, &mut pages_data)
+        } else {
+            Ok(())
+        }
+    }) {
+        Ok(report) => report,
+        Err(e) => {
+            return Err(ExecutionError {
+                program_id,
+                gas_amount: e.gas_amount.clone(),
+                reason: ExecutionErrorReason::Backend(e.to_string()),
+            })
+        }
+    };
 
     log::trace!("term reason = {:?}", termination);
 

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -32,7 +32,7 @@ use gear_core::{
     memory::{AllocationsContext, Memory, PageBuf, PageNumber, WasmPageNumber},
     message::{HandlePacket, InitPacket, MessageContext, ReplyPacket},
 };
-use gear_core_errors::{ExtError, TerminationReason, MemoryError};
+use gear_core_errors::{ExtError, MemoryError, TerminationReason};
 
 /// Trait to which ext must have to work in processor wasm executor.
 /// Currently used only for lazy-pages support.
@@ -174,10 +174,7 @@ impl ProcessorExt for Ext {
 }
 
 impl IntoExtInfo for Ext {
-    fn into_ext_info(
-        self,
-        memory: &dyn Memory,
-    ) -> Result<ExtInfo, (MemoryError, GasAmount)> {
+    fn into_ext_info(self, memory: &dyn Memory) -> Result<ExtInfo, (MemoryError, GasAmount)> {
         let wasm_pages = self.allocations_context.allocations().clone();
         let mut pages_data = BTreeMap::new();
         for page in wasm_pages.iter().flat_map(|p| p.to_gear_pages_iter()) {

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -231,7 +231,11 @@ impl core::ops::Sub for WasmPageNumber {
     }
 }
 
-/// Memory interface for the allocator.
+/// Host pointer type.
+/// Host pointer can be 64bit or less, to support both we use u64.
+pub type HostPointer = u64;
+
+/// Backend wasm memory interface.
 pub trait Memory {
     /// Grow memory by number of pages.
     fn grow(&mut self, pages: WasmPageNumber) -> Result<PageNumber, Error>;
@@ -249,7 +253,7 @@ pub trait Memory {
     fn data_size(&self) -> usize;
 
     /// Returns native addr of wasm memory buffer in wasm executor
-    fn get_wasm_memory_begin_addr(&self) -> u64;
+    fn get_buffer_host_addr(&self) -> HostPointer;
 }
 
 /// Pages allocations context for the running program.

--- a/examples/ping-gas/src/lib.rs
+++ b/examples/ping-gas/src/lib.rs
@@ -1,23 +1,10 @@
 #![no_std]
 
-// trait T {
-//     fn lol();
-// }
-
-// struct A;
-// impl T for A {
-//     fn lol() {};
-// }
-
-// environmental::environmental!(ext: trait T);
-
 use gstd::{debug, msg, prelude::*};
 
 #[no_mangle]
 pub unsafe extern "C" fn handle() {
     debug!("Hello from ping handle");
-
-    // let mVut a = A;
 
     let new_msg = String::from_utf8(msg::load_bytes()).expect("Invalid message");
 

--- a/examples/ping-gas/src/lib.rs
+++ b/examples/ping-gas/src/lib.rs
@@ -1,10 +1,23 @@
 #![no_std]
 
+// trait T {
+//     fn lol();
+// }
+
+// struct A;
+// impl T for A {
+//     fn lol() {};
+// }
+
+// environmental::environmental!(ext: trait T);
+
 use gstd::{debug, msg, prelude::*};
 
 #[no_mangle]
 pub unsafe extern "C" fn handle() {
     debug!("Hello from ping handle");
+
+    // let mVut a = A;
 
     let new_msg = String::from_utf8(msg::load_bytes()).expect("Invalid message");
 

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -33,7 +33,7 @@ use gear_core::{
     memory::{AllocationsContext, Memory, PageBuf, PageNumber, WasmPageNumber},
     message::{HandlePacket, MessageContext, ReplyPacket},
 };
-use gear_core_errors::{CoreError, ExtError, TerminationReason};
+use gear_core_errors::{CoreError, ExtError, TerminationReason, MemoryError};
 use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -84,9 +84,7 @@ pub struct LazyPagesExt {
 }
 
 impl IntoExtInfo for LazyPagesExt {
-    fn into_ext_info<F, T>(self, mut get_page_data: F) -> Result<ExtInfo, (T, GasAmount)>
-    where
-        F: FnMut(usize, &mut [u8]) -> Result<(), T>,
+    fn into_ext_info(self, memory: &dyn Memory) -> Result<ExtInfo, (MemoryError, GasAmount)>
     {
         // accessed pages are all pages except current lazy pages
         let allocations = self.inner.allocations_context.allocations().clone();
@@ -104,7 +102,7 @@ impl IntoExtInfo for LazyPagesExt {
         let mut accessed_pages_data = BTreeMap::new();
         for page in accessed_pages {
             let mut buf = PageBuf::new_zeroed();
-            if let Err(err) = get_page_data(page.offset(), buf.as_mut_slice()) {
+            if let Err(err) = memory.read(page.offset(), buf.as_mut_slice()) {
                 return Err((err, self.into_gas_amount()));
             }
             accessed_pages_data.insert(page, buf);
@@ -180,19 +178,19 @@ impl ProcessorExt for LazyPagesExt {
     }
 
     fn lazy_pages_protect_and_init_info(
+        mem: &dyn Memory,
         memory_pages: &BTreeSet<PageNumber>,
         prog_id: ProgramId,
-        wasm_mem_begin_addr: u64,
     ) -> Result<(), Self::Error> {
-        lazy_pages::protect_pages_and_init_info(memory_pages, prog_id, wasm_mem_begin_addr)
+        lazy_pages::protect_pages_and_init_info(mem, memory_pages, prog_id)
             .map_err(Error::LazyPages)
     }
 
     fn lazy_pages_post_execution_actions(
+        mem: &dyn Memory,
         memory_pages: &mut BTreeMap<PageNumber, PageBuf>,
-        wasm_mem_begin_addr: u64,
     ) -> Result<(), Self::Error> {
-        lazy_pages::post_execution_actions(memory_pages, wasm_mem_begin_addr)
+        lazy_pages::post_execution_actions(mem, memory_pages)
             .map_err(Error::LazyPages)
     }
 }
@@ -224,8 +222,8 @@ impl EnvExt for LazyPagesExt {
         // So we remove protections from lazy-pages
         // and set protection back for new wasm memory buffer pages.
         // Also we correct lazy-pages info if need.
-        let old_mem_addr = mem.get_wasm_memory_begin_addr();
-        lazy_pages::remove_lazy_pages_prot(old_mem_addr)?;
+        let old_mem_addr = mem.get_buffer_host_addr();
+        lazy_pages::remove_lazy_pages_prot(mem)?;
 
         let result = self
             .inner
@@ -256,8 +254,7 @@ impl EnvExt for LazyPagesExt {
         }
 
         // Protect all lazy pages including new allocations
-        let new_mem_addr = mem.get_wasm_memory_begin_addr();
-        lazy_pages::protect_lazy_pages_and_update_wasm_mem_addr(old_mem_addr, new_mem_addr)?;
+        lazy_pages::protect_lazy_pages_and_update_wasm_mem_addr(mem, old_mem_addr)?;
 
         // Returns back greedily used gas for grow
         let new_mem_size = mem.size();

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -33,7 +33,7 @@ use gear_core::{
     memory::{AllocationsContext, Memory, PageBuf, PageNumber, WasmPageNumber},
     message::{HandlePacket, MessageContext, ReplyPacket},
 };
-use gear_core_errors::{CoreError, ExtError, TerminationReason, MemoryError};
+use gear_core_errors::{CoreError, ExtError, MemoryError, TerminationReason};
 use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -84,8 +84,7 @@ pub struct LazyPagesExt {
 }
 
 impl IntoExtInfo for LazyPagesExt {
-    fn into_ext_info(self, memory: &dyn Memory) -> Result<ExtInfo, (MemoryError, GasAmount)>
-    {
+    fn into_ext_info(self, memory: &dyn Memory) -> Result<ExtInfo, (MemoryError, GasAmount)> {
         // accessed pages are all pages except current lazy pages
         let allocations = self.inner.allocations_context.allocations().clone();
         let mut accessed_pages: BTreeSet<PageNumber> = allocations
@@ -190,8 +189,7 @@ impl ProcessorExt for LazyPagesExt {
         mem: &dyn Memory,
         memory_pages: &mut BTreeMap<PageNumber, PageBuf>,
     ) -> Result<(), Self::Error> {
-        lazy_pages::post_execution_actions(mem, memory_pages)
-            .map_err(Error::LazyPages)
+        lazy_pages::post_execution_actions(mem, memory_pages).map_err(Error::LazyPages)
     }
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 900,
+    spec_version: 910,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 910,
+    spec_version: 920,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/scripts/gear.sh
+++ b/scripts/gear.sh
@@ -319,7 +319,7 @@ case "$COMMAND" in
         test_usage
         exit 1; ;;
     esac;;
-  
+
   coverage)
     case "$SUBCOMMAND" in
       -h | --help | help)

--- a/scripts/src/init.sh
+++ b/scripts/src/init.sh
@@ -48,12 +48,12 @@ cargo_init() {
   if [ -z $CI ]; then
     cargo install cargo-hack
     cargo install cargo-nextest
-  else 
-    curl "https://api.github.com/repos/taiki-e/cargo-hack/releases/latest" | 
-    grep -wo "https.*x86_64-unknown-linux-gnu.tar.gz" | 
-    xargs curl -L | 
+  else
+    curl "https://api.github.com/repos/taiki-e/cargo-hack/releases/latest" |
+    grep -wo "https.*x86_64-unknown-linux-gnu.tar.gz" |
+    xargs curl -L |
     tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
-    
+
     curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
   fi
 }


### PR DESCRIPTION
fix wasmtime backend:
Later we unprotect pages after memory deallocation (memory move causes memory deallocation and we cannot touch pages after that)

Add dependency from memory in lazy-pages to avoid this types of bugs in future