### PR TITLE
Optimize gas nodes consumption

### DIFF
--- a/common/src/gas_provider/internal.rs
+++ b/common/src/gas_provider/internal.rs
@@ -253,7 +253,7 @@ where
     /// That's due to the 12-th invariant stated in [`super::property_tests`] module docs. When node becomes consumed without unspec refs (i.e., stops being a patron)
     /// `consume` procedure call on such node either moves value upstream (if there is an ancestor patron) or returns value to the origin. So any repetitive `catch_value` call on
     /// such nodes results in `CatchValueOutput::Caught(0)` (if there are is ancestor patron). So if `consume` procedure on the node with `key` id resulted in value being caught,
-    /// it means that there are no ancestor patrons, so non of `catch_value` calls on the node's ancestors will return `CatchValueOutput::Missed`, but will return `CatchValueOutput::Caught(0)`.
+    /// it means that there are no ancestor patrons, so none of `catch_value` calls on the node's ancestors will return `CatchValueOutput::Missed`, but will return `CatchValueOutput::Caught(0)`.
     fn try_remove_consumed_ancestors(
         key: MapKey,
         descendant_catch_output: CatchValueOutput<Balance>,

--- a/common/src/gas_provider/internal.rs
+++ b/common/src/gas_provider/internal.rs
@@ -252,7 +252,7 @@ where
     /// 3. If `catch_value` call ended up with `CatchValueOutput::Caught(x)` in `consume`, all the calls of `catch_value` on ancestor nodes will be `CatchValueOutput::Caught(0)`.
     /// That's due to the 12-th invariant stated in [`super::property_tests`] module docs. When node becomes consumed without unspec refs (i.e., stops being a patron)
     /// `consume` procedure call on such node either moves value upstream (if there is an ancestor patron) or returns value to the origin. So any repetitive `catch_value` call on
-    /// such nodes results in `CatchValueOutput::Caught(0)` (if there are is ancestor patron). So if `consume` procedure on the node with `key` id resulted in value being caught,
+    /// such nodes results in `CatchValueOutput::Caught(0)` (if there is an ancestor patron). So if `consume` procedure on the node with `key` id resulted in value being caught,
     /// it means that there are no ancestor patrons, so none of `catch_value` calls on the node's ancestors will return `CatchValueOutput::Missed`, but will return `CatchValueOutput::Caught(0)`.
     fn try_remove_consumed_ancestors(
         key: MapKey,
@@ -264,7 +264,7 @@ where
         let (_, origin) = Self::get_origin(key)?.expect("existing node always have origin");
 
         // Descendant's `catch_value` output is used for the sake of optimization.
-        // We could easily run `catch_value` in the bellow `while` loop each time
+        // We could easily run `catch_value` in the below `while` loop each time
         // we process the ancestor. But that would lead to quadratic complexity of
         // the `consume` & `try_remove_consumed_ancestors` procedures. In order to
         // optimize that we use internal properties of the `consume` procedure described

--- a/common/src/gas_provider/internal.rs
+++ b/common/src/gas_provider/internal.rs
@@ -253,7 +253,7 @@ where
     /// That's due to the 12-th invariant stated in [`super::property_tests`] module docs. When node becomes consumed without unspec refs (i.e., stops being a patron)
     /// `consume` procedure call on such node either moves value upstream (if there is an ancestor patron) or returns value to the origin. So any repetitive `catch_value` call on
     /// such nodes results in `CatchValueOutput::Caught(0)` (if there are is ancestor patron). So if `consume` procedure on the node with `key` id resulted in value being caught,
-    /// it means that there are no ancestor patrons, so non of `cath_value` calls on the node's ancestors will return `CatchValueOutput::Missed`, but will return `CatchValueOutput::Caught(0)`.
+    /// it means that there are no ancestor patrons, so non of `catch_value` calls on the node's ancestors will return `CatchValueOutput::Missed`, but will return `CatchValueOutput::Caught(0)`.
     fn try_remove_consumed_ancestors(
         key: MapKey,
         descendant_catch_output: CatchValueOutput<Balance>,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -125,7 +125,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear-node"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 1430,
+    spec_version: 1440,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -122,7 +122,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1410,
+    spec_version: 1420,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Resolves #1212 .

- Makes optional run of `catch_value` procedure depending on the result of the child's run (in `try_remove_consumed_ancestors`).
- Describes all the optimization details in the doc comments.

@gear-tech/dev
