### PR TITLE
chore(core): bumps the version of parity-wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,7 +2352,7 @@ dependencies = [
  "hex",
  "log",
  "parity-scale-codec",
- "parity-wasm 0.42.2",
+ "parity-wasm 0.45.0",
  "pwasm-utils",
  "scale-info",
  "wabt",
@@ -5372,6 +5372,12 @@ name = "parity-wasm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
+
+[[package]]
+name = "parity-wasm"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
 
 [[package]]
 name = "parity-ws"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,7 @@ codec = { package = "parity-scale-codec", version = "3.1.2", features = [
 scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
 derive_more = "0.99.17"
 log = { version = "0.4.17", default-features = false }
-parity-wasm = { version = "0.42.2", default-features = false }
+parity-wasm = { version = "0.45.0", default-features = false }
 wasm-instrument = { version = "0.1", default-features = false }
 pwasm-utils = { version = "0.19.0", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -169,6 +169,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,12 +490,14 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.16"
+version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn",
 ]
 
@@ -670,6 +678,19 @@ dependencies = [
 [[package]]
 name = "gcore"
 version = "0.1.0"
+dependencies = [
+ "gear-core-errors",
+ "parity-scale-codec 3.1.2",
+]
+
+[[package]]
+name = "gear-core-errors"
+version = "0.1.0"
+dependencies = [
+ "derive_more",
+ "parity-scale-codec 3.1.2",
+ "scale-info 2.0.1",
+]
 
 [[package]]
 name = "generic-array"
@@ -698,6 +719,7 @@ dependencies = [
  "futures",
  "galloc",
  "gcore",
+ "gear-core-errors",
  "gstd-codegen",
  "hex",
  "parity-scale-codec 3.1.2",
@@ -1194,6 +1216,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,6 +1302,12 @@ checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
 
 [[package]]
 name = "serde"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 970,
+    spec_version: 980,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Summary

- update the version of parity-wasm in gear-core
-
-

@reviewer-or-team
