### PR TITLE
Update mailbox logic

### DIFF
--- a/pallets/gear/src/manager.rs
+++ b/pallets/gear/src/manager.rs
@@ -477,52 +477,35 @@ where
                 }
             };
 
-            let (mut expiration, mailbox_threshold) = (None, T::MailboxThreshold::get());
+            let mailbox_threshold = T::MailboxThreshold::get();
 
-            let mut append_message_to_mailbox = |gas_limit: u64| {
-                // Being placed into a user's mailbox means the end of a message life cycle.
-                // There can be no further processing whatsoever, hence any gas attempted to be
-                // passed along must be returned (i.e. remain in the parent message's value tree).
-
-                // TODO: update logic of insertion into mailbox following new
-                // flow and deposit appropriate event (issue #1010).
-                match MailboxOf::<T>::insert(message.clone()) {
-                    Ok(_) => {
-                        // TODO: replace this temporary (zero) value for expiration
-                        // block number with properly calculated one
-                        // (issues #646 and #969).
-                        expiration = Some(T::BlockNumber::zero());
-
-                        let _ = GasHandlerOf::<T>::cut(message_id, message.id(), gas_limit);
-                    }
-                    Err(e) => {
-                        log::error!("{:?}", e);
-                    }
-                }
-            };
-
-            if let Some(gas_limit) = gas_limit {
-                if gas_limit >= mailbox_threshold {
-                    append_message_to_mailbox(gas_limit);
-                }
-            } else {
-                let gas_limit = GasHandlerOf::<T>::get_limit(message_id)
-                    .unwrap_or_else(|e| {
-                        log::error!("{:?}", e);
-                        None
-                    })
-                    .map(|(g, _)| g)
-                    .unwrap_or(0);
-
-                if gas_limit >= mailbox_threshold {
-                    append_message_to_mailbox(mailbox_threshold);
-                }
-            }
-
-            Pallet::<T>::deposit_event(Event::UserMessageSent {
-                message,
-                expiration,
+            // TODO: replace this unwrap_or_default in #1130.
+            let gas_limit = gas_limit.unwrap_or_else(|| {
+                GasHandlerOf::<T>::get_limit(message_id)
+                    .ok()
+                    .flatten()
+                    .map(|(v, _)| v)
+                    .unwrap_or_default()
+                    .min(mailbox_threshold)
             });
+
+            if gas_limit >= mailbox_threshold {
+                MailboxOf::<T>::insert(message.clone())
+                    .unwrap_or_else(|e| unreachable!("Mailbox corrupted! {:?}", e));
+                let _ = GasHandlerOf::<T>::cut(message_id, message.id(), gas_limit);
+                // TODO: replace this temporary (zero) value for expiration
+                // block number with properly calculated one
+                // (issues #646 and #969).
+                Pallet::<T>::deposit_event(Event::UserMessageSent {
+                    message,
+                    expiration: Some(T::BlockNumber::zero()),
+                })
+            } else {
+                Pallet::<T>::deposit_event(Event::UserMessageSent {
+                    message,
+                    expiration: None,
+                });
+            }
         }
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -123,7 +123,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1230,
+    spec_version: 1240,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
# About PR
Resolves #1010 and seems resolves #1074.
Also cleans up after #642 and unignores tests.
Sums up new concept to correct release notes.

<a name="concepts"></a>
# Main statements about interaction types and mailbox usage:
## Program to program messaging
* Never affects `Mailbox`.

## User to program messaging
* Never affects `Mailbox`.

## User to user messaging
* Never affects `Mailbox`.
* Propagates event `UserMessageSent`
* Value claims (transfers) instantly.

## Program to user messaging
* `Mailbox` contain minimal gas limit for insertions: `MailboxThreshold`.
* `Mailbox` charges rent in gas for holding messages there (see #646 and #1135).
* Only messages, which holds in `Mailbox` can be replied by user.

#### Note: we will not be talking about cases when program sends message to program, all of you know that it will go into MQ and so on.
#### Note: to avoid copy pasting, some actions merged into (SCENARIO A) and (SCENARIO B) "tags", see [below](#scenarios).

### Program sends message with gas
If gas > 0, but < `MailboxThreshold`, program runs into sys call error directly inside the program.
If gas = 0, than (SCENARIO A), else gas > `MailboxThreshold` and (SCENARIO B)

### Program sends message without explicit gas limit (gasless message)
if remaining gas < `MailboxThreshold` and destination is user, this message means as message with gas = 0 and (SCENARIO A)
if remaining gas >= `MailboxThreshold` and destination is user, this message means as message with gas = `MailboxThreshold` and (SCENARIO B)

<a name="scenarios"></a>
#### (SCENARIO A):
* Never affects `Mailbox`
* Propagates event `UserMessageSent`
* Value claims (transfers) instantly
* This message can’t be replied in future.

#### (SCENARIO B):
* Message inserted into `Mailbox`
* Propagates event `UserMessageSent`
* This message can be claimed or replied, that means the value moves to user, who claimed it, depositing event `UserMessageRead`
* If message won't be replied or claimed, than once message won't be able to pay rent, it got removed from `Mailbox`, value transfers back to source program. (see #646 and #1135 also)

# Release notes
Mailbox interaction logic updated, read about changes [above](#concepts)

@gear-tech/dev 