### PR TITLE
Value sendings and ED fixes for `gtest`

### DIFF
--- a/gtest/src/mailbox.rs
+++ b/gtest/src/mailbox.rs
@@ -132,7 +132,7 @@ mod tests {
     };
 
     #[test]
-    fn mailbox_walkthrough_test() {
+    fn mailbox_walk_through_test() {
         //Arranging data for future messages
         let system = System::new();
         let message_id: MessageId = Default::default();
@@ -151,7 +151,7 @@ mod tests {
             destination_user_id,
             encoded_message_payload.clone(),
             Default::default(),
-            2,
+            0,
             None,
         );
 
@@ -168,7 +168,7 @@ mod tests {
         let message_replier = destination_user_mailbox.take_message(log);
 
         //Replying on sended message and extracting log
-        let reply_log = message_replier.reply(reply_payload, 1).log;
+        let reply_log = message_replier.reply(reply_payload, 0).log;
         let last_reply_log = reply_log.last().expect("No message log in run result");
 
         //Sending one more message to be sure that no critical move semantic didn't occur
@@ -208,7 +208,7 @@ mod tests {
             destination_user_id,
             message_payload.encode(),
             Default::default(),
-            2,
+            0,
             None,
         );
 
@@ -217,7 +217,7 @@ mod tests {
 
         //Getting mailbox of destination user and replying on it
         let mut destination_user_mailbox = system.get_mailbox(destination_user_id);
-        destination_user_mailbox.reply(message_log.clone(), reply_payload, 1);
+        destination_user_mailbox.reply(message_log.clone(), reply_payload, 0);
 
         //Making sure that original message deletes after reply
         destination_user_mailbox = system.get_mailbox(destination_user_id);
@@ -243,7 +243,7 @@ mod tests {
             destination_user_id,
             message_payload.encode(),
             Default::default(),
-            2,
+            0,
             None,
         );
 
@@ -255,7 +255,7 @@ mod tests {
         let message_replier = destination_user_mailbox.take_message(log);
 
         //Replying by bytes and extracting result log
-        let result = message_replier.reply_bytes(&reply_payload_array, 1);
+        let result = message_replier.reply_bytes(&reply_payload_array, 0);
         let result_log = result.log;
         let last_result_log = result_log.last().expect("No message log in run result");
 
@@ -279,7 +279,7 @@ mod tests {
             destination_user_id,
             message_payload.encode(),
             Default::default(),
-            2,
+            0,
             None,
         );
 

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -756,6 +756,10 @@ impl JournalHandler for ExtManager {
                 }
 
                 *balance -= value;
+
+                if *balance < crate::EXISTENTIAL_DEPOSIT {
+                    *balance = 0;
+                }
             }
 
             self.mint_to(to, value);

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -356,17 +356,6 @@ impl<'a> Program<'a> {
 
         let source = from.into().0;
 
-        if !system.is_user(&source) {
-            panic!("Sending messages allowed only from users id");
-        }
-
-        if 0 < value && value < crate::EXISTENTIAL_DEPOSIT {
-            panic!(
-                "Value greater than 0, but less than required existential deposit ({})",
-                crate::EXISTENTIAL_DEPOSIT
-            );
-        }
-
         let message = Message::new(
             MessageId::generate_from_user(
                 system.block_info.height,
@@ -383,20 +372,14 @@ impl<'a> Program<'a> {
 
         let (actor, _) = system.actors.get_mut(&self.id).expect("Can't fail");
 
-        let kind = if let TestActor::Uninitialized(id, _) = actor {
-            if id.is_none() {
-                *id = Some(message.id());
-                DispatchKind::Init
-            } else {
-                DispatchKind::Handle
-            }
+        let kind = if let TestActor::Uninitialized(id @ None, _) = actor {
+            *id = Some(message.id());
+            DispatchKind::Init
         } else {
             DispatchKind::Handle
         };
 
-        let dispatch = Dispatch::new(kind, message);
-
-        system.run_dispatch(dispatch)
+        system.run_dispatch(Dispatch::new(kind, message))
     }
 
     pub fn id(&self) -> ProgramId {
@@ -542,5 +525,32 @@ mod tests {
 
         // Check program's balance is empty
         assert_eq!(prog.balance(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "An attempt to mint value (1) less than existential deposit (500)")]
+    fn mint_less_than_deposit() {
+        System::new().mint_to(1, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "Insufficient value: user \
+    (0x0100000000000000000000000000000000000000000000000000000000000000) tries \
+    to send (501) value, while his balance (500)")]
+    fn fails_on_insufficient_balance() {
+        let sys = System::new();
+
+        let user = 1;
+        let prog = Program::from_file_with_id(
+            &sys,
+            2,
+            "../target/wasm32-unknown-unknown/release/demo_piggy_bank.wasm",
+        );
+
+        assert_eq!(sys.balance_of(user), 0);
+        sys.mint_to(user, crate::EXISTENTIAL_DEPOSIT);
+        assert_eq!(sys.balance_of(user), crate::EXISTENTIAL_DEPOSIT);
+
+        prog.send_bytes_with_value(user, b"init", crate::EXISTENTIAL_DEPOSIT + 1);
     }
 }

--- a/gtest/src/system.rs
+++ b/gtest/src/system.rs
@@ -78,8 +78,9 @@ impl System {
     }
 
     pub fn spend_blocks(&self, amount: u32) {
-        self.0.borrow_mut().block_info.height += amount;
-        self.0.borrow_mut().block_info.timestamp += amount as u64;
+        let mut manager = self.0.borrow_mut();
+        manager.block_info.height += amount;
+        manager.block_info.timestamp += amount as u64;
     }
 
     /// Returns a [`Program`] by `id`.


### PR DESCRIPTION
By request of @LouiseMedova.

Things to lead gtest closer to real runtime behaviour:
- Panic occurs while trying to mint value less than ED 
- Panic occurs while trying to send value, greater than users balance
- If after sending value your balance is less than ED, it becomes 0

@gear-tech/dev 
