### PR TITLE
feat(sandbox): downcast ExtError in `gr_read`

### DIFF
--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -330,7 +330,7 @@ where
             let msg_slice = &msg[at..(at + len)];
 
             if exit_code == ReturnValue::Value(Value::I32(crate::ERR_EXIT_CODE)) {
-                if let Ok(e) = ExtError::decode(&mut msg_slice.clone()) {
+                if let Ok(e) = ExtError::decode(&mut msg_slice.as_ref()) {
                     return Err(FuncError::Core(e.into()));
                 }
             }

--- a/core-backend/sandbox/src/lib.rs
+++ b/core-backend/sandbox/src/lib.rs
@@ -28,3 +28,6 @@ pub mod memory;
 
 pub use env::SandboxEnvironment;
 pub use memory::MemoryWrap;
+
+/// Error exit code.
+pub const ERR_EXIT_CODE: gear_core::message::ExitCode = 1;

--- a/core-errors/src/lib.rs
+++ b/core-errors/src/lib.rs
@@ -30,7 +30,7 @@ use core::fmt;
 use scale_info::TypeInfo;
 
 /// Core error.
-pub trait CoreError: fmt::Display + fmt::Debug {}
+pub trait CoreError: fmt::Display + fmt::Debug + From<ExtError> {}
 
 /// Error using messages.
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, derive_more::Display)]

--- a/gcore/src/msg.rs
+++ b/gcore/src/msg.rs
@@ -34,7 +34,7 @@ mod sys {
     extern "C" {
         pub fn gr_exit_code() -> i32;
         pub fn gr_msg_id(val: *mut u8);
-        pub fn gr_read(at: u32, len: u32, dest: *mut u8);
+        pub fn gr_read(at: u32, len: u32, dest: *mut u8) -> SyscallError;
         pub fn gr_reply(
             data_ptr: *const u8,
             data_len: u32,
@@ -146,14 +146,15 @@ pub fn id() -> MessageId {
 ///     msg::load(&mut result[..]);
 /// }
 /// ```
-pub fn load(buffer: &mut [u8]) {
+pub fn load(buffer: &mut [u8]) -> Result<()> {
     unsafe {
         let message_size = sys::gr_size() as usize;
         if message_size != buffer.len() {
             panic!("Cannot load message - buffer length does not match");
         }
 
-        sys::gr_read(0, message_size as _, buffer.as_mut_ptr() as _);
+        sys::gr_read(0, message_size as _, buffer.as_mut_ptr() as _).into_result()?;
+        Ok(())
     }
 }
 

--- a/gstd/src/msg/basic.rs
+++ b/gstd/src/msg/basic.rs
@@ -25,7 +25,7 @@ use crate::{
     prelude::{convert::AsRef, vec, Vec},
     ActorId, MessageId,
 };
-use codec::{Decode, Output};
+use codec::{Decode, Encode, Output};
 use gstd_codegen::wait_for_reply;
 
 trait IntoContractResult<T> {
@@ -180,9 +180,11 @@ pub fn id() -> MessageId {
 ///     let payload_bytes = msg::load_bytes();
 /// }
 /// ```
-pub fn load_bytes() -> Vec<u8> {
+pub fn load_bytes() -> Result<Vec<u8>> {
     let mut result = vec![0u8; size()];
-    gcore::msg::load(&mut result[..]);
+
+    gcore::msg::load(&mut result[..])?;
+
     result
 }
 

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -40,6 +40,12 @@ pub enum Error {
     LazyPages(lazy_pages::Error),
 }
 
+impl From<ExtError> for Error {
+    fn from(e: ExtError) -> Self {
+        Error::Processor(ProcessorError::Core(e))
+    }
+}
+
 impl CoreError for Error {}
 
 impl IntoExtError for Error {


### PR DESCRIPTION
Resolves #1084.

- [x] throw error in `gr_read` once error replies are received
- [ ] do the same in the wasmtime backend
- [ ] update tests and examples
- [ ] update gear-test
- 

@gear-tech/dev

---

NOTE:  downcast the `ExtError` in `gr_read` maybe the most convenient solution but this will cause break-changes in our api ( `gstd::load_bytes()` ).

Feal free to comment on this PR
