### PR TITLE
remove `encoder` bin from `demo-chat`

### DIFF
--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -7,7 +7,3 @@ license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive"] }
-
-[[bin]]
-name = "encoder"
-path = "src/encode.rs"


### PR DESCRIPTION
Needed to update CI cache without `encoder.wasm`

@gear-tech/dev 
