### PR TITLE
Add gas burned counter to `gtest`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2823,6 +2823,7 @@ name = "gtest"
 version = "0.1.0"
 dependencies = [
  "colored",
+ "derive_more",
  "env_logger",
  "gear-backend-wasmtime",
  "gear-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,6 +1322,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "demo-gas-burned"
+version = "0.1.0"
+dependencies = [
+ "gear-wasm-builder",
+ "gstd",
+ "gtest",
+]
+
+[[package]]
 name = "demo-init-wait"
 version = "0.1.0"
 dependencies = [

--- a/examples/binaries/gas-burned/Cargo.toml
+++ b/examples/binaries/gas-burned/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "demo-gas-burned"
+version = "0.1.0"
+authors = ["Gear Technologies"]
+edition = "2021"
+license = "GPL-3.0"
+workspace = "../../../"
+
+[dependencies]
+gstd = { path = "../../../gstd" }
+
+[build-dependencies]
+gear-wasm-builder = { path = "../../../utils/wasm-builder" }
+
+[dev-dependencies]
+gtest = { path = "../../../gtest" }
+
+[features]
+std = []
+default = ["std"]

--- a/examples/binaries/gas-burned/build.rs
+++ b/examples/binaries/gas-burned/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    gear_wasm_builder::build();
+}

--- a/examples/binaries/gas-burned/src/lib.rs
+++ b/examples/binaries/gas-burned/src/lib.rs
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn handle() {
 
 #[cfg(test)]
 mod tests {
-    use gtest::{Program, System};
+    use gtest::{Gas, Program, System};
 
     #[test]
     fn gas_burned() {
@@ -42,7 +42,7 @@ mod tests {
         let res = program.send_bytes(from, "init");
         let init_gas_burned = res.gas_burned();
         println!("Init gas burned: {}", init_gas_burned);
-        assert!(init_gas_burned > 0);
+        assert!(init_gas_burned > Gas::zero());
 
         let res = program.send_bytes(from, "handle");
         let handle_gas_burned = res.gas_burned();

--- a/examples/binaries/gas-burned/src/lib.rs
+++ b/examples/binaries/gas-burned/src/lib.rs
@@ -15,7 +15,6 @@ pub unsafe extern "C" fn init() {
     for (i, item) in v.iter_mut().enumerate() {
         *item = i * i;
     }
-
     msg::reply_bytes(&format!("init: {}", v.into_iter().sum::<usize>()), 0).unwrap();
 }
 

--- a/examples/binaries/gas-burned/src/lib.rs
+++ b/examples/binaries/gas-burned/src/lib.rs
@@ -40,12 +40,12 @@ mod tests {
 
         let program = Program::current(&system);
         let res = program.send_bytes(from, "init");
-        let init_gas_burned = res.gas_burned();
+        let init_gas_burned = res.main_gas_burned();
         println!("Init gas burned: {}", init_gas_burned);
         assert!(init_gas_burned > Gas::zero());
 
         let res = program.send_bytes(from, "handle");
-        let handle_gas_burned = res.gas_burned();
+        let handle_gas_burned = res.main_gas_burned();
         println!("Handle gas burned: {}", handle_gas_burned);
         assert!(handle_gas_burned > init_gas_burned);
     }

--- a/examples/binaries/gas-burned/src/lib.rs
+++ b/examples/binaries/gas-burned/src/lib.rs
@@ -1,0 +1,53 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::missing_safety_doc)]
+
+extern crate alloc;
+
+use alloc::vec;
+use gstd::{msg, prelude::*};
+
+const SHORT: usize = 100;
+const LONG: usize = 10000;
+
+#[no_mangle]
+pub unsafe extern "C" fn init() {
+    let mut v = vec![0; SHORT];
+    for (i, item) in v.iter_mut().enumerate() {
+        *item = i * i;
+    }
+
+    msg::reply_bytes(&format!("init: {}", v.into_iter().sum::<usize>()), 0).unwrap();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn handle() {
+    let mut v = vec![0; LONG];
+    for (i, item) in v.iter_mut().enumerate() {
+        *item = i * i;
+    }
+    msg::reply_bytes(&format!("handle: {}", v.into_iter().sum::<usize>()), 0).unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use gtest::{Program, System};
+
+    #[test]
+    fn gas_burned() {
+        let system = System::new();
+        system.init_logger();
+
+        let from = 42;
+
+        let program = Program::current(&system);
+        let res = program.send_bytes(from, "init");
+        let init_gas_burned = res.gas_burned();
+        println!("Init gas burned: {}", init_gas_burned);
+        assert!(init_gas_burned > 0);
+
+        let res = program.send_bytes(from, "handle");
+        let handle_gas_burned = res.gas_burned();
+        println!("Handle gas burned: {}", handle_gas_burned);
+        assert!(handle_gas_burned > init_gas_burned);
+    }
+}

--- a/gtest/Cargo.toml
+++ b/gtest/Cargo.toml
@@ -14,7 +14,8 @@ codec = { package = "parity-scale-codec", version = "3.1.2", features = ["derive
 logger = { package = "log", version = "0.4.17" }
 hex = "0.4.3"
 colored = "2.0.0"
+derive_more = "0.99.17"
 env_logger = "0.9.0"
 path-clean = "0.1.0"
-wasm-instrument = { version = "0.1" }
+wasm-instrument = "0.1.1"
 wasmtime = { version = "0.35.1", default-features = false, features = ["parallel-compilation", "cranelift"]}

--- a/gtest/Cargo.toml
+++ b/gtest/Cargo.toml
@@ -14,8 +14,8 @@ codec = { package = "parity-scale-codec", version = "3.1.2", features = ["derive
 logger = { package = "log", version = "0.4.17" }
 hex = "0.4.3"
 colored = "2.0.0"
-derive_more = "0.99.17"
+derive_more = { version = "0.99.17", features = ["add", "add_assign", "display", "mul", "mul_assign"] }
 env_logger = "0.9.0"
 path-clean = "0.1.0"
-wasm-instrument = "0.1.1"
+wasm-instrument = "0.1"
 wasmtime = { version = "0.35.1", default-features = false, features = ["parallel-compilation", "cranelift"]}

--- a/gtest/src/lib.rs
+++ b/gtest/src/lib.rs
@@ -6,7 +6,7 @@ mod system;
 mod wasm_executor;
 
 pub use log::{CoreLog, Log, RunResult};
-pub use program::{calculate_program_id, Program, WasmProgram};
+pub use program::{calculate_program_id, Gas, Program, WasmProgram};
 pub use system::System;
 
 pub const EXISTENTIAL_DEPOSIT: u128 = 500;

--- a/gtest/src/log.rs
+++ b/gtest/src/log.rs
@@ -222,7 +222,8 @@ pub struct RunResult {
     pub(crate) others_failed: bool,
     pub(crate) message_id: MessageId,
     pub(crate) total_processed: u32,
-    pub(crate) gas_burned: Gas,
+    pub(crate) main_gas_burned: Gas,
+    pub(crate) others_gas_burned: Gas,
 }
 
 impl RunResult {
@@ -252,8 +253,12 @@ impl RunResult {
         self.total_processed
     }
 
-    pub fn gas_burned(&self) -> Gas {
-        self.gas_burned
+    pub fn main_gas_burned(&self) -> Gas {
+        self.main_gas_burned
+    }
+
+    pub fn others_gas_burned(&self) -> Gas {
+        self.others_gas_burned
     }
 
     pub fn decoded_log<T: Codec + Debug>(&self) -> Vec<DecodedCoreLog<T>> {

--- a/gtest/src/log.rs
+++ b/gtest/src/log.rs
@@ -222,6 +222,7 @@ pub struct RunResult {
     pub(crate) others_failed: bool,
     pub(crate) message_id: MessageId,
     pub(crate) total_processed: u32,
+    pub(crate) gas_burned: u64,
 }
 
 impl RunResult {
@@ -249,6 +250,10 @@ impl RunResult {
 
     pub fn total_processed(&self) -> u32 {
         self.total_processed
+    }
+
+    pub fn gas_burned(&self) -> u64 {
+        self.gas_burned
     }
 
     pub fn decoded_log<T: Codec + Debug>(&self) -> Vec<DecodedCoreLog<T>> {

--- a/gtest/src/log.rs
+++ b/gtest/src/log.rs
@@ -1,4 +1,4 @@
-use crate::program::ProgramIdWrapper;
+use crate::program::{Gas, ProgramIdWrapper};
 use codec::{Codec, Encode};
 use gear_core::{
     ids::{MessageId, ProgramId},
@@ -222,7 +222,7 @@ pub struct RunResult {
     pub(crate) others_failed: bool,
     pub(crate) message_id: MessageId,
     pub(crate) total_processed: u32,
-    pub(crate) gas_burned: u64,
+    pub(crate) gas_burned: Gas,
 }
 
 impl RunResult {
@@ -252,7 +252,7 @@ impl RunResult {
         self.total_processed
     }
 
-    pub fn gas_burned(&self) -> u64 {
+    pub fn gas_burned(&self) -> Gas {
         self.gas_burned
     }
 

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -436,7 +436,6 @@ impl ExtManager {
             .get(&dispatch.id())
             .expect("Unable to find gas limit for message")
             .unwrap_or(u64::MAX);
-
         let journal = core_processor::process::<Ext, WasmtimeEnvironment<Ext>>(
             executable_actor,
             dispatch.into_incoming(gas_limit),

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -31,6 +31,12 @@ use wasm_instrument::gas_metering::ConstantCostRules;
     Ord,
     derive_more::Add,
     derive_more::AddAssign,
+    derive_more::Sub,
+    derive_more::SubAssign,
+    derive_more::Mul,
+    derive_more::MulAssign,
+    derive_more::Div,
+    derive_more::DivAssign,
     derive_more::Display,
 )]
 pub struct Gas(pub(crate) u64);
@@ -38,6 +44,22 @@ pub struct Gas(pub(crate) u64);
 impl Gas {
     pub const fn zero() -> Self {
         Self(0)
+    }
+
+    pub const fn saturating_add(self, rhs: Self) -> Self {
+        Self(self.0.saturating_add(rhs.0))
+    }
+
+    pub const fn saturating_sub(self, rhs: Self) -> Self {
+        Self(self.0.saturating_sub(rhs.0))
+    }
+
+    pub const fn saturating_mul(self, rhs: Self) -> Self {
+        Self(self.0.saturating_mul(rhs.0))
+    }
+
+    pub const fn saturating_div(self, rhs: Self) -> Self {
+        Self(self.0.saturating_div(rhs.0))
     }
 }
 

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -20,6 +20,27 @@ use std::{
 };
 use wasm_instrument::gas_metering::ConstantCostRules;
 
+#[derive(
+    Default,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    derive_more::Add,
+    derive_more::AddAssign,
+    derive_more::Display,
+)]
+pub struct Gas(pub(crate) u64);
+
+impl Gas {
+    pub const fn zero() -> Self {
+        Self(0)
+    }
+}
+
 pub trait WasmProgram: Debug {
     fn init(&mut self, payload: Vec<u8>) -> Result<Option<Vec<u8>>, &'static str>;
     fn handle(&mut self, payload: Vec<u8>) -> Result<Option<Vec<u8>>, &'static str>;


### PR DESCRIPTION
- Add `main_gas_burned` and `others_gas_burned` counters to the `gtest`'s `RunResult`.
- Actual weights for the `wasmtime` backend will be applied in a separate PR.

@gear-tech/dev 

**Release Notes**: ...
