### PR TITLE
Fix get gas spent and update cascade test

### DIFF
--- a/core-processor/src/handler.rs
+++ b/core-processor/src/handler.rs
@@ -28,7 +28,7 @@ pub fn handle_journal(
     let mut exit_list = vec![];
     let mut allocations_update = BTreeMap::new();
 
-    for note in journal.into_iter() {
+    for note in journal {
         match note {
             JournalNote::MessageDispatched(outcome) => handler.message_dispatched(outcome),
             JournalNote::GasBurned { message_id, amount } => handler.gas_burned(message_id, amount),

--- a/examples/binaries/mul-by-const/Cargo.toml
+++ b/examples/binaries/mul-by-const/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { path = "../../../gstd", features = ["debug"] }
+gstd = { path = "../../../gstd" }
 codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 

--- a/examples/binaries/mul-by-const/Cargo.toml
+++ b/examples/binaries/mul-by-const/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { path = "../../../gstd" }
+gstd = { path = "../../../gstd", features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 

--- a/examples/binaries/mul-by-const/src/lib.rs
+++ b/examples/binaries/mul-by-const/src/lib.rs
@@ -18,7 +18,7 @@
 
 // This contract recursively composes itself with another contract (the other contract
 // being applied to the input data first): `c(f) = (c(f) . f) x`.
-// Every call to the auto_composer contract incremets the internal `ITER` counter.
+// Every call to the auto_composer contract increments the internal `ITER` counter.
 // As soon as the counter reaches the `MAX_ITER`, the recursion stops.
 // Effectively, this procedure executes a composition of `MAX_ITER` contracts `f`
 // where the output of the previous call is fed to the input of the next call.

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -571,10 +571,8 @@ pub mod pallet {
                             b"Internal error: unable to get gas limit after execution".to_vec()
                         })?
                     {
-                        let gas_spent = initial_gas.saturating_sub(remaining_gas);
-                        if gas_spent > max_gas_spent {
-                            max_gas_spent = gas_spent;
-                        }
+                        max_gas_spent =
+                            max_gas_spent.max(initial_gas.saturating_sub(remaining_gas));
                     };
 
                     if let JournalNote::MessageDispatched(CoreDispatchOutcome::MessageTrap {

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -565,9 +565,8 @@ pub mod pallet {
                 core_processor::handle_journal(journal.clone(), &mut ext_manager);
 
                 let remaining_gas = T::GasHandler::get_limit(root_message_id)
-                    .map_err(|_| {
-                        b"Internal error: unable to get gas limit after execution".to_vec()
-                    })?
+                    .ok()
+                    .flatten()
                     .ok_or_else(|| {
                         b"Internal error: unable to get gas limit after execution".to_vec()
                     })?;

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -570,7 +570,7 @@ pub mod pallet {
                 };
 
                 // TODO: Check whether we charge gas fee for submitting code after #646
-                for note in journal.into_iter() {
+                for note in journal {
                     core_processor::handle_journal(vec![note.clone()], &mut ext_manager);
 
                     if let Some(remaining_gas) =

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -562,44 +562,215 @@ pub mod pallet {
                     )
                 };
 
-                // TODO: Check whether we charge gas fee for submitting code after #646
-                let notes = journal
-                    .into_iter()
-                    .filter_map(|note| -> Option<Result<JournalNote, _>> {
-                        match note {
-                            JournalNote::GasBurned { .. }
-                            | JournalNote::WakeMessage { .. }
-                            | JournalNote::SendDispatch { .. }
-                            | JournalNote::WaitDispatch(..) => Some(Ok(note)),
-                            JournalNote::MessageDispatched(CoreDispatchOutcome::MessageTrap {
-                                trap,
-                                ..
-                            }) => Some(Err(format!(
-                                "Program terminated with a trap: {}",
-                                trap.unwrap_or_else(|| "No reason".to_string())
-                            )
-                            .into_bytes())),
-                            _ => None,
-                        }
-                    })
-                    .collect::<Result<Vec<JournalNote>, _>>();
+                 // TODO: Check whether we charge gas fee for submitting code after #646
+                 for note in journal.into_iter() {
+                    core_processor::handle_journal(vec![note.clone()], &mut ext_manager);
 
-                core_processor::handle_journal(notes?, &mut ext_manager);
+                    if let Some(remaining_gas) = T::GasHandler::get_limit(root_message_id)
+                        .map_err(|_| {
+                            b"Internal error: unable to get gas limit after execution".to_vec()
+                        })? {
+                            let gas_spent = initial_gas.saturating_sub(remaining_gas);
+                            if gas_spent > max_gas_spent {
+                                max_gas_spent = gas_spent;
+                            }
+                    };
 
-                let remaining_gas = T::GasHandler::get_limit(root_message_id)
-                    .ok()
-                    .flatten()
-                    .ok_or_else(|| {
-                        b"Internal error: unable to get gas limit after execution".to_vec()
-                    })?;
-
-                let gas_spent = initial_gas.saturating_sub(remaining_gas);
-                if gas_spent > max_gas_spent {
-                    max_gas_spent = gas_spent;
-                }
-            }
+                    if let JournalNote::MessageDispatched(CoreDispatchOutcome::MessageTrap {
+                        trap,
+                        ..
+                    }) = note {
+                        return Err(format!(
+                            "Program terminated with a trap: {}",
+                            trap.unwrap_or_else(|| "No reason".to_string())
+                        )
+                        .into_bytes());
+                    };
+                 }
+             }
 
             Ok(max_gas_spent)
+        }
+
+        pub fn get_gas_spent_burned(
+            source: H256,
+            kind: HandleKind,
+            payload: Vec<u8>,
+            value: u128,
+        ) -> Result<u64, Vec<u8>> {
+            let schedule = T::Schedule::get();
+            let mut ext_manager = ExtManager::<T>::default();
+
+            let bn: u64 = <frame_system::Pallet<T>>::block_number().unique_saturated_into();
+            let root_message_id = MessageId::from(bn).into_origin();
+
+            let dispatch = match kind {
+                HandleKind::Init(ref code) => {
+                    let program_id = ProgramId::generate(CodeId::generate(code), b"gas_spent_salt");
+
+                    let schedule = T::Schedule::get();
+                    let code = Code::try_new(
+                        code.clone(),
+                        schedule.instruction_weights.version,
+                        |module| schedule.rules(module),
+                    )
+                    .map_err(|_| b"Code failed to load: {}".to_vec())?;
+
+                    let code_and_id = CodeAndId::new(code);
+                    let code_id = code_and_id.code_id();
+
+                    let _ = Self::set_code_with_metadata(code_and_id, source);
+
+                    ExtManager::<T>::default().set_program(program_id, code_id, root_message_id);
+
+                    Dispatch::new(
+                        DispatchKind::Init,
+                        Message::new(
+                            MessageId::from_origin(root_message_id),
+                            ProgramId::from_origin(source),
+                            program_id,
+                            payload,
+                            Some(u64::MAX),
+                            value,
+                            None,
+                        ),
+                    )
+                }
+                HandleKind::Handle(dest) => Dispatch::new(
+                    DispatchKind::Handle,
+                    Message::new(
+                        MessageId::from_origin(root_message_id),
+                        ProgramId::from_origin(source),
+                        ProgramId::from_origin(dest),
+                        payload,
+                        Some(u64::MAX),
+                        value,
+                        None,
+                    ),
+                ),
+                HandleKind::Reply(msg_id, exit_code) => {
+                    let msg = MailboxOf::<T>::remove(
+                        <T::AccountId as Origin>::from_origin(source),
+                        MessageId::from_origin(msg_id),
+                    )
+                    .map_err(|_| b"Internal error: unable to find message in mailbox".to_vec())?;
+                    Dispatch::new(
+                        DispatchKind::Reply,
+                        Message::new(
+                            MessageId::from_origin(root_message_id),
+                            ProgramId::from_origin(source),
+                            msg.source(),
+                            payload,
+                            Some(u64::MAX),
+                            value,
+                            Some((msg.id(), exit_code)),
+                        ),
+                    )
+                }
+            };
+
+            let initial_gas = <T as pallet_gas::Config>::BlockGasLimit::get();
+            T::GasHandler::create(source.into_origin(), root_message_id, initial_gas)
+                .map_err(|_| b"Internal error: unable to create gas handler".to_vec())?;
+
+            let dispatch = dispatch.into_stored();
+
+            QueueOf::<T>::remove_all();
+
+            QueueOf::<T>::queue(dispatch).map_err(|_| b"Messages storage corrupted".to_vec())?;
+
+            let block_info = BlockInfo {
+                height: <frame_system::Pallet<T>>::block_number().unique_saturated_into(),
+                timestamp: <pallet_timestamp::Pallet<T>>::get().unique_saturated_into(),
+            };
+
+            let existential_deposit =
+                <T as Config>::Currency::minimum_balance().unique_saturated_into();
+
+            let mut max_gas_spent = 0;
+
+            let mut burned = 0;
+
+            while let Some(queued_dispatch) =
+                QueueOf::<T>::dequeue().map_err(|_| b"MQ storage corrupted".to_vec())?
+            {
+                let actor_id = queued_dispatch.destination();
+
+                let lazy_pages_enabled =
+                    cfg!(feature = "lazy-pages") && lazy_pages::try_to_enable_lazy_pages();
+
+                let actor = ext_manager
+                    .get_executable_actor(actor_id.into_origin(), !lazy_pages_enabled)
+                    .ok_or_else(|| b"Program not found in the storage".to_vec())?;
+
+                let allocations_config = AllocationsConfig {
+                    max_pages: gear_core::memory::WasmPageNumber(schedule.limits.memory_pages),
+                    init_cost: schedule.memory_weights.initial_cost,
+                    alloc_cost: schedule.memory_weights.allocation_cost,
+                    mem_grow_cost: schedule.memory_weights.grow_cost,
+                    load_page_cost: schedule.memory_weights.load_cost,
+                };
+
+                let journal = if lazy_pages_enabled {
+                    core_processor::process::<LazyPagesExt, SandboxEnvironment<_>>(
+                        Some(actor),
+                        queued_dispatch.into_incoming(initial_gas),
+                        block_info,
+                        allocations_config,
+                        existential_deposit,
+                        ProgramId::from_origin(source),
+                        actor_id,
+                        u64::MAX,
+                        T::OutgoingLimit::get(),
+                        schedule.host_fn_weights.clone().into_core(),
+                    )
+                } else {
+                    core_processor::process::<Ext, SandboxEnvironment<_>>(
+                        Some(actor),
+                        queued_dispatch.into_incoming(initial_gas),
+                        block_info,
+                        allocations_config,
+                        existential_deposit,
+                        ProgramId::from_origin(source),
+                        actor_id,
+                        u64::MAX,
+                        T::OutgoingLimit::get(),
+                        schedule.host_fn_weights.clone().into_core(),
+                    )
+                };
+
+                 // TODO: Check whether we charge gas fee for submitting code after #646
+                 for note in journal.into_iter() {
+                    core_processor::handle_journal(vec![note.clone()], &mut ext_manager);
+
+                    if let JournalNote::GasBurned{ amount , .. } = note {
+                        burned += amount;
+                    };
+
+                    if let Some(remaining_gas) = T::GasHandler::get_limit(root_message_id)
+                        .map_err(|_| {
+                            b"Internal error: unable to get gas limit after execution".to_vec()
+                        })? {
+                            let gas_spent = initial_gas.saturating_sub(remaining_gas);
+                            if gas_spent > max_gas_spent {
+                                max_gas_spent = gas_spent;
+                            }
+                    };
+
+                    if let JournalNote::MessageDispatched(CoreDispatchOutcome::MessageTrap {
+                        trap,
+                        ..
+                    }) = note {
+                        return Err(format!(
+                            "Program terminated with a trap: {}",
+                            trap.unwrap_or_else(|| "No reason".to_string())
+                        )
+                        .into_bytes());
+                    };
+                 }
+             }
+
+            Ok(burned)
         }
 
         /// Returns true if a program has been successfully initialized

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -534,10 +534,17 @@ pub mod pallet {
                     load_page_cost: schedule.memory_weights.load_cost,
                 };
 
+                let gas_limit = T::GasHandler::get_limit(queued_dispatch.id().into_origin())
+                    .ok()
+                    .flatten()
+                    .ok_or_else(|| {
+                        b"Internal error: unable to get gas limit after execution".to_vec()
+                    })?;
+
                 let journal = if lazy_pages_enabled {
                     core_processor::process::<LazyPagesExt, SandboxEnvironment<_>>(
                         Some(actor),
-                        queued_dispatch.into_incoming(initial_gas),
+                        queued_dispatch.into_incoming(gas_limit),
                         block_info,
                         allocations_config,
                         existential_deposit,
@@ -550,7 +557,7 @@ pub mod pallet {
                 } else {
                     core_processor::process::<Ext, SandboxEnvironment<_>>(
                         Some(actor),
-                        queued_dispatch.into_incoming(initial_gas),
+                        queued_dispatch.into_incoming(gas_limit),
                         block_info,
                         allocations_config,
                         existential_deposit,

--- a/pallets/gear/src/manager.rs
+++ b/pallets/gear/src/manager.rs
@@ -353,7 +353,7 @@ where
                     let gas_left = neg_imbalance.peek();
 
                     if gas_left > 0 {
-                        log::debug!("Unreserve balance on message processed: {}", gas_left);
+                        log::debug!("Unreserve balance on message processed: {} to {}", gas_left, external);
 
                         let refund = T::GasPrice::gas_price(gas_left);
 

--- a/pallets/gear/src/manager.rs
+++ b/pallets/gear/src/manager.rs
@@ -353,7 +353,11 @@ where
                     let gas_left = neg_imbalance.peek();
 
                     if gas_left > 0 {
-                        log::debug!("Unreserve balance on message processed: {} to {}", gas_left, external);
+                        log::debug!(
+                            "Unreserve balance on message processed: {} to {}",
+                            gas_left,
+                            external
+                        );
 
                         let refund = T::GasPrice::gas_price(gas_left);
 

--- a/pallets/gear/src/manager.rs
+++ b/pallets/gear/src/manager.rs
@@ -380,9 +380,10 @@ where
         }
 
         log::debug!(
-            "Sending message {:?} from {:?}",
+            "Sending message {:?} from {:?} with gas limit {:?}",
             dispatch.message(),
-            message_id
+            message_id,
+            gas_limit,
         );
 
         if GearProgramPallet::<T>::program_exists(dispatch.destination().into_origin())

--- a/pallets/gear/src/mock.rs
+++ b/pallets/gear/src/mock.rs
@@ -478,7 +478,7 @@ where
         };
 
         // TODO: Check whether we charge gas fee for submitting code after #646
-        for note in journal.iter() {
+        for note in &journal {
             match note {
                 JournalNote::GasBurned { amount, .. } => {
                     burned += amount;

--- a/pallets/gear/src/mock.rs
+++ b/pallets/gear/src/mock.rs
@@ -323,10 +323,11 @@ pub fn calc_handle_gas_spent(source: H256, dest: H256, payload: Vec<u8>) -> (u64
     (gas_burned, gas_to_send)
 }
 
-pub fn get_gas_spent_burned<T>(
+pub fn get_gas_burned<T>(
     source: H256,
     kind: HandleKind,
     payload: Vec<u8>,
+    gas_limit: Option<u64>,
     value: u128,
 ) -> Result<u64, Vec<u8>>
 where
@@ -404,7 +405,7 @@ where
         }
     };
 
-    let initial_gas = <T as pallet_gas::Config>::BlockGasLimit::get();
+    let initial_gas = gas_limit.unwrap_or_else(<T as pallet_gas::Config>::BlockGasLimit::get);
     T::GasHandler::create(source.into_origin(), root_message_id, initial_gas)
         .map_err(|_| b"Internal error: unable to create gas handler".to_vec())?;
 

--- a/pallets/gear/src/mock.rs
+++ b/pallets/gear/src/mock.rs
@@ -17,16 +17,23 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate as pallet_gear;
-use crate::{ext::LazyPagesExt, manager::ExtManager};
-use common::{lazy_pages, Origin as _};
+use crate::{
+    ext::LazyPagesExt,
+    manager::{ExtManager, HandleKind},
+    *,
+};
+use alloc::format;
+use common::{self, lazy_pages, Origin as _, ValueTree};
 use core_processor::{
-    common::{DispatchOutcome, JournalNote},
+    common::{DispatchOutcome, DispatchOutcome as CoreDispatchOutcome, JournalNote},
     configs::{AllocationsConfig, BlockInfo},
     Ext,
 };
 use frame_support::{
-    construct_runtime, parameter_types,
-    traits::{Currency, FindAuthor, OnFinalize, OnIdle, OnInitialize},
+    construct_runtime,
+    pallet_prelude::*,
+    parameter_types,
+    traits::{Currency, FindAuthor, Get},
 };
 use frame_system as system;
 use gear_backend_sandbox::SandboxEnvironment;
@@ -314,4 +321,187 @@ pub fn calc_handle_gas_spent(source: H256, dest: H256, payload: Vec<u8>) -> (u64
     }
 
     (gas_burned, gas_to_send)
+}
+
+pub fn get_gas_spent_burned<T>(
+    source: H256,
+    kind: HandleKind,
+    payload: Vec<u8>,
+    value: u128,
+) -> Result<u64, Vec<u8>>
+where
+    T: crate::Config,
+    T::AccountId: common::Origin,
+{
+    let schedule = T::Schedule::get();
+    let mut ext_manager = ExtManager::<T>::default();
+
+    let bn: u64 = <frame_system::Pallet<T>>::block_number().unique_saturated_into();
+    let root_message_id = MessageId::from(bn).into_origin();
+
+    let dispatch = match kind {
+        HandleKind::Init(ref code) => {
+            let program_id = ProgramId::generate(CodeId::generate(code), b"gas_spent_salt");
+
+            let schedule = T::Schedule::get();
+            let code = Code::try_new(
+                code.clone(),
+                schedule.instruction_weights.version,
+                |module| schedule.rules(module),
+            )
+            .map_err(|_| b"Code failed to load: {}".to_vec())?;
+
+            let code_and_id = CodeAndId::new(code);
+            let code_id = code_and_id.code_id();
+
+            let _ = crate::Pallet::<T>::set_code_with_metadata(code_and_id, source);
+
+            ExtManager::<T>::default().set_program(program_id, code_id, root_message_id);
+
+            Dispatch::new(
+                DispatchKind::Init,
+                Message::new(
+                    MessageId::from_origin(root_message_id),
+                    ProgramId::from_origin(source),
+                    program_id,
+                    payload,
+                    Some(u64::MAX),
+                    value,
+                    None,
+                ),
+            )
+        }
+        HandleKind::Handle(dest) => Dispatch::new(
+            DispatchKind::Handle,
+            Message::new(
+                MessageId::from_origin(root_message_id),
+                ProgramId::from_origin(source),
+                ProgramId::from_origin(dest),
+                payload,
+                Some(u64::MAX),
+                value,
+                None,
+            ),
+        ),
+        HandleKind::Reply(msg_id, exit_code) => {
+            let msg = MailboxOf::<T>::remove(
+                <T::AccountId as common::Origin>::from_origin(source),
+                MessageId::from_origin(msg_id),
+            )
+            .map_err(|_| b"Internal error: unable to find message in mailbox".to_vec())?;
+            Dispatch::new(
+                DispatchKind::Reply,
+                Message::new(
+                    MessageId::from_origin(root_message_id),
+                    ProgramId::from_origin(source),
+                    msg.source(),
+                    payload,
+                    Some(u64::MAX),
+                    value,
+                    Some((msg.id(), exit_code)),
+                ),
+            )
+        }
+    };
+
+    let initial_gas = <T as pallet_gas::Config>::BlockGasLimit::get();
+    T::GasHandler::create(source.into_origin(), root_message_id, initial_gas)
+        .map_err(|_| b"Internal error: unable to create gas handler".to_vec())?;
+
+    let dispatch = dispatch.into_stored();
+
+    QueueOf::<T>::remove_all();
+
+    QueueOf::<T>::queue(dispatch).map_err(|_| b"Messages storage corrupted".to_vec())?;
+
+    let block_info = BlockInfo {
+        height: <frame_system::Pallet<T>>::block_number().unique_saturated_into(),
+        timestamp: <pallet_timestamp::Pallet<T>>::get().unique_saturated_into(),
+    };
+
+    let existential_deposit = <T as Config>::Currency::minimum_balance().unique_saturated_into();
+
+    let mut max_gas_spent = 0;
+
+    let mut burned = 0;
+
+    while let Some(queued_dispatch) =
+        QueueOf::<T>::dequeue().map_err(|_| b"MQ storage corrupted".to_vec())?
+    {
+        let actor_id = queued_dispatch.destination();
+
+        let lazy_pages_enabled =
+            cfg!(feature = "lazy-pages") && lazy_pages::try_to_enable_lazy_pages();
+
+        let actor = ext_manager
+            .get_executable_actor(actor_id.into_origin(), !lazy_pages_enabled)
+            .ok_or_else(|| b"Program not found in the storage".to_vec())?;
+
+        let allocations_config = AllocationsConfig {
+            max_pages: gear_core::memory::WasmPageNumber(schedule.limits.memory_pages),
+            init_cost: schedule.memory_weights.initial_cost,
+            alloc_cost: schedule.memory_weights.allocation_cost,
+            mem_grow_cost: schedule.memory_weights.grow_cost,
+            load_page_cost: schedule.memory_weights.load_cost,
+        };
+
+        let journal = if lazy_pages_enabled {
+            core_processor::process::<LazyPagesExt, SandboxEnvironment<_>>(
+                Some(actor),
+                queued_dispatch.into_incoming(initial_gas),
+                block_info,
+                allocations_config,
+                existential_deposit,
+                ProgramId::from_origin(source),
+                actor_id,
+                u64::MAX,
+                T::OutgoingLimit::get(),
+                schedule.host_fn_weights.clone().into_core(),
+            )
+        } else {
+            core_processor::process::<Ext, SandboxEnvironment<_>>(
+                Some(actor),
+                queued_dispatch.into_incoming(initial_gas),
+                block_info,
+                allocations_config,
+                existential_deposit,
+                ProgramId::from_origin(source),
+                actor_id,
+                u64::MAX,
+                T::OutgoingLimit::get(),
+                schedule.host_fn_weights.clone().into_core(),
+            )
+        };
+
+        // TODO: Check whether we charge gas fee for submitting code after #646
+        for note in journal.into_iter() {
+            core_processor::handle_journal(vec![note.clone()], &mut ext_manager);
+
+            if let JournalNote::GasBurned { amount, .. } = note {
+                burned += amount;
+            };
+
+            if let Some(remaining_gas) = T::GasHandler::get_limit(root_message_id)
+                .map_err(|_| b"Internal error: unable to get gas limit after execution".to_vec())?
+            {
+                let gas_spent = initial_gas.saturating_sub(remaining_gas);
+                if gas_spent > max_gas_spent {
+                    max_gas_spent = gas_spent;
+                }
+            };
+
+            if let JournalNote::MessageDispatched(CoreDispatchOutcome::MessageTrap {
+                trap, ..
+            }) = note
+            {
+                return Err(format!(
+                    "Program terminated with a trap: {}",
+                    trap.unwrap_or_else(|| "No reason".to_string())
+                )
+                .into_bytes());
+            };
+        }
+    }
+
+    Ok(burned)
 }

--- a/pallets/gear/src/mock.rs
+++ b/pallets/gear/src/mock.rs
@@ -444,10 +444,15 @@ where
             load_page_cost: schedule.memory_weights.load_cost,
         };
 
+        let gas_limit = T::GasHandler::get_limit(queued_dispatch.id().into_origin())
+            .ok()
+            .flatten()
+            .ok_or_else(|| b"Internal error: unable to get gas limit after execution".to_vec())?;
+
         let journal = if lazy_pages_enabled {
             core_processor::process::<LazyPagesExt, SandboxEnvironment<_>>(
                 Some(actor),
-                queued_dispatch.into_incoming(initial_gas),
+                queued_dispatch.into_incoming(gas_limit),
                 block_info,
                 allocations_config,
                 existential_deposit,
@@ -460,7 +465,7 @@ where
         } else {
             core_processor::process::<Ext, SandboxEnvironment<_>>(
                 Some(actor),
-                queued_dispatch.into_incoming(initial_gas),
+                queued_dispatch.into_incoming(gas_limit),
                 block_info,
                 allocations_config,
                 existential_deposit,

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -19,9 +19,9 @@
 use crate::{
     manager::HandleKind,
     mock::{
-        calc_handle_gas_spent, get_gas_spent_burned, new_test_ext, run_to_block,
-        Event as MockEvent, Gear, GearProgram, Origin, System, Test, BLOCK_AUTHOR,
-        LOW_BALANCE_USER, USER_1, USER_2, USER_3,
+        calc_handle_gas_spent, get_gas_burned, new_test_ext, run_to_block, Event as MockEvent,
+        Gear, GearProgram, Origin, System, Test, BLOCK_AUTHOR, LOW_BALANCE_USER, USER_1, USER_2,
+        USER_3,
     },
     pallet, Config, DispatchOutcome, Error, Event, ExecutionResult, GearProgramPallet, MailboxOf,
     MessageInfo, Pallet as GearPallet, Reason,
@@ -3187,10 +3187,11 @@ fn cascading_messages_with_value_do_not_overcharge() {
 
         run_to_block(3, None);
 
-        let gas_to_spend = get_gas_spent_burned::<Test>(
+        let gas_to_spend = get_gas_burned::<Test>(
             USER_1.into_origin(),
             HandleKind::Handle(wrapper_id),
             payload.clone(),
+            Some(gas_reserved),
             0,
         )
         .expect("Failed to get gas burned");

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -19,8 +19,9 @@
 use crate::{
     manager::HandleKind,
     mock::{
-        calc_handle_gas_spent, new_test_ext, run_to_block, Event as MockEvent, Gear, GearProgram,
-        Origin, System, Test, BLOCK_AUTHOR, LOW_BALANCE_USER, USER_1, USER_2, USER_3,
+        calc_handle_gas_spent, get_gas_spent_burned, new_test_ext, run_to_block,
+        Event as MockEvent, Gear, GearProgram, Origin, System, Test, BLOCK_AUTHOR,
+        LOW_BALANCE_USER, USER_1, USER_2, USER_3,
     },
     pallet, Config, DispatchOutcome, Error, Event, ExecutionResult, GearProgramPallet, MailboxOf,
     MessageInfo, Pallet as GearPallet, Reason,
@@ -3186,7 +3187,7 @@ fn cascading_messages_with_value_do_not_overcharge() {
 
         run_to_block(3, None);
 
-        let gas_to_spend = Gear::get_gas_spent_burned(
+        let gas_to_spend = get_gas_spent_burned::<Test>(
             USER_1.into_origin(),
             HandleKind::Handle(wrapper_id),
             payload.clone(),
@@ -3194,7 +3195,7 @@ fn cascading_messages_with_value_do_not_overcharge() {
         )
         .expect("Failed to get gas spent");
 
-        assert_ne!(gas_reserved, gas_to_spend);
+        assert!(gas_reserved > gas_to_spend);
 
         run_to_block(4, None);
 

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -3193,7 +3193,7 @@ fn cascading_messages_with_value_do_not_overcharge() {
             payload.clone(),
             0,
         )
-        .expect("Failed to get gas spent");
+        .expect("Failed to get gas burned");
 
         assert!(gas_reserved > gas_to_spend);
 
@@ -3226,7 +3226,6 @@ fn cascading_messages_with_value_do_not_overcharge() {
 
         let gas_to_spend = gas_to_spend as u128;
         let gas_reserved = gas_reserved as u128;
-
         let reserved_balance = gas_reserved + value;
 
         assert_eq!(
@@ -3243,8 +3242,6 @@ fn cascading_messages_with_value_do_not_overcharge() {
 
         assert_eq!(BalancesPallet::<Test>::reserved_balance(USER_1), 0);
 
-        // The bug is that initial message doesn't destroy for some
-        // reason and reservation_delta doesn't return back.
         assert_eq!(
             BalancesPallet::<Test>::free_balance(USER_1),
             user_initial_balance - gas_to_spend - value

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 920,
+    spec_version: 930,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
- Checkouted from #975 so fixes #977 and contains refactored and right calculation in `get_gas_spent`.
- Provided similar to `get_gas_spent` function `get_gas_burned` which adds up only gas which will never returned.
- Cascade test now depend on this functions return values, not on constants.

@gear-tech/dev 
