### PR TITLE
Set RUSTUP_HOME

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -13,7 +13,6 @@ env:
   CARGO_TERM_COLOR: always
   TERM: xterm-256color
   NIGHTLY_TOOLCHAIN_VERSION: ${{ secrets.NIGHTLY_TOOLCHAIN_VERSION }}
-  RUSTUP_HOME: /tmp/rustup_home
 
 jobs:
   spec_version:
@@ -35,6 +34,8 @@ jobs:
   check:
     needs: spec_version
     runs-on: [self-hosted, cachepot, epyc]
+    env:
+      RUSTUP_HOME: /tmp/rustup_home
     steps:
       - name: Cancel Previous Runs
         if: ${{ github.event_name == 'pull_request' }}
@@ -117,6 +118,7 @@ jobs:
     runs-on: [self-hosted, cachepot, epyc]
     env:
       LLVM_PROFILE_FILE: "gear-%p-%m.profraw"
+      RUSTUP_HOME: /tmp/rustup_home
     steps:
       - name: Cancel Previous Runs
         if: ${{ github.event_name == 'pull_request' }}
@@ -137,6 +139,10 @@ jobs:
           target: wasm32-unknown-unknown
           components: llvm-tools-preview
 
+      - name: "Install: Show specific nightly version"
+        if: ${{ env.NIGHTLY_TOOLCHAIN_VERSION != '' }}
+        run: echo $NIGHTLY_TOOLCHAIN_VERSION | sed 's/-/ - /g'
+
       - name: "Install: Specific nightly toolchain"
         if: ${{ env.NIGHTLY_TOOLCHAIN_VERSION != '' }}
         uses: actions-rs/toolchain@v1
@@ -148,8 +154,8 @@ jobs:
       - name: "Install: Pin to specific nightly toolchain"
         if: ${{ env.NIGHTLY_TOOLCHAIN_VERSION != '' }}
         run: |
-          rm -rf /root/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu
-          ln -s /root/.rustup/toolchains/nightly-$NIGHTLY_TOOLCHAIN_VERSION-x86_64-unknown-linux-gnu /root/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu
+          rm -rf $RUSTUP_HOME/toolchains/nightly-x86_64-unknown-linux-gnu
+          ln -s $RUSTUP_HOME/toolchains/nightly-$NIGHTLY_TOOLCHAIN_VERSION-x86_64-unknown-linux-gnu $RUSTUP_HOME/toolchains/nightly-x86_64-unknown-linux-gnu
 
       - name: "Install: Node.js"
         uses: actions/setup-node@v2

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -13,6 +13,7 @@ env:
   CARGO_TERM_COLOR: always
   TERM: xterm-256color
   NIGHTLY_TOOLCHAIN_VERSION: ${{ secrets.NIGHTLY_TOOLCHAIN_VERSION }}
+  RUSTUP_HOME: /tmp/rustup_home
 
 jobs:
   spec_version:
@@ -54,6 +55,10 @@ jobs:
           components: clippy, rustfmt
           target: wasm32-unknown-unknown
 
+      - name: "Install: Show specific nightly version"
+        if: ${{ env.NIGHTLY_TOOLCHAIN_VERSION != '' }}
+        run: echo $NIGHTLY_TOOLCHAIN_VERSION | sed 's/-/ - /g'
+
       - name: "Install: Specific nightly toolchain"
         if: ${{ env.NIGHTLY_TOOLCHAIN_VERSION != '' }}
         uses: actions-rs/toolchain@v1
@@ -65,8 +70,8 @@ jobs:
       - name: "Install: Pin to specific nightly toolchain"
         if: ${{ env.NIGHTLY_TOOLCHAIN_VERSION != '' }}
         run: |
-          rm -rf /root/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu
-          ln -s /root/.rustup/toolchains/nightly-$NIGHTLY_TOOLCHAIN_VERSION-x86_64-unknown-linux-gnu /root/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu
+          rm -rf $RUSTUP_HOME/toolchains/nightly-x86_64-unknown-linux-gnu
+          ln -s $RUSTUP_HOME/toolchains/nightly-$NIGHTLY_TOOLCHAIN_VERSION-x86_64-unknown-linux-gnu $RUSTUP_HOME/toolchains/nightly-x86_64-unknown-linux-gnu
 
       - name: "Install: Build deps"
         run: |


### PR DESCRIPTION
Resolves #1237 

Don't hardcode paths since GitHub runners images are updated and jobs aren't executed as root anymore - https://github.com/myoung34/docker-github-actions-runner/issues/225

@gear-tech/dev 
