### PR TITLE
gtest: Add capability to check actors balances

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -428,6 +428,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "demo-piggy-bank"
+version = "0.1.0"
+dependencies = [
+ "gstd",
+]
+
+[[package]]
 name = "demo-ping"
 version = "0.1.0"
 dependencies = [

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "multiping",
     "mutex",
     "panicker",
+    "piggy-bank",
     "ping",
     "ping-gas",
     "program_generator",

--- a/examples/piggy-bank/Cargo.toml
+++ b/examples/piggy-bank/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "demo-piggy-bank"
+version = "0.1.0"
+authors = ["Gear Technologies"]
+edition = "2021"
+license = "GPL-3.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+gstd = { path = "../../gstd", features = ["debug"] }

--- a/examples/piggy-bank/src/lib.rs
+++ b/examples/piggy-bank/src/lib.rs
@@ -1,0 +1,19 @@
+#![no_std]
+
+use gstd::{debug, exec, msg};
+
+#[no_mangle]
+unsafe extern "C" fn handle() {
+    match &msg::load_bytes()[..] {
+        b"insert" => debug!(
+            "inserted: {}, total: {}",
+            msg::value(),
+            exec::value_available()
+        ),
+        b"smash" => {
+            debug!("smashing, total: {}", exec::value_available());
+            msg::send_bytes(msg::source(), b"send", exec::value_available()).unwrap();
+        }
+        _ => (),
+    }
+}

--- a/examples/piggy-bank/src/lib.rs
+++ b/examples/piggy-bank/src/lib.rs
@@ -4,16 +4,11 @@ use gstd::{debug, exec, msg};
 
 #[no_mangle]
 unsafe extern "C" fn handle() {
-    match &msg::load_bytes()[..] {
-        b"insert" => debug!(
-            "inserted: {}, total: {}",
-            msg::value(),
-            exec::value_available()
-        ),
-        b"smash" => {
-            debug!("smashing, total: {}", exec::value_available());
-            msg::send_bytes(msg::source(), b"send", exec::value_available()).unwrap();
-        }
-        _ => (),
+    let available_value = exec::value_available();
+    debug!("inserted: {}, total: {}", msg::value(), available_value);
+
+    if msg::load_bytes() == b"smash" {
+        debug!("smashing, total: {}", available_value);
+        msg::reply_bytes(b"send", available_value).unwrap();
     }
 }

--- a/gtest/src/log.rs
+++ b/gtest/src/log.rs
@@ -253,7 +253,7 @@ impl RunResult {
         self.log.iter().any(|e| e == &log)
     }
 
-    pub fn log(&self) -> &Vec<CoreLog> {
+    pub fn log(&self) -> &[CoreLog] {
         &self.log
     }
 

--- a/gtest/src/mailbox.rs
+++ b/gtest/src/mailbox.rs
@@ -292,29 +292,30 @@ mod tests {
     #[test]
     #[should_panic(expected = "No message that satisfies log")]
     fn take_unknown_log_message() {
-        //Arranging data for future messages
+        // Arranging data for future messages
         let system = System::new();
-        let source_user_id = ProgramIdWrapper::from(100).0;
-        let destination_user_id = ProgramIdWrapper::from(200).0;
+        let source_user_id = 100;
+        let destination_user_id = 200;
         let log = Log::builder().source(source_user_id);
 
-        //Taking mailbox and message that doesn't exists
+        // Taking mailbox and message that doesn't exists
         let mailbox = system.get_mailbox(destination_user_id);
         mailbox.take_message(log);
     }
 
     #[test]
-    #[should_panic(expected = "Such program id is already in actors list")]
+    #[should_panic(expected = "Mailbox available only for users")]
     fn take_programs_mailbox() {
-        //Setting up variables for test
+        // Setting up variables for test
         let system = System::new();
-        let restricted_user_id = ProgramIdWrapper::from(1).0;
-        Program::from_file(
+        let restricted_user_id = 42;
+        Program::from_file_with_id(
             &system,
+            restricted_user_id,
             "../target/wasm32-unknown-unknown/release/demo_futures_unordered.wasm",
         );
 
-        //Getting user id that is already registered as a program
+        // Getting user id that is already registered as a program
         system.get_mailbox(restricted_user_id);
     }
 }

--- a/gtest/src/mailbox.rs
+++ b/gtest/src/mailbox.rs
@@ -351,7 +351,7 @@ mod tests {
         system.send_dispatch(Dispatch::new(DispatchKind::Handle, message));
 
         let receiver_mailbox = system.get_mailbox(receiver_id);
-        receiver_mailbox.claim_value(log.clone());
+        receiver_mailbox.claim_value(log);
 
         assert_eq!(system.balance_of(receiver_id), 1000);
     }

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -322,13 +322,16 @@ impl ExtManager {
         !self.actors.contains_key(id) || matches!(self.actors.get(id), Some((Actor::User, _)))
     }
 
-    pub(crate) fn add_value_to(&mut self, id: &ProgramId, value: Balance) {
+    pub(crate) fn mint_to(&mut self, id: &ProgramId, value: Balance) {
         let (_, balance) = self.actors.entry(*id).or_insert((Actor::User, 0));
         *balance = balance.saturating_add(value);
     }
 
-    pub(crate) fn actor_balance(&self, id: &ProgramId) -> Option<Balance> {
-        self.actors.get(id).map(|(_, balance)| *balance)
+    pub(crate) fn balance_of(&self, id: &ProgramId) -> Balance {
+        self.actors
+            .get(id)
+            .map(|(_, balance)| *balance)
+            .unwrap_or_default()
     }
 
     pub(crate) fn claim_value_from_mailbox(&mut self, id: &ProgramId) {
@@ -584,7 +587,7 @@ impl JournalHandler for ExtManager {
 
     fn exit_dispatch(&mut self, id_exited: ProgramId, value_destination: ProgramId) {
         if let Some((_, balance)) = self.actors.remove(&id_exited) {
-            self.add_value_to(&value_destination, balance);
+            self.mint_to(&value_destination, balance);
         }
     }
 
@@ -679,7 +682,7 @@ impl JournalHandler for ExtManager {
                 *balance -= value;
             };
 
-            self.add_value_to(to, value);
+            self.mint_to(to, value);
         }
     }
 

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -23,7 +23,6 @@ use crate::{
     Result,
 };
 use codec::{Codec, Decode, Encode};
-use core::ops::Deref;
 use gear_core::{
     code::{Code, CodeAndId, InstrumentedCodeAndId},
     ids::{CodeId, MessageId, ProgramId},
@@ -141,20 +140,6 @@ impl From<&str> for ProgramIdWrapper {
         }
 
         Self(bytes.into())
-    }
-}
-
-impl Deref for ProgramIdWrapper {
-    type Target = ProgramId;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl AsRef<ProgramId> for ProgramIdWrapper {
-    fn as_ref(&self) -> &ProgramId {
-        &self.0
     }
 }
 

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -18,11 +18,12 @@
 
 use crate::{
     log::RunResult,
-    manager::{Actor, ExtManager, Program as InnerProgram},
+    manager::{Actor, Balance, ExtManager, Program as InnerProgram},
     system::System,
     Result,
 };
 use codec::{Codec, Decode, Encode};
+use core::ops::Deref;
 use gear_core::{
     code::{Code, CodeAndId, InstrumentedCodeAndId},
     ids::{CodeId, MessageId, ProgramId},
@@ -140,6 +141,20 @@ impl From<&str> for ProgramIdWrapper {
         }
 
         Self(bytes.into())
+    }
+}
+
+impl Deref for ProgramIdWrapper {
+    type Target = ProgramId;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<ProgramId> for ProgramIdWrapper {
+    fn as_ref(&self) -> &ProgramId {
+        &self.0
     }
 }
 
@@ -356,7 +371,7 @@ impl<'a> Program<'a> {
 
         let source = from.into().0;
 
-        if system.actors.contains_key(&source) {
+        if !system.is_user(&source) {
             panic!("Sending messages allowed only from users id");
         }
 
@@ -423,6 +438,14 @@ impl<'a> Program<'a> {
             .call_meta(&self.id, None, "meta_state")
     }
 
+    pub fn add_value(&mut self, value: Balance) {
+        self.manager.borrow_mut().add_value_to(&self.id(), value)
+    }
+
+    pub fn balance(&self) -> Option<Balance> {
+        self.manager.borrow().actor_balance(&self.id())
+    }
+
     fn wasm_path(extension: &str) -> PathBuf {
         let current_dir = env::current_dir().expect("Unable to get current dir");
         let path_file = current_dir.join(".binpath");
@@ -465,5 +488,74 @@ mod tests {
 
         assert!(!run_result.main_failed());
         assert!(run_result.contains(&expected_log));
+    }
+
+    #[test]
+    fn simple_balance() {
+        let sys = System::new();
+        sys.init_logger();
+
+        let user_id = 42;
+        sys.add_value_to(user_id, 5000);
+        assert_eq!(sys.actor_balance(user_id), Some(5000));
+
+        let mut prog = Program::from_file(
+            &sys,
+            "../target/wasm32-unknown-unknown/release/demo_ping.wasm",
+        );
+
+        prog.add_value(1000);
+        assert_eq!(prog.balance(), Some(1000));
+
+        prog.send_with_value(user_id, "init".to_string(), 500);
+        assert_eq!(prog.balance(), Some(1500));
+        assert_eq!(sys.actor_balance(user_id), Some(4500));
+
+        prog.send_with_value(user_id, "PING".to_string(), 1000);
+        assert_eq!(prog.balance(), Some(2500));
+        assert_eq!(sys.actor_balance(user_id), Some(3500));
+    }
+
+    #[test]
+    fn piggy_bank() {
+        let sys = System::new();
+        sys.init_logger();
+
+        let receiver = 42;
+        let sender0 = 43;
+        let sender1 = 44;
+        let sender2 = 45;
+
+        // Top-up senders balances
+        sys.add_value_to(sender0, 10000);
+        sys.add_value_to(sender1, 10000);
+        sys.add_value_to(sender2, 10000);
+
+        let prog = Program::from_file(
+            &sys,
+            "../target/wasm32-unknown-unknown/release/demo_piggy_bank.wasm",
+        );
+
+        prog.send_bytes(receiver, b"init");
+        assert_eq!(prog.balance(), Some(0));
+
+        // Send values to the program
+        prog.send_bytes_with_value(sender0, b"insert", 1000);
+        assert_eq!(sys.actor_balance(sender0), Some(9000));
+        prog.send_bytes_with_value(sender1, b"insert", 2000);
+        assert_eq!(sys.actor_balance(sender1), Some(8000));
+        prog.send_bytes_with_value(sender2, b"insert", 3000);
+        assert_eq!(sys.actor_balance(sender2), Some(7000));
+
+        // Check program's balance
+        assert_eq!(prog.balance(), Some(1000 + 2000 + 3000));
+
+        // Request to smash the piggy bank and send the value to the receiver address
+        prog.send_bytes(receiver, b"smash");
+        sys.claim_value_from_mailbox(receiver);
+        assert_eq!(sys.actor_balance(receiver), Some(1000 + 2000 + 3000));
+
+        // Check program's balance is empty
+        assert_eq!(prog.balance(), Some(0));
     }
 }

--- a/gtest/src/system.rs
+++ b/gtest/src/system.rs
@@ -132,19 +132,19 @@ impl System {
 
     /// Add value to the actor.
     pub fn add_value_to<ID: Into<ProgramIdWrapper>>(&self, id: ID, value: Balance) {
-        let actor_id = id.into();
+        let actor_id = id.into().0;
         self.0.borrow_mut().add_value_to(&actor_id, value);
     }
 
     /// Return actor balance (value) if exists.
     pub fn actor_balance<ID: Into<ProgramIdWrapper>>(&self, id: ID) -> Option<Balance> {
-        let actor_id = id.into();
+        let actor_id = id.into().0;
         self.0.borrow().actor_balance(&actor_id)
     }
 
     /// Claim the user's value from the mailbox.
     pub fn claim_value_from_mailbox<ID: Into<ProgramIdWrapper>>(&self, id: ID) {
-        let actor_id = id.into();
+        let actor_id = id.into().0;
         self.0.borrow_mut().claim_value_from_mailbox(&actor_id);
     }
 }

--- a/gtest/src/system.rs
+++ b/gtest/src/system.rs
@@ -131,15 +131,15 @@ impl System {
     }
 
     /// Add value to the actor.
-    pub fn add_value_to<ID: Into<ProgramIdWrapper>>(&self, id: ID, value: Balance) {
+    pub fn mint_to<ID: Into<ProgramIdWrapper>>(&self, id: ID, value: Balance) {
         let actor_id = id.into().0;
-        self.0.borrow_mut().add_value_to(&actor_id, value);
+        self.0.borrow_mut().mint_to(&actor_id, value);
     }
 
     /// Return actor balance (value) if exists.
-    pub fn actor_balance<ID: Into<ProgramIdWrapper>>(&self, id: ID) -> Option<Balance> {
+    pub fn balance_of<ID: Into<ProgramIdWrapper>>(&self, id: ID) -> Balance {
         let actor_id = id.into().0;
-        self.0.borrow().actor_balance(&actor_id)
+        self.0.borrow().balance_of(&actor_id)
     }
 
     /// Claim the user's value from the mailbox.

--- a/gtest/src/system.rs
+++ b/gtest/src/system.rs
@@ -19,7 +19,7 @@
 use crate::{
     log::RunResult,
     mailbox::Mailbox,
-    manager::ExtManager,
+    manager::{Balance, ExtManager},
     program::{Program, ProgramIdWrapper},
 };
 use colored::Colorize;
@@ -97,7 +97,7 @@ impl System {
 
     pub fn is_active_program<ID: Into<ProgramIdWrapper>>(&self, id: ID) -> bool {
         let program_id = id.into().0;
-        self.0.borrow().actors.contains_key(&program_id)
+        !self.0.borrow().is_user(&program_id)
     }
 
     /// Saves code to the storage and returns it's code hash
@@ -119,8 +119,8 @@ impl System {
 
     pub fn get_mailbox<ID: Into<ProgramIdWrapper>>(&self, id: ID) -> Mailbox {
         let program_id = id.into().0;
-        if self.0.borrow_mut().actors.contains_key(&program_id) {
-            panic!("Such program id is already in actors list");
+        if !self.0.borrow().is_user(&program_id) {
+            panic!("Mailbox available only for users");
         }
         self.0
             .borrow_mut()
@@ -128,5 +128,23 @@ impl System {
             .entry(program_id)
             .or_insert_with(Vec::default);
         Mailbox::new(program_id, &self.0)
+    }
+
+    /// Add value to the actor.
+    pub fn add_value_to<ID: Into<ProgramIdWrapper>>(&self, id: ID, value: Balance) {
+        let actor_id = id.into();
+        self.0.borrow_mut().add_value_to(&actor_id, value);
+    }
+
+    /// Return actor balance (value) if exists.
+    pub fn actor_balance<ID: Into<ProgramIdWrapper>>(&self, id: ID) -> Option<Balance> {
+        let actor_id = id.into();
+        self.0.borrow().actor_balance(&actor_id)
+    }
+
+    /// Claim the user's value from the mailbox.
+    pub fn claim_value_from_mailbox<ID: Into<ProgramIdWrapper>>(&self, id: ID) {
+        let actor_id = id.into();
+        self.0.borrow_mut().claim_value_from_mailbox(&actor_id);
     }
 }


### PR DESCRIPTION
- Added methods to `gtest::Program` and `gtest::System` for adding value and getting balance.
- Fixed value processing in `gtest`.
- Added a `piggy-bank` example to test the value movement.
- Minor refactoring.

Using example: https://github.com/gear-tech/gear/pull/1125/files#diff-ff8da23646ffba628a78b81a75f0ebdf5c1cb5489ad431aee84613408e0ea8a4R505

**Release Notes:** ...

@gear-tech/dev 
