### PR TITLE
gtest: Fix panic message decoding in log

### DIFF
--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -668,7 +668,16 @@ impl JournalHandler for ExtManager {
         if !self.is_user(&dispatch.destination()) {
             self.dispatches.push_back(dispatch.into_stored());
         } else {
-            let message = dispatch.into_parts().1.into_stored();
+            let message = match dispatch.exit_code() {
+                Some(0) | None => dispatch.into_parts().1.into_stored(),
+                _ => {
+                    let message = dispatch.into_parts().1.into_stored();
+                    message
+                        .clone()
+                        .with_string_payload::<ExecutionErrorReason>()
+                        .unwrap_or(message)
+                }
+            };
 
             self.mailbox
                 .entry(message.destination())

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -475,6 +475,11 @@ mod tests {
         let run_result = prog.send(user_id, init_msg_payload);
         assert!(run_result.main_failed);
 
+        let log = run_result.log();
+        assert!(!log.is_empty());
+
+        assert_eq!(log[0].payload(), b"'Invalid input, should be three IDs separated by comma', futures-unordered/src/lib.rs:17:9");
+
         let run_result = prog.send(user_id, String::from("should_be_skipped"));
 
         let expected_log = Log::error_builder(2).source(prog.id()).dest(user_id);


### PR DESCRIPTION
The panic message in the log had been encoded by the SCALE codec. Now it is decoded to be a plain string.

@gear-tech/dev
