### PR TITLE
add checks for wasm memory buffer begin addr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,6 +2355,7 @@ dependencies = [
  "parity-wasm 0.42.2",
  "pwasm-utils",
  "scale-info",
+ "static_assertions",
  "wabt",
  "wasm-instrument",
 ]
@@ -2505,6 +2506,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-runtime-interface",
  "sp-std",
+ "static_assertions",
 ]
 
 [[package]]

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -184,11 +184,6 @@ where
             }
         };
 
-        log::debug!(
-            "wasm mem addr = {:#x?}",
-            runtime.memory.get_buffer_host_addr()
-        );
-
         let entries = match get_module_exports(binary) {
             Ok(entries) => entries,
             Err(e) => {

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -184,6 +184,11 @@ where
             }
         };
 
+        log::debug!(
+            "wasm mem addr = {:#x?}",
+            runtime.memory.get_buffer_host_addr()
+        );
+
         let entries = match get_module_exports(binary) {
             Ok(entries) => entries,
             Err(e) => {

--- a/core-backend/sandbox/src/memory.rs
+++ b/core-backend/sandbox/src/memory.rs
@@ -18,7 +18,7 @@
 
 //! sp-sandbox extensions for memory.
 
-use gear_core::memory::{Error, Memory, PageNumber, WasmPageNumber};
+use gear_core::memory::{Error, HostPointer, Memory, PageNumber, WasmPageNumber};
 use sp_sandbox::SandboxMemory;
 
 /// Wrapper for sp_sandbox::Memory.
@@ -60,8 +60,8 @@ impl Memory for MemoryWrap {
         self.0.size() as usize * WasmPageNumber::size()
     }
 
-    fn get_buffer_host_addr(&self) -> u64 {
-        unsafe { self.0.get_buff() }
+    unsafe fn get_buffer_host_addr_unsafe(&self) -> HostPointer {
+        self.0.get_buff()
     }
 }
 

--- a/core-backend/wasmtime/src/memory.rs
+++ b/core-backend/wasmtime/src/memory.rs
@@ -60,8 +60,8 @@ impl<'a, E: Ext> Memory for MemoryWrap<'a, E> {
         self.mem.data_size(&self.store)
     }
 
-    fn get_buffer_host_addr(&self) -> u64 {
-        self.mem.data_ptr(&self.store) as u64
+    unsafe fn get_buffer_host_addr_unsafe(&self) -> HostPointer {
+        self.mem.data_ptr(&self.store) as HostPointer
     }
 }
 
@@ -98,7 +98,7 @@ impl<E: Ext> Memory for MemoryWrapExternal<E> {
         self.mem.data_size(&self.store)
     }
 
-    fn get_buffer_host_addr(&self) -> HostPointer {
-        self.mem.data_ptr(&self.store) as u64
+    unsafe fn get_buffer_host_addr_unsafe(&self) -> HostPointer {
+        self.mem.data_ptr(&self.store) as HostPointer
     }
 }

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -237,10 +237,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
 
     // Execute program in backend env.
     let BackendReport { termination, info } = match env.execute(kind.into_entry(), |mem| {
-        // accessed lazy pages old data will be added to `initial_pages`
-        // TODO: if post execution actions err is connected, with removing pages protections,
-        // then we should panic here, because protected pages may cause UB later, during signal handling,
-        // if somebody will try to access this pages.
+        // released pages initial data will be added to `pages_data`
         if A::is_lazy_pages_enabled() {
             A::lazy_pages_post_execution_actions(mem, &mut pages_data)
         } else {

--- a/core-processor/src/processor.rs
+++ b/core-processor/src/processor.rs
@@ -307,7 +307,11 @@ pub fn process_executable<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: E
         execution_context,
         execution_settings,
         msg_ctx_settings,
-    );
+    )
+    .map_err(|err| {
+        log::debug!("Wasm execution err: {}", err.reason);
+        err
+    });
 
     match exec_result {
         Ok(res) => match res.kind {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,7 @@ parity-wasm = { version = "0.42.2", default-features = false }
 wasm-instrument = { version = "0.1", default-features = false }
 pwasm-utils = { version = "0.19.0", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
+static_assertions = "1"
 
 [dev-dependencies]
 wabt = "0.10.0"

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -235,6 +235,10 @@ impl core::ops::Sub for WasmPageNumber {
 /// Host pointer can be 64bit or less, to support both we use u64.
 pub type HostPointer = u64;
 
+static_assertions::const_assert!(
+    core::mem::size_of::<HostPointer>() >= core::mem::size_of::<usize>()
+);
+
 /// Backend wasm memory interface.
 pub trait Memory {
     /// Grow memory by number of pages.
@@ -253,7 +257,18 @@ pub trait Memory {
     fn data_size(&self) -> usize;
 
     /// Returns native addr of wasm memory buffer in wasm executor
-    fn get_buffer_host_addr(&self) -> HostPointer;
+    fn get_buffer_host_addr(&self) -> Option<HostPointer> {
+        if self.size() == 0.into() {
+            None
+        } else {
+            unsafe { Some(self.get_buffer_host_addr_unsafe()) }
+        }
+    }
+
+    /// Get buffer addr unsafe.
+    /// # Safety
+    /// if memory size is 0 then buffer addr can be garbage
+    unsafe fn get_buffer_host_addr_unsafe(&self) -> HostPointer;
 }
 
 /// Pages allocations context for the running program.

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -261,6 +261,8 @@ pub trait Memory {
         if self.size() == 0.into() {
             None
         } else {
+            // We call this method only in case memory size is not zero,
+            // so memory buffer exists and has addr in host memory.
             unsafe { Some(self.get_buffer_host_addr_unsafe()) }
         }
     }

--- a/lazy-pages/src/unix.rs
+++ b/lazy-pages/src/unix.rs
@@ -47,7 +47,7 @@ extern "C" fn handle_sigsegv(_x: i32, info: *mut siginfo_t, _z: *mut c_void) {
 
         let mem = (*info).si_addr();
         let native_page = (mem as usize / native_ps) * native_ps;
-        let wasm_mem_begin = WASM_MEM_BEGIN.with(|x| *x.borrow());
+        let wasm_mem_begin = WASM_MEM_BEGIN.with(|x| *x.borrow()) as usize;
 
         assert!(wasm_mem_begin != 0, "Wasm memory begin addr is not set");
         assert!(

--- a/runtime-interface/Cargo.toml
+++ b/runtime-interface/Cargo.toml
@@ -20,6 +20,7 @@ errno = { version = "0.2.8", optional = true }
 codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false }
 page_size = { version = "0.4.2", optional = true }
 derive_more = "0.99.17"
+static_assertions = "1"
 
 [dev-dependencies]
 libc = { version = "0.2.101", default-features = false }

--- a/runtime-interface/src/deprecated.rs
+++ b/runtime-interface/src/deprecated.rs
@@ -1,0 +1,85 @@
+// This file is part of Gear.
+
+// Copyright (C) 2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Deprecated backend for runtime interface.
+//! TODO: remove before release
+
+use codec::{Decode, Encode};
+use gear_core::memory::HostPointer;
+
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, derive_more::Display)]
+pub enum MprotectError {
+    #[display(fmt = "Page error")]
+    PageError,
+    #[display(fmt = "OS error")]
+    OsError,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, derive_more::Display)]
+#[display(fmt = "Failed to get released page")]
+pub struct GetReleasedPageError;
+
+#[cfg(feature = "std")]
+#[cfg(unix)]
+pub(crate) unsafe fn sys_mprotect_wasm_pages(
+    from_ptr: HostPointer,
+    pages_nums: &[u32],
+    prot_read: bool,
+    prot_write: bool,
+    prot_exec: bool,
+) -> Result<(), MprotectError> {
+    use gear_core::memory::WasmPageNumber;
+
+    let mut prot_mask = libc::PROT_NONE;
+    if prot_read {
+        prot_mask |= libc::PROT_READ;
+    }
+    if prot_write {
+        prot_mask |= libc::PROT_WRITE;
+    }
+    if prot_exec {
+        prot_mask |= libc::PROT_EXEC;
+    }
+    for page in pages_nums {
+        let addr = from_ptr as usize + *page as usize * WasmPageNumber::size();
+        let res = libc::mprotect(addr as *mut libc::c_void, WasmPageNumber::size(), prot_mask);
+        if res != 0 {
+            log::error!(
+                "Cannot set page protection for {:#x}: {}",
+                addr,
+                errno::errno()
+            );
+            return Err(MprotectError::PageError);
+        }
+        log::trace!("mprotect wasm page: {:#x}, mask {:#x}", addr, prot_mask);
+    }
+    Ok(())
+}
+
+#[cfg(feature = "std")]
+#[cfg(not(unix))]
+pub(crate) unsafe fn sys_mprotect_wasm_pages(
+    _from_ptr: HostPointer,
+    _pages_nums: &[u32],
+    _prot_read: bool,
+    _prot_write: bool,
+    _prot_exec: bool,
+) -> Result<(), MprotectError> {
+    log::error!("unsupported OS for pages protectection");
+    Err(RIError::MprotectOsError)
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 970,
+    spec_version: 980,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
1) Solve problem, that if memory size == 0 then wasm executors  can have garbage in pointer to memory buffer.
2) Some refactoring in lazy pages errors