### PR TITLE
gtest: Provide block height and timestamp to `meta_state` function

### DIFF
--- a/examples/block-info/src/lib.rs
+++ b/examples/block-info/src/lib.rs
@@ -13,3 +13,9 @@ unsafe extern "C" fn handle() {
     let bh = exec::block_height();
     msg::reply_bytes(format!("{}_{}", payload, bh), 0).unwrap();
 }
+
+#[no_mangle]
+unsafe extern "C" fn meta_state() -> *mut [i32; 2] {
+    let timestamp = exec::block_timestamp();
+    gstd::util::to_leak_ptr(timestamp.to_le_bytes())
+}

--- a/gear-test/spec_no_runtime/test_block_info.yaml
+++ b/gear-test/spec_no_runtime/test_block_info.yaml
@@ -2,7 +2,7 @@ title: Block info
 
 programs:
   - id: 1
-    path: target/wasm32-unknown-unknown/release/demo_block_info.wasm
+    path: target/wasm32-unknown-unknown/release/demo_block_info.opt.wasm
     source:
       kind: account
       value: alice

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -208,7 +208,7 @@ impl ExtManager {
                 timestamp: SystemTime::now()
                     .duration_since(UNIX_EPOCH)
                     .expect("Time went backwards")
-                    .as_secs(),
+                    .as_millis() as u64,
             },
             ..Default::default()
         }
@@ -357,6 +357,7 @@ impl ExtManager {
         function_name: &str,
     ) -> Result<Vec<u8>> {
         let mut executor = self.get_executor(program_id, payload)?;
+        executor.update_ext(self);
         executor.execute(function_name)
     }
 

--- a/gtest/src/system.rs
+++ b/gtest/src/system.rs
@@ -80,7 +80,17 @@ impl System {
     pub fn spend_blocks(&self, amount: u32) {
         let mut manager = self.0.borrow_mut();
         manager.block_info.height += amount;
-        manager.block_info.timestamp += amount as u64;
+        manager.block_info.timestamp += 1000 * amount as u64;
+    }
+
+    /// Return the current block height.
+    pub fn block_height(&self) -> u32 {
+        self.0.borrow().block_info.height
+    }
+
+    /// Return the current block timestamp.
+    pub fn block_timestamp(&self) -> u64 {
+        self.0.borrow().block_info.timestamp
     }
 
     /// Returns a [`Program`] by `id`.


### PR DESCRIPTION
Sometimes it is needed to get the current block's height and timestamp while debugging `meta_state` function. Now when calling `exec::block_height` and `exec::block_timestamp` functions in `meta_state`, they provide actual data according to the `gtest` runtime.

@gear-tech/dev
