### PR TITLE
Remove `pub` qualifier from `extern` functions

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -48,16 +48,16 @@ Here is a minimal program for a classic ping-pong contract:
 use gstd::{ext, msg};
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let new_msg = String::from_utf8(msg::load_bytes()).expect("Invalid message: should be utf-8");
 
     if &new_msg == "PING" {
-        msg::send(msg::source(), b"PONG", 10_000_000);
+        msg::send_bytes(msg::source(), b"PONG", 0);
     }
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {}
+unsafe extern "C" fn init() {}
 ```
 
 It will just send `PONG` back to the original sender (this can be you!)

--- a/examples/async-multisig/src/lib.rs
+++ b/examples/async-multisig/src/lib.rs
@@ -40,7 +40,7 @@ gstd::metadata! {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let args: InputArgs = msg::load().expect("Failed to decode `InputArgs`");
 
     DESTINATION = args.destination;

--- a/examples/async-recursion/src/lib.rs
+++ b/examples/async-recursion/src/lib.rs
@@ -14,7 +14,7 @@ fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let input = String::from_utf8(msg::load_bytes()).expect("Invalid message: should be utf-8");
     DEST = ActorId::from_slice(
         &decode_hex(&input).expect("Initialization failed: invalid program ID"),

--- a/examples/async-sign/src/lib.rs
+++ b/examples/async-sign/src/lib.rs
@@ -35,7 +35,7 @@ gstd::metadata! {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let args: InputArgs = msg::load().expect("Failed to decode `InputArgs`");
 
     DESTINATION = args.destination;

--- a/examples/async/src/lib.rs
+++ b/examples/async/src/lib.rs
@@ -18,7 +18,7 @@ gstd::metadata! {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let input = String::from_utf8(msg::load_bytes()).expect("Invalid message: should be utf-8");
     let dests: Vec<&str> = input.split(',').collect();
     if dests.len() != 3 {

--- a/examples/binaries/async-tester/src/code.rs
+++ b/examples/binaries/async-tester/src/code.rs
@@ -5,7 +5,7 @@ use gstd::{
 };
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {}
+unsafe extern "C" fn init() {}
 
 #[gstd::async_main]
 async fn main() {

--- a/examples/binaries/btree/src/lib.rs
+++ b/examples/binaries/btree/src/lib.rs
@@ -17,7 +17,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 #![no_std]
-#![allow(clippy::missing_safety_doc)]
 
 #[cfg(feature = "std")]
 mod code {
@@ -58,7 +57,7 @@ mod wasm {
     static mut STATE: Option<BTreeMap<u32, u32>> = None;
 
     #[no_mangle]
-    pub unsafe extern "C" fn handle() {
+    unsafe extern "C" fn handle() {
         let reply = match msg::load() {
             Ok(request) => process(request),
             Err(e) => {
@@ -89,7 +88,7 @@ mod wasm {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn init() {
+    unsafe extern "C" fn init() {
         STATE = Some(BTreeMap::new());
         msg::reply((), 0).unwrap();
     }

--- a/examples/binaries/compose/src/lib.rs
+++ b/examples/binaries/compose/src/lib.rs
@@ -139,7 +139,7 @@ mod wasm {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn init() {
+    unsafe extern "C" fn init() {
         let (contract_a, contract_b): (ActorId, ActorId) =
             msg::load().expect("Expecting two contract addresses");
         STATE = State::new(contract_a, contract_b);

--- a/examples/binaries/contract-template/src/lib.rs
+++ b/examples/binaries/contract-template/src/lib.rs
@@ -220,7 +220,7 @@ mod wasm {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn init() {
+    unsafe extern "C" fn init() {
         let programs: Vec<ActorId> =
             msg::load().expect("Malformed input: expecting vectors of program IDs and random IDs");
         STATE = State::new(programs);

--- a/examples/binaries/distributor/src/lib.rs
+++ b/examples/binaries/distributor/src/lib.rs
@@ -17,7 +17,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(clippy::missing_safety_doc)]
 
 extern crate alloc;
 
@@ -203,19 +202,19 @@ mod wasm {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn handle() {
+    unsafe extern "C" fn handle() {
         debug!("Handling sequence started");
         gstd::message_loop(Program::handle_request());
         debug!("Handling sequence terminated");
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn handle_reply() {
+    unsafe extern "C" fn handle_reply() {
         gstd::record_reply();
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn init() {
+    unsafe extern "C" fn init() {
         STATE = Some(ProgramState::default());
         msg::reply((), 0).unwrap();
         debug!("Program initialized");

--- a/examples/binaries/exit-handle/src/lib.rs
+++ b/examples/binaries/exit-handle/src/lib.rs
@@ -14,12 +14,12 @@ mod wasm {
     use gstd::{exec, msg};
 
     #[no_mangle]
-    pub unsafe extern "C" fn handle() {
+    unsafe extern "C" fn handle() {
         exec::exit(msg::source());
         // should not be executed
         msg::reply(b"reply", 0).unwrap();
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn init() {}
+    unsafe extern "C" fn init() {}
 }

--- a/examples/binaries/exit-init/src/lib.rs
+++ b/examples/binaries/exit-init/src/lib.rs
@@ -15,10 +15,10 @@ mod wasm {
     use gstd::{exec, msg};
 
     #[no_mangle]
-    pub unsafe extern "C" fn handle() {}
+    unsafe extern "C" fn handle() {}
 
     #[no_mangle]
-    pub unsafe extern "C" fn init() {
+    unsafe extern "C" fn init() {
         let shall_reply_before_exit: bool = {
             let mut flag = [0u8];
             load(&mut flag);

--- a/examples/binaries/gas-burned/src/lib.rs
+++ b/examples/binaries/gas-burned/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(clippy::missing_safety_doc)]
 
 extern crate alloc;
 
@@ -10,7 +9,7 @@ const SHORT: usize = 100;
 const LONG: usize = 10000;
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let mut v = vec![0; SHORT];
     for (i, item) in v.iter_mut().enumerate() {
         *item = i * i;
@@ -19,7 +18,7 @@ pub unsafe extern "C" fn init() {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let mut v = vec![0; LONG];
     for (i, item) in v.iter_mut().enumerate() {
         *item = i * i;

--- a/examples/binaries/init-wait/src/code.rs
+++ b/examples/binaries/init-wait/src/code.rs
@@ -12,7 +12,7 @@ static mut INIT_MESSAGE: MessageId = MessageId::new([0; 32]);
 static mut TEST_DYNAMIC_MEMORY: BTreeMap<u32, ()> = BTreeMap::new();
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     if STATE != State::Inited {
         panic!("not initialized");
     }
@@ -21,7 +21,7 @@ pub unsafe extern "C" fn handle() {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     match STATE {
         State::NotInited => {
             for k in 0..20 {
@@ -48,7 +48,7 @@ pub unsafe extern "C" fn init() {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn handle_reply() {
+unsafe extern "C" fn handle_reply() {
     if STATE == State::WaitForReply {
         for k in 20..40 {
             TEST_DYNAMIC_MEMORY.insert(k, ());

--- a/examples/binaries/init-with-value/src/lib.rs
+++ b/examples/binaries/init-with-value/src/lib.rs
@@ -56,7 +56,7 @@ mod wasm {
         hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a");
 
     #[no_mangle]
-    pub unsafe extern "C" fn init() {
+    unsafe extern "C" fn init() {
         let data: gstd::Vec<SendMessage> = msg::load().expect("provided invalid payload");
         let init = |wgas: bool, value: u128| {
             let submitted_code = CHILD_CODE_HASH.into();

--- a/examples/binaries/mul-by-const/src/lib.rs
+++ b/examples/binaries/mul-by-const/src/lib.rs
@@ -69,14 +69,14 @@ mod wasm {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn handle() {
+    unsafe extern "C" fn handle() {
         let x: u64 = msg::load().expect("Expecting a u64 number");
 
         msg::reply(STATE.unchecked_mul(x), 0).unwrap();
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn init() {
+    unsafe extern "C" fn init() {
         let val: u64 = msg::load().expect("Expecting a u64 number");
         STATE = State::new(val);
         DEBUG = DebugInfo {

--- a/examples/binaries/ncompose/src/lib.rs
+++ b/examples/binaries/ncompose/src/lib.rs
@@ -160,7 +160,7 @@ mod wasm {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn init() {
+    unsafe extern "C" fn init() {
         let (actor, max_iter): (ActorId, u16) =
             msg::load().expect("Malformed input: expecting a program ID and a number");
         STATE = State::new(max_iter, actor);

--- a/examples/binaries/node/src/lib.rs
+++ b/examples/binaries/node/src/lib.rs
@@ -18,7 +18,6 @@
 
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(clippy::missing_safety_doc)]
 
 extern crate alloc;
 
@@ -85,7 +84,7 @@ struct NodeState {
 static mut STATE: Option<NodeState> = None;
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let reply = match msg::load() {
         Ok(request) => process(request),
         Err(e) => {
@@ -245,7 +244,7 @@ fn process(request: Request) -> Reply {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn handle_reply() {
+unsafe extern "C" fn handle_reply() {
     if let Some(ref mut transition) = state().transition {
         if msg::reply_to() != transition.last_sent_message_id {
             return;
@@ -272,7 +271,7 @@ pub unsafe extern "C" fn handle_reply() {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let init: Initialization = msg::load().expect("Failed to decode init");
 
     STATE = Some(NodeState {

--- a/examples/binaries/program-factory/src/lib.rs
+++ b/examples/binaries/program-factory/src/lib.rs
@@ -56,12 +56,12 @@ mod wasm {
     static mut ORIGIN: Option<ActorId> = None;
 
     #[no_mangle]
-    pub unsafe extern "C" fn init() {
+    unsafe extern "C" fn init() {
         ORIGIN = Some(msg::source());
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn handle() {
+    unsafe extern "C" fn handle() {
         match msg::load().expect("provided invalid payload") {
             CreateProgram::Default => {
                 let submitted_code = CHILD_CODE_HASH.into();
@@ -90,7 +90,7 @@ mod wasm {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn handle_reply() {
+    unsafe extern "C" fn handle_reply() {
         if msg::exit_code() != 0 {
             let origin = ORIGIN.clone().unwrap();
             msg::send_bytes(origin, [], 0).unwrap();

--- a/examples/binaries/proxy/src/lib.rs
+++ b/examples/binaries/proxy/src/lib.rs
@@ -48,12 +48,12 @@ mod wasm {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn handle() {
+    unsafe extern "C" fn handle() {
         msg::send(DESTINATION, b"proxied message", msg::value());
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn init() {
+    unsafe extern "C" fn init() {
         let args: InputArgs = msg::load().expect("Failed to decode `InputArgs'");
         DESTINATION = args.destination;
     }

--- a/examples/binaries/syscall-error/src/lib.rs
+++ b/examples/binaries/syscall-error/src/lib.rs
@@ -17,7 +17,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(clippy::missing_safety_doc)]
 
 use gstd::{msg, prelude::*, ActorId};
 
@@ -31,7 +30,7 @@ pub use code::WASM_BINARY_OPT as WASM_BINARY;
 use gstd::errors::{ContractError, ExtError, MessageError};
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let res = msg::send(ActorId::default(), "dummy", 250);
     assert_eq!(
         res,

--- a/examples/binaries/unchecked-mul/src/lib.rs
+++ b/examples/binaries/unchecked-mul/src/lib.rs
@@ -35,7 +35,7 @@ mod wasm {
     use gstd::{debug, exec, msg};
 
     #[no_mangle]
-    pub unsafe extern "C" fn handle() {
+    unsafe extern "C" fn handle() {
         let (x, y): (u64, u64) = msg::load().expect("Expected a pair of u64 numbers");
         let z: u64 = x.checked_mul(y).expect("Multiplication overflow");
         debug!(
@@ -47,7 +47,7 @@ mod wasm {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn init() {
+    unsafe extern "C" fn init() {
         msg::reply_bytes([], 0).unwrap();
     }
 }

--- a/examples/binaries/wait_wake/src/lib.rs
+++ b/examples/binaries/wait_wake/src/lib.rs
@@ -17,7 +17,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(clippy::missing_safety_doc)]
 
 extern crate alloc;
 
@@ -55,12 +54,12 @@ fn process_request(request: Request) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     msg::reply((), 0).unwrap();
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     if let Some(reply) = ECHOES.get_or_insert_with(BTreeMap::new).remove(&msg::id()) {
         msg::reply(reply, 0).unwrap();
     } else {
@@ -69,7 +68,7 @@ pub unsafe extern "C" fn handle() {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn handle_reply() {}
+unsafe extern "C" fn handle_reply() {}
 
 #[cfg(test)]
 mod tests {

--- a/examples/binaries/waiting-proxy/src/lib.rs
+++ b/examples/binaries/waiting-proxy/src/lib.rs
@@ -44,7 +44,7 @@ mod wasm {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn init() {
+    unsafe extern "C" fn init() {
         let dest: ActorId = msg::load().expect("Expecting a contract address");
         DESTINATION = dest;
         msg::reply((), 0);

--- a/examples/block-info/src/lib.rs
+++ b/examples/block-info/src/lib.rs
@@ -4,7 +4,7 @@ use core::time::Duration;
 use gstd::{debug, exec, msg, prelude::*};
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let payload = String::from_utf8(msg::load_bytes()).expect("Invalid message");
 
     let bt = Duration::from_millis(exec::block_timestamp());

--- a/examples/bot/src/lib.rs
+++ b/examples/bot/src/lib.rs
@@ -159,7 +159,7 @@ gstd::metadata! {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let reply = &HANDLER_MAP
         .get_mut(&msg::load_bytes())
         .and_then(|i| i.next());
@@ -169,7 +169,7 @@ pub unsafe extern "C" fn handle() {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let maybe_handlers: Result<Vec<Handler>, _> = msg::load();
 
     maybe_handlers

--- a/examples/capacitor/src/lib.rs
+++ b/examples/capacitor/src/lib.rs
@@ -10,7 +10,7 @@ static mut LIMIT: u32 = 0;
 static mut DISCHARGE_HISTORY: Vec<u32> = Vec::new();
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let new_msg = String::from_utf8(msg::load_bytes()).expect("Invalid message: should be utf-8");
 
     let to_add = u32::from_str(new_msg.as_ref()).expect("Invalid number");
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn handle() {
 // End of demo
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let initstr = String::from_utf8(msg::load_bytes()).expect("Invalid message: should be utf-8");
     let limit = u32::from_str(initstr.as_ref()).expect("Invalid number");
 

--- a/examples/chat/bot/src/lib.rs
+++ b/examples/chat/bot/src/lib.rs
@@ -30,7 +30,7 @@ impl State {
 static mut STATE: State = State { name: "" };
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     bot(msg::load().expect("Failed to decode incoming message"));
 }
 
@@ -59,7 +59,7 @@ fn bot(message: MemberMessage) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let input = String::from_utf8(msg::load_bytes()).expect("Invalid message: should be utf-8");
 
     let split = input.split(' ').collect::<Vec<_>>();

--- a/examples/chat/room/src/lib.rs
+++ b/examples/chat/room/src/lib.rs
@@ -32,7 +32,7 @@ static mut STATE: State = State {
 };
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     room(msg::load().expect("Failed to decode incoming message"));
 }
 
@@ -73,7 +73,7 @@ unsafe fn room(room_msg: RoomMessage) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let s: &'static str = Box::leak(
         String::from_utf8(msg::load_bytes())
             .expect("Invalid message: should be utf-8")

--- a/examples/collector/src/lib.rs
+++ b/examples/collector/src/lib.rs
@@ -11,7 +11,7 @@ static mut MY_COLLECTION: BTreeMap<usize, String> = BTreeMap::new();
 static mut COUNTER: usize = 0;
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let new_msg = String::from_utf8(msg::load_bytes()).expect("Invalid message: should be utf-8");
     if new_msg == "log" {
         let collapsed = mem::take(&mut MY_COLLECTION)

--- a/examples/create-program/src/lib.rs
+++ b/examples/create-program/src/lib.rs
@@ -16,7 +16,7 @@ static mut COUNTER: i32 = 0;
 /// )"#;
 /// ```
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let command = String::from_utf8(msg::load_bytes()).expect("Unable to decode string");
     let submitted_code: CodeHash =
         hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a")

--- a/examples/decoder/src/lib.rs
+++ b/examples/decoder/src/lib.rs
@@ -3,7 +3,7 @@
 use gstd::{msg, prelude::*};
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let new_msg =
         String::from_utf8(gstd::msg::load_bytes()).expect("Invalid message: should be utf-8");
 

--- a/examples/exit-code/src/lib.rs
+++ b/examples/exit-code/src/lib.rs
@@ -9,9 +9,9 @@ static mut HOST: ActorId = ActorId::new([0u8; 32]);
 // cause we can't receive reply on message if we never send it.
 // For this demo in real conditions handle_reply is unreachable.
 #[no_mangle]
-pub unsafe extern "C" fn handle() {}
+unsafe extern "C" fn handle() {}
 
 #[no_mangle]
-pub unsafe extern "C" fn handle_reply() {
+unsafe extern "C" fn handle_reply() {
     msg::send_bytes(HOST, msg::exit_code().to_string(), 0).unwrap();
 }

--- a/examples/fib/src/lib.rs
+++ b/examples/fib/src/lib.rs
@@ -14,7 +14,7 @@ fn make_fib(n: usize) -> Vec<i32> {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let new_msg: i32 = msg::load().expect("Should be i32");
     MESSAGE_LOG.push(format!("New msg: {:?}", new_msg));
     debug!("fib gas_available: {}", exec::gas_available());

--- a/examples/fungible-token/src/lib.rs
+++ b/examples/fungible-token/src/lib.rs
@@ -236,7 +236,7 @@ gstd::metadata! {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let action: Action = msg::load().expect("Could not load Action");
 
     match action {
@@ -278,7 +278,7 @@ pub unsafe extern "C" fn handle() {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let config: InitConfig = msg::load().expect("Unable to decode InitConfig");
     debug!("FUNGIBLE_TOKEN {:?}", config);
     FUNGIBLE_TOKEN.set_name(config.name);

--- a/examples/futures-unordered/src/lib.rs
+++ b/examples/futures-unordered/src/lib.rs
@@ -10,7 +10,7 @@ static mut DEMO_ASYNC: ActorId = ActorId::new([0u8; 32]);
 static mut DEMO_PING: ActorId = ActorId::new([0u8; 32]);
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let input = String::from_utf8(msg::load_bytes()).expect("Invalid message: should be utf-8");
     let dests: Vec<&str> = input.split(',').collect();
     if dests.len() != 2 {

--- a/examples/guestbook/src/lib.rs
+++ b/examples/guestbook/src/lib.rs
@@ -26,7 +26,7 @@ gstd::metadata! {
 static mut MESSAGES: Vec<MessageIn> = Vec::new();
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let action: Action = msg::load().unwrap();
 
     match action {

--- a/examples/gui-test/src/lib.rs
+++ b/examples/gui-test/src/lib.rs
@@ -36,7 +36,7 @@ gstd::metadata! {
 type InitIncoming = Action<AStruct, Option<CustomStruct<u8>>, BTreeMap<String, u8>>;
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let incoming: InitIncoming = msg::load().expect("Unable to decode payload");
 
     let outgoing: Result<u8, Option<String>> = match incoming {
@@ -62,7 +62,7 @@ pub unsafe extern "C" fn init() {
 type HandleIncoming = (BTreeMap<String, u8>, Option<(Option<u8>, u128, [u8; 3])>);
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let incoming: HandleIncoming = msg::load().expect("Unable to decode payload");
 
     let outgoing = match incoming {

--- a/examples/incomplete_async_payloads/src/lib.rs
+++ b/examples/incomplete_async_payloads/src/lib.rs
@@ -82,7 +82,7 @@ fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let input = String::from_utf8(msg::load_bytes()).expect("Invalid message: should be utf-8");
     DEMO_PING =
         ActorId::from_slice(&decode_hex(&input).expect("INTIALIZATION FAILED: INVALID PROGRAM ID"))

--- a/examples/mem/src/lib.rs
+++ b/examples/mem/src/lib.rs
@@ -4,7 +4,7 @@ use gcore::msg;
 use gstd::prelude::*;
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let data = vec![0u8; 32768];
     msg::reply(&data, 0).unwrap();
     panic!()

--- a/examples/meta/src/lib.rs
+++ b/examples/meta/src/lib.rs
@@ -116,7 +116,7 @@ gstd::metadata! {
 static mut WALLETS: Vec<Wallet> = Vec::new();
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let message_in: MessageIn = msg::load().unwrap();
     let message_out: MessageOut = message_in.into();
 
@@ -124,7 +124,7 @@ pub unsafe extern "C" fn handle() {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     WALLETS.push(Wallet {
         id: Id {
             decimal: 1,
@@ -153,7 +153,7 @@ pub unsafe extern "C" fn init() {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn meta_state() -> *mut [i32; 2] {
+unsafe extern "C" fn meta_state() -> *mut [i32; 2] {
     let person: Option<Id> = msg::load().expect("failed to decode input argument");
     let encoded = match person {
         None => WALLETS.encode(),

--- a/examples/minimal/src/lib.rs
+++ b/examples/minimal/src/lib.rs
@@ -3,6 +3,6 @@
 use gstd::msg;
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     msg::reply(b"Hello world!", 0).unwrap();
 }

--- a/examples/multiping/src/lib.rs
+++ b/examples/multiping/src/lib.rs
@@ -6,7 +6,7 @@ use gstd::prelude::*;
 static mut COUNTER: usize = 0;
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let new_msg =
         String::from_utf8(gstd::msg::load_bytes()).expect("Invalid message: should be utf-8");
 

--- a/examples/mutex/src/lib.rs
+++ b/examples/mutex/src/lib.rs
@@ -7,7 +7,7 @@ static mut PING_DEST: ActorId = ActorId::new([0u8; 32]);
 static MUTEX: Mutex<u32> = Mutex::new(0);
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let dest = String::from_utf8(msg::load_bytes()).expect("Invalid message: should be utf-8");
     PING_DEST = ActorId::from_slice(
         &decode_hex(dest.as_ref()).expect("INTIALIZATION FAILED: INVALID DEST PROGRAM ID"),

--- a/examples/panicker/src/lib.rs
+++ b/examples/panicker/src/lib.rs
@@ -3,7 +3,7 @@
 use gstd::debug;
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     debug!("Starting panicker handle");
     panic!("I just panic every time")
 }

--- a/examples/ping-gas/src/lib.rs
+++ b/examples/ping-gas/src/lib.rs
@@ -3,7 +3,7 @@
 use gstd::{debug, msg, prelude::*};
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     debug!("Hello from ping handle");
 
     let new_msg = String::from_utf8(msg::load_bytes()).expect("Invalid message");
@@ -22,6 +22,6 @@ pub unsafe extern "C" fn handle() {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     debug!("Hello from ping init");
 }

--- a/examples/ping/src/lib.rs
+++ b/examples/ping/src/lib.rs
@@ -9,7 +9,7 @@ use galloc::prelude::vec;
 use gcore::msg;
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let mut bytes = vec![0; msg::size()];
     msg::load(&mut bytes);
 

--- a/examples/program-id/src/lib.rs
+++ b/examples/program-id/src/lib.rs
@@ -3,7 +3,7 @@
 use gstd::{debug, exec, msg};
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     debug!("Starting program id");
     let program_id = exec::program_id();
     debug!("My program id: {:?}", program_id);

--- a/examples/program_generator/src/lib.rs
+++ b/examples/program_generator/src/lib.rs
@@ -16,7 +16,7 @@ fn salt_uniqueness_test() {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let submitted_code: CodeHash =
         hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a")
             .into();

--- a/examples/rwlock/src/lib.rs
+++ b/examples/rwlock/src/lib.rs
@@ -12,7 +12,7 @@ static mut PING_DEST: ActorId = ActorId::new([0u8; 32]);
 static RWLOCK: RwLock<u32> = RwLock::new(0);
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let dest = String::from_utf8(msg::load_bytes()).expect("Invalid message: should be utf-8");
     PING_DEST = ActorId::from_slice(&hex::decode(dest).expect("Invalid hex"))
         .expect("Unable to create ActorId");

--- a/examples/rwlock_write/src/lib.rs
+++ b/examples/rwlock_write/src/lib.rs
@@ -7,7 +7,7 @@ static mut PING_DEST: ActorId = ActorId::new([0u8; 32]);
 static RWLOCK: RwLock<u32> = RwLock::new(0);
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let dest = String::from_utf8(msg::load_bytes()).expect("Invalid message: should be utf-8");
     PING_DEST = ActorId::from_slice(
         &decode_hex(dest.as_ref()).expect("INTIALIZATION FAILED: INVALID DEST PROGRAM ID"),

--- a/examples/state_rollback/src/lib.rs
+++ b/examples/state_rollback/src/lib.rs
@@ -9,7 +9,7 @@ fn value() -> String {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     if let Ok(message) = String::from_utf8(msg::load_bytes()) {
         // prev value
         msg::send_bytes(msg::source(), value(), 0).unwrap();

--- a/examples/sum/src/lib.rs
+++ b/examples/sum/src/lib.rs
@@ -30,7 +30,7 @@ fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let new_msg: i32 = msg::load().expect("Should be i32");
     MESSAGE_LOG.push(format!("(sum) New msg: {:?}", new_msg));
     debug!("sum gas_available: {}", exec::gas_available());
@@ -45,7 +45,7 @@ pub unsafe extern "C" fn handle() {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let input = String::from_utf8(msg::load_bytes()).expect("Invalid message: should be utf-8");
     let send_to = ActorId::from_slice(
         &decode_hex(&input).expect("INITIALIZATION FAILED: INVALID PROGRAM ID"),

--- a/examples/sync_duplicate/src/lib.rs
+++ b/examples/sync_duplicate/src/lib.rs
@@ -6,7 +6,7 @@ static mut DEST: ActorId = ActorId::new([0u8; 32]);
 static mut COUNTER: usize = 0;
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let dest = String::from_utf8(msg::load_bytes()).expect("Invalid message: should be utf-8");
     DEST = ActorId::from_slice(&hex::decode(dest).expect("Invalid hex"))
         .expect("Unable to create ActorId");

--- a/examples/token-vendor/src/lib.rs
+++ b/examples/token-vendor/src/lib.rs
@@ -198,7 +198,7 @@ async fn main() {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     let config: InitConfig = msg::load().expect("Unable to decode InitConfig");
 
     debug!("Got InitConfig: {:?}", config);

--- a/examples/token-vendor/workshop-example/src/lib.rs
+++ b/examples/token-vendor/workshop-example/src/lib.rs
@@ -30,14 +30,14 @@ impl State {
 static mut STATE: State = State { user_id: None };
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     STATE.set_user_id(msg::source());
 
     debug!("CONTRACT: Inited successfully");
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let payload: String = msg::load().expect("CONTRACT: Unable to decode handle input");
 
     debug!("CONTRACT: Got payload: '{}'", payload);

--- a/examples/vec/src/lib.rs
+++ b/examples/vec/src/lib.rs
@@ -5,7 +5,7 @@ use gstd::{debug, msg, prelude::*};
 static mut MESSAGE_LOG: Vec<String> = vec![];
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     let new_msg: i32 = msg::load().expect("Should be i32");
     MESSAGE_LOG.push(format!("(vec) New msg: {:?}", new_msg));
     let v = vec![1u8; new_msg as usize];

--- a/examples/wait/src/lib.rs
+++ b/examples/wait/src/lib.rs
@@ -10,7 +10,7 @@ static mut MSG_ID_1: MessageId = MessageId([0; 32]);
 static mut MSG_ID_2: MessageId = MessageId([0; 32]);
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     gstd::debug!(STATE);
     match STATE {
         0 => {

--- a/gcore/src/exec.rs
+++ b/gcore/src/exec.rs
@@ -49,7 +49,7 @@ mod sys {
 /// use gcore::{exec, msg};
 ///
 /// // Send a reply after the block height reaches the number 1000
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     if exec::block_height() >= 1000 {
 ///         msg::reply(b"Block #1000 reached", 0).unwrap();
 ///     }
@@ -69,7 +69,7 @@ pub fn block_height() -> u32 {
 /// use gcore::{exec, msg};
 ///
 /// // Send a reply after the block timestamp reaches the February 22, 2022
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     if exec::block_timestamp() >= 1645488000000 {
 ///         msg::reply(b"The current block is generated after February 22, 2022", 0).unwrap();
 ///     }
@@ -90,7 +90,7 @@ pub fn block_timestamp() -> u64 {
 /// ```
 /// use gcore::{exec, msg};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     exec::exit(msg::source());
 /// }
@@ -113,7 +113,7 @@ pub fn exit(value_destination: ActorId) -> ! {
 /// use gcore::exec;
 ///
 /// // Perform work while `gas_available` is more than 1000
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     while exec::gas_available() > 1000 {
 ///         // ...
 ///     }
@@ -133,7 +133,7 @@ pub fn gas_available() -> u64 {
 /// ```
 /// use gcore::exec;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     exec::leave();
 /// }
@@ -153,7 +153,7 @@ pub fn leave() -> ! {
 /// use gcore::exec;
 ///
 /// // Get self value balance in program
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     let _my_balance = exec::value_available();
 /// }
 /// ```
@@ -179,7 +179,7 @@ pub fn value_available() -> u128 {
 /// ```
 /// use gcore::exec;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     exec::wait();
 /// }
@@ -200,7 +200,7 @@ pub fn wait() -> ! {
 /// ```
 /// use gcore::{exec, MessageId};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     exec::wake(MessageId::default());
 /// }
@@ -218,7 +218,7 @@ pub fn wake(waker_id: MessageId) {
 /// ```
 /// use gcore::{exec, ActorId};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let me = exec::program_id();
 /// }
@@ -237,7 +237,7 @@ pub fn program_id() -> ActorId {
 /// ```
 /// use gcore::{exec, ActorId};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let _user = exec::origin();
 /// }

--- a/gcore/src/general.rs
+++ b/gcore/src/general.rs
@@ -43,7 +43,7 @@
 /// ```
 /// use gcore::msg;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let msg_handle = msg::send_init();
 /// }
@@ -64,7 +64,7 @@ pub struct MessageHandle(pub u32);
 /// ```
 /// use gcore::msg;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     let current_message_id = msg::id();
 /// }
 /// ```
@@ -108,7 +108,7 @@ impl MessageId {
 /// ```
 /// use gcore::msg;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     let program_id = msg::source();
 /// }
 /// ```

--- a/gcore/src/msg.rs
+++ b/gcore/src/msg.rs
@@ -102,7 +102,7 @@ mod sys {
 /// ```
 /// use gcore::msg;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let exit_code = msg::exit_code();
 /// }
@@ -121,7 +121,7 @@ pub fn exit_code() -> i32 {
 /// ```
 /// use gcore::msg;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     let current_message_id = msg::id();
 /// }
 /// ```
@@ -141,7 +141,7 @@ pub fn id() -> MessageId {
 /// ```
 /// use gcore::msg;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     let mut result = vec![0u8; msg::size()];
 ///     msg::load(&mut result[..]);
 /// }
@@ -178,7 +178,7 @@ pub fn load(buffer: &mut [u8]) {
 /// ```
 /// use gcore::{exec, msg};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     msg::reply(b"PING", 0).unwrap();
 /// }
@@ -208,7 +208,7 @@ pub fn reply(payload: &[u8], value: u128) -> Result<MessageId> {
 /// ```
 /// use gcore::{exec, msg};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     msg::reply_with_gas(b"PING", 0, 0).unwrap();
 /// }
@@ -249,7 +249,7 @@ pub fn reply_with_gas(payload: &[u8], gas_limit: u64, value: u128) -> Result<Mes
 /// ```
 /// use gcore::{exec, msg};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     msg::reply_push(b"Part 1").unwrap();
 ///     // ...
@@ -281,7 +281,7 @@ pub fn reply_commit(value: u128) -> Result<MessageId> {
 /// ```
 /// use gcore::{exec, msg};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     msg::reply_push(b"Part 1").unwrap();
 ///     // ...
@@ -322,7 +322,7 @@ pub fn reply_commit_with_gas(gas_limit: u64, value: u128) -> Result<MessageId> {
 /// ```
 /// use gcore::msg;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     msg::reply_push(b"Part 1").unwrap();
 ///     // ...
@@ -345,7 +345,7 @@ pub fn reply_push(payload: &[u8]) -> Result<()> {
 /// ```
 /// use gcore::msg;
 ///
-/// pub unsafe extern "C" fn handle_reply() {
+/// unsafe extern "C" fn handle_reply() {
 ///     // ...
 ///     let orginal_message_id = msg::reply_to();
 /// }
@@ -377,7 +377,7 @@ pub fn reply_to() -> MessageId {
 /// ```
 /// use gcore::{msg, ActorId};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let mut id: [u8; 32] = [0; 32];
 ///     for i in 0..id.len() {
@@ -414,7 +414,7 @@ pub fn send(program: ActorId, payload: &[u8], value: u128) -> Result<MessageId> 
 /// ```
 /// use gcore::{msg, ActorId};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let mut id: [u8; 32] = [0; 32];
 ///     for i in 0..id.len() {
@@ -470,7 +470,7 @@ pub fn send_with_gas(
 /// ```
 /// use gcore::{exec, msg};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let msg_handle = msg::send_init().unwrap();
 ///     msg::send_push(&msg_handle, b"PING");
@@ -505,7 +505,7 @@ pub fn send_commit(handle: MessageHandle, program: ActorId, value: u128) -> Resu
 /// ```
 /// use gcore::{exec, msg};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let msg_handle = msg::send_init().unwrap();
 ///     msg::send_push(&msg_handle, b"PING");
@@ -550,7 +550,7 @@ pub fn send_commit_with_gas(
 /// ```
 /// use gcore::{exec, msg};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let msg_handle = msg::send_init().unwrap();
 ///     msg::send_push(&msg_handle, b"PING");
@@ -582,7 +582,7 @@ pub fn send_init() -> Result<MessageHandle> {
 /// ```
 /// use gcore::{exec, msg};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let msg_handle = msg::send_init().unwrap();
 ///     msg::send_push(&msg_handle, b"PING");
@@ -610,7 +610,7 @@ pub fn send_push(handle: &MessageHandle, payload: &[u8]) -> Result<()> {
 /// ```
 /// use gcore::msg;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let payload_size = msg::size();
 /// }
@@ -629,7 +629,7 @@ pub fn size() -> usize {
 /// ```
 /// use gcore::msg;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let who_sends_message = msg::source();
 /// }
@@ -650,7 +650,7 @@ pub fn source() -> ActorId {
 /// ```
 /// use gcore::msg;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let amount_sent_with_message = msg::value();
 /// }

--- a/gcore/src/prog.rs
+++ b/gcore/src/prog.rs
@@ -102,7 +102,7 @@ pub fn create_program(
 ///     unsafe { NONCE }
 /// }
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     let submitted_code: CodeHash =
 ///         hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a")
 ///             .into();
@@ -116,7 +116,7 @@ pub fn create_program(
 /// use gcore::{msg, prog};
 /// # use gcore::CodeHash;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     # let submitted_code: CodeHash = hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a").into();
 ///     let mut salt = vec![0u8; msg::size()];
 ///     msg::load(&mut salt[..]);
@@ -129,7 +129,7 @@ pub fn create_program(
 /// use gcore::{msg, prog};
 /// # use gcore::CodeHash;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     # let submitted_code: CodeHash = hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a").into();
 ///     # let mut salt = vec![0u8; msg::size()];
 ///     # msg::load(&mut salt[..]);

--- a/gstd/codegen/src/lib.rs
+++ b/gstd/codegen/src/lib.rs
@@ -75,7 +75,7 @@ fn generate_handle_reply_if_required(mut code: TokenStream) -> TokenStream {
     if !reply_generated {
         let handle_reply: TokenStream = quote!(
             #[no_mangle]
-            pub unsafe extern "C" fn handle_reply() {
+            unsafe extern "C" fn handle_reply() {
                 gstd::record_reply();
             }
         )
@@ -114,7 +114,7 @@ pub fn async_main(_attr: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         #[no_mangle]
-        pub unsafe extern "C" fn handle() {
+        unsafe extern "C" fn handle() {
             __main_safe();
         }
     )
@@ -146,7 +146,7 @@ pub fn async_init(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let body = &function.block;
     let code: TokenStream = quote!(
         #[no_mangle]
-        pub unsafe extern "C" fn init() {
+        unsafe extern "C" fn init() {
             gstd::message_loop(async #body);
         }
     )

--- a/gstd/src/exec.rs
+++ b/gstd/src/exec.rs
@@ -43,7 +43,7 @@
 //! use gstd::{exec, msg};
 //!
 //! // Send a reply after the block height reaches the number 1000
-//! pub unsafe extern "C" fn handle() {
+//! unsafe extern "C" fn handle() {
 //!     if exec::block_height() >= 1000 {
 //!         msg::reply(b"Block #1000 reached", 0).unwrap();
 //!     }
@@ -53,7 +53,7 @@
 //! use gstd::{exec, msg};
 //!
 //! // Send a reply after the block timestamp reaches the February 22, 2022
-//! pub unsafe extern "C" fn handle() {
+//! unsafe extern "C" fn handle() {
 //!     if exec::block_timestamp() >= 1645488000000 {
 //!         msg::reply(b"The current block is generated after February 22, 2022", 0).unwrap();
 //!     }
@@ -63,7 +63,7 @@
 //! use gstd::exec;
 //!
 //! // Perform work while `gas_available` is more than 1000
-//! pub unsafe extern "C" fn handle() {
+//! unsafe extern "C" fn handle() {
 //!     while exec::gas_available() > 1000 {
 //!         // ...
 //!     }
@@ -73,7 +73,7 @@
 //! use gstd::exec;
 //!
 //! // Get self value balance in program
-//! pub unsafe extern "C" fn handle() {
+//! unsafe extern "C" fn handle() {
 //!     let _my_balance = exec::value_available();
 //! }
 //! ```
@@ -91,7 +91,7 @@ pub use gcore::exec::{block_height, block_timestamp, gas_available, value_availa
 /// ```
 /// use gstd::{exec, msg};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     exec::exit(msg::source());
 /// }
@@ -110,7 +110,7 @@ pub fn exit(value_destination: ActorId) -> ! {
 /// ```
 /// use gstd::exec;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     exec::leave();
 /// }
@@ -133,7 +133,7 @@ pub fn leave() -> ! {
 /// ```
 /// use gstd::exec;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     exec::wait();
 /// }
@@ -154,7 +154,7 @@ pub fn wait() -> ! {
 /// ```
 /// use gstd::{exec, msg};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let msg_id = msg::id();
 ///     exec::wake(msg_id);
@@ -171,7 +171,7 @@ pub fn wake(waker_id: MessageId) {
 /// ```
 /// use gstd::{exec, ActorId};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let me = exec::program_id();
 /// }
@@ -188,7 +188,7 @@ pub fn program_id() -> ActorId {
 /// ```
 /// use gstd::{exec, ActorId};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let _user = exec::origin();
 /// }

--- a/gstd/src/macros/export.rs
+++ b/gstd/src/macros/export.rs
@@ -24,7 +24,7 @@
 macro_rules! export {
     ($f:ident -> $val:expr) => {
         #[no_mangle]
-        pub unsafe extern "C" fn $f() -> *mut [i32; 2] {
+        unsafe extern "C" fn $f() -> *mut [i32; 2] {
             let buffer = $val.to_string();
             let result = $crate::util::to_wasm_ptr(buffer.as_bytes());
             core::mem::forget(buffer);

--- a/gstd/src/msg/basic.rs
+++ b/gstd/src/msg/basic.rs
@@ -74,7 +74,7 @@ where
 /// ```
 /// use gstd::msg;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let msg_handle = msg::send_init();
 /// }
@@ -139,7 +139,7 @@ impl From<gcore::MessageHandle> for MessageHandle {
 /// ```
 /// use gstd::msg;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let exit_code = msg::exit_code();
 /// }
@@ -158,7 +158,7 @@ pub fn exit_code() -> i32 {
 /// ```
 /// use gstd::msg;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     let current_message_id = msg::id();
 /// }
 /// ```
@@ -176,7 +176,7 @@ pub fn id() -> MessageId {
 /// ```
 /// use gstd::msg;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     let payload_bytes = msg::load_bytes();
 /// }
 /// ```
@@ -210,7 +210,7 @@ pub fn load_bytes() -> Vec<u8> {
 /// ```
 /// use gcore::{exec, msg};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     msg::reply_with_gas(b"PING", 0, 0).unwrap();
 /// }
@@ -257,7 +257,7 @@ pub fn reply_bytes_with_gas(
 /// ```
 /// use gstd::{exec, msg};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     msg::reply_push(b"Part 1").unwrap();
 ///     // ...
@@ -282,7 +282,7 @@ pub fn reply_commit(value: u128) -> Result<MessageId> {
 /// ```
 /// use gstd::{exec, msg};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     msg::reply_push(b"Part 1").unwrap();
 ///     // ...
@@ -315,7 +315,7 @@ pub fn reply_commit_with_gas(gas_limit: u64, value: u128) -> Result<MessageId> {
 /// ```
 /// use gstd::msg;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     msg::reply_push(b"Part 1").unwrap();
 ///     // ...
@@ -338,7 +338,7 @@ pub fn reply_push<T: AsRef<[u8]>>(payload: T) -> Result<()> {
 /// ```
 /// use gstd::msg;
 ///
-/// pub unsafe extern "C" fn handle_reply() {
+/// unsafe extern "C" fn handle_reply() {
 ///     // ...
 ///     let original_message_id = msg::reply_to();
 /// }
@@ -369,7 +369,7 @@ pub fn reply_to() -> MessageId {
 /// ```
 /// use gstd::{msg, ActorId};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let id = msg::source();
 ///
@@ -393,7 +393,7 @@ pub fn send_bytes<T: AsRef<[u8]>>(program: ActorId, payload: T, value: u128) -> 
 /// ```
 /// use gstd::{msg, ActorId};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let id = msg::source();
 ///
@@ -434,7 +434,7 @@ pub fn send_bytes_with_gas<T: AsRef<[u8]>>(
 /// ```
 /// use gstd::{exec, msg};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let msg_handle = msg::send_init();
 ///     msg::send_push(&msg_handle, b"PING");
@@ -460,7 +460,7 @@ pub fn send_commit(handle: MessageHandle, program: ActorId, value: u128) -> Resu
 /// ```
 /// use gstd::{exec, msg};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let msg_handle = msg::send_init();
 ///     msg::send_push(&msg_handle, b"PING");
@@ -496,7 +496,7 @@ pub fn send_commit_with_gas(
 /// ```
 /// use gstd::{exec, msg};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let msg_handle = msg::send_init();
 ///     msg::send_push(&msg_handle, b"PING");
@@ -524,7 +524,7 @@ pub fn send_init() -> Result<MessageHandle> {
 /// ```
 /// use gstd::{exec, msg};
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let msg_handle = msg::send_init();
 ///     msg::send_push(&msg_handle, b"PING");
@@ -552,7 +552,7 @@ pub fn send_push<T: AsRef<[u8]>>(handle: &MessageHandle, payload: T) -> Result<(
 /// ```
 /// use gstd::msg;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let payload_size = msg::size();
 /// }
@@ -571,7 +571,7 @@ pub fn size() -> usize {
 /// ```
 /// use gstd::msg;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let who_sends_message = msg::source();
 /// }
@@ -590,7 +590,7 @@ pub fn source() -> ActorId {
 /// ```
 /// use gstd::msg;
 ///
-/// pub unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle() {
 ///     // ...
 ///     let amount_sent_with_message = msg::value();
 /// }

--- a/scripts/src/clippy.sh
+++ b/scripts/src/clippy.sh
@@ -27,7 +27,6 @@ gear_clippy() {
 examples_clippy() {
   cd "$1"/examples
   SKIP_WASM_BUILD=1 cargo +nightly hack clippy --workspace --release -- --no-deps \
-    -A clippy::missing_safety_doc \
 	  -A clippy::stable_sort_primitive \
     -D warnings
   cd "$1"

--- a/utils/wasm-builder/test-program/src/lib.rs
+++ b/utils/wasm-builder/test-program/src/lib.rs
@@ -3,13 +3,13 @@
 use gstd::{debug, msg};
 
 #[no_mangle]
-pub unsafe extern "C" fn handle() {
+unsafe extern "C" fn handle() {
     debug!("handle()");
     msg::reply_bytes("Hello world!", 0).unwrap();
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn init() {
+unsafe extern "C" fn init() {
     debug!("init()");
 }
 


### PR DESCRIPTION
No need to declare `extern` functions as `pub`. This avoids adding these functions to generated documentation and suppresses `missing_safety_doc` clippy warnings.

@gear-tech/dev 
