### PR TITLE
Build WASM projects in their own unified directory

### DIFF
--- a/utils/wasm-builder/src/cargo_command.rs
+++ b/utils/wasm-builder/src/cargo_command.rs
@@ -28,6 +28,7 @@ pub struct CargoCommand {
     args: Vec<&'static str>,
     profile: String,
     rustc_flags: Vec<&'static str>,
+    target_dir: PathBuf,
 }
 
 impl CargoCommand {
@@ -39,12 +40,18 @@ impl CargoCommand {
             args: vec!["+nightly", "rustc", "--target=wasm32-unknown-unknown"],
             profile: "dev".to_string(),
             rustc_flags: vec!["-C", "link-arg=--import-memory", "-C", "linker-plugin-lto"],
+            target_dir: "target".into(),
         }
     }
 
     /// Set path to the `Cargo.toml` file.
     pub fn set_manifest_path(&mut self, path: PathBuf) {
         self.manifest_path = path;
+    }
+
+    /// Set path to the `target` directory.
+    pub fn set_target_dir(&mut self, path: PathBuf) {
+        self.target_dir = path;
     }
 
     /// Set profile.
@@ -64,6 +71,7 @@ impl CargoCommand {
             .arg("--release")
             .arg("--")
             .args(&self.rustc_flags)
+            .env("CARGO_TARGET_DIR", &self.target_dir)
             .env(self.skip_build_env(), ""); // Don't build the original crate recursively
 
         self.remove_cargo_encoded_rustflags(&mut cargo);

--- a/utils/wasm-builder/src/lib.rs
+++ b/utils/wasm-builder/src/lib.rs
@@ -64,6 +64,7 @@ impl WasmBuilder {
         self.wasm_project.generate()?;
         self.cargo
             .set_manifest_path(self.wasm_project.manifest_path());
+        self.cargo.set_target_dir(self.wasm_project.target_dir());
         self.cargo
             .set_profile(self.wasm_project.profile().to_string());
         self.cargo.run()?;

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -62,6 +62,7 @@ impl WasmProject {
             }
         }
         target_dir.push("wasm-projects");
+        target_dir.push(profile);
 
         let profile = if profile == "debug" {
             "dev".to_string()

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -61,8 +61,7 @@ impl WasmProject {
                 break;
             }
         }
-        target_dir.push("wasm32-unknown-unknown");
-        target_dir.push(profile);
+        target_dir.push("wasm-projects");
 
         let profile = if profile == "debug" {
             "dev".to_string()
@@ -82,6 +81,11 @@ impl WasmProject {
     /// Return the path to the temporary generated `Cargo.toml`.
     pub fn manifest_path(&self) -> PathBuf {
         self.out_dir.join("Cargo.toml")
+    }
+
+    /// Return the path to the target directory.
+    pub fn target_dir(&self) -> PathBuf {
+        self.target_dir.clone()
     }
 
     /// Return the profile name based on the `OUT_DIR` path.
@@ -159,8 +163,8 @@ impl WasmProject {
             .expect("Run `WasmProject::create_project()` first");
 
         let from_path = self
-            .out_dir
-            .join("target/wasm32-unknown-unknown/release")
+            .target_dir
+            .join("wasm32-unknown-unknown/release")
             .join(format!("{}.wasm", &file_base_name));
 
         fs::create_dir_all(&self.target_dir)?;

--- a/utils/wasm-builder/test-program/src/lib.rs
+++ b/utils/wasm-builder/test-program/src/lib.rs
@@ -52,15 +52,15 @@ mod tests {
     #[cfg(debug_assertions)]
     fn debug_wasm() {
         assert_eq!(
-            fs::read("target/wasm32-unknown-unknown/debug/test_program.wasm").unwrap(),
+            fs::read("target/wasm-projects/debug/test_program.wasm").unwrap(),
             code::WASM_BINARY,
         );
         assert_eq!(
-            fs::read("target/wasm32-unknown-unknown/debug/test_program.opt.wasm").unwrap(),
+            fs::read("target/wasm-projects/debug/test_program.opt.wasm").unwrap(),
             code::WASM_BINARY_OPT,
         );
         assert_eq!(
-            fs::read("target/wasm32-unknown-unknown/debug/test_program.meta.wasm").unwrap(),
+            fs::read("target/wasm-projects/debug/test_program.meta.wasm").unwrap(),
             code::WASM_BINARY_META,
         );
     }
@@ -69,15 +69,15 @@ mod tests {
     #[cfg(not(debug_assertions))]
     fn release_wasm() {
         assert_eq!(
-            fs::read("target/wasm32-unknown-unknown/release/test_program.wasm").unwrap(),
+            fs::read("target/wasm-projects/release/test_program.wasm").unwrap(),
             code::WASM_BINARY,
         );
         assert_eq!(
-            fs::read("target/wasm32-unknown-unknown/release/test_program.opt.wasm").unwrap(),
+            fs::read("target/wasm-projects/release/test_program.opt.wasm").unwrap(),
             code::WASM_BINARY_OPT,
         );
         assert_eq!(
-            fs::read("target/wasm32-unknown-unknown/release/test_program.meta.wasm").unwrap(),
+            fs::read("target/wasm-projects/release/test_program.meta.wasm").unwrap(),
             code::WASM_BINARY_META,
         );
     }


### PR DESCRIPTION
I expect it will reduce build size and compilation time during iterative development (e.g. branch switches, demo changes and so on)