### PR TITLE
Add authority into benches

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -245,6 +245,11 @@ jobs:
       - name: "Test: Runtime upgrade and queue processing"
         run: ./scripts/gear.sh test runtime-upgrade
 
+      - name: "Test: Runtime benchmarks work"
+        run: |
+          cargo build -p gear-node --release --features runtime-benchmarks
+          ./target/release/gear-node benchmark pallet --chain=dev --steps=1 --repeat=1 --pallet=pallet_gear --extrinsic="*" --execution=wasm --wasm-execution=compiled --heap-pages=4096
+
       - name: Find comment (performance)
         uses: peter-evans/find-comment@v2
         if: ${{ github.ref != 'refs/heads/master' }}
@@ -388,7 +393,7 @@ jobs:
           .\rustup-init.exe -y
           rustup --version
 
-      - name: "Install: Disable rustup autoupdate"
+      - name: "Install: Disable rustup auto-update"
         run: rustup set auto-self-update disable
 
       - name: "Install: Nightly toolchain"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4931,6 +4931,7 @@ dependencies = [
  "rand_pcg 0.3.1",
  "scale-info",
  "serde",
+ "sp-consensus-aura",
  "sp-core",
  "sp-externalities",
  "sp-io",

--- a/pallets/gear/Cargo.toml
+++ b/pallets/gear/Cargo.toml
@@ -43,6 +43,8 @@ pallet-authorship = { version = "4.0.0-dev", default-features = false, git = "ht
 pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 pallet-gear-program = { path = "../gear-program", default-features = false }
 
+sp-consensus-aura = { version = "0.10.0-dev", optional = true, git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false }
+
 # Benchmark deps
 sp-sandbox = { version = "0.10.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false, optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
@@ -107,6 +109,7 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"common/runtime-benchmarks",
 	"sp-sandbox",
+	"sp-consensus-aura",
 	"rand",
 	"rand_pcg",
 ]

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -42,13 +42,15 @@ use common::{
 };
 use core_processor::configs::{AllocationsConfig, BlockConfig, BlockInfo, MessageExecutionContext};
 use frame_benchmarking::{benchmarks, whitelisted_caller};
-use frame_support::traits::{Currency, Get, ReservableCurrency};
-use frame_system::RawOrigin;
+use frame_support::traits::{Currency, Get, Hooks, ReservableCurrency};
+use frame_system::{Pallet as SystemPallet, RawOrigin};
 use gear_core::ids::{MessageId, ProgramId};
+use pallet_authorship::Pallet as AuthorshipPallet;
+use sp_consensus_aura::{Slot, AURA_ENGINE_ID};
 use sp_core::H256;
 use sp_runtime::{
-    traits::{Bounded, UniqueSaturatedInto},
-    Perbill,
+    traits::{Bounded, One, UniqueSaturatedInto},
+    Digest, DigestItem, Perbill,
 };
 use sp_std::prelude::*;
 use wasm_instrument::parity_wasm::elements::{BlockType, BrTableData, Instruction, ValueType};
@@ -61,6 +63,26 @@ const API_BENCHMARK_BATCHES: u32 = 20;
 
 /// How many batches we do per Instruction benchmark.
 const INSTR_BENCHMARK_BATCHES: u32 = 50;
+
+/// Initializes block and runs queue processing.
+fn process_queue<T: Config>()
+where
+    T::AccountId: Origin,
+{
+    let slot = Slot::from(0);
+    let pre_digest = Digest {
+        logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode())],
+    };
+
+    let bn = One::one();
+
+    SystemPallet::<T>::initialize(&bn, &SystemPallet::<T>::parent_hash(), &pre_digest);
+    SystemPallet::<T>::set_block_number(bn);
+    SystemPallet::<T>::on_initialize(bn);
+    AuthorshipPallet::<T>::on_initialize(bn);
+
+    Gear::<T>::process_queue(Default::default());
+}
 
 /// An instantiated and deployed program.
 struct Program<T: Config> {
@@ -111,7 +133,7 @@ where
             value,
         )?;
 
-        Gear::<T>::process_queue(Default::default());
+        process_queue::<T>();
 
         let result = Program { caller, addr };
 
@@ -394,7 +416,7 @@ benchmarks! {
         let salt = vec![255u8; 32];
     }: {
         let _ = Gear::<T>::submit_program(RawOrigin::Signed(caller).into(), code, salt, vec![], 100_000_000u64, 0u32.into());
-        Gear::<T>::process_queue(Default::default());
+        process_queue::<T>();
     }
     verify {
         assert!(matches!(QueueOf::<T>::dequeue(), Ok(None)));
@@ -408,7 +430,7 @@ benchmarks! {
         let salt = vec![255u8; 32];
     }: {
         let _ = Gear::<T>::submit_program(RawOrigin::Signed(caller).into(), code, salt, vec![], 100_000_000u64, 0u32.into());
-        Gear::<T>::process_queue(Default::default());
+        process_queue::<T>();
     }
     verify {
         assert!(matches!(QueueOf::<T>::dequeue(), Ok(None)));
@@ -853,16 +875,15 @@ benchmarks! {
         });
         let instance = Program::<T>::new(code, vec![])?;
         let Exec {
-            mut ext_manager,
+            ext_manager,
             block_config,
             message_execution_context,
         } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 0u32.into())?;
     }: {
-        let journal = core_processor::process::<
+        core_processor::process::<
             ext::LazyPagesExt,
             SandboxEnvironment<ext::LazyPagesExt>,
         >(&block_config, message_execution_context);
-        core_processor::handle_journal(journal, &mut ext_manager);
     }
 
     gr_send_push {
@@ -895,16 +916,15 @@ benchmarks! {
         });
         let instance = Program::<T>::new(code, vec![])?;
         let Exec {
-            mut ext_manager,
+            ext_manager,
             block_config,
             message_execution_context,
         } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 0u32.into())?;
     }: {
-        let journal = core_processor::process::<
+        core_processor::process::<
             ext::LazyPagesExt,
             SandboxEnvironment<ext::LazyPagesExt>,
         >(&block_config, message_execution_context);
-        core_processor::handle_journal(journal, &mut ext_manager);
     }
 
     gr_send_push_per_kb {
@@ -937,16 +957,15 @@ benchmarks! {
         });
         let instance = Program::<T>::new(code, vec![])?;
         let Exec {
-            mut ext_manager,
+            ext_manager,
             block_config,
             message_execution_context,
         } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 0u32.into())?;
     }: {
-        let journal = core_processor::process::<
+        core_processor::process::<
             ext::LazyPagesExt,
             SandboxEnvironment<ext::LazyPagesExt>,
         >(&block_config, message_execution_context);
-        core_processor::handle_journal(journal, &mut ext_manager);
     }
 
     // Benchmark the `gr_send_commit` call.
@@ -990,16 +1009,15 @@ benchmarks! {
         let instance = Program::<T>::new(code, vec![])?;
 
         let Exec {
-            mut ext_manager,
+            ext_manager,
             block_config,
             message_execution_context,
         } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 10000000u32.into())?;
     }: {
-        let journal = core_processor::process::<
+        core_processor::process::<
             ext::LazyPagesExt,
             SandboxEnvironment<ext::LazyPagesExt>,
         >(&block_config, message_execution_context);
-        core_processor::handle_journal(journal, &mut ext_manager);
     }
 
     // Benchmark the `gr_send_commit` call.
@@ -1043,16 +1061,15 @@ benchmarks! {
         });
         let instance = Program::<T>::new(code, vec![])?;
         let Exec {
-            mut ext_manager,
+            ext_manager,
             block_config,
             message_execution_context,
         } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 10000000u32.into())?;
     }: {
-        let journal = core_processor::process::<
+        core_processor::process::<
             ext::LazyPagesExt,
             SandboxEnvironment<ext::LazyPagesExt>,
         >(&block_config, message_execution_context);
-        core_processor::handle_journal(journal, &mut ext_manager);
     }
 
     // Benchmark the `gr_reply_commit` call.
@@ -1086,16 +1103,15 @@ benchmarks! {
         });
         let instance = Program::<T>::new(code, vec![])?;
         let Exec {
-            mut ext_manager,
+            ext_manager,
             block_config,
             message_execution_context,
         } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 10000000u32.into())?;
     }: {
-        let journal = core_processor::process::<
+        core_processor::process::<
             ext::LazyPagesExt,
             SandboxEnvironment<ext::LazyPagesExt>,
         >(&block_config, message_execution_context);
-        core_processor::handle_journal(journal, &mut ext_manager);
     }
 
     gr_reply_commit_per_kb {
@@ -1127,16 +1143,15 @@ benchmarks! {
         });
         let instance = Program::<T>::new(code, vec![])?;
         let Exec {
-            mut ext_manager,
+            ext_manager,
             block_config,
             message_execution_context,
         } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 10000000u32.into())?;
     }: {
-        let journal = core_processor::process::<
+        core_processor::process::<
             ext::LazyPagesExt,
             SandboxEnvironment<ext::LazyPagesExt>,
         >(&block_config, message_execution_context);
-        core_processor::handle_journal(journal, &mut ext_manager);
     }
 
     // Benchmark the `gr_reply_push` call.
@@ -1240,16 +1255,15 @@ benchmarks! {
         let msg = gear_core::message::Message::new(msg_id, instance.addr.as_bytes().into(), ProgramId::from(instance.caller.clone().into_origin().as_bytes()), vec![], Some(1_000_000), 0, None).into_stored();
         MailboxOf::<T>::insert(msg, u32::MAX.unique_saturated_into()).expect("Error during mailbox insertion");
         let Exec {
-            mut ext_manager,
+            ext_manager,
             block_config,
             message_execution_context,
         } = prepare::<T>(instance.caller.into_origin(), HandleKind::Reply(msg_id, 0), vec![], 0u32.into())?;
     }: {
-        let journal = core_processor::process::<
+        core_processor::process::<
             ext::LazyPagesExt,
             SandboxEnvironment<ext::LazyPagesExt>,
         >(&block_config, message_execution_context);
-        core_processor::handle_journal(journal, &mut ext_manager);
     }
 
     gr_debug {
@@ -1271,16 +1285,15 @@ benchmarks! {
         });
         let instance = Program::<T>::new(code, vec![])?;
         let Exec {
-            mut ext_manager,
+            ext_manager,
             block_config,
             message_execution_context,
         } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 0u32.into())?;
     }: {
-        let journal = core_processor::process::<
+        core_processor::process::<
             ext::LazyPagesExt,
             SandboxEnvironment<ext::LazyPagesExt>,
         >(&block_config, message_execution_context);
-        core_processor::handle_journal(journal, &mut ext_manager);
     }
 
     gr_exit_code {
@@ -1304,16 +1317,15 @@ benchmarks! {
         let msg = gear_core::message::Message::new(msg_id, instance.addr.as_bytes().into(), ProgramId::from(instance.caller.clone().into_origin().as_bytes()), vec![], Some(1_000_000), 0, None).into_stored();
         MailboxOf::<T>::insert(msg, u32::MAX.unique_saturated_into()).expect("Error during mailbox insertion");
         let Exec {
-            mut ext_manager,
+            ext_manager,
             block_config,
             message_execution_context,
         } = prepare::<T>(instance.caller.into_origin(), HandleKind::Reply(msg_id, 0), vec![], 0u32.into())?;
     }: {
-        let journal = core_processor::process::<
+        core_processor::process::<
             ext::LazyPagesExt,
             SandboxEnvironment<ext::LazyPagesExt>,
         >(&block_config, message_execution_context);
-        core_processor::handle_journal(journal, &mut ext_manager);
     }
 
     // We cannot call `gr_exit` multiple times. Therefore our weight determination is not
@@ -1344,16 +1356,15 @@ benchmarks! {
         });
         let instance = Program::<T>::new(code, vec![])?;
         let Exec {
-            mut ext_manager,
+            ext_manager,
             block_config,
             message_execution_context,
         } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 0u32.into())?;
     }: {
-        let journal = core_processor::process::<
+        core_processor::process::<
             ext::LazyPagesExt,
             SandboxEnvironment<ext::LazyPagesExt>,
         >(&block_config, message_execution_context);
-        core_processor::handle_journal(journal, &mut ext_manager);
     }
 
     // We cannot call `gr_leave` multiple times. Therefore our weight determination is not
@@ -1375,16 +1386,15 @@ benchmarks! {
         });
         let instance = Program::<T>::new(code, vec![])?;
         let Exec {
-            mut ext_manager,
+            ext_manager,
             block_config,
             message_execution_context,
         } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 0u32.into())?;
     }: {
-        let journal = core_processor::process::<
+        core_processor::process::<
             ext::LazyPagesExt,
             SandboxEnvironment<ext::LazyPagesExt>,
         >(&block_config, message_execution_context);
-        core_processor::handle_journal(journal, &mut ext_manager);
     }
 
     // We cannot call `gr_wait` multiple times. Therefore our weight determination is not
@@ -1406,16 +1416,15 @@ benchmarks! {
         });
         let instance = Program::<T>::new(code, vec![])?;
         let Exec {
-            mut ext_manager,
+            ext_manager,
             block_config,
             message_execution_context,
         } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 0u32.into())?;
     }: {
-        let journal = core_processor::process::<
+        core_processor::process::<
             ext::LazyPagesExt,
             SandboxEnvironment<ext::LazyPagesExt>,
         >(&block_config, message_execution_context);
-        core_processor::handle_journal(journal, &mut ext_manager);
     }
 
     gr_wake {
@@ -1452,16 +1461,15 @@ benchmarks! {
             WaitlistOf::<T>::insert(dispatch.clone(), u32::MAX.unique_saturated_into()).expect("Duplicate wl message");
         }
         let Exec {
-            mut ext_manager,
+            ext_manager,
             block_config,
             message_execution_context,
         } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 0u32.into())?;
     }: {
-        let journal = core_processor::process::<
+        core_processor::process::<
             ext::LazyPagesExt,
             SandboxEnvironment<ext::LazyPagesExt>,
         >(&block_config, message_execution_context);
-        core_processor::handle_journal(journal, &mut ext_manager);
     }
 
     gr_create_program_wgas {
@@ -1516,17 +1524,15 @@ benchmarks! {
         });
         let instance = Program::<T>::new(code, vec![])?;
         let Exec {
-            mut ext_manager,
+            ext_manager,
             block_config,
             message_execution_context,
         } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 0u32.into())?;
     }: {
-        let journal = core_processor::process::<
+        core_processor::process::<
             ext::LazyPagesExt,
             SandboxEnvironment<ext::LazyPagesExt>,
         >(&block_config, message_execution_context);
-        core_processor::handle_journal(journal, &mut ext_manager);
-
     }
 
     gr_create_program_wgas_per_kb {
@@ -1581,17 +1587,15 @@ benchmarks! {
         });
         let instance = Program::<T>::new(code, vec![])?;
         let Exec {
-            mut ext_manager,
+            ext_manager,
             block_config,
             message_execution_context,
         } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 0u32.into())?;
     }: {
-        let journal = core_processor::process::<
+        core_processor::process::<
             ext::LazyPagesExt,
             SandboxEnvironment<ext::LazyPagesExt>,
         >(&block_config, message_execution_context);
-        core_processor::handle_journal(journal, &mut ext_manager);
-
     }
 
     // We make the assumption that pushing a constant and dropping a value takes roughly

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -122,7 +122,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1410,
+    spec_version: 1420,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Resolves #1230.

- Authority and proper block initialisation added into benchmarks.
- Journal processing removed from benchmarks.
- Simple no-op run of benchmarks added to CI.
