### PR TITLE
Correct most obvious mistakes in docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           toolchain: nightly
 
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+
       - name: Build docs
         run: make doc
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,6 @@ jobs:
         run: make doc
 
       - name: Copy logo image
-        if: github.event_name == 'push'
         run: cp ./images/logo.svg ./target/doc/
 
       - name: Deploy
@@ -37,3 +36,11 @@ jobs:
           force_orphan: true
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Deploy PR
+        if: github.event_name == 'pull_request'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc
+          destination_dir: pr-${{ github.event.number }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,8 @@
 name: Docs
 
 on:
+  pull_request:
+    branches: [master]
   push:
     branches: [master]
 
@@ -13,17 +15,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: "Install nightly toolchain"
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+
       - name: Build docs
-        run: |
-          cargo doc -p galloc -p gcore -p gear-backend-common -p gear-backend-sandbox \
-                -p gear-core -p gear-core-processor -p gear-lazy-pages -p gear-core-errors \
-                -p gstd -p gtest -p gear-wasm-builder -p gear-common --no-deps
-          echo "<html><head><meta http-equiv=\"refresh\" content=\"0; url=/galloc/index.html\" /></head><body></body></html>" > ./target/doc/index.html
+        run: make doc
 
       - name: Copy logo image
+        if: github.event_name == 'push'
         run: cp ./images/logo.svg ./target/doc/
 
       - name: Deploy
+        if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,15 @@ test-pallet-release:
 test-runtime-upgrade: init-js examples node-release
 	@ ./scripts/gear.sh test runtime-upgrade
 
+# Misc section
+.PHONY: doc
+doc:
+	@ RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo +nightly doc --no-deps \
+		-p galloc -p gcore -p gear-backend-common -p gear-backend-sandbox \
+		-p gear-core -p gear-core-processor -p gear-lazy-pages -p gear-core-errors \
+		-p gstd -p gtest -p gear-wasm-builder -p gear-common
+	@ cp -f images/logo.svg target/doc/rust-logo.svg
+
 .PHONY: fuzz
 fuzz:
 	@ ./scripts/gear.sh test fuzz

--- a/common/src/gas_provider/mod.rs
+++ b/common/src/gas_provider/mod.rs
@@ -92,14 +92,14 @@ pub trait Tree {
 
     /// The external origin for a key, if the latter exists, `None` otherwise.
     ///
-    /// Check [`get_origin`] for more details.
+    /// Check [`get_origin`](Self::get_origin) for more details.
     fn get_external(key: Self::Key) -> Result<Option<Self::ExternalOrigin>, Self::Error> {
         Self::get_origin(key).map(|result| result.map(|(_, external)| external))
     }
 
     /// The id of external node for a key, if the latter exists, `None` otherwise.
     ///
-    /// Check [`get_origin`] for more details.
+    /// Check [`get_origin`](Self::get_origin) for more details.
     fn get_origin_key(key: Self::Key) -> Result<Option<Self::Key>, Self::Error> {
         Self::get_origin(key).map(|result| result.map(|(key, _)| key))
     }

--- a/gcore/src/msg.rs
+++ b/gcore/src/msg.rs
@@ -201,7 +201,7 @@ pub fn reply(payload: &[u8], value: u128) -> Result<MessageId> {
     }
 }
 
-/// Same as ['reply'], but with explicit gas limit.
+/// Same as [`reply`], but with explicit gas limit.
 ///
 /// # Examples
 ///
@@ -240,7 +240,7 @@ pub fn reply_with_gas(payload: &[u8], gas_limit: u64, value: u128) -> Result<Mes
 /// function.
 ///
 /// This function allows sending reply messages filled with payload parts sent
-/// via ['reply_push'] during the message handling. Finalization of the
+/// via [`reply_push`] during the message handling. Finalization of the
 /// reply message is done via [`reply_commit`] function similar to
 /// [`send_commit`].
 ///
@@ -274,7 +274,7 @@ pub fn reply_commit(value: u128) -> Result<MessageId> {
     }
 }
 
-/// Same as ['reply_commit'], but with explicit gas limit.
+/// Same as [`reply_commit`], but with explicit gas limit.
 ///
 /// # Examples
 ///
@@ -314,7 +314,7 @@ pub fn reply_commit_with_gas(gas_limit: u64, value: u128) -> Result<MessageId> {
 /// logic. Basic implementation is covered in [`reply`](crate::msg::reply)
 /// function.
 ///
-/// This function allows filling the reply payload parts via ['reply_push']
+/// This function allows filling the reply payload parts via [`reply_push`]
 /// during the message `handling`. The payload can consist of several parts.
 ///
 /// # Examples
@@ -407,7 +407,7 @@ pub fn send(program: ActorId, payload: &[u8], value: u128) -> Result<MessageId> 
     }
 }
 
-/// Same as ['send'], but with explicit gas limit.
+/// Same as [`send`], but with explicit gas limit.
 ///
 /// # Examples
 ///
@@ -498,7 +498,7 @@ pub fn send_commit(handle: MessageHandle, program: ActorId, value: u128) -> Resu
     }
 }
 
-/// Same as ['send_commit'], but with explicit gas limit.
+/// Same as [`send_commit`], but with explicit gas limit.
 ///
 /// # Examples
 ///

--- a/gstd/codegen/src/lib.rs
+++ b/gstd/codegen/src/lib.rs
@@ -124,7 +124,7 @@ pub fn async_main(_attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 /// Mark async function to be the program initialization method.
-/// Can be used together with [`async_main`].
+/// Can be used together with [`macro@async_main`].
 /// Functions `init`, `handle_reply` cannot be specified if this macro is used.
 /// If you need to specify `init`, `handle_reply` explicitly don't use this macro.
 ///
@@ -170,12 +170,12 @@ pub fn async_init(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// outputs:
 ///
 /// ```ignore
-/// Same as [`send_bytes`](crate::msg::basic::send_bytes), but the program
-/// will interrupt until the reply is received.
-///
-/// # See also
-///
-/// - [`send_bytes_for_reply_as`](crate::msg::basic::send_bytes_for_reply_as)
+/// /// Same as [`send_bytes`](crate::msg::send_bytes), but the program
+/// /// will interrupt until the reply is received.
+/// ///
+/// /// # See also
+/// ///
+/// /// - [`send_bytes_for_reply_as`](crate::msg::send_bytes_for_reply_as)
 /// pub fn send_bytes_for_reply<T: AsRef<[u8]>>(
 ///     program: ActorId,
 ///     payload: T,
@@ -187,15 +187,15 @@ pub fn async_init(_attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     Ok(MessageFuture { waiting_reply_to })
 /// }
 ///
-/// /// Same as [`send_bytes`](crate::msg::basic::send_bytes), but the program
+/// /// Same as [`send_bytes`](crate::msg::send_bytes), but the program
 /// /// will interrupt until the reply is received.
 /// ///
-/// /// The output should be decodable via [`SCALE CODEC`].
+/// /// The output should be decodable via SCALE codec.
 /// ///
 /// /// # See also
 /// ///
-/// /// - [`send_bytes_for_reply`](crate::msg::basic::send_bytes_for_reply)
-/// /// - https://docs.substrate.io/v3/advanced/scale-codec
+/// /// - [`send_bytes_for_reply`](crate::msg::send_bytes_for_reply)
+/// /// - <https://docs.substrate.io/v3/advanced/scale-codec>
 /// pub fn send_bytes_for_reply_as<T: AsRef<[u8]>, D: Decode>(
 ///     program: ActorId,
 ///     payload: T,

--- a/gstd/codegen/src/utils.rs
+++ b/gstd/codegen/src/utils.rs
@@ -28,12 +28,12 @@ const SPAN_CODEC: &str = "${CODEC}";
 const SPAN_ELSE: &str = "${ELSE}";
 const SPAN_IDENT: &str = "${IDENT}";
 const WAIT_FOR_REPLY_DOCS_TEMPLATE: &str = r#"
- Same as [`${IDENT}`](crate::msg::basic::${IDENT}), but the program
+ Same as [`${IDENT}`](crate::msg::${IDENT}), but the program
  will interrupt until the reply is received. ${CODEC}
 
  # See also
 
- - [`${ELSE}`](crate::msg::basic::${ELSE})
+ - [`${ELSE}`](crate::msg::${ELSE})
 "#;
 
 /// New `Ident`
@@ -77,8 +77,8 @@ pub fn wait_for_reply_docs(name: String) -> (String, String) {
             .replace(SPAN_CODEC, ""),
         docs.replace(SPAN_ELSE, &(name + "_for_reply")).replace(
             SPAN_CODEC,
-            "\n\n The output should be decodable via [`SCALE CODEC`].",
-        ) + " - https://docs.substrate.io/v3/advanced/scale-codec",
+            "\n\n The output should be decodable via SCALE codec.",
+        ) + " - <https://docs.substrate.io/v3/advanced/scale-codec>",
     )
 }
 

--- a/gstd/src/msg/basic.rs
+++ b/gstd/src/msg/basic.rs
@@ -186,7 +186,7 @@ pub fn load_bytes() -> Vec<u8> {
     result
 }
 
-/// Same as ['reply'], but with explicit gas limit.
+/// Same as [`reply`](crate::msg::reply), but with explicit gas limit.
 ///
 /// Some programs can reply to other programs, i.e. check another program's
 /// state and use it as a parameter for its own business logic [`MessageId`].
@@ -224,13 +224,13 @@ pub fn reply_with_gas(payload: &[u8], gas_limit: u64, value: u128) -> Result<Mes
     gcore::msg::reply_with_gas(payload, gas_limit, value).into_contract_result()
 }
 
-/// Same as [`reply`](crate::msg::encoded::reply), without encoding payload.
+/// Same as [`reply`](crate::msg::reply), without encoding payload.
 #[wait_for_reply]
 pub fn reply_bytes(payload: impl AsRef<[u8]>, value: u128) -> Result<MessageId> {
     gcore::msg::reply(payload.as_ref(), value).into_contract_result()
 }
 
-/// Same as [`reply_bytes`](crate::msg::encoded::reply_bytes), with gas limit.
+/// Same as [`reply_bytes`], with gas limit.
 #[wait_for_reply]
 pub fn reply_bytes_with_gas(
     payload: impl AsRef<[u8]>,
@@ -248,7 +248,7 @@ pub fn reply_bytes_with_gas(
 /// function.
 ///
 /// This function allows sending reply messages filled with payload parts sent
-/// via ['reply_push'] during the message handling. Finalization of the
+/// via [`reply_push`] during the message handling. Finalization of the
 /// reply message is done via [`reply_commit`] function similar to
 /// [`send_commit`].
 ///
@@ -275,7 +275,7 @@ pub fn reply_commit(value: u128) -> Result<MessageId> {
     gcore::msg::reply_commit(value).into_contract_result()
 }
 
-/// Same as ['reply_commit'], but with explicit gas limit.
+/// Same as [`reply_commit`], but with explicit gas limit.
 ///
 /// # Examples
 ///
@@ -307,7 +307,7 @@ pub fn reply_commit_with_gas(gas_limit: u64, value: u128) -> Result<MessageId> {
 /// logic. Basic implementation is covered in [`reply`](crate::msg::reply)
 /// function.
 ///
-/// This function allows filling the reply payload parts via ['reply_push']
+/// This function allows filling the reply payload parts via [`reply_push`]
 /// during the message `handling`. The payload can consist of several parts.
 ///
 /// # Examples
@@ -386,7 +386,7 @@ pub fn send_bytes<T: AsRef<[u8]>>(program: ActorId, payload: T, value: u128) -> 
     gcore::msg::send(program.into(), payload.as_ref(), value).into_contract_result()
 }
 
-/// Same as ['send_bytes'], but with explicit gas limit.
+/// Same as [`send_bytes`], but with explicit gas limit.
 ///
 /// # Examples
 ///
@@ -453,7 +453,7 @@ pub fn send_commit(handle: MessageHandle, program: ActorId, value: u128) -> Resu
     gcore::msg::send_commit(handle.into(), program.into(), value).into_contract_result()
 }
 
-/// Same as ['send_commit'], but with explicit gas limit.
+/// Same as [`send_commit`], but with explicit gas limit.
 ///
 /// # Examples
 ///

--- a/gstd/src/msg/encoded.rs
+++ b/gstd/src/msg/encoded.rs
@@ -45,16 +45,19 @@ pub fn load<D: Decode>() -> Result<D> {
     D::decode(&mut super::load_bytes().as_ref()).map_err(ContractError::Decode)
 }
 
+/// Send a new message as a reply to the message currently being processed.
 #[wait_for_reply]
 pub fn reply<E: Encode>(payload: E, value: u128) -> Result<MessageId> {
     super::reply_bytes(payload.encode(), value)
 }
 
+/// Send a new message to the program or user.
 #[wait_for_reply]
 pub fn send<E: Encode>(program: ActorId, payload: E, value: u128) -> Result<MessageId> {
     super::send_bytes(program, payload.encode(), value)
 }
 
+/// Same as [`send`], but with explicit gas limit.
 #[wait_for_reply]
 pub fn send_with_gas<E: Encode>(
     program: ActorId,

--- a/gtest/src/error.rs
+++ b/gtest/src/error.rs
@@ -69,7 +69,7 @@ pub enum TestError {
     #[display(fmt = "{}", _0)]
     ExecutionError(ProcessorError),
 
-    /// Wrapper for [`MemoryAccessError`].
+    /// Wrapper for [`wasmtime::MemoryAccessError`](https://docs.rs/wasmtime/latest/wasmtime/struct.MemoryAccessError.html).
     #[display(fmt = "{}", _0)]
     MemoryError(MemoryAccessError),
 
@@ -77,7 +77,7 @@ pub enum TestError {
     #[display(fmt = "{}", _0)]
     WasmtimeError(AnyhowError),
 
-    /// Wrapper for `parity-scale-codec` error (see [`parity_scale_codec::Error`]).
+    /// Wrapper for [`parity_scale_codec::Error`](https://docs.rs/parity-scale-codec/latest/parity_scale_codec/struct.Error.html).
     #[display(fmt = "{}", _0)]
     ScaleCodecError(CodecError),
 }


### PR DESCRIPTION
Correct many minor mistakes in docs.

- Fixed broken links.
- Added `make doc` command.
- Make PRs docs be deployed to `https://docs.gear.rs/pr-#/`.

Rendered: https://docs.gear.rs/pr-1186/