### PR TITLE
refactor(gear): estimate gas only with notes that have spent gas

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 920,
+    spec_version: 930,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Resolves #977 

- [x] estimate gas only with notes that have spent gas
  - [x] removed `MessageConsumed` because it doesn't spend any gas on current node
  - [x] added `WaitDispatch` because it spends gas also

## References

- #975 
- #971
