### PR TITLE
Store module exports in `gear_core::code::Code`

### DIFF
--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -127,7 +127,7 @@ pub trait Environment<E: Ext + IntoExtInfo + 'static>: Sized {
     fn new(
         ext: E,
         binary: &[u8],
-        entries: Vec<Vec<u8>>,
+        entries: BTreeSet<Vec<u8>>,
         mem_size: WasmPageNumber,
     ) -> Result<Self, BackendError<Self::Error>>;
 

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -127,6 +127,7 @@ pub trait Environment<E: Ext + IntoExtInfo + 'static>: Sized {
     fn new(
         ext: E,
         binary: &[u8],
+        entries: Vec<Vec<u8>>,
         mem_size: WasmPageNumber,
     ) -> Result<Self, BackendError<Self::Error>>;
 

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -37,7 +37,7 @@ use gear_core::{
     gas::GasAmount,
     ids::{CodeId, MessageId, ProgramId},
     memory::{Memory, PageBuf, PageNumber, WasmPageNumber},
-    message::{ContextStore, Dispatch},
+    message::{ContextStore, Dispatch, DispatchKind},
 };
 use gear_core_errors::{ExtError, MemoryError};
 
@@ -127,7 +127,7 @@ pub trait Environment<E: Ext + IntoExtInfo + 'static>: Sized {
     fn new(
         ext: E,
         binary: &[u8],
-        entries: BTreeSet<Vec<u8>>,
+        entries: BTreeSet<DispatchKind>,
         mem_size: WasmPageNumber,
     ) -> Result<Self, BackendError<Self::Error>>;
 
@@ -144,7 +144,7 @@ pub trait Environment<E: Ext + IntoExtInfo + 'static>: Sized {
     /// Also runs `post_execution_handler` after running instance at provided entry point.
     fn execute<F, T>(
         self,
-        entry_point: &str,
+        entry_point: &DispatchKind,
         post_execution_handler: F,
     ) -> Result<BackendReport, BackendError<Self::Error>>
     where

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -66,7 +66,7 @@ pub enum SandboxEnvironmentError {
 pub struct SandboxEnvironment<E: Ext + IntoExtInfo> {
     runtime: Runtime<E>,
     instance: Instance<Runtime<E>>,
-    entries: Vec<String>,
+    entries: Vec<Vec<u8>>,
 }
 
 pub(crate) struct Runtime<E: Ext> {
@@ -103,17 +103,6 @@ impl<E: Ext> From<EnvBuilder<'_, E>> for EnvironmentDefinitionBuilder<Runtime<E>
     }
 }
 
-fn get_module_exports(binary: &[u8]) -> Result<Vec<String>, String> {
-    Ok(parity_wasm::elements::Module::from_bytes(binary)
-        .map_err(|e| format!("Unable to create wasm module: {}", e))?
-        .export_section()
-        .ok_or_else(|| String::from("Unable to get wasm module section"))?
-        .entries()
-        .iter()
-        .map(|v| String::from(v.field()))
-        .collect())
-}
-
 impl<E> Environment<E> for SandboxEnvironment<E>
 where
     E: Ext + IntoExtInfo + 'static,
@@ -124,6 +113,7 @@ where
     fn new(
         ext: E,
         binary: &[u8],
+        entries: Vec<Vec<u8>>,
         mem_size: WasmPageNumber,
     ) -> Result<Self, BackendError<Self::Error>> {
         let mut builder = EnvBuilder::<E> {
@@ -201,17 +191,6 @@ where
             }
         };
 
-        let entries = match get_module_exports(binary) {
-            Ok(entries) => entries,
-            Err(e) => {
-                return Err(BackendError {
-                    reason: SandboxEnvironmentError::GetWasmExports,
-                    description: Some(format!("{:?}", e).into()),
-                    gas_amount: runtime.ext.into_inner().into_gas_amount(),
-                })
-            }
-        };
-
         Ok(SandboxEnvironment {
             runtime,
             instance,
@@ -250,7 +229,7 @@ where
         F: FnOnce(&dyn Memory) -> Result<(), T>,
         T: fmt::Display,
     {
-        let res = if self.entries.contains(&String::from(entry_point)) {
+        let res = if self.entries.contains(&entry_point.as_bytes().to_vec()) {
             self.instance.invoke(entry_point, &[], &mut self.runtime)
         } else {
             Ok(ReturnValue::Unit)

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -66,7 +66,7 @@ pub enum SandboxEnvironmentError {
 pub struct SandboxEnvironment<E: Ext + IntoExtInfo> {
     runtime: Runtime<E>,
     instance: Instance<Runtime<E>>,
-    entries: Vec<Vec<u8>>,
+    entries: BTreeSet<Vec<u8>>,
 }
 
 pub(crate) struct Runtime<E: Ext> {
@@ -113,7 +113,7 @@ where
     fn new(
         ext: E,
         binary: &[u8],
-        entries: Vec<Vec<u8>>,
+        entries: BTreeSet<Vec<u8>>,
         mem_size: WasmPageNumber,
     ) -> Result<Self, BackendError<Self::Error>> {
         let mut builder = EnvBuilder::<E> {

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -87,6 +87,7 @@ where
     fn new(
         ext: E,
         binary: &[u8],
+        _entries: Vec<Vec<u8>>,
         mem_size: WasmPageNumber,
     ) -> Result<Self, BackendError<Self::Error>> {
         let forbidden_funcs = ext.forbidden_funcs().clone();

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -35,6 +35,7 @@ use gear_core::{
     env::{ClonedExtCarrier, Ext, ExtCarrier},
     gas::GasAmount,
     memory::{Memory, WasmPageNumber},
+    message::DispatchKind,
 };
 use gear_core_errors::MemoryError;
 use wasmtime::{
@@ -86,7 +87,7 @@ where
     fn new(
         ext: E,
         binary: &[u8],
-        _entries: BTreeSet<Vec<u8>>,
+        _entries: BTreeSet<DispatchKind>,
         mem_size: WasmPageNumber,
     ) -> Result<Self, BackendError<Self::Error>> {
         let forbidden_funcs = ext.forbidden_funcs().clone();
@@ -210,7 +211,7 @@ where
 
     fn execute<F, T>(
         mut self,
-        entry_point: &str,
+        entry_point: &DispatchKind,
         post_execution_handler: F,
     ) -> Result<BackendReport, BackendError<Self::Error>>
     where
@@ -219,7 +220,7 @@ where
     {
         let func = self
             .instance
-            .get_func(&mut self.memory_wrap.store, entry_point);
+            .get_func(&mut self.memory_wrap.store, entry_point.into_entry());
 
         let prepare_info =
             |this: Self| -> Result<(ExtInfo, MemoryWrapExternal<E>), BackendError<Self::Error>> {

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -22,6 +22,7 @@ use core::fmt;
 
 use crate::{funcs_tree, memory::MemoryWrapExternal};
 use alloc::{
+    collections::BTreeSet,
     format,
     string::{String, ToString},
     vec::Vec,
@@ -85,7 +86,7 @@ where
     fn new(
         ext: E,
         binary: &[u8],
-        _entries: Vec<Vec<u8>>,
+        _entries: BTreeSet<Vec<u8>>,
         mem_size: WasmPageNumber,
     ) -> Result<Self, BackendError<Self::Error>> {
         let forbidden_funcs = ext.forbidden_funcs().clone();

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -333,7 +333,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
     log::trace!("Stack end page = {:?}", stack_end_page);
 
     // Execute program in backend env.
-    let BackendReport { termination, info } = match env.execute(kind.into_entry(), |mem| {
+    let BackendReport { termination, info } = match env.execute(&kind, |mem| {
         // released pages initial data will be added to `pages_intial_data` after execution.
         if A::is_lazy_pages_enabled() {
             A::lazy_pages_post_execution_actions(mem, &mut pages_initial_data)

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -302,7 +302,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
     let mut env = E::new(
         ext,
         program.raw_code(),
-        program.code().exports().to_vec(),
+        program.code().exports().clone(),
         mem_size,
     )
     .map_err(|err| {

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -299,7 +299,13 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
         settings.forbidden_funcs,
     );
 
-    let mut env = E::new(ext, program.raw_code(), mem_size).map_err(|err| {
+    let mut env = E::new(
+        ext,
+        program.raw_code(),
+        program.code().exports().to_vec(),
+        mem_size,
+    )
+    .map_err(|err| {
         log::debug!("Setup instance err = {}", err);
         ExecutionError {
             program_id,

--- a/core/src/code.rs
+++ b/core/src/code.rs
@@ -201,7 +201,7 @@ impl Code {
                         .map_err(|_| CodeError::Encode)?;
 
                 Ok(Self {
-                    raw_code: original_code.clone(),
+                    raw_code: original_code,
                     code: instrumented,
                     exports,
                     static_pages,

--- a/core/src/code.rs
+++ b/core/src/code.rs
@@ -102,7 +102,7 @@ impl Code {
 
         let exports = module
             .export_section()
-            .ok_or_else(|| CodeError::ExportSectionNotFound)?
+            .ok_or(CodeError::ExportSectionNotFound)?
             .entries()
             .iter()
             .map(|v| v.field().as_bytes().to_vec())
@@ -153,7 +153,7 @@ impl Code {
 
         let exports = module
             .export_section()
-            .ok_or_else(|| CodeError::ExportSectionNotFound)?
+            .ok_or(CodeError::ExportSectionNotFound)?
             .entries()
             .iter()
             .map(|v| v.field().as_bytes().to_vec())

--- a/core/src/code.rs
+++ b/core/src/code.rs
@@ -59,6 +59,7 @@ pub struct Code {
     code: Vec<u8>,
     /// The uninstrumented, original version of the code.
     raw_code: Vec<u8>,
+    /// Exports of the wasm module.
     exports: Vec<Vec<u8>>,
     static_pages: WasmPageNumber,
     #[codec(compact)]
@@ -178,6 +179,11 @@ impl Code {
         &self.code
     }
 
+    /// Returns wasm module exports.
+    pub fn exports(&self) -> &[Vec<u8>] {
+        &self.exports
+    }
+
     /// Returns instruction weights version.
     pub fn instruction_weights_version(&self) -> u32 {
         self.instruction_weights_version
@@ -258,7 +264,7 @@ impl InstrumentedCode {
         self.version
     }
 
-    /// Returns initial memory size from memory import.
+    /// Returns wasm module exports.
     pub fn exports(&self) -> &[Vec<u8>] {
         &self.exports
     }

--- a/examples/exit-code/src/lib.rs
+++ b/examples/exit-code/src/lib.rs
@@ -5,6 +5,9 @@ use gstd::{msg, prelude::ToString, ActorId};
 static mut HOST: ActorId = ActorId::new([0u8; 32]);
 
 #[no_mangle]
+pub unsafe extern "C" fn handle() {}
+
+#[no_mangle]
 pub unsafe extern "C" fn handle_reply() {
     msg::send_bytes(HOST, msg::exit_code().to_string(), 0).unwrap();
 }

--- a/examples/exit-code/src/lib.rs
+++ b/examples/exit-code/src/lib.rs
@@ -4,6 +4,10 @@ use gstd::{msg, prelude::ToString, ActorId};
 
 static mut HOST: ActorId = ActorId::new([0u8; 32]);
 
+// It was containing the only handle_reply previously
+// what is just for testing and isn't valid at all
+// cause we can't receive reply on message if we never send it.
+// For this demo in real conditions handle_reply is unreachable.
 #[no_mangle]
 pub unsafe extern "C" fn handle() {}
 

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -203,7 +203,7 @@ impl<'a> Program<'a> {
         let program_id = id.clone().into().0;
 
         let code = fs::read(&path).unwrap_or_else(|_| panic!("Failed to read file {:?}", path));
-        let code = Code::new_raw(code, 1, None).expect("Failed to create Program from code");
+        let code = Code::new_raw(code, 1, None, true).expect("Failed to create Program from code");
 
         let code_and_id: InstrumentedCodeAndId = CodeAndId::new(code).into();
         let (code, _) = code_and_id.into_parts();

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -18,7 +18,6 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
-use wasm_instrument::gas_metering::ConstantCostRules;
 
 pub trait WasmProgram: Debug {
     fn init(&mut self, payload: Vec<u8>) -> Result<Option<Vec<u8>>, &'static str>;
@@ -161,8 +160,7 @@ impl<'a> Program<'a> {
         let program_id = id.clone().into().0;
 
         let code = fs::read(&path).unwrap_or_else(|_| panic!("Failed to read file {:?}", path));
-        let code = Code::try_new(code, 1, |_| ConstantCostRules::default())
-            .expect("Failed to create Program from code");
+        let code = Code::new_raw(code, 1, None).expect("Failed to create Program from code");
 
         let code_and_id: InstrumentedCodeAndId = CodeAndId::new(code).into();
         let (code, _) = code_and_id.into_parts();

--- a/pallets/gear-program/Cargo.toml
+++ b/pallets/gear-program/Cargo.toml
@@ -17,6 +17,7 @@ codec = { package = "parity-scale-codec", version = "3.1.2", default-features = 
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 primitive-types = { version = "0.11.1", default-features = false, features = ["scale-info"] }
 log = { version = "0.4.17", default-features = false }
+wasm-instrument = { version = "0.1", default-features = false }
 
 # Internal deps
 common = { package = "gear-common", path = "../../common", default-features = false }
@@ -34,7 +35,6 @@ pallet-balances = { version = "4.0.0-dev", default-features = false, git = "http
 
 [dev-dependencies]
 hex-literal = "0.3.3"
-wasm-instrument = { version = "0.1", default-features = false }
 env_logger = "0.9"
 pallet-gear-messenger = { path = "../gear-messenger", default-features = false }
 

--- a/pallets/gear-program/src/lib.rs
+++ b/pallets/gear-program/src/lib.rs
@@ -67,7 +67,7 @@ pub mod pallet {
     const LOCK_ID: LockIdentifier = *b"resume_p";
 
     /// The current storage version.
-    const PROGRAM_STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
+    const PROGRAM_STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 
     #[pallet::config]
     pub trait Config: frame_system::Config {

--- a/pallets/gear-program/src/lib.rs
+++ b/pallets/gear-program/src/lib.rs
@@ -67,7 +67,7 @@ pub mod pallet {
     const LOCK_ID: LockIdentifier = *b"resume_p";
 
     /// The current storage version.
-    const PROGRAM_STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+    const PROGRAM_STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 
     #[pallet::config]
     pub trait Config: frame_system::Config {

--- a/pallets/gear-program/src/migration.rs
+++ b/pallets/gear-program/src/migration.rs
@@ -37,6 +37,7 @@ pub fn migrate<T: Config>() -> Weight {
 mod v2 {
     use super::*;
     use sp_std::vec::Vec;
+    use sp_std::collections::btree_set::BTreeSet;
 
     #[derive(Encode, Decode)]
     struct WasmPageNumber(u32);
@@ -57,7 +58,7 @@ mod v2 {
     struct Code {
         code: Vec<u8>,
         raw_code: Vec<u8>,
-        exports: Vec<Vec<u8>>,
+        exports: BTreeSet<Vec<u8>>,
         static_pages: WasmPageNumber,
         #[codec(compact)]
         instruction_weights_version: u32,
@@ -73,7 +74,7 @@ mod v2 {
     #[derive(Encode, Decode)]
     struct InstrumentedCode {
         code: Vec<u8>,
-        exports: Vec<Vec<u8>>,
+        exports: BTreeSet<Vec<u8>>,
         static_pages: WasmPageNumber,
         version: u32,
     }
@@ -94,14 +95,14 @@ mod v2 {
                     wasm_instrument::parity_wasm::elements::Module,
                 >(&orig_code)
                 {
-                    let exports = if let Some(export_section) = module.export_section() {
+                    let exports: BTreeSet<Vec<u8>> = if let Some(export_section) = module.export_section() {
                         export_section
                             .entries()
                             .iter()
                             .map(|v| v.field().as_bytes().to_vec())
                             .collect()
                     } else {
-                        Vec::new()
+                        BTreeSet::<Vec<u8>>::new()
                     };
 
                     if exports.contains(&b"init".to_vec()) || exports.contains(&b"handle".to_vec())

--- a/pallets/gear-program/src/migration.rs
+++ b/pallets/gear-program/src/migration.rs
@@ -113,6 +113,8 @@ mod v2 {
                             version: old.version,
                         })
                     } else {
+                        <OriginalCodeStorage<T>>::remove(key); 
+                        weight = weight.saturating_add(T::DbWeight::get().reads_writes(0, 1));
                         None
                     }
                 } else {

--- a/pallets/gear-program/src/migration.rs
+++ b/pallets/gear-program/src/migration.rs
@@ -17,11 +17,12 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{Config, Pallet, Weight};
+use common::Origin;
 
 /// Wrapper for all migrations of this pallet, based on `StorageVersion`.
 pub fn migrate<T: Config>() -> Weight
 where
-    <T as frame_system::Config>::AccountId: common::Origin,
+    <T as frame_system::Config>::AccountId: Origin,
 {
     use frame_support::traits::StorageVersion;
 

--- a/pallets/gear-program/src/migration.rs
+++ b/pallets/gear-program/src/migration.rs
@@ -36,8 +36,7 @@ pub fn migrate<T: Config>() -> Weight {
 /// V2: `gear_core::Code` is changed to have an exports field.
 mod v2 {
     use super::*;
-    use sp_std::vec::Vec;
-    use sp_std::collections::btree_set::BTreeSet;
+    use sp_std::{collections::btree_set::BTreeSet, vec::Vec};
 
     #[derive(Encode, Decode)]
     struct WasmPageNumber(u32);
@@ -95,15 +94,16 @@ mod v2 {
                     wasm_instrument::parity_wasm::elements::Module,
                 >(&orig_code)
                 {
-                    let exports: BTreeSet<Vec<u8>> = if let Some(export_section) = module.export_section() {
-                        export_section
-                            .entries()
-                            .iter()
-                            .map(|v| v.field().as_bytes().to_vec())
-                            .collect()
-                    } else {
-                        BTreeSet::<Vec<u8>>::new()
-                    };
+                    let exports: BTreeSet<Vec<u8>> =
+                        if let Some(export_section) = module.export_section() {
+                            export_section
+                                .entries()
+                                .iter()
+                                .map(|v| v.field().as_bytes().to_vec())
+                                .collect()
+                        } else {
+                            BTreeSet::<Vec<u8>>::new()
+                        };
 
                     if exports.contains(&b"init".to_vec()) || exports.contains(&b"handle".to_vec())
                     {

--- a/pallets/gear-program/src/migration.rs
+++ b/pallets/gear-program/src/migration.rs
@@ -17,13 +17,107 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{Config, Pallet, Weight};
+use codec::{Decode, Encode};
+use frame_support::{codec, pallet_prelude::*, storage_alias, traits::Get, Identity};
 
 /// Wrapper for all migrations of this pallet, based on `StorageVersion`.
 pub fn migrate<T: Config>() -> Weight {
-    use frame_support::traits::StorageVersion;
+    let version = StorageVersion::get::<Pallet<T>>();
+    let mut weight: Weight = 0;
 
-    let _version = StorageVersion::get::<Pallet<T>>();
-    let weight: Weight = 0;
+    if version < 2 {
+        weight = weight.saturating_add(v2::migrate::<T>());
+        StorageVersion::new(2).put::<Pallet<T>>();
+    }
 
     weight
+}
+
+/// V2: `gear_core::Code` is changed to have an exports field.
+mod v2 {
+    use super::*;
+    use sp_std::vec::Vec;
+
+    #[derive(Encode, Decode)]
+    struct WasmPageNumber(u32);
+
+    #[derive(Encode, Decode)]
+    struct CodeId([u8; 32]);
+
+    #[derive(Encode, Decode)]
+    struct OldCode {
+        code: Vec<u8>,
+        raw_code: Vec<u8>,
+        static_pages: WasmPageNumber,
+        #[codec(compact)]
+        instruction_weights_version: u32,
+    }
+
+    #[derive(Encode, Decode)]
+    struct Code {
+        code: Vec<u8>,
+        raw_code: Vec<u8>,
+        exports: Vec<Vec<u8>>,
+        static_pages: WasmPageNumber,
+        #[codec(compact)]
+        instruction_weights_version: u32,
+    }
+
+    #[derive(Encode, Decode)]
+    struct OldInstrumentedCode {
+        code: Vec<u8>,
+        static_pages: WasmPageNumber,
+        version: u32,
+    }
+
+    #[derive(Encode, Decode)]
+    struct InstrumentedCode {
+        code: Vec<u8>,
+        exports: Vec<Vec<u8>>,
+        static_pages: WasmPageNumber,
+        version: u32,
+    }
+
+    #[storage_alias]
+    type CodeStorage<T: Config> = StorageMap<Pallet<T>, Identity, CodeId, InstrumentedCode>;
+
+    #[storage_alias]
+    type OriginalCodeStorage<T: Config> = StorageMap<Pallet<T>, Identity, CodeId, Vec<u8>>;
+
+    pub fn migrate<T: Config>() -> Weight {
+        let mut weight: Weight = 0;
+
+        <CodeStorage<T>>::translate(|key, old: OldInstrumentedCode| {
+            weight = weight.saturating_add(T::DbWeight::get().reads_writes(2, 1));
+            if let Some(orig_code) = <OriginalCodeStorage<T>>::get(key) {
+                if let Ok(module) = wasm_instrument::parity_wasm::deserialize_buffer::<
+                    wasm_instrument::parity_wasm::elements::Module,
+                >(&orig_code)
+                {
+                    let exports = if let Some(export_section) = module.export_section() {
+                        export_section
+                            .entries()
+                            .iter()
+                            .map(|v| v.field().as_bytes().to_vec())
+                            .collect()
+                    } else {
+                        Vec::new()
+                    };
+
+                    Some(InstrumentedCode {
+                        code: old.code,
+                        exports,
+                        static_pages: old.static_pages,
+                        version: old.version,
+                    })
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        });
+
+        weight
+    }
 }

--- a/pallets/gear-program/src/migration.rs
+++ b/pallets/gear-program/src/migration.rs
@@ -113,7 +113,7 @@ mod v2 {
                             version: old.version,
                         })
                     } else {
-                        <OriginalCodeStorage<T>>::remove(key); 
+                        <OriginalCodeStorage<T>>::remove(key);
                         weight = weight.saturating_add(T::DbWeight::get().reads_writes(0, 1));
                         None
                     }

--- a/pallets/gear-program/src/migration.rs
+++ b/pallets/gear-program/src/migration.rs
@@ -17,115 +17,16 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{Config, Pallet, Weight};
-use codec::{Decode, Encode};
-use frame_support::{codec, pallet_prelude::*, storage_alias, traits::Get, Identity};
 
 /// Wrapper for all migrations of this pallet, based on `StorageVersion`.
-pub fn migrate<T: Config>() -> Weight {
-    let version = StorageVersion::get::<Pallet<T>>();
-    let mut weight: Weight = 0;
+pub fn migrate<T: Config>() -> Weight
+where
+    <T as frame_system::Config>::AccountId: common::Origin,
+{
+    use frame_support::traits::StorageVersion;
 
-    if version < 2 {
-        weight = weight.saturating_add(v2::migrate::<T>());
-        StorageVersion::new(2).put::<Pallet<T>>();
-    }
+    let _version = StorageVersion::get::<Pallet<T>>();
+    let weight: Weight = 0;
 
     weight
-}
-
-/// V2: `gear_core::Code` is changed to have an exports field.
-mod v2 {
-    use super::*;
-    use sp_std::{collections::btree_set::BTreeSet, vec::Vec};
-
-    #[derive(Encode, Decode)]
-    struct WasmPageNumber(u32);
-
-    #[derive(Encode, Decode, Clone, Copy)]
-    struct CodeId([u8; 32]);
-
-    #[derive(Encode, Decode)]
-    struct OldCode {
-        code: Vec<u8>,
-        raw_code: Vec<u8>,
-        static_pages: WasmPageNumber,
-        #[codec(compact)]
-        instruction_weights_version: u32,
-    }
-
-    #[derive(Encode, Decode)]
-    struct Code {
-        code: Vec<u8>,
-        raw_code: Vec<u8>,
-        exports: BTreeSet<Vec<u8>>,
-        static_pages: WasmPageNumber,
-        #[codec(compact)]
-        instruction_weights_version: u32,
-    }
-
-    #[derive(Encode, Decode)]
-    struct OldInstrumentedCode {
-        code: Vec<u8>,
-        static_pages: WasmPageNumber,
-        version: u32,
-    }
-
-    #[derive(Encode, Decode)]
-    struct InstrumentedCode {
-        code: Vec<u8>,
-        exports: BTreeSet<Vec<u8>>,
-        static_pages: WasmPageNumber,
-        version: u32,
-    }
-
-    #[storage_alias]
-    type CodeStorage<T: Config> = StorageMap<Pallet<T>, Identity, CodeId, InstrumentedCode>;
-
-    #[storage_alias]
-    type OriginalCodeStorage<T: Config> = StorageMap<Pallet<T>, Identity, CodeId, Vec<u8>>;
-
-    pub fn migrate<T: Config>() -> Weight {
-        let mut weight: Weight = 0;
-
-        <CodeStorage<T>>::translate(|key, old: OldInstrumentedCode| {
-            weight = weight.saturating_add(T::DbWeight::get().reads_writes(2, 1));
-            if let Some(orig_code) = <OriginalCodeStorage<T>>::get(key) {
-                if let Ok(module) = wasm_instrument::parity_wasm::deserialize_buffer::<
-                    wasm_instrument::parity_wasm::elements::Module,
-                >(&orig_code)
-                {
-                    let exports: BTreeSet<Vec<u8>> =
-                        if let Some(export_section) = module.export_section() {
-                            export_section
-                                .entries()
-                                .iter()
-                                .map(|v| v.field().as_bytes().to_vec())
-                                .collect()
-                        } else {
-                            BTreeSet::<Vec<u8>>::new()
-                        };
-
-                    if exports.contains(&b"init".to_vec()) || exports.contains(&b"handle".to_vec())
-                    {
-                        Some(InstrumentedCode {
-                            code: old.code,
-                            exports,
-                            static_pages: old.static_pages,
-                            version: old.version,
-                        })
-                    } else {
-                        <OriginalCodeStorage<T>>::remove(key);
-                        weight = weight.saturating_add(T::DbWeight::get().reads_writes(0, 1));
-                        None
-                    }
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        });
-
-        weight
-    }
 }

--- a/pallets/gear-program/src/migration.rs
+++ b/pallets/gear-program/src/migration.rs
@@ -41,7 +41,7 @@ mod v2 {
     #[derive(Encode, Decode)]
     struct WasmPageNumber(u32);
 
-    #[derive(Encode, Decode)]
+    #[derive(Encode, Decode, Clone, Copy)]
     struct CodeId([u8; 32]);
 
     #[derive(Encode, Decode)]
@@ -104,12 +104,17 @@ mod v2 {
                         Vec::new()
                     };
 
-                    Some(InstrumentedCode {
-                        code: old.code,
-                        exports,
-                        static_pages: old.static_pages,
-                        version: old.version,
-                    })
+                    if exports.contains(&b"init".to_vec()) || exports.contains(&b"handle".to_vec())
+                    {
+                        Some(InstrumentedCode {
+                            code: old.code,
+                            exports,
+                            static_pages: old.static_pages,
+                            version: old.version,
+                        })
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 }

--- a/pallets/gear-program/src/tests.rs
+++ b/pallets/gear-program/src/tests.rs
@@ -34,7 +34,7 @@ use wasm_instrument::gas_metering::ConstantCostRules;
 #[test]
 fn pause_program_works() {
     new_test_ext().execute_with(|| {
-        let raw_code = hex!("0061736d01000000020f0103656e76066d656d6f7279020001").to_vec();
+        let raw_code = hex!("0061736d01000000010401600000020f0103656e76066d656d6f727902000103020100070a010668616e646c6500000a040102000b0019046e616d650203010000060d01000a656e762e6d656d6f7279").to_vec();
         let code = Code::try_new(raw_code, 1, |_| ConstantCostRules::default())
             .expect("Error creating Code");
 
@@ -115,7 +115,7 @@ fn pause_program_works() {
 #[test]
 fn pause_program_twice_fails() {
     new_test_ext().execute_with(|| {
-        let raw_code = hex!("0061736d01000000020f0103656e76066d656d6f7279020001").to_vec();
+        let raw_code = hex!("0061736d01000000010401600000020f0103656e76066d656d6f727902000103020100070a010668616e646c6500000a040102000b0019046e616d650203010000060d01000a656e762e6d656d6f7279").to_vec();
         let code = Code::try_new(raw_code, 1, |_| ConstantCostRules::default())
             .expect("Error creating Code");
 
@@ -148,7 +148,7 @@ fn pause_program_twice_fails() {
 #[test]
 fn pause_terminated_program_fails() {
     new_test_ext().execute_with(|| {
-        let raw_code = hex!("0061736d01000000020f0103656e76066d656d6f7279020001").to_vec();
+        let raw_code = hex!("0061736d01000000010401600000020f0103656e76066d656d6f727902000103020100070a010668616e646c6500000a040102000b0019046e616d650203010000060d01000a656e762e6d656d6f7279").to_vec();
         let code = Code::try_new(raw_code, 1, |_| ConstantCostRules::default())
             .expect("Error creating Code");
 
@@ -413,7 +413,7 @@ mod utils {
     pub fn create_uninitialized_program_messages(
         wasm_static_pages: WasmPageNumber,
     ) -> CreateProgramResult {
-        let raw_code = hex!("0061736d01000000020f0103656e76066d656d6f7279020001").to_vec();
+        let raw_code = hex!("0061736d01000000010401600000020f0103656e76066d656d6f727902000103020100070a010668616e646c6500000a040102000b0019046e616d650203010000060d01000a656e762e6d656d6f7279").to_vec();
         let code = Code::try_new(raw_code, 1, |_| ConstantCostRules::default())
             .expect("Error creating Code");
 

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -378,7 +378,7 @@ benchmarks! {
     reinstrument {
         let c in 0 .. T::Schedule::get().limits.code_len;
         let WasmModule { code, hash, .. } = WasmModule::<T>::sized(c, Location::Handle);
-        let code = Code::new_raw(code, 1, None).unwrap();
+        let code = Code::new_raw(code, 1, None, false).unwrap();
         let code_and_id = CodeAndId::new(code);
         let code_id = code_and_id.code_id();
 

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -435,11 +435,16 @@ pub mod pallet {
                 Error::<T>::FailedToConstructProgram
             })?;
 
-            let code = Code::new_raw(code, schedule.instruction_weights.version, Some(module))
-                .map_err(|e| {
-                    log::debug!("Code failed to load: {:?}", e);
-                    Error::<T>::FailedToConstructProgram
-                })?;
+            let code = Code::new_raw(
+                code,
+                schedule.instruction_weights.version,
+                Some(module),
+                false,
+            )
+            .map_err(|e| {
+                log::debug!("Code failed to load: {:?}", e);
+                Error::<T>::FailedToConstructProgram
+            })?;
 
             let code_and_id = CodeAndId::new(code);
             let code_id = code_and_id.code_id();

--- a/pallets/usage/src/migration.rs
+++ b/pallets/usage/src/migration.rs
@@ -17,11 +17,12 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{Config, Pallet, Weight};
+use common::Origin;
 
 /// Wrapper for all migrations of this pallet, based on `StorageVersion`.
 pub fn migrate<T: Config>() -> Weight
 where
-    <T as frame_system::Config>::AccountId: common::Origin,
+    <T as frame_system::Config>::AccountId: Origin,
 {
     use frame_support::traits::StorageVersion;
 

--- a/pallets/usage/src/mock.rs
+++ b/pallets/usage/src/mock.rs
@@ -290,7 +290,7 @@ pub(crate) fn set_program<T: pallet_gear::Config>(
     bn: u32,
 ) -> Program {
     let code = Code::try_new(
-        hex!("0061736d01000000020f0103656e76066d656d6f7279020001").to_vec(),
+        hex!("0061736d01000000010401600000020f0103656e76066d656d6f727902000103020100070a010668616e646c6500000a040102000b0019046e616d650203010000060d01000a656e762e6d656d6f7279").to_vec(),
         1,
         |_| ConstantCostRules::default(),
     )

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -123,7 +123,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1120,
+    spec_version: 1130,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -123,7 +123,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1150,
+    spec_version: 1160,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Store the exports of the wasm module in `gear_core::code::Code` so that they can be reused.
On each execution we deserialize the binary code into a `parity_wasm::Module` which affects the performance in a bad way.

I will perform a storage migration for this change.

@gear-tech/dev 
