### PR TITLE
Fix `gtest` logic with async inits 

### DIFF
--- a/gtest/src/error.rs
+++ b/gtest/src/error.rs
@@ -45,7 +45,7 @@ pub enum TestError {
     /// Actor is not executable.
     #[from(ignore)]
     #[display(fmt = "Actor is not executable: `{}`", _0)]
-    ActorIsntExecutable(ProgramId),
+    ActorIsNotExecutable(ProgramId),
 
     /// Meta WASM binary hasn't been provided.
     #[display(fmt = "Meta WASM binary hasn't been provided")]


### PR DESCRIPTION
By request of @LouiseMedova, resolves unreachable panic:
```shell
'internal error: entered unreachable code: No pages update for non-initialized program`
```

