### PR TITLE
gtest: Add possibility to load both `.wasm` and `.opt.wasm`

### DIFF
--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -161,13 +161,20 @@ impl<'a> Program<'a> {
         system: &'a System,
         id: I,
     ) -> Self {
-        let current_dir = env::current_dir().expect("Unable to get current dir");
-        let path_file = current_dir.join(".binpath");
-        let path_bytes = fs::read(path_file).expect("Unable to read path bytes");
-        let relative_path: PathBuf = String::from_utf8(path_bytes).expect("Invalid path").into();
-        let path = current_dir.join(relative_path);
+        Self::from_file_with_id(system, id, Self::wasm_path("wasm"))
+    }
 
-        Self::from_file_with_id(system, id, path)
+    pub fn current_opt(system: &'a System) -> Self {
+        let nonce = system.0.borrow_mut().free_id_nonce();
+
+        Self::current_opt_with_id(system, nonce)
+    }
+
+    pub fn current_opt_with_id<I: Into<ProgramIdWrapper> + Clone + Debug>(
+        system: &'a System,
+        id: I,
+    ) -> Self {
+        Self::from_file_with_id(system, id, Self::wasm_path("opt.wasm"))
     }
 
     pub fn mock<T: WasmProgram + 'static>(system: &'a System, mock: T) -> Self {
@@ -310,6 +317,16 @@ impl<'a> Program<'a> {
         self.manager
             .borrow_mut()
             .call_meta(&self.id, None, "meta_state")
+    }
+
+    fn wasm_path(extension: &str) -> PathBuf {
+        let current_dir = env::current_dir().expect("Unable to get current dir");
+        let path_file = current_dir.join(".binpath");
+        let path_bytes = fs::read(path_file).expect("Unable to read path bytes");
+        let mut relative_path: PathBuf =
+            String::from_utf8(path_bytes).expect("Invalid path").into();
+        relative_path.set_extension(extension);
+        current_dir.join(relative_path)
     }
 }
 

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -184,14 +184,14 @@ impl WasmProject {
 
         let wasm_binary_path = self.original_dir.join(".binpath");
 
-        let relative_path_to_opt = pathdiff::diff_paths(&to_opt_path, &self.original_dir)
+        let mut relative_path = pathdiff::diff_paths(&to_path, &self.original_dir)
             .expect("Unable to calculate relative path");
 
-        fs::write(
-            &wasm_binary_path,
-            format!("{}", relative_path_to_opt.display()),
-        )
-        .context("unable to write `.binpath`")?;
+        // Remove extension
+        relative_path.set_extension("");
+
+        fs::write(&wasm_binary_path, format!("{}", relative_path.display()))
+            .context("unable to write `.binpath`")?;
 
         let wasm_binary_rs = self.out_dir.join("wasm_binary.rs");
         fs::write(


### PR DESCRIPTION
One should have the possibility to use `.wasm` instead of `.opt.wasm` in `gtest` to be able to test meta functions too.

- `Program::current/current_with_id` now loads `.wasm` binary instead of `.opt.wasm`.
- Added `Program::current_opt/current_opt_with_id` to load `.opt.wasm` binary.
- Updated `gear-wasm-builder` to write the only base path to the `.binpath` file.

@gear-tech/dev 
