### PR TITLE
feat(gas): introduce `ValueType::ReservedLocal`

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -243,6 +243,14 @@ pub trait ValueTree {
     /// If `key` does not identify any value an error is returned.
     /// This can't create imbalance as no value is burned or created.
     fn split(key: Self::Key, new_key: Self::Key) -> DispatchResult;
+
+    /// Cut underlying value to a reserved node.
+    ///
+    /// If `key` does not identify any value or the `amount` exceeds what's locked under that key,
+    /// an error is returned.
+    ///
+    /// This can't create imbalance as no value is burned or created.
+    fn cut(key: Self::Key, new_key: Self::Key, amount: Self::Balance) -> DispatchResult;
 }
 
 type ConsumeOutput<Imbalance, External> = Option<(Imbalance, External)>;

--- a/pallets/gas/src/lib.rs
+++ b/pallets/gas/src/lib.rs
@@ -24,6 +24,7 @@ use frame_support::{dispatch::DispatchError, pallet_prelude::*, traits::Imbalanc
 pub use pallet::*;
 pub use primitive_types::H256;
 use scale_info::TypeInfo;
+use sp_runtime::traits::Saturating;
 use sp_std::convert::TryInto;
 
 #[cfg(test)]
@@ -100,7 +101,9 @@ impl ValueNode {
     }
 
     pub fn refs(&self) -> u32 {
-        self.spec_refs.saturating_add(self.unspec_refs)
+        self.spec_refs
+            .saturating_add(self.unspec_refs)
+            .saturating_add(self.reserved_refs)
     }
 
     /// The first upstream node (self included), that is able to hold a concrete value, but doesn't
@@ -226,7 +229,7 @@ pub mod pallet {
     // Gas pallet error.
     #[pallet::error]
     pub enum Error<T> {
-        /// Forbidden operation of the value node
+        /// Forbidden operation for the value node
         Forbidden,
 
         /// Gas (gas tree) has already been created for the provided key.

--- a/pallets/gas/src/lib.rs
+++ b/pallets/gas/src/lib.rs
@@ -326,13 +326,16 @@ pub mod pallet {
                 GasTree::<T>::remove(node_id);
 
                 match node.inner {
-                    ValueType::External { id, value } | ValueType::ReservedLocal { id, value } => {
+                    ValueType::External { id, value } => {
                         return Ok(Some((NegativeImbalance::new(value), id)))
                     }
                     ValueType::SpecifiedLocal { parent, .. }
                     | ValueType::UnspecifiedLocal { parent } => {
                         node_id = parent;
                         node = Self::get_node(node_id).ok_or(Error::<T>::ParentIsLost)?;
+                    }
+                    ValueType::ReservedLocal { .. } => {
+                        unreachable!("node is guaranteed to be a parent, but reserved nodes have no children")
                     }
                 }
             }

--- a/pallets/gas/src/tests.rs
+++ b/pallets/gas/src/tests.rs
@@ -418,17 +418,20 @@ fn limit_vs_origin() {
         let split_1_2 = H256::random();
         let split_1_1_1 = H256::random();
 
-        assert_ok!(Gas::create(origin, root_node, 1000));
+        assert_ok!(Gas::create(origin, root_node, 1100));
 
-        assert_ok!(Gas::cut(root_node, cut, 200));
+        assert_ok!(Gas::cut(root_node, cut, 300));
         assert_ok!(Gas::split(root_node, split_1));
         assert_ok!(Gas::split(root_node, split_2));
         assert_ok!(Gas::split_with_value(split_1, split_1_1, 600));
         assert_ok!(Gas::split(split_1, split_1_2));
         assert_ok!(Gas::split(split_1_1, split_1_1_1));
 
-        // Original 1000 less 200 that were `cut` and `split_with_value`
+        // Original 1100 less 200 that were `cut` and `split_with_value`
         assert_eq!(Gas::get_limit(root_node).unwrap(), Some(200));
+
+        // 300 cut from the root node
+        assert_eq!(Gas::get_limit(cut).unwrap(), Some(300));
 
         // Parent's 200
         assert_eq!(Gas::get_limit(split_1).unwrap(), Some(200));

--- a/pallets/gas/src/tests.rs
+++ b/pallets/gas/src/tests.rs
@@ -47,7 +47,7 @@ fn simple_value_tree() {
 }
 
 #[test]
-fn can_cut_reserved_nodes() {
+fn can_cut_nodes() {
     new_test_ext().execute_with(|| {
         let (root, specified, unspecified, cut_a, cut_b, cut_c) = (
             H256::random(),

--- a/pallets/gas/src/tests.rs
+++ b/pallets/gas/src/tests.rs
@@ -185,6 +185,7 @@ fn value_tree_known_errors() {
         let split_1 = H256::random();
         let split_2 = H256::random();
         let cut = H256::random();
+        let cut_1 = H256::random();
 
         {
             let pos_imb = Gas::create(origin, new_root, 1000).unwrap();
@@ -219,6 +220,9 @@ fn value_tree_known_errors() {
                 Gas::split_with_value(cut, split_1, 50),
                 Error::<Test>::Forbidden
             );
+
+            // Try to cut the reserved node
+            assert_noop!(Gas::cut(cut, cut_1, 50), Error::<Test>::Forbidden);
 
             // Total supply not affected so far - imbalance is not yet dropped
             assert_eq!(pos_imb.peek(), 1000);

--- a/pallets/gas/src/tests.rs
+++ b/pallets/gas/src/tests.rs
@@ -184,10 +184,14 @@ fn value_tree_known_errors() {
         let origin = H256::random();
         let split_1 = H256::random();
         let split_2 = H256::random();
+        let cut = H256::random();
 
         {
             let pos_imb = Gas::create(origin, new_root, 1000).unwrap();
             assert_eq!(pos_imb.peek(), 1000);
+
+            // Cut a reserved node
+            assert_ok!(Gas::cut(new_root, cut, 100));
 
             // Attempt to re-create an existing node
             assert_noop!(
@@ -205,6 +209,15 @@ fn value_tree_known_errors() {
             assert_noop!(
                 Gas::split_with_value(new_root, split_1, 5000),
                 Error::<Test>::InsufficientBalance
+            );
+
+            // Try to split the reserved node
+            assert_noop!(Gas::split(cut, split_1), Error::<Test>::Forbidden);
+
+            // Try to split the reserved node with value
+            assert_noop!(
+                Gas::split_with_value(cut, split_1, 50),
+                Error::<Test>::Forbidden
             );
 
             // Total supply not affected so far - imbalance is not yet dropped

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -123,7 +123,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1150,
+    spec_version: 1160,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Ref #1063.

- [x] introduce `ValueType::ReservedLocal`
- [x] restrict calling `split_*` for `ValueType::ReservedLocal`
- [x] introduce `ValueNode::cut`
- [x] tests for this

