### PR TITLE
Revert previous WASM path in `gear-wasm-builder` + minor cleanup

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -16,8 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#![cfg_attr(not(feature = "std"), feature(thread_local))]
-#![cfg_attr(not(feature = "std"), feature(const_btree_new))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_use]

--- a/examples/binaries/calc-hash/over-blocks/src/lib.rs
+++ b/examples/binaries/calc-hash/over-blocks/src/lib.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 #![no_std]
-#![feature(const_btree_new)]
+#![cfg_attr(not(feature = "std"), feature(const_btree_new))]
 
 use codec::{Decode, Encode};
 use shared::PackageId;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -123,7 +123,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1260,
+    spec_version: 1270,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -61,7 +61,7 @@ impl WasmProject {
                 break;
             }
         }
-        target_dir.push("wasm-projects");
+        target_dir.push("wasm32-unknown-unknown");
         target_dir.push(profile);
 
         let profile = if profile == "debug" {

--- a/utils/wasm-builder/test-program/src/lib.rs
+++ b/utils/wasm-builder/test-program/src/lib.rs
@@ -52,15 +52,15 @@ mod tests {
     #[cfg(debug_assertions)]
     fn debug_wasm() {
         assert_eq!(
-            fs::read("target/wasm-projects/debug/test_program.wasm").unwrap(),
+            fs::read("target/wasm32-unknown-unknown/debug/test_program.wasm").unwrap(),
             code::WASM_BINARY,
         );
         assert_eq!(
-            fs::read("target/wasm-projects/debug/test_program.opt.wasm").unwrap(),
+            fs::read("target/wasm32-unknown-unknown/debug/test_program.opt.wasm").unwrap(),
             code::WASM_BINARY_OPT,
         );
         assert_eq!(
-            fs::read("target/wasm-projects/debug/test_program.meta.wasm").unwrap(),
+            fs::read("target/wasm32-unknown-unknown/debug/test_program.meta.wasm").unwrap(),
             code::WASM_BINARY_META,
         );
     }
@@ -69,15 +69,15 @@ mod tests {
     #[cfg(not(debug_assertions))]
     fn release_wasm() {
         assert_eq!(
-            fs::read("target/wasm-projects/release/test_program.wasm").unwrap(),
+            fs::read("target/wasm32-unknown-unknown/release/test_program.wasm").unwrap(),
             code::WASM_BINARY,
         );
         assert_eq!(
-            fs::read("target/wasm-projects/release/test_program.opt.wasm").unwrap(),
+            fs::read("target/wasm32-unknown-unknown/release/test_program.opt.wasm").unwrap(),
             code::WASM_BINARY_OPT,
         );
         assert_eq!(
-            fs::read("target/wasm-projects/release/test_program.meta.wasm").unwrap(),
+            fs::read("target/wasm32-unknown-unknown/release/test_program.meta.wasm").unwrap(),
             code::WASM_BINARY_META,
         );
     }


### PR DESCRIPTION
The output WASM binary path has been accidentally changed in #1126.

- Reverted the WASM binary path to keep compatibility with building without a build script.
- Minor cleanup.

@gear-tech/dev 
