### PR TITLE
lazy pages optimization

### DIFF
--- a/common/src/lazy_pages.rs
+++ b/common/src/lazy_pages.rs
@@ -82,16 +82,14 @@ pub fn protect_pages_and_init_info(mem: &impl Memory, prog_id: ProgramId) -> Res
     let prog_prefix = crate::pages_prefix(prog_id.into_origin());
     gear_ri::set_program_prefix(prog_prefix);
 
-    let addr = if let Some(addr) = mem.get_buffer_host_addr() {
-        addr
+    if let Some(addr) = mem.get_buffer_host_addr() {
+        gear_ri::set_wasm_mem_begin_addr(addr).map_err(|e| {
+            log::error!("{} (it's better to stop node now)", e);
+            e
+        })?;
     } else {
         return Ok(());
-    };
-
-    gear_ri::set_wasm_mem_begin_addr(addr).map_err(|e| {
-        log::error!("{} (it's better to stop node now)", e);
-        e
-    })?;
+    }
 
     let size = (mem.size().0 + 1) * WasmPageNumber::size() as u32;
     gear_ri::set_wasm_mem_size(size)?;

--- a/common/src/lazy_pages.rs
+++ b/common/src/lazy_pages.rs
@@ -22,7 +22,7 @@ use crate::Origin;
 use core::fmt;
 use gear_core::{
     ids::ProgramId,
-    memory::{HostPointer, Memory, PageBuf, PageNumber},
+    memory::{HostPointer, Memory, PageBuf, PageNumber, WasmPageNumber},
 };
 use gear_runtime_interface::{gear_ri, RIError};
 use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
@@ -46,11 +46,11 @@ impl From<RIError> for Error {
 }
 
 fn mprotect_lazy_pages(mem: &impl Memory, protect: bool) -> Result<(), Error> {
-    let wasm_mem_addr = match mem.get_buffer_host_addr() {
-        None => return Ok(()),
-        Some(addr) => addr,
-    };
-    gear_ri::mprotect_lazy_pages(wasm_mem_addr, protect)
+    if mem.get_buffer_host_addr().is_none() {
+        return Ok(());
+    }
+
+    gear_ri::mprotect_lazy_pages(protect)
         .map_err(Into::into)
         .map_err(|e| {
             log::error!("{} (it's better to stop node now)", e);
@@ -76,33 +76,25 @@ pub fn is_lazy_pages_enabled() -> bool {
 }
 
 /// Protect and save storage keys for pages which has no data
-pub fn protect_pages_and_init_info(
-    mem: &impl Memory,
-    lazy_pages: impl Iterator<Item = PageNumber>,
-    prog_id: ProgramId,
-) -> Result<(), Error> {
-    let prog_id_hash = prog_id.into_origin();
-    let mut lay_pages_peekable = lazy_pages.peekable();
-
+pub fn protect_pages_and_init_info(mem: &impl Memory, prog_id: ProgramId) -> Result<(), Error> {
     gear_ri::reset_lazy_pages_info();
 
-    let addr = match mem.get_buffer_host_addr() {
-        None => {
-            return if lay_pages_peekable.peek().is_none() {
-                // In this case wasm buffer cannot be undefined
-                Err(Error::WasmMemBufferIsUndefined)
-            } else {
-                Ok(())
-            };
-        }
-        Some(addr) => addr,
+    let prog_prefix = crate::pages_prefix(prog_id.into_origin());
+    gear_ri::set_program_prefix(prog_prefix);
+
+    let addr = if let Some(addr) = mem.get_buffer_host_addr() {
+        addr
+    } else {
+        return Ok(());
     };
+
     gear_ri::set_wasm_mem_begin_addr(addr).map_err(|e| {
         log::error!("{} (it's better to stop node now)", e);
         e
     })?;
 
-    crate::save_page_lazy_info(prog_id_hash, lay_pages_peekable);
+    let size = (mem.size().0 + 1) * WasmPageNumber::size() as u32;
+    gear_ri::set_wasm_mem_size(size)?;
 
     mprotect_lazy_pages(mem, true)
 }
@@ -131,10 +123,11 @@ pub fn remove_lazy_pages_prot(mem: &impl Memory) -> Result<(), Error> {
     mprotect_lazy_pages(mem, false)
 }
 
-/// Protect lazy-pages and set new wasm mem addr if it has been changed
-pub fn protect_lazy_pages_and_update_wasm_mem_addr(
+/// Protect lazy-pages and set new wasm mem addr and size, if they have been changed
+pub fn update_lazy_pages_and_protect_again(
     mem: &impl Memory,
     old_mem_addr: Option<HostPointer>,
+    old_mem_size: WasmPageNumber,
 ) -> Result<(), Error> {
     struct PointerDisplay(HostPointer);
 
@@ -157,15 +150,14 @@ pub fn protect_lazy_pages_and_update_wasm_mem_addr(
                 e
             })?;
     }
-    mprotect_lazy_pages(mem, true)
-}
 
-/// Returns list of current lazy pages numbers
-pub fn get_lazy_pages_numbers() -> Vec<PageNumber> {
-    gear_ri::get_lazy_pages_numbers()
-        .iter()
-        .map(|p| PageNumber(*p))
-        .collect()
+    let new_mem_size = mem.size();
+    if new_mem_size > old_mem_size {
+        let size = (new_mem_size.0 + 1) * WasmPageNumber::size() as u32;
+        gear_ri::set_wasm_mem_size(size)?;
+    }
+
+    mprotect_lazy_pages(mem, true)
 }
 
 /// Returns list of realeased pages numbers

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -46,7 +46,6 @@ use gear_core::{
     ids::{CodeId, MessageId, ProgramId},
     memory::{Error as MemoryError, PageBuf, PageNumber, WasmPageNumber},
 };
-use gear_runtime_interface as gear_ri;
 use primitive_types::H256;
 use scale_info::TypeInfo;
 use sp_arithmetic::traits::{BaseArithmetic, Unsigned};
@@ -327,14 +326,6 @@ pub fn get_program_page_data(
     let key = page_key(id, page_idx);
     let data = sp_io::storage::get(&key)?;
     Some(PageBuf::new_from_vec(data))
-}
-
-/// Save page data key in storage
-pub fn save_page_lazy_info(id: H256, page_nums: impl Iterator<Item = PageNumber>) {
-    let prefix = pages_prefix(id);
-    let pages = page_nums.map(|p| p.0).collect();
-    log::trace!("lazy pages = {:?}", &pages);
-    gear_ri::gear_ri::save_page_lazy_info(pages, prefix);
 }
 
 pub fn get_program_pages_data(

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -336,6 +336,9 @@ pub enum ExecutionErrorReason {
     /// Message killed from storage as out of rent.
     #[display(fmt = "Out of rent")]
     OutOfRent,
+    /// Initial pages data must be empty when execute with lazy pages
+    #[display(fmt = "Initial pages data must be empty when execute with lazy pages")]
+    InitialPagesDataWhenLazyPages,
 }
 
 /// Actor.

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -338,7 +338,7 @@ pub enum ExecutionErrorReason {
     OutOfRent,
     /// Initial pages data must be empty when execute with lazy pages
     #[display(fmt = "Initial pages data must be empty when execute with lazy pages")]
-    InitialPagesDataWhenLazyPages,
+    InitialPagesContainsDataInLazyPagesMode,
 }
 
 /// Actor.

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -123,7 +123,7 @@ fn prepare_memory<A: ProcessorExt, M: Memory>(
 
     if A::is_lazy_pages_enabled() {
         if !pages_data.is_empty() {
-            return Err(ExecutionErrorReason::InitialPagesDataWhenLazyPages);
+            return Err(ExecutionErrorReason::InitialPagesContainsDataInLazyPagesMode);
         }
         A::lazy_pages_protect_and_init_info(mem, program_id)
             .map_err(|err| ExecutionErrorReason::LazyPagesInitFailed(err.to_string()))?;

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -112,7 +112,6 @@ fn make_checks_and_charge_gas_for_pages<'a>(
 fn prepare_memory<A: ProcessorExt, M: Memory>(
     program_id: ProgramId,
     pages_data: &mut BTreeMap<PageNumber, PageBuf>,
-    allocations: &BTreeSet<WasmPageNumber>,
     static_pages: WasmPageNumber,
     mem: &mut M,
 ) -> Result<(), ExecutionErrorReason> {
@@ -123,12 +122,10 @@ fn prepare_memory<A: ProcessorExt, M: Memory>(
     }
 
     if A::is_lazy_pages_enabled() {
-        // All program wasm pages, which has no data in actor, is supposed to be lazy page candidate.
-        let lazy_pages = allocations
-            .iter()
-            .flat_map(|page| page.to_gear_pages_iter())
-            .filter(|page| !pages_data.contains_key(page));
-        A::lazy_pages_protect_and_init_info(mem, lazy_pages, program_id)
+        if !pages_data.is_empty() {
+            return Err(ExecutionErrorReason::InitialPagesDataWhenLazyPages);
+        }
+        A::lazy_pages_protect_and_init_info(mem, program_id)
             .map_err(|err| ExecutionErrorReason::LazyPagesInitFailed(err.to_string()))?;
     } else {
         // If we executes without lazy pages, then we have to save all initial data for static pages,
@@ -313,7 +310,6 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
     if let Err(reason) = prepare_memory::<A, E::Memory>(
         program_id,
         &mut pages_initial_data,
-        &allocations,
         static_pages,
         env.get_mem_mut(),
     ) {

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -90,7 +90,6 @@ pub trait ProcessorExt {
     /// Protect and save storage keys for pages which has no data
     fn lazy_pages_protect_and_init_info(
         mem: &impl Memory,
-        lazy_pages: impl Iterator<Item = PageNumber>,
         prog_id: ProgramId,
     ) -> Result<(), Self::Error>;
 
@@ -201,7 +200,6 @@ impl ProcessorExt for Ext {
 
     fn lazy_pages_protect_and_init_info(
         _mem: &impl Memory,
-        _memory_pages: impl Iterator<Item = PageNumber>,
         _prog_id: ProgramId,
     ) -> Result<(), Self::Error> {
         unreachable!()

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -39,8 +39,8 @@
 //! in storage. But program may have some significant data for next execution - so we have a bug.
 //! To avoid this we restrict double releasing.
 //! You can also check another cases in test: memory_access_cases.
-//!
-//! TODO: remove all deprecated code before release (issue #1147)
+
+// TODO: remove all deprecated code before release (issue #1147)
 
 #![allow(useless_deprecated, deprecated)]
 

--- a/lazy-pages/src/sys.rs
+++ b/lazy-pages/src/sys.rs
@@ -1,4 +1,24 @@
-use crate::{LazyPage, LazyPageError, LAZY_PAGES_INFO, WASM_MEM_BEGIN};
+// This file is part of Gear.
+
+// Copyright (C) 2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Lazy pages signal handler functionality.
+
+use crate::{Error, LAZY_PAGES_CONTEXT};
 use cfg_if::cfg_if;
 use gear_core::memory::{PageBuf, PageNumber};
 use region::Protection;
@@ -15,37 +35,19 @@ cfg_if! {
     }
 }
 
-#[derive(Debug, derive_more::Display, derive_more::From)]
-pub enum Error {
-    #[display(fmt = "WASM memory begin address is not set")]
-    WasmBeginIsNotSet,
-    #[display(
-        fmt = "Exception is from unknown memory (WASM {:#x} > native page {:x})",
-        wasm_mem_begin,
-        native_page
-    )]
-    UnknownMemory {
-        wasm_mem_begin: usize,
-        native_page: usize,
-    },
-    #[display(
-        fmt = "Page data must contain {} bytes, actually has {}",
-        expected,
-        actual
-    )]
-    InvalidPageSize { expected: usize, actual: u32 },
-    #[display(fmt = "Protection error: {}", _0)]
-    #[from]
-    Protect(region::Error),
-    #[display(fmt = "Lazy page error: {}", _0)]
-    #[from]
-    LazyPage(LazyPageError),
-}
-
 #[derive(Debug)]
 pub struct ExceptionInfo {
     /// Address where fault is occurred
     pub fault_addr: *const (),
+}
+
+/// Returns key which `page` has in storage.
+/// `prefix` is current program prefix in storage.
+fn page_key_in_storage(prefix: &Vec<u8>, page: PageNumber) -> Vec<u8> {
+    let mut key = Vec::with_capacity(prefix.len() + std::mem::size_of::<u32>());
+    key.extend(prefix);
+    key.extend(page.0.to_le_bytes());
+    key
 }
 
 /// Before contract execution some pages from wasm memory buffer are protected,
@@ -67,21 +69,19 @@ pub unsafe fn user_signal_handler(info: ExceptionInfo) -> Result<(), Error> {
 
     let mem = info.fault_addr;
     let native_page = region::page::floor(mem) as usize;
-    let wasm_mem_begin = WASM_MEM_BEGIN.with(|x| *x.borrow()) as usize;
-
-    if wasm_mem_begin == 0 {
-        return Err(Error::WasmBeginIsNotSet);
-    }
+    let wasm_mem_begin = LAZY_PAGES_CONTEXT
+        .with(|ctx| ctx.borrow().wasm_mem_addr)
+        .ok_or(Error::WasmMemAddrIsNotSet)? as usize;
 
     if wasm_mem_begin > native_page {
-        return Err(Error::UnknownMemory {
+        return Err(Error::SignalFromUnknownMemory {
             wasm_mem_begin,
             native_page,
         });
     }
 
     // First gear page which must be unprotected
-    let gear_page = PageNumber::from(((native_page - wasm_mem_begin) / gear_ps) as u32);
+    let gear_page = PageNumber(((native_page - wasm_mem_begin) / gear_ps) as u32);
 
     let (gear_page, gear_pages_num, unprot_addr) = if native_ps > gear_ps {
         assert_eq!(native_ps % gear_ps, 0);
@@ -91,7 +91,7 @@ pub unsafe fn user_signal_handler(info: ExceptionInfo) -> Result<(), Error> {
         (gear_page, 1usize, wasm_mem_begin + gear_page.offset())
     };
 
-    let accessed_page = PageNumber::from(((mem as usize - wasm_mem_begin) / gear_ps) as u32);
+    let accessed_page = PageNumber(((mem as usize - wasm_mem_begin) / gear_ps) as u32);
     log::debug!(
         "mem={:?} accessed={:?},{:?} pages={:?} page_native_addr={:#x}",
         mem,
@@ -105,24 +105,31 @@ pub unsafe fn user_signal_handler(info: ExceptionInfo) -> Result<(), Error> {
 
     region::protect(unprot_addr as *mut (), unprot_size, Protection::READ_WRITE)?;
 
-    LAZY_PAGES_INFO.with(|lazy_pages_info| {
-        let mut pages_info = lazy_pages_info.borrow_mut();
+    LAZY_PAGES_CONTEXT.with(|ctx| {
+        let mut ctx = ctx.borrow_mut();
         for idx in 0..gear_pages_num as u32 {
-            let page = LazyPage::from(gear_page) + idx;
+            let page = gear_page + idx.into();
 
-            let hash_key_in_storage = pages_info.remove(&page).ok_or(LazyPageError::UnknownInfo(page))?;
             let ptr = (unprot_addr as *mut u8).add(idx as usize * gear_ps);
             let buffer_as_slice = std::slice::from_raw_parts_mut(ptr, gear_ps);
 
-            let res = sp_io::storage::read(&hash_key_in_storage, buffer_as_slice, 0);
+            // TODO: simplify before release (issue #1147). Currently we must support here all old runtimes.
+            // In new runtimes we have to clalc page key from program page key.
+            let page_key = if let Some(prefix) = &ctx.program_storage_prefix {
+                page_key_in_storage(prefix, page)
+            } else {
+                // This case is for old runtimes support
+                ctx.lazy_pages_info.remove(&page).ok_or(Error::LazyPageNotExistForSignalAddr(mem, page))?
+            };
+            let res = sp_io::storage::read(&page_key, buffer_as_slice, 0);
 
             if res.is_none() {
                 log::trace!(
-                    "Page #{} has no data in storage, so just save current page data to released pages",
+                    "{:?} has no data in storage, so just save current page data to released pages",
                     page
                 );
             } else {
-                log::trace!("Page #{} has data in storage, so set this data for page and save it in released pages", page);
+                log::trace!("{:?} has data in storage, so set this data for page and save it in released pages", page);
             }
 
             if let Some(size) = res.filter(|&size| size as usize != PageNumber::size()) {
@@ -134,7 +141,14 @@ pub unsafe fn user_signal_handler(info: ExceptionInfo) -> Result<(), Error> {
 
             let page_buf = PageBuf::new_from_vec(buffer_as_slice.to_vec())
                 .expect("Cannot panic here, because we create slice with PageBuf size");
-            page.release(page_buf)?;
+
+            if ctx
+                .released_lazy_pages
+                .insert(page, Some(page_buf))
+                .is_some()
+            {
+                return Err(Error::DoubleRelease(page));
+            }
         }
         Ok(())
     })

--- a/lazy-pages/src/sys.rs
+++ b/lazy-pages/src/sys.rs
@@ -114,7 +114,7 @@ pub unsafe fn user_signal_handler(info: ExceptionInfo) -> Result<(), Error> {
             let buffer_as_slice = std::slice::from_raw_parts_mut(ptr, gear_ps);
 
             // TODO: simplify before release (issue #1147). Currently we must support here all old runtimes.
-            // In new runtimes we have to clalc page key from program page key.
+            // For new runtimes we have to calc page key from program pages prefix.
             let page_key = if let Some(prefix) = &ctx.program_storage_prefix {
                 page_key_in_storage(prefix, page)
             } else {

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -613,7 +613,7 @@ fn memory_access_cases() {
             br 1
         )
 
-        ;; in first run access pages
+        ;; in first run we will access some pages
 
         ;; alloc 2nd page
         (block
@@ -773,7 +773,7 @@ fn memory_access_cases() {
 #[cfg(feature = "lazy-pages")]
 #[test]
 fn lazy_pages() {
-    use gear_core::memory::{PageNumber, WasmPageNumber};
+    use gear_core::memory::PageNumber;
     use gear_runtime_interface as gear_ri;
     use std::collections::BTreeSet;
 
@@ -856,27 +856,27 @@ fn lazy_pages() {
         // Dirty hack: lazy pages info is stored in thread local static variables,
         // so after contract execution lazy-pages information
         // remains correct and we can use it here.
-        let lazy_pages: BTreeSet<PageNumber> = gear_ri::gear_ri::get_lazy_pages_numbers()
-            .iter()
-            .map(|p| PageNumber(*p))
-            .collect();
+        // let lazy_pages: BTreeSet<PageNumber> = gear_ri::gear_ri::get_lazy_pages_numbers()
+        //     .iter()
+        //     .map(|p| PageNumber(*p))
+        //     .collect();
         let released_pages: BTreeSet<PageNumber> = gear_ri::gear_ri::get_released_pages()
             .iter()
             .map(|p| PageNumber(*p))
             .collect();
 
         // Checks that released pages + lazy pages == all pages
-        let all_pages = {
-            let all_wasm_pages: BTreeSet<WasmPageNumber> = (0..10u32).map(WasmPageNumber).collect();
-            all_wasm_pages
-                .iter()
-                .flat_map(|p| p.to_gear_pages_iter())
-                .collect()
-        };
-        let mut res_pages = lazy_pages;
-        res_pages.extend(released_pages.iter());
+        // let all_pages = {
+        //     let all_wasm_pages: BTreeSet<WasmPageNumber> = (0..10u32).map(WasmPageNumber).collect();
+        //     all_wasm_pages
+        //         .iter()
+        //         .flat_map(|p| p.to_gear_pages_iter())
+        //         .collect()
+        // };
+        // let mut res_pages = lazy_pages;
+        // res_pages.extend(released_pages.iter());
 
-        assert_eq!(res_pages, all_pages);
+        // assert_eq!(res_pages, all_pages);
 
         // checks accessed pages set
         let native_size = page_size::get();
@@ -884,8 +884,12 @@ fn lazy_pages() {
 
         let page_to_accessed = |p: u32| {
             if native_size > PageNumber::size() {
+                // `x` is number of gear pages in one native page for current host
                 let x = (native_size / PageNumber::size()) as u32;
-                (p / x) * x..=(p / x) * x + x - 1
+                // each native page contains several gear pages
+                let first_accessed_gear_page = (p / x) * x;
+                // accessed gear pages range:
+                first_accessed_gear_page..=first_accessed_gear_page + x - 1
             } else {
                 p..=p
             }

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -856,27 +856,10 @@ fn lazy_pages() {
         // Dirty hack: lazy pages info is stored in thread local static variables,
         // so after contract execution lazy-pages information
         // remains correct and we can use it here.
-        // let lazy_pages: BTreeSet<PageNumber> = gear_ri::gear_ri::get_lazy_pages_numbers()
-        //     .iter()
-        //     .map(|p| PageNumber(*p))
-        //     .collect();
         let released_pages: BTreeSet<PageNumber> = gear_ri::gear_ri::get_released_pages()
             .iter()
             .map(|p| PageNumber(*p))
             .collect();
-
-        // Checks that released pages + lazy pages == all pages
-        // let all_pages = {
-        //     let all_wasm_pages: BTreeSet<WasmPageNumber> = (0..10u32).map(WasmPageNumber).collect();
-        //     all_wasm_pages
-        //         .iter()
-        //         .flat_map(|p| p.to_gear_pages_iter())
-        //         .collect()
-        // };
-        // let mut res_pages = lazy_pages;
-        // res_pages.extend(released_pages.iter());
-
-        // assert_eq!(res_pages, all_pages);
 
         // checks accessed pages set
         let native_size = page_size::get();

--- a/runtime-interface/src/deprecated.rs
+++ b/runtime-interface/src/deprecated.rs
@@ -19,9 +19,14 @@
 //! Deprecated backend for runtime interface.
 //! TODO: remove before release
 
+use crate::RIError;
 use codec::{Decode, Encode};
-use gear_core::memory::HostPointer;
+use gear_core::memory::{HostPointer, PageNumber};
 
+#[cfg(feature = "std")]
+use crate::sys_mprotect_interval;
+
+#[deprecated]
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, derive_more::Display)]
 pub enum MprotectError {
     #[display(fmt = "Page error")]
@@ -30,10 +35,12 @@ pub enum MprotectError {
     OsError,
 }
 
+#[deprecated]
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, derive_more::Display)]
 #[display(fmt = "Failed to get released page")]
 pub struct GetReleasedPageError;
 
+#[deprecated]
 #[cfg(feature = "std")]
 #[cfg(unix)]
 pub(crate) unsafe fn sys_mprotect_wasm_pages(
@@ -72,6 +79,7 @@ pub(crate) unsafe fn sys_mprotect_wasm_pages(
     Ok(())
 }
 
+#[deprecated]
 #[cfg(feature = "std")]
 #[cfg(not(unix))]
 pub(crate) unsafe fn sys_mprotect_wasm_pages(
@@ -83,4 +91,37 @@ pub(crate) unsafe fn sys_mprotect_wasm_pages(
 ) -> Result<(), MprotectError> {
     log::error!("unsupported OS for pages protectection");
     Err(MprotectError::OsError)
+}
+
+#[deprecated]
+#[cfg(feature = "std")]
+pub(crate) fn mprotect_pages_slice(
+    mem_addr: HostPointer,
+    pages: &[PageNumber],
+    protect: bool,
+) -> Result<(), RIError> {
+    let mprotect = |start: PageNumber, count, protect: bool| unsafe {
+        let addr = mem_addr + (start.0 as usize * PageNumber::size()) as HostPointer;
+        let size = count as usize * PageNumber::size();
+        sys_mprotect_interval(addr, size, !protect, !protect, false)
+    };
+
+    // Collects continuous intervals of memory from lazy pages to protect them.
+    let mut start = if let Some(&start) = pages.first() {
+        start
+    } else {
+        return Ok(());
+    };
+
+    let mut count = 1;
+    for &page in pages.iter().skip(1) {
+        if start + count.into() == page {
+            count = count.saturating_add(1);
+        } else {
+            mprotect(start, count, protect)?;
+            start = page as _;
+            count = 1;
+        }
+    }
+    mprotect(start, count, protect)
 }

--- a/runtime-interface/src/deprecated.rs
+++ b/runtime-interface/src/deprecated.rs
@@ -17,7 +17,8 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Deprecated backend for runtime interface.
-//! TODO: remove before release
+
+// TODO: remove before release (issue #1147)
 
 use crate::RIError;
 use codec::{Decode, Encode};

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -17,8 +17,8 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Runtime interface for gear node
-//!
-//! TODO: remove all deprecated code before release (issue #1147)
+
+// TODO: remove all deprecated code before release (issue #1147)
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(useless_deprecated, deprecated)]

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -17,6 +17,8 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Runtime interface for gear node
+//!
+//! TODO: remove all deprecated code before release (issue #1147)
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(useless_deprecated, deprecated)]
@@ -36,9 +38,12 @@ static_assertions::const_assert!(
 #[cfg(feature = "std")]
 use gear_core::memory::PageNumber;
 #[cfg(feature = "std")]
-use gear_lazy_pages::LazyPage;
+use gear_lazy_pages as lazy_pages;
 
 pub use sp_std::{result::Result, vec::Vec};
+
+#[cfg(test)]
+mod tests;
 
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, derive_more::Display)]
 pub enum RIError {
@@ -66,7 +71,7 @@ pub enum RIError {
 /// Mprotect native memory interval [`addr`, `addr` + `size`].
 /// Protection mask is set according to protection arguments.
 #[cfg(feature = "std")]
-unsafe fn sys_mprotect_interval(
+pub(crate) unsafe fn sys_mprotect_interval(
     addr: HostPointer,
     size: usize,
     prot_read: bool,
@@ -113,43 +118,40 @@ unsafe fn sys_mprotect_interval(
     Ok(())
 }
 
+/// Protect all pages in memory interval, except pages from `except_pages`.
+/// If `protect` is true then restrict read/write access, else allow them.
 #[cfg(feature = "std")]
-fn mprotect_pages_slice(
+fn mprotect_mem_interval_except_pages(
     mem_addr: HostPointer,
-    pages: &[LazyPage],
+    mem_size: usize,
+    except_pages: impl Iterator<Item = PageNumber>,
     protect: bool,
 ) -> Result<(), RIError> {
-    let mprotect = |start: LazyPage, count, protect: bool| unsafe {
-        let addr = mem_addr + (start.as_u32() as usize * PageNumber::size()) as HostPointer;
-        let size = count as usize * PageNumber::size();
-        sys_mprotect_interval(addr, size, !protect, !protect, false)
+    let mprotect = |start, end| {
+        let addr = mem_addr + start as HostPointer;
+        let size = end - start;
+        unsafe { sys_mprotect_interval(addr, size, !protect, !protect, false) }
     };
 
-    // Collects continuous intervals of memory from lazy pages to protect them.
-    let mut start = if let Some(&start) = pages.first() {
-        start
-    } else {
-        return Ok(());
-    };
-
-    let mut count = 1;
-    for &page in pages.iter().skip(1) {
-        if start + count == page {
-            count = count.saturating_add(1);
-        } else {
-            mprotect(start, count, protect)?;
-            start = page as _;
-            count = 1;
+    let mut interval_offset = 0usize;
+    for page in except_pages {
+        let page_offset = page.offset();
+        if page_offset > interval_offset {
+            mprotect(interval_offset, page_offset)?;
         }
+        interval_offset = page_offset.saturating_add(PageNumber::size());
     }
-    mprotect(start, count, protect)
+    if mem_size > interval_offset {
+        mprotect(interval_offset, mem_size)
+    } else {
+        Ok(())
+    }
 }
 
 /// Runtime interface for gear node and runtime.
 /// Note: name is expanded as gear_ri
 #[runtime_interface]
 pub trait GearRI {
-    // TODO: deprecated, remove before release
     #[deprecated]
     fn mprotect_wasm_pages(
         from_ptr: u64,
@@ -163,7 +165,6 @@ pub trait GearRI {
         }
     }
 
-    // TODO: deprecated, remove before release.
     #[version(2)]
     #[deprecated]
     fn mprotect_wasm_pages(
@@ -176,68 +177,65 @@ pub trait GearRI {
         unsafe { sys_mprotect_wasm_pages(from_ptr, pages_nums, prot_read, prot_write, prot_exec) }
     }
 
-    // TODO: deprecated, remove before release
     #[deprecated]
     fn mprotect_lazy_pages(wasm_mem_addr: u64, protect: bool) -> Result<(), MprotectError> {
-        let lazy_pages = gear_lazy_pages::available_pages();
+        let lazy_pages = lazy_pages::get_lazy_pages_numbers();
         mprotect_pages_slice(wasm_mem_addr, &lazy_pages, protect).map_err(|err| match err {
             RIError::UnsupportedOS => MprotectError::OsError,
             _ => MprotectError::PageError,
         })
     }
 
-    /// Mprotect all lazy pages.
-    /// If `protect` argument is true then restrict all accesses to pages,
-    /// else allows read and write accesses.
+    #[deprecated]
     #[version(2)]
     fn mprotect_lazy_pages(wasm_mem_addr: u64, protect: bool) -> Result<(), RIError> {
-        let lazy_pages = gear_lazy_pages::available_pages();
+        let lazy_pages = lazy_pages::get_lazy_pages_numbers();
         mprotect_pages_slice(wasm_mem_addr, &lazy_pages, protect)
     }
 
-    // TODO: deprecated, remove before release
+    /// Mprotect all wasm mem buffer except released pages.
+    /// If `protect` argument is true then restrict all accesses to pages,
+    /// else allows read and write accesses.
+    #[version(3)]
+    fn mprotect_lazy_pages(protect: bool) -> Result<(), RIError> {
+        log::trace!("mem size = {:?}", lazy_pages::get_wasm_mem_size());
+        mprotect_mem_interval_except_pages(
+            // TODO: remove panics and make an errors (issue #1147)
+            lazy_pages::get_wasm_mem_addr()
+                .expect("Wasm mem addr must be set before using this method"),
+            lazy_pages::get_wasm_mem_size()
+                .expect("Wasm mem size must be set before using this method"),
+            lazy_pages::get_released_pages().iter().copied(),
+            protect,
+        )
+    }
+
     #[deprecated]
     fn save_page_lazy_info(page: u32, key: &[u8]) {
-        LazyPage::from(page).set_info(key);
+        lazy_pages::set_lazy_page_info(page.into(), key);
     }
 
+    #[deprecated]
     #[version(2)]
     fn save_page_lazy_info(pages: Vec<u32>, prefix: Vec<u8>) {
-        gear_lazy_pages::save_lazy_pages_info(pages, prefix);
-    }
-
-    // TODO: deprecated, remove before release
-    #[deprecated]
-    fn get_wasm_lazy_pages_numbers() -> Vec<u32> {
-        gear_lazy_pages::available_pages()
-            .into_iter()
-            .map(LazyPage::as_u32)
-            .collect()
-    }
-
-    fn get_lazy_pages_numbers() -> Vec<u32> {
-        gear_lazy_pages::available_pages()
-            .into_iter()
-            .map(LazyPage::as_u32)
-            .collect()
+        lazy_pages::append_lazy_pages_info(pages, prefix);
     }
 
     fn init_lazy_pages() -> bool {
-        unsafe { gear_lazy_pages::init() }
+        unsafe { lazy_pages::init() }
     }
 
     fn is_lazy_pages_enabled() -> bool {
-        gear_lazy_pages::is_enabled()
+        lazy_pages::is_enabled()
     }
 
     fn reset_lazy_pages_info() {
-        gear_lazy_pages::reset_info()
+        lazy_pages::reset_context()
     }
 
-    // TODO: deprecated, remove before release
     #[deprecated]
     fn set_wasm_mem_begin_addr(addr: u64) {
-        gear_lazy_pages::set_wasm_mem_begin_addr(addr);
+        lazy_pages::set_wasm_mem_begin_addr(addr);
     }
 
     #[version(2)]
@@ -254,152 +252,70 @@ pub trait GearRI {
         Ok(())
     }
 
+    fn set_wasm_mem_size(size: u32) -> Result<(), RIError> {
+        let size = size as usize;
+
+        // TODO: remove this panic before release and make an error (issue #1147)
+        assert_eq!(
+            size % region::page::size(),
+            0,
+            "Wasm memory buffer size is not aligned by host native page size"
+        );
+
+        lazy_pages::set_wasm_mem_size(size);
+        Ok(())
+    }
+
+    fn set_program_prefix(prefix: Vec<u8>) {
+        lazy_pages::set_program_prefix(prefix);
+    }
+
     fn get_released_pages() -> Vec<u32> {
-        gear_lazy_pages::released_pages()
+        lazy_pages::get_released_pages()
             .into_iter()
-            .map(LazyPage::as_u32)
+            .map(|p| p.0)
             .collect()
     }
 
-    // TODO: deprecated, remove before release
     #[deprecated]
     fn get_released_page_old_data(page: u32) -> Vec<u8> {
-        LazyPage::from(page)
-            .take_data()
+        lazy_pages::get_released_page_data(page.into())
             .expect("Must have data for released page")
             .to_vec()
     }
 
-    // TODO: deprecated, remove before release
     #[version(2)]
     #[deprecated]
     fn get_released_page_old_data(page: u32) -> Result<Vec<u8>, GetReleasedPageError> {
-        LazyPage::from(page)
-            .take_data()
+        lazy_pages::get_released_page_data(page.into())
             .ok_or(GetReleasedPageError)
             .map(|data| data.to_vec())
     }
 
-    // TODO: deprecated, remove before release
     #[version(3)]
     #[deprecated]
     fn get_released_page_old_data(page: u32) -> Result<PageBuf, GetReleasedPageError> {
-        LazyPage::from(page).take_data().ok_or(GetReleasedPageError)
+        lazy_pages::get_released_page_data(page.into()).ok_or(GetReleasedPageError)
     }
 
     #[version(4)]
     fn get_released_page_old_data(page: u32) -> Option<PageBuf> {
-        LazyPage::from(page).take_data()
+        lazy_pages::get_released_page_data(page.into())
     }
 
-    fn print_hello() {
-        println!("Hello from gear runtime interface!!!");
-    }
-}
-
-#[cfg(feature = "std")]
-#[test]
-fn test_mprotect_pages_vec() {
-    use gear_core::memory::WasmPageNumber;
-
-    const OLD_VALUE: u8 = 99;
-    const NEW_VALUE: u8 = 100;
-
-    unsafe fn test_handler(mem: usize) {
-        let ps = region::page::size();
-        let addr = ((mem / ps) * ps) as *mut ();
-        region::protect(addr, ps, region::Protection::READ_WRITE).unwrap();
-        for p in 0..ps / PageNumber::size() {
-            *((mem + p * PageNumber::size()) as *mut u8) = NEW_VALUE;
-        }
-        region::protect(addr, ps, region::Protection::READ).unwrap();
+    #[deprecated]
+    fn get_wasm_lazy_pages_numbers() -> Vec<u32> {
+        gear_lazy_pages::get_lazy_pages_numbers()
+            .iter()
+            .map(|p| p.0)
+            .collect()
     }
 
-    #[cfg(unix)]
-    unsafe {
-        use libc::{c_void, siginfo_t};
-        use nix::sys::signal;
-
-        extern "C" fn handle_sigsegv(_: i32, info: *mut siginfo_t, _: *mut c_void) {
-            unsafe {
-                let mem = (*info).si_addr() as usize;
-                test_handler(mem);
-            }
-        }
-
-        let sig_handler = signal::SigHandler::SigAction(handle_sigsegv);
-        let sig_action = signal::SigAction::new(
-            sig_handler,
-            signal::SaFlags::SA_SIGINFO,
-            signal::SigSet::empty(),
-        );
-        signal::sigaction(signal::SIGSEGV, &sig_action).expect("Must be correct");
-        signal::sigaction(signal::SIGBUS, &sig_action).expect("Must be correct");
+    #[deprecated]
+    fn get_lazy_pages_numbers() -> Vec<u32> {
+        gear_lazy_pages::get_lazy_pages_numbers()
+            .iter()
+            .map(|p| p.0)
+            .collect()
     }
-
-    #[cfg(windows)]
-    unsafe {
-        use winapi::{
-            shared::ntdef::LONG,
-            um::{
-                errhandlingapi::SetUnhandledExceptionFilter,
-                minwinbase::EXCEPTION_ACCESS_VIOLATION, winnt::EXCEPTION_POINTERS,
-            },
-            vc::excpt::EXCEPTION_CONTINUE_EXECUTION,
-        };
-
-        unsafe extern "system" fn exception_handler(
-            exception_info: *mut EXCEPTION_POINTERS,
-        ) -> LONG {
-            let record = (*exception_info).ExceptionRecord;
-            assert_eq!((*record).ExceptionCode, EXCEPTION_ACCESS_VIOLATION);
-            assert_eq!((*record).NumberParameters, 2);
-
-            let mem = (*record).ExceptionInformation[1] as usize;
-            test_handler(mem);
-
-            EXCEPTION_CONTINUE_EXECUTION
-        }
-
-        SetUnhandledExceptionFilter(Some(exception_handler));
-    }
-
-    let mut v = vec![0u8; 3 * WasmPageNumber::size()];
-    let buff = v.as_mut_ptr() as usize;
-    let page_begin = (((buff + WasmPageNumber::size()) / WasmPageNumber::size())
-        * WasmPageNumber::size()) as u64;
-
-    let pages_to_protect = [0, 1, 2, 3, 16, 17, 18, 19, 20, 21, 22, 23].map(LazyPage::from);
-    let pages_unprotected = [
-        4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31,
-    ]
-    .map(LazyPage::from);
-
-    // Set `OLD_VALUE` as value for each first byte of gear pages
-    unsafe {
-        for &p in pages_to_protect.iter().chain(pages_unprotected.iter()) {
-            let addr = page_begin as usize + p.as_u32() as usize * PageNumber::size() + 1;
-            *(addr as *mut u8) = OLD_VALUE;
-        }
-    }
-
-    mprotect_pages_slice(page_begin, &pages_to_protect, true).expect("Must be correct");
-
-    unsafe {
-        for &p in pages_to_protect.iter() {
-            let addr = page_begin as usize + p.as_u32() as usize * PageNumber::size() + 1;
-            let x = *(addr as *mut u8);
-            // value must be changed to `NEW_VALUE` in sig handler
-            assert_eq!(x, NEW_VALUE);
-        }
-
-        for &p in pages_unprotected.iter() {
-            let addr = page_begin as usize + p.as_u32() as usize * PageNumber::size() + 1;
-            let x = *(addr as *mut u8);
-            // value must not be changed
-            assert_eq!(x, OLD_VALUE);
-        }
-    }
-
-    mprotect_pages_slice(page_begin, &pages_to_protect, false).expect("Must be correct");
 }

--- a/runtime-interface/src/tests.rs
+++ b/runtime-interface/src/tests.rs
@@ -1,0 +1,141 @@
+// This file is part of Gear.
+
+// Copyright (C) 2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::*;
+
+#[test]
+fn test_mprotect_pages() {
+    use gear_core::memory::WasmPageNumber;
+
+    const OLD_VALUE: u8 = 99;
+    const NEW_VALUE: u8 = 100;
+
+    unsafe fn test_handler(mem: usize) {
+        let ps = region::page::size();
+        let addr = ((mem / ps) * ps) as *mut ();
+        region::protect(addr, ps, region::Protection::READ_WRITE).unwrap();
+        for p in 0..ps / PageNumber::size() {
+            *((mem + p * PageNumber::size()) as *mut u8) = NEW_VALUE;
+        }
+        region::protect(addr, ps, region::Protection::READ).unwrap();
+    }
+
+    #[cfg(unix)]
+    unsafe {
+        use libc::{c_void, siginfo_t};
+        use nix::sys::signal;
+
+        extern "C" fn handle_sigsegv(_: i32, info: *mut siginfo_t, _: *mut c_void) {
+            unsafe {
+                let mem = (*info).si_addr() as usize;
+                test_handler(mem);
+            }
+        }
+
+        let sig_handler = signal::SigHandler::SigAction(handle_sigsegv);
+        let sig_action = signal::SigAction::new(
+            sig_handler,
+            signal::SaFlags::SA_SIGINFO,
+            signal::SigSet::empty(),
+        );
+        signal::sigaction(signal::SIGSEGV, &sig_action).expect("Must be correct");
+        signal::sigaction(signal::SIGBUS, &sig_action).expect("Must be correct");
+    }
+
+    #[cfg(windows)]
+    unsafe {
+        use winapi::{
+            shared::ntdef::LONG,
+            um::{
+                errhandlingapi::SetUnhandledExceptionFilter,
+                minwinbase::EXCEPTION_ACCESS_VIOLATION, winnt::EXCEPTION_POINTERS,
+            },
+            vc::excpt::EXCEPTION_CONTINUE_EXECUTION,
+        };
+
+        unsafe extern "system" fn exception_handler(
+            exception_info: *mut EXCEPTION_POINTERS,
+        ) -> LONG {
+            let record = (*exception_info).ExceptionRecord;
+            assert_eq!((*record).ExceptionCode, EXCEPTION_ACCESS_VIOLATION);
+            assert_eq!((*record).NumberParameters, 2);
+
+            let mem = (*record).ExceptionInformation[1] as usize;
+            test_handler(mem);
+
+            EXCEPTION_CONTINUE_EXECUTION
+        }
+
+        SetUnhandledExceptionFilter(Some(exception_handler));
+    }
+
+    let mut v = vec![0u8; 3 * WasmPageNumber::size()];
+    let buff = v.as_mut_ptr() as usize;
+    let page_begin = (((buff + WasmPageNumber::size()) / WasmPageNumber::size())
+        * WasmPageNumber::size()) as u64;
+    let mem_size = 2 * WasmPageNumber::size();
+
+    // Gear pages in 2 wasm pages. Randomly choose pages, which will be protected,
+    // but because macos with M1 has page size == 16kB, we should include all gear pages from 16kB interval.
+    // This test can fail if page size is bigger than 16kB.
+    let pages_protected = [0, 1, 2, 3, 16, 17, 18, 19, 20, 21, 22, 23].map(PageNumber::from);
+    let pages_unprotected = [
+        4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31,
+    ]
+    .map(PageNumber::from);
+
+    // Set `OLD_VALUE` as value for each first byte of gear pages
+    unsafe {
+        for &p in pages_unprotected.iter().chain(pages_protected.iter()) {
+            let addr = page_begin as usize + p.0 as usize * PageNumber::size() + 1;
+            *(addr as *mut u8) = OLD_VALUE;
+        }
+    }
+
+    mprotect_mem_interval_except_pages(
+        page_begin,
+        mem_size,
+        pages_unprotected.iter().copied(),
+        true,
+    )
+    .expect("Must be correct");
+
+    unsafe {
+        for &p in pages_protected.iter() {
+            let addr = page_begin as usize + p.0 as usize * PageNumber::size() + 1;
+            let x = *(addr as *mut u8);
+            // value must be changed to `NEW_VALUE` in sig handler
+            assert_eq!(x, NEW_VALUE);
+        }
+
+        for &p in pages_unprotected.iter() {
+            let addr = page_begin as usize + p.0 as usize * PageNumber::size() + 1;
+            let x = *(addr as *mut u8);
+            // value must not be changed
+            assert_eq!(x, OLD_VALUE);
+        }
+    }
+
+    mprotect_mem_interval_except_pages(
+        page_begin,
+        mem_size,
+        pages_unprotected.iter().copied(),
+        false,
+    )
+    .expect("Must be correct");
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -123,7 +123,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1260,
+    spec_version: 1270,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/scripts/src/test.sh
+++ b/scripts/src/test.sh
@@ -82,7 +82,7 @@ pallet_test() {
   cargo test -p pallet-usage "$@"
   cargo test -p pallet-gear-messenger "$@"
   cargo test -p pallet-gear-program "$@"
-  cargo test -p pallet-gas "$@"
+  cargo test -p pallet-gear-gas "$@"
 }
 
 # $1 - ROOT DIR


### PR DESCRIPTION
in order to  optimise lazy pages work - move logic which calc keys for pages in signal handler.
Also completely remove lazy_pages set because it can be very costly to support it when memory size is big

### Perf
I have run gr_read benchmarks to test perf increase:
```
perf record --all-user --call-graph=dwarf --freq 997 ./target/release/gear-node benchmark pallet --chain=dev --steps=50 --repeat=100 --pallet=pallet_gear --execution=native --extrinsic="gr_read"
``` 
gear_core_processor::executor::prepare_memory  (where lazy pages init info is called) takes
```
master       :    24.9% from all samples
this branch  :    0.01% from all samples
```

time for gr_read:
```
master       :    42.93 µs
this branch  :    32.65 µs
```

time for gr_reply_commit:
```
master       :    68.2 µs
this branch  :    49.92 µs
```


### Testing
Run node with this patch over all test-net chain - all OK

### Important
This patch requires node binary update after runtime update.