### PR TITLE
Add feature to generate `handle_reply` in bechmarks generator

### DIFF
--- a/gcore/src/msg.rs
+++ b/gcore/src/msg.rs
@@ -94,15 +94,15 @@ mod sys {
 
 /// Get the exit code of the message being processed.
 ///
-/// This function is used to check the reply message was processed
-/// successfully or not.
+/// This function is used in reply handler to check the message
+/// was processed successfully or not.
 ///
 /// # Examples
 ///
 /// ```
 /// use gcore::msg;
 ///
-/// unsafe extern "C" fn handle() {
+/// unsafe extern "C" fn handle_reply() {
 ///     // ...
 ///     let exit_code = msg::exit_code();
 /// }

--- a/pallets/gear/src/benchmarking/code.rs
+++ b/pallets/gear/src/benchmarking/code.rs
@@ -71,10 +71,10 @@ pub struct ModuleDefinition {
     /// Function body of the exported `handle` function. Body is empty if `None`.
     /// Its index is `imported_functions.len() + 1`.
     pub handle_body: Option<FuncBody>,
-    /// Function body of the exported `handle_reply` function. Body is missing if `None`.
+    /// Function body of the exported `handle_reply` function. Body is empty if `None`.
     /// Its index is `imported_functions.len() + 2`.
     pub reply_body: Option<FuncBody>,
-    /// Function body of a non-exported function with index `imported_functions.len() + 2`.
+    /// Function body of a non-exported function with index `imported_functions.len() + 3`.
     pub aux_body: Option<FuncBody>,
     /// The amount of I64 arguments the aux function should have.
     pub aux_arg_num: u32,
@@ -134,6 +134,11 @@ pub struct WasmModule<T> {
     _data: PhantomData<T>,
 }
 
+pub const OFFSET_INIT: u32 = 0;
+pub const OFFSET_HANDLE: u32 = OFFSET_INIT + 1;
+pub const OFFSET_REPLY: u32 = OFFSET_HANDLE + 1;
+pub const OFFSET_AUX: u32 = OFFSET_REPLY + 1;
+
 impl<T: Config> From<ModuleDefinition> for WasmModule<T>
 where
     T: Config,
@@ -165,17 +170,17 @@ where
             .export()
             .field("init")
             .internal()
-            .func(func_offset)
+            .func(func_offset + OFFSET_INIT)
             .build()
             .export()
             .field("handle")
             .internal()
-            .func(func_offset + 1)
+            .func(func_offset + OFFSET_HANDLE)
             .build()
             .export()
             .field("handle_reply")
             .internal()
-            .func(func_offset + 2)
+            .func(func_offset + OFFSET_REPLY)
             .build();
 
         // If specified we add an additional internal function

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -28,6 +28,7 @@ use self::{
     code::{
         body::{self, DynInstr::*},
         DataSegment, ImportedFunction, ImportedMemory, Location, ModuleDefinition, WasmModule,
+        OFFSET_AUX,
     },
     sandbox::Sandbox,
 };
@@ -1838,7 +1839,7 @@ benchmarks! {
                 Instruction::End,
             ])),
             handle_body: Some(body::repeated(r * INSTR_BENCHMARK_BATCH_SIZE, &[
-                Instruction::Call(2), // call aux
+                Instruction::Call(OFFSET_AUX),
             ])),
             inject_stack_metering: false,
             .. Default::default()
@@ -1867,7 +1868,7 @@ benchmarks! {
             inject_stack_metering: false,
             table: Some(TableSegment {
                 num_elements,
-                function_index: 2, // aux
+                function_index: OFFSET_AUX,
             }),
             .. Default::default()
         }));
@@ -1900,7 +1901,7 @@ benchmarks! {
             inject_stack_metering: false,
             table: Some(TableSegment {
                 num_elements,
-                function_index: 2, // aux
+                function_index: OFFSET_AUX,
             }),
             .. Default::default()
         }));

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -1262,11 +1262,12 @@ benchmarks! {
                 params: vec![ValueType::I32],
                 return_type: None,
             }],
-            handle_body: Some(body::repeated(r * API_BENCHMARK_BATCH_SIZE, &[
-                Instruction::I32Const(0), // dest_ptr
+            reply_body: Some(body::repeated(r * API_BENCHMARK_BATCH_SIZE, &[
+                // dest_ptr
+                Instruction::I32Const(0),
                 Instruction::Call(0),
                 ])),
-                .. Default::default()
+            .. Default::default()
         });
         let instance = Program::<T>::new(code, vec![])?;
         let msg_id = MessageId::from(10);
@@ -1324,7 +1325,7 @@ benchmarks! {
                 params: vec![],
                 return_type: Some(ValueType::I32),
             }],
-            handle_body: Some(body::repeated(r * API_BENCHMARK_BATCH_SIZE, &[
+            reply_body: Some(body::repeated(r * API_BENCHMARK_BATCH_SIZE, &[
                 Instruction::Call(0),
                 Instruction::Drop,
             ])),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -125,7 +125,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear-node"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 1440,
+    spec_version: 1450,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,


### PR DESCRIPTION
Resolves #1244 

- add optional reply_body field to ModuleDefinition
- fix gr_exit_code & gr_reply_to benchmarks by calling the function in `handle_reply`
- fix docs for `gr_exit_code`

@gear-tech/dev 
