### PR TITLE
production profile w\ fat lto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ opt-level = "s"
 
 [profile.release.package.galloc]
 opt-level = "s"
- 
+
 [profile.release.package.gtest]
 opt-level = "s"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,21 @@ members = [
 [profile.release]
 panic = "unwind"
 
+[profile.release.package.gcore]
+opt-level = "s"
+
+[profile.release.package.gstd]
+opt-level = "s"
+
+[profile.release.package.gear-test]
+opt-level = "s"
+
+[profile.release.package.galloc]
+opt-level = "s"
+ 
+[profile.release.package.gtest]
+opt-level = "s"
+
 [profile.production]
 inherits = "release"
 
@@ -42,12 +57,3 @@ inherits = "release"
 lto = "fat"
 # https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
 codegen-units = 1
-
-[profile.release.package.gcore]
-opt-level = "s"
-
-[profile.release.package.gstd]
-opt-level = "s"
-
-[profile.release.package.gear-test]
-opt-level = "s"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,3 @@
-[profile.release]
-panic = "unwind"
-
-[profile.release.package.gcore]
-opt-level = "s"
-
-[profile.release.package.gstd]
-opt-level = "s"
-
-[profile.release.package.gear-test]
-opt-level = "s"
-
 [workspace]
 resolver = "2"
 
@@ -41,3 +29,25 @@ members = [
     "utils/economic-checks",
     "utils/economic-checks/fuzz",
 ]
+
+[profile.release]
+panic = "unwind"
+
+[profile.production]
+inherits = "release"
+
+# Sacrifice compile speed for execution speed by using optimization flags:
+
+# https://doc.rust-lang.org/rustc/linker-plugin-lto.html
+lto = "fat"
+# https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
+codegen-units = 1
+
+[profile.release.package.gcore]
+opt-level = "s"
+
+[profile.release.package.gstd]
+opt-level = "s"
+
+[profile.release.package.gear-test]
+opt-level = "s"

--- a/core-backend/wasmi/src/funcs.rs
+++ b/core-backend/wasmi/src/funcs.rs
@@ -1,6 +1,6 @@
 // This file is part of Gear.
 
-// Copyright (C) 2022 Gear Techn&&ologies Inc.
+// Copyright (C) 2022 Gear Technologies Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,20 +1,20 @@
 FROM paritytech/ci-linux:staging as builder
 LABEL description="This is the build stage for Gear. Here we create the binary."
 
-ARG PROFILE=release
+ARG PROFILE=production
 WORKDIR /gear
 
 COPY . /gear
 RUN apt-get update && apt-get install -y libsecp256k1-dev openssl wget
 RUN wget https://static.rust-lang.org/rustup/archive/1.24.3/x86_64-unknown-linux-gnu/rustup-init
 RUN chmod +x rustup-init && ./rustup-init -y
-RUN cargo build -p gear-node --$PROFILE
+RUN cargo build -p gear-node --profile $PROFILE
 
 # ===== SECOND STAGE ======
 
 FROM debian:stable-slim
 LABEL description="This is the 2nd stage: a very small image where we copy the Gear binary."
-ARG PROFILE=release
+ARG PROFILE=production
 COPY --from=builder /gear/target/$PROFILE/gear-node /usr/local/bin
 RUN apt-get update && apt-get install -y openssl
 RUN useradd -m -u 1000 -U -s /bin/sh -d /gear gear && \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -14,7 +14,7 @@ GITREPO=gear
 
 # Build the image
 echo "Building ${GITUSER}/${GITREPO}:latest docker image, hang on!"
-time docker build -f ./docker/Dockerfile --build-arg RUSTC_WRAPPER= --build-arg PROFILE=release -t ${GITUSER}/${GITREPO}:latest .
+time docker build -f ./docker/Dockerfile --build-arg RUSTC_WRAPPER= --build-arg PROFILE=production -t ${GITUSER}/${GITREPO}:latest .
 
 # Show the list of available images for this repo
 echo "Image is ready"


### PR DESCRIPTION
`wasmi 0.14.0` API has been changed to match the `wasmtime` style. I think we can switch to this later.

These params speed up execution time of benchmarks by 20-30%.
After this PR, we need to publish our production profile builds and also run them on our nodes.

```
./target/production/gear-node benchmark pallet --chain=dev --steps=50 --repeat=40 --pallet=pallet_gear --execution=wasm --wasm-execution=compiled --heap-pages=4096 --extrinsic="gr_reply_commit"
100.9 µs
./target/release/gear-node benchmark pallet --chain=dev --steps=50 --repeat=40 --pallet=pallet_gear --execution=wasm --wasm-execution=compiled --heap-pages=4096 --extrinsic="gr_reply_commit"
163.9 µs
```

Create production profile:
```
[profile.production]
inherits = "release"

# Sacrifice compile speed for execution speed by using optimization flags:

# https://doc.rust-lang.org/rustc/linker-plugin-lto.html
lto = "fat"
# https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
codegen-units = 1
```
See https://github.com/paritytech/wasmi/issues/339.

@gear-tech/dev 
