### PR TITLE
feat(wasm-builder): check crate-type while parsing manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 .vscode
 .DS_Store
 .idea
+.log

--- a/examples/binaries/init-wait/Cargo.toml
+++ b/examples/binaries/init-wait/Cargo.toml
@@ -12,6 +12,8 @@ gstd = { path = "../../../gstd", features = ["debug"] }
 [build-dependencies]
 gear-wasm-builder = { path = "../../../utils/wasm-builder" }
 
+[lib]
+
 [features]
 std = []
 default = ["std"]

--- a/examples/binaries/init-wait/Cargo.toml
+++ b/examples/binaries/init-wait/Cargo.toml
@@ -12,8 +12,7 @@ gstd = { path = "../../../gstd", features = ["debug"] }
 [build-dependencies]
 gear-wasm-builder = { path = "../../../utils/wasm-builder" }
 
-[lib]
-
 [features]
 std = []
 default = ["std"]
+

--- a/examples/binaries/init-wait/Cargo.toml
+++ b/examples/binaries/init-wait/Cargo.toml
@@ -15,4 +15,3 @@ gear-wasm-builder = { path = "../../../utils/wasm-builder" }
 [features]
 std = []
 default = ["std"]
-

--- a/utils/wasm-builder/src/builder_error.rs
+++ b/utils/wasm-builder/src/builder_error.rs
@@ -25,6 +25,9 @@ pub enum BuilderError {
     #[error("invalid manifest path `{0}`")]
     InvalidManifestPath(PathBuf),
 
+    #[error("please add \"rlib\" to [lib.crate-type]")]
+    InvalidCrateType,
+
     #[error("cargo command run failed: {0}")]
     CargoRunFailed(String),
 

--- a/utils/wasm-builder/src/crate_info.rs
+++ b/utils/wasm-builder/src/crate_info.rs
@@ -48,7 +48,7 @@ impl CrateInfo {
             .context("unable to invoke `cargo metadata`")?;
 
         let root_package = Self::root_package(&metadata)
-            .ok_or(BuilderError::RootPackageNotFound.into())
+            .ok_or_else(|| BuilderError::RootPackageNotFound.into())
             .and_then(Self::check)?;
         let name = root_package.name.clone();
         let snake_case_name = name.replace('-', "_");

--- a/utils/wasm-builder/src/crate_info.rs
+++ b/utils/wasm-builder/src/crate_info.rs
@@ -34,36 +34,6 @@ pub struct CrateInfo {
 }
 
 impl CrateInfo {
-    /// check package
-    ///
-    /// - if crate-type includes "lib" or "rlib":
-    fn check(pkg: &Package) -> StdResult<&Package, BuilderError> {
-        // cargo can't import executables (bin, cdylib etc), but libs
-        // only (rlib).
-        //
-        // if no `[lib]` table, the `crate_types` will be [ "lib" ]
-        // by default, we can not detect if this is "rlib" because it
-        // is the "compiler recommended" style of library.
-        //
-        // see also https://doc.rust-lang.org/reference/linkage.html
-        let lib_s = "lib".to_string();
-        let rlib_s = "rlib".to_string();
-        let _ = pkg
-            .targets
-            .iter()
-            .find(|target| {
-                target.name.eq(&target.name)
-                    && target
-                        .crate_types
-                        .iter()
-                        .find(|ty| **ty == lib_s || **ty == rlib_s)
-                        .is_some()
-            })
-            .ok_or(BuilderError::InvalidCrateType)?;
-
-        Ok(pkg)
-    }
-
     /// Create a new `CrateInfo` from a path to the `Cargo.toml`.
     pub fn from_manifest(manifest_path: &Path) -> Result<Self> {
         anyhow::ensure!(
@@ -97,5 +67,35 @@ impl CrateInfo {
             .packages
             .iter()
             .find(|package| package.id == *root_id)
+    }
+
+    /// check package
+    ///
+    /// - if crate-type contains "lib" or "rlib":
+    fn check(pkg: &Package) -> StdResult<&Package, BuilderError> {
+        // cargo can't import executables (bin, cdylib etc), but libs
+        // only (rlib).
+        //
+        // if no `[lib]` table, the `crate_types` will be [ "lib" ]
+        // by default, we can not detect if this is "rlib" because it
+        // is the "compiler recommended" style of library.
+        //
+        // see also https://doc.rust-lang.org/reference/linkage.html
+        let lib_s = "lib".to_string();
+        let rlib_s = "rlib".to_string();
+        let _ = pkg
+            .targets
+            .iter()
+            .find(|target| {
+                target.name.eq(&target.name)
+                    && target
+                        .crate_types
+                        .iter()
+                        .find(|ty| **ty == lib_s || **ty == rlib_s)
+                        .is_some()
+            })
+            .ok_or(BuilderError::InvalidCrateType)?;
+
+        Ok(pkg)
     }
 }

--- a/utils/wasm-builder/src/crate_info.rs
+++ b/utils/wasm-builder/src/crate_info.rs
@@ -91,8 +91,7 @@ impl CrateInfo {
                     && target
                         .crate_types
                         .iter()
-                        .find(|ty| **ty == lib_s || **ty == rlib_s)
-                        .is_some()
+                        .any(|ty| **ty == lib_s || **ty == rlib_s)
             })
             .ok_or(BuilderError::InvalidCrateType)?;
 

--- a/utils/wasm-builder/src/crate_info.rs
+++ b/utils/wasm-builder/src/crate_info.rs
@@ -81,17 +81,12 @@ impl CrateInfo {
         // is the "compiler recommended" style of library.
         //
         // see also https://doc.rust-lang.org/reference/linkage.html
-        let lib_s = "lib";
-        let rlib_s = "rlib";
+        let validated_lib = |ty: &String| ty == "lib" || ty == "rlib";
         let _ = pkg
             .targets
             .iter()
             .find(|target| {
-                target.name.eq(&pkg.name)
-                    && target
-                        .crate_types
-                        .iter()
-                        .any(|ty| ty == lib_s || ty == rlib_s)
+                target.name.eq(&pkg.name) && target.crate_types.iter().any(validated_lib)
             })
             .ok_or(BuilderError::InvalidCrateType)?;
 


### PR DESCRIPTION
Resolves #985 

- check `[lib.crate-type]` in `wasm-builder`
-
-

@reviewer-or-team
