### PR TITLE
rtest: Don't process queue if not all messages have been sent

### DIFF
--- a/utils/gear-runtime-test-cli/src/util.rs
+++ b/utils/gear-runtime-test-cli/src/util.rs
@@ -35,7 +35,7 @@ pub fn get_dispatch_queue() -> Vec<StoredDispatch> {
 
 pub fn process_queue(snapshots: &mut Vec<DebugData>, mailbox: &mut Vec<StoredMessage>) {
     while !QueueOf::<Runtime>::is_empty() {
-        run_to_block(System::block_number() + 1, None);
+        run_to_block(System::block_number() + 1, None, false);
         // Parse data from events
         for event in System::events() {
             if let gear_runtime::Event::GearDebug(pallet_gear_debug::Event::DebugDataSnapshot(
@@ -76,7 +76,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
     ext
 }
 
-pub fn run_to_block(n: u32, remaining_weight: Option<u64>) {
+pub fn run_to_block(n: u32, remaining_weight: Option<u64>, skip_process_queue: bool) {
     while System::block_number() < n {
         System::on_finalize(System::block_number());
         System::set_block_number(System::block_number() + 1);
@@ -86,6 +86,10 @@ pub fn run_to_block(n: u32, remaining_weight: Option<u64>) {
         Gear::on_initialize(System::block_number());
         let remaining_weight =
             remaining_weight.unwrap_or_else(<Runtime as pallet_gas::Config>::BlockGasLimit::get);
-        Gear::on_idle(System::block_number(), remaining_weight);
+        if skip_process_queue {
+            Gas::update_gas_allowance(remaining_weight);
+        } else {
+            Gear::on_idle(System::block_number(), remaining_weight);
+        }
     }
 }


### PR DESCRIPTION
Resolves #1105 .

Do not process the queue if not all fixture messages have been sent.
Now all messages can be sent with the maximum gas_limit.

@reviewer-or-team
