### PR TITLE
Avoid dynamic dispatching

### DIFF
--- a/common/src/lazy_pages.rs
+++ b/common/src/lazy_pages.rs
@@ -45,7 +45,7 @@ impl From<RIError> for Error {
     }
 }
 
-fn mprotect_lazy_pages(mem: &dyn Memory, protect: bool) -> Result<(), Error> {
+fn mprotect_lazy_pages(mem: &impl Memory, protect: bool) -> Result<(), Error> {
     let wasm_mem_addr = match mem.get_buffer_host_addr() {
         None => return Ok(()),
         Some(addr) => addr,
@@ -77,7 +77,7 @@ pub fn is_lazy_pages_enabled() -> bool {
 
 /// Protect and save storage keys for pages which has no data
 pub fn protect_pages_and_init_info(
-    mem: &dyn Memory,
+    mem: &impl Memory,
     lazy_pages: impl Iterator<Item = PageNumber>,
     prog_id: ProgramId,
 ) -> Result<(), Error> {
@@ -109,7 +109,7 @@ pub fn protect_pages_and_init_info(
 
 /// Lazy pages contract post execution actions
 pub fn post_execution_actions(
-    mem: &dyn Memory,
+    mem: &impl Memory,
     pages_data: &mut BTreeMap<PageNumber, PageBuf>,
 ) -> Result<(), Error> {
     // Loads data for released lazy pages. Data which was before execution.
@@ -127,13 +127,13 @@ pub fn post_execution_actions(
 }
 
 /// Remove lazy-pages protection, returns wasm memory begin addr
-pub fn remove_lazy_pages_prot(mem: &dyn Memory) -> Result<(), Error> {
+pub fn remove_lazy_pages_prot(mem: &impl Memory) -> Result<(), Error> {
     mprotect_lazy_pages(mem, false)
 }
 
 /// Protect lazy-pages and set new wasm mem addr if it has been changed
 pub fn protect_lazy_pages_and_update_wasm_mem_addr(
-    mem: &dyn Memory,
+    mem: &impl Memory,
     old_mem_addr: Option<HostPointer>,
 ) -> Result<(), Error> {
     struct PointerDisplay(HostPointer);

--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -20,24 +20,24 @@ use alloc::{vec, vec::Vec};
 use gear_core::memory::Memory;
 use gear_core_errors::MemoryError;
 
-pub fn get_bytes32(mem: &dyn Memory, ptr: usize) -> Result<[u8; 32], MemoryError> {
+pub fn get_bytes32(mem: &impl Memory, ptr: usize) -> Result<[u8; 32], MemoryError> {
     let mut ret = [0u8; 32];
     mem.read(ptr, &mut ret)?;
     Ok(ret)
 }
 
-pub fn get_u128(mem: &dyn Memory, ptr: usize) -> Result<u128, MemoryError> {
+pub fn get_u128(mem: &impl Memory, ptr: usize) -> Result<u128, MemoryError> {
     let mut u128_le = [0u8; 16];
     mem.read(ptr, &mut u128_le)?;
     Ok(u128::from_le_bytes(u128_le))
 }
 
-pub fn get_vec(mem: &dyn Memory, ptr: usize, len: usize) -> Result<Vec<u8>, MemoryError> {
+pub fn get_vec(mem: &impl Memory, ptr: usize, len: usize) -> Result<Vec<u8>, MemoryError> {
     let mut vec = vec![0u8; len];
     mem.read(ptr, &mut vec)?;
     Ok(vec)
 }
 
-pub fn set_u128(mem: &mut dyn Memory, ptr: usize, val: u128) -> Result<(), MemoryError> {
+pub fn set_u128(mem: &mut impl Memory, ptr: usize, val: u128) -> Result<(), MemoryError> {
     mem.write(ptr, &val.to_le_bytes())
 }

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -112,7 +112,7 @@ pub struct ExtInfo {
 pub trait IntoExtInfo {
     fn into_ext_info(
         self,
-        memory: &dyn Memory,
+        memory: &impl Memory,
     ) -> Result<(ExtInfo, Option<TrapExplanation>), (MemoryError, GasAmount)>;
 
     fn into_gas_amount(self) -> GasAmount;

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -133,7 +133,10 @@ pub struct BackendError<T> {
 }
 
 pub trait Environment<E: Ext + IntoExtInfo + 'static>: Sized {
-    /// An error issues in environment
+    /// Memory type for current environment.
+    type Memory: Memory;
+
+    /// An error issues in environment.
     type Error: fmt::Display;
 
     /// Creates new external environment to execute wasm binary:
@@ -151,10 +154,10 @@ pub trait Environment<E: Ext + IntoExtInfo + 'static>: Sized {
     fn get_stack_mem_end(&mut self) -> Option<WasmPageNumber>;
 
     /// Get ref to mem wrapper
-    fn get_mem(&self) -> &dyn Memory;
+    fn get_mem(&self) -> &Self::Memory;
 
     /// Get mut ref to mem wrapper
-    fn get_mem_mut(&mut self) -> &mut dyn Memory;
+    fn get_mem_mut(&mut self) -> &mut Self::Memory;
 
     /// Run instance setup starting at `entry_point` - wasm export function name.
     /// Also runs `post_execution_handler` after running instance at provided entry point.
@@ -164,7 +167,7 @@ pub trait Environment<E: Ext + IntoExtInfo + 'static>: Sized {
         post_execution_handler: F,
     ) -> Result<BackendReport, BackendError<Self::Error>>
     where
-        F: FnOnce(&dyn Memory) -> Result<(), T>,
+        F: FnOnce(&Self::Memory) -> Result<(), T>,
         T: fmt::Display;
 
     /// Consumes environment and returns gas state.

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -34,7 +34,7 @@ use gear_backend_common::{
 use gear_core::{
     env::{Ext, ExtCarrier},
     gas::GasAmount,
-    memory::{Memory, WasmPageNumber},
+    memory::WasmPageNumber,
     message::DispatchKind,
 };
 use gear_core_errors::MemoryError;
@@ -106,6 +106,7 @@ where
     E: Ext + IntoExtInfo + 'static,
     E::Error: AsTerminationReason + IntoExtError,
 {
+    type Memory = MemoryWrap;
     type Error = SandboxEnvironmentError;
 
     fn new(
@@ -207,11 +208,11 @@ where
         })
     }
 
-    fn get_mem(&self) -> &dyn Memory {
+    fn get_mem(&self) -> &Self::Memory {
         &self.runtime.memory
     }
 
-    fn get_mem_mut(&mut self) -> &mut dyn Memory {
+    fn get_mem_mut(&mut self) -> &mut Self::Memory {
         &mut self.runtime.memory
     }
 
@@ -221,7 +222,7 @@ where
         post_execution_handler: F,
     ) -> Result<BackendReport, BackendError<Self::Error>>
     where
-        F: FnOnce(&dyn Memory) -> Result<(), T>,
+        F: FnOnce(&Self::Memory) -> Result<(), T>,
         T: fmt::Display,
     {
         let res = if self.entries.contains(entry_point) {

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -71,7 +71,7 @@ pub(crate) fn return_i64<T: TryInto<i64>>(val: T) -> SyscallOutput {
         .map_err(|_| HostError)
 }
 
-fn wto<E>(memory: &mut dyn Memory, ptr: usize, buff: &[u8]) -> Result<(), FuncError<E>> {
+fn wto<E>(memory: &mut impl Memory, ptr: usize, buff: &[u8]) -> Result<(), FuncError<E>> {
     memory.write(ptr, buff).map_err(FuncError::Memory)
 }
 

--- a/core-backend/wasmtime/src/env.rs
+++ b/core-backend/wasmtime/src/env.rs
@@ -33,7 +33,7 @@ use gear_backend_common::{
 use gear_core::{
     env::{ClonedExtCarrier, Ext, ExtCarrier},
     gas::GasAmount,
-    memory::{Memory, WasmPageNumber},
+    memory::WasmPageNumber,
     message::DispatchKind,
 };
 use gear_core_errors::MemoryError;
@@ -79,6 +79,7 @@ where
     E: Ext + IntoExtInfo,
     E::Error: AsTerminationReason + IntoExtError,
 {
+    type Memory = MemoryWrapExternal<E>;
     type Error = WasmtimeEnvironmentError;
 
     fn new(
@@ -190,11 +191,11 @@ where
             })
     }
 
-    fn get_mem(&self) -> &dyn Memory {
+    fn get_mem(&self) -> &Self::Memory {
         &self.memory_wrap
     }
 
-    fn get_mem_mut(&mut self) -> &mut dyn Memory {
+    fn get_mem_mut(&mut self) -> &mut Self::Memory {
         &mut self.memory_wrap
     }
 
@@ -204,7 +205,7 @@ where
         post_execution_handler: F,
     ) -> Result<BackendReport, BackendError<Self::Error>>
     where
-        F: FnOnce(&dyn Memory) -> Result<(), T>,
+        F: FnOnce(&Self::Memory) -> Result<(), T>,
         T: fmt::Display,
     {
         struct PreparedInfo<E: Ext> {

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -109,12 +109,12 @@ fn make_checks_and_charge_gas_for_pages<'a>(
 }
 
 /// Writes initial pages data to memory and prepare memory for execution.
-fn prepare_memory<A: ProcessorExt>(
+fn prepare_memory<A: ProcessorExt, M: Memory>(
     program_id: ProgramId,
     pages_data: &mut BTreeMap<PageNumber, PageBuf>,
     allocations: &BTreeSet<WasmPageNumber>,
     static_pages: WasmPageNumber,
-    mem: &mut dyn Memory,
+    mem: &mut M,
 ) -> Result<(), ExecutionErrorReason> {
     // Set initial data for pages
     for (page, data) in pages_data.iter_mut() {
@@ -308,7 +308,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
         }
     })?;
 
-    if let Err(reason) = prepare_memory::<A>(
+    if let Err(reason) = prepare_memory::<A, E::Memory>(
         program_id,
         &mut pages_initial_data,
         &allocations,

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -72,14 +72,14 @@ pub trait ProcessorExt {
 
     /// Protect and save storage keys for pages which has no data
     fn lazy_pages_protect_and_init_info(
-        mem: &dyn Memory,
+        mem: &impl Memory,
         lazy_pages: impl Iterator<Item = PageNumber>,
         prog_id: ProgramId,
     ) -> Result<(), Self::Error>;
 
     /// Lazy pages contract post execution actions
     fn lazy_pages_post_execution_actions(
-        mem: &dyn Memory,
+        mem: &impl Memory,
         memory_pages: &mut BTreeMap<PageNumber, PageBuf>,
     ) -> Result<(), Self::Error>;
 }
@@ -238,7 +238,7 @@ impl ProcessorExt for Ext {
     }
 
     fn lazy_pages_protect_and_init_info(
-        _mem: &dyn Memory,
+        _mem: &impl Memory,
         _memory_pages: impl Iterator<Item = PageNumber>,
         _prog_id: ProgramId,
     ) -> Result<(), Self::Error> {
@@ -246,7 +246,7 @@ impl ProcessorExt for Ext {
     }
 
     fn lazy_pages_post_execution_actions(
-        _mem: &dyn Memory,
+        _mem: &impl Memory,
         _memory_pages: &mut BTreeMap<PageNumber, PageBuf>,
     ) -> Result<(), Self::Error> {
         unreachable!()
@@ -256,7 +256,7 @@ impl ProcessorExt for Ext {
 impl IntoExtInfo for Ext {
     fn into_ext_info(
         self,
-        memory: &dyn Memory,
+        memory: &impl Memory,
     ) -> Result<(ExtInfo, Option<TrapExplanation>), (MemoryError, GasAmount)> {
         let wasm_pages = self.allocations_context.allocations().clone();
         let mut pages_data = BTreeMap::new();
@@ -362,7 +362,7 @@ impl EnvExt for Ext {
     fn alloc(
         &mut self,
         pages_num: WasmPageNumber,
-        mem: &mut dyn Memory,
+        mem: &mut impl Memory,
     ) -> Result<WasmPageNumber, Self::Error> {
         // Greedily charge gas for allocations
         self.charge_gas(pages_num.0.saturating_mul(self.config.alloc_cost as u32))?;

--- a/core-processor/src/handler.rs
+++ b/core-processor/src/handler.rs
@@ -22,7 +22,7 @@ use alloc::{collections::BTreeMap, vec};
 /// Handle some journal records passing them to the journal handler.
 pub fn handle_journal(
     journal: impl IntoIterator<Item = JournalNote>,
-    handler: &mut dyn JournalHandler,
+    handler: &mut impl JournalHandler,
 ) {
     let mut page_updates = BTreeMap::new();
     let mut exit_list = vec![];

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -51,7 +51,7 @@ pub trait Ext {
     fn alloc(
         &mut self,
         pages: WasmPageNumber,
-        mem: &mut dyn Memory,
+        mem: &mut impl Memory,
     ) -> Result<WasmPageNumber, Self::Error>;
 
     /// Get the current block height.
@@ -274,7 +274,7 @@ mod tests {
         fn alloc(
             &mut self,
             _pages: WasmPageNumber,
-            _mem: &mut dyn Memory,
+            _mem: &mut impl Memory,
         ) -> Result<WasmPageNumber, Self::Error> {
             Err(AllocError)
         }

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -344,7 +344,7 @@ impl AllocationsContext {
     pub fn alloc(
         &mut self,
         pages: WasmPageNumber,
-        mem: &mut dyn Memory,
+        mem: &mut impl Memory,
     ) -> Result<WasmPageNumber, Error> {
         let last_static_page = self.static_pages.saturating_sub(1.into());
 

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -96,7 +96,7 @@ pub struct LazyPagesExt {
 impl IntoExtInfo for LazyPagesExt {
     fn into_ext_info(
         self,
-        memory: &dyn Memory,
+        memory: &impl Memory,
     ) -> Result<(ExtInfo, Option<TrapExplanation>), (MemoryError, GasAmount)> {
         // Accessed pages are all pages except current lazy pages
         let allocations = self.inner.allocations_context.allocations().clone();
@@ -193,7 +193,7 @@ impl ProcessorExt for LazyPagesExt {
     }
 
     fn lazy_pages_protect_and_init_info(
-        mem: &dyn Memory,
+        mem: &impl Memory,
         memory_pages: impl Iterator<Item = PageNumber>,
         prog_id: ProgramId,
     ) -> Result<(), Self::Error> {
@@ -202,7 +202,7 @@ impl ProcessorExt for LazyPagesExt {
     }
 
     fn lazy_pages_post_execution_actions(
-        mem: &dyn Memory,
+        mem: &impl Memory,
         memory_pages: &mut BTreeMap<PageNumber, PageBuf>,
     ) -> Result<(), Self::Error> {
         lazy_pages::post_execution_actions(mem, memory_pages).map_err(Error::LazyPages)
@@ -215,7 +215,7 @@ impl EnvExt for LazyPagesExt {
     fn alloc(
         &mut self,
         pages_num: WasmPageNumber,
-        mem: &mut dyn Memory,
+        mem: &mut impl Memory,
     ) -> Result<WasmPageNumber, Self::Error> {
         // Greedily charge gas for allocations
         self.charge_gas(

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -123,7 +123,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1240,
+    spec_version: 1250,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
In theory, `dyn` usage in affected by this PR code should has runtime overhead, but benchmarks show that this part got optimised by the compiler and there are no performance increase, but code become a bit more canonical. 

@gear-tech/dev 
