### PR TITLE
add wat examples and specs to run them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ all: gear examples
 .PHONY: all-release
 all-release: gear-release examples
 
+.PHONY: build-wat-examples
+build-wat-examples:
+	@ ./scripts/gear.sh build wat-examples
+
 .PHONY: gear
 gear:
 	@ ./scripts/gear.sh build gear
@@ -246,5 +250,3 @@ doc:
 fuzz:
 	@ ./scripts/gear.sh test fuzz
 
-build-wat-examples:
-	@ ./scripts/gear.sh build wat-examples

--- a/Makefile
+++ b/Makefile
@@ -245,3 +245,6 @@ doc:
 .PHONY: fuzz
 fuzz:
 	@ ./scripts/gear.sh test fuzz
+
+build-wat-examples:
+	@ ./scripts/gear.sh build wat-examples

--- a/examples/wat-examples/read_access.wat
+++ b/examples/wat-examples/read_access.wat
@@ -1,0 +1,36 @@
+(module
+    (import "env" "memory" (memory 0))
+    (import "env" "alloc" (func $alloc (param i32) (result i32)))
+    (export "init" (func $init))
+    (func $init
+        (local $i i32)
+
+        ;; alloc 0x100 pages, so mem pages are: 0..=0xff
+        (block
+            i32.const 0x100
+            call $alloc
+            i32.eqz
+            br_if 0
+            unreachable
+        )
+
+        ;; make read for all gear pages
+        (loop
+            local.get $i
+            i32.const 1
+            i32.add
+            local.set $i
+
+            local.get $i
+            i32.const 0x1000
+            i32.mul
+            i32.load
+            drop
+
+            local.get $i
+            i32.const 0xfff
+            i32.ne
+            br_if 0
+        )
+    )
+)

--- a/examples/wat-examples/read_write_access.wat
+++ b/examples/wat-examples/read_write_access.wat
@@ -1,0 +1,45 @@
+(module
+    (import "env" "memory" (memory 0))
+    (import "env" "alloc" (func $alloc (param i32) (result i32)))
+    (export "init" (func $init))
+    (func $init
+        (local $i i32)
+
+        ;; alloc 0x200 pages, so mem pages are: 0..=0x1ff
+        (block
+            i32.const 0x200
+            call $alloc
+            i32.eqz
+            br_if 0
+            unreachable
+        )
+
+        ;; make read and then write for all gear pages
+        (loop
+            local.get $i
+            i32.const 1
+            i32.add
+            local.set $i
+
+            local.get $i
+            i32.const 0x1000
+            i32.mul
+            i32.load
+            drop
+
+            local.get $i
+            i32.const 0x1000
+            i32.mul
+            i32.const 0x800
+            i32.add
+            i32.const 0x42
+            i32.store
+
+
+            local.get $i
+            i32.const 0x1fff
+            i32.ne
+            br_if 0
+        )
+    )
+)

--- a/gear-test/src/proc.rs
+++ b/gear-test/src/proc.rs
@@ -205,7 +205,7 @@ where
     let fixture = &test.fixtures[fixture_no];
 
     let empty = Vec::new();
-    for message in fixture.messages.as_ref().unwrap_or_else(|| &empty) {
+    for message in fixture.messages.as_ref().unwrap_or(&empty) {
         let payload = match &message.payload {
             Some(PayloadVariant::Utf8(s)) => parse_payload(s.clone()).as_bytes().to_vec(),
             Some(PayloadVariant::Custom(v)) => {

--- a/gear-test/src/proc.rs
+++ b/gear-test/src/proc.rs
@@ -204,7 +204,8 @@ where
 
     let fixture = &test.fixtures[fixture_no];
 
-    for message in &fixture.messages {
+    let empty = Vec::new();
+    for message in fixture.messages.as_ref().unwrap_or_else(|| &empty) {
         let payload = match &message.payload {
             Some(PayloadVariant::Utf8(s)) => parse_payload(s.clone()).as_bytes().to_vec(),
             Some(PayloadVariant::Custom(v)) => {

--- a/gear-test/src/sample.rs
+++ b/gear-test/src/sample.rs
@@ -124,9 +124,9 @@ pub struct Fixture {
     /// Fixture title
     pub title: String,
     /// Messages being sent to programs, defined in the test
-    pub messages: Vec<Message>,
+    pub messages: Option<Vec<Message>>,
     /// Expected results of the test run.
-    pub expected: Vec<Expectation>,
+    pub expected: Option<Vec<Expectation>>,
 }
 
 /// Payload data types being used in messages.
@@ -278,8 +278,8 @@ fn check_sample() {
     let path = test.programs.get(0).expect("Must have one").path.clone();
 
     assert_eq!(test.title, "basic");
-    assert_eq!(test.fixtures[0].messages.len(), 1);
-    assert_eq!(test.fixtures[0].messages.len(), 1);
+    assert_eq!(test.fixtures[0].messages.as_ref().unwrap().len(), 1);
+    assert_eq!(test.fixtures[0].messages.as_ref().unwrap().len(), 1);
     assert_eq!(
         path,
         "examples/target/wasm32-unknown-unknown/release/demo_ping.wasm"

--- a/gear-test/wat-spec/read_access.yaml
+++ b/gear-test/wat-spec/read_access.yaml
@@ -1,0 +1,11 @@
+title: Read-access
+
+programs:
+  - id: 1
+    path: target/wat-examples/read_access.wasm
+    source:
+      kind: account
+      value: alice
+
+fixtures:
+  - title: empty

--- a/gear-test/wat-spec/read_access.yaml
+++ b/gear-test/wat-spec/read_access.yaml
@@ -8,4 +8,4 @@ programs:
       value: alice
 
 fixtures:
-  - title: empty
+  - title: read from all pages in memory

--- a/gear-test/wat-spec/read_write_access.yaml
+++ b/gear-test/wat-spec/read_write_access.yaml
@@ -1,0 +1,11 @@
+title: Read-access
+
+programs:
+  - id: 1
+    path: target/wat-examples/read_write_access.wasm
+    source:
+      kind: account
+      value: alice
+
+fixtures:
+  - title: empty

--- a/gear-test/wat-spec/read_write_access.yaml
+++ b/gear-test/wat-spec/read_write_access.yaml
@@ -8,4 +8,4 @@ programs:
       value: alice
 
 fixtures:
-  - title: empty
+  - title: read and then write to all pages in memory

--- a/gear-test/wat-spec/read_write_access.yaml
+++ b/gear-test/wat-spec/read_write_access.yaml
@@ -1,4 +1,4 @@
-title: Read-access
+title: Read-write-access
 
 programs:
   - id: 1

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -125,7 +125,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear-node"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 1460,
+    spec_version: 1470,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/scripts/gear.sh
+++ b/scripts/gear.sh
@@ -133,6 +133,10 @@ case "$COMMAND" in
         header "Building gear node"
         node_build "$@"; ;;
 
+      wat-examples)
+        header "Build wat examples"
+        wat_examples_build "$ROOT_DIR" "$TARGET_DIR" "$@"; ;;
+
       *)
         header  "Unknown option: '$SUBCOMMAND'"
         build_usage

--- a/scripts/src/build.sh
+++ b/scripts/src/build.sh
@@ -81,3 +81,15 @@ examples_build() {
     done
   fi
 }
+
+wat_examples_build() {
+  ROOT_DIR="$1"
+  TARGET_DIR="$2"/wat-examples
+  WAT_DIR="$ROOT_DIR/examples/wat-examples"
+  mkdir -p $TARGET_DIR
+  for wat in `ls $WAT_DIR`; do
+    target_name=$TARGET_DIR/$(basename $wat .wat).wasm
+    wat2wasm $WAT_DIR/$wat -o $target_name;
+    echo "Built OK: $wat";
+  done
+}

--- a/utils/gear-runtime-test-cli/src/command.rs
+++ b/utils/gear-runtime-test-cli/src/command.rs
@@ -261,7 +261,8 @@ fn run_fixture(test: &'_ sample::Test, fixture: &sample::Fixture) -> ColoredStri
     let mut errors = vec![];
     let mut expected_log = vec![];
 
-    for message in &fixture.messages {
+    let empty = Vec::new();
+    for message in fixture.messages.as_ref().unwrap_or_else(|| &empty) {
         let payload = match &message.payload {
             Some(PayloadVariant::Utf8(s)) => parse_payload(s.clone()).as_bytes().to_vec(),
             Some(PayloadVariant::Custom(v)) => {
@@ -372,7 +373,8 @@ fn run_fixture(test: &'_ sample::Test, fixture: &sample::Fixture) -> ColoredStri
         }
     }
 
-    for exp in &fixture.expected {
+    let empty = Vec::new();
+    for exp in fixture.expected.as_ref().unwrap_or_else(|| &empty) {
         let snapshot: DebugData = if let Some(step) = exp.step {
             if snapshots.len() < (step + test.programs.len()) {
                 Default::default()

--- a/utils/gear-runtime-test-cli/src/command.rs
+++ b/utils/gear-runtime-test-cli/src/command.rs
@@ -262,7 +262,7 @@ fn run_fixture(test: &'_ sample::Test, fixture: &sample::Fixture) -> ColoredStri
     let mut expected_log = vec![];
 
     let empty = Vec::new();
-    for message in fixture.messages.as_ref().unwrap_or_else(|| &empty) {
+    for message in fixture.messages.as_ref().unwrap_or(&empty) {
         let payload = match &message.payload {
             Some(PayloadVariant::Utf8(s)) => parse_payload(s.clone()).as_bytes().to_vec(),
             Some(PayloadVariant::Custom(v)) => {
@@ -374,7 +374,7 @@ fn run_fixture(test: &'_ sample::Test, fixture: &sample::Fixture) -> ColoredStri
     }
 
     let empty = Vec::new();
-    for exp in fixture.expected.as_ref().unwrap_or_else(|| &empty) {
+    for exp in fixture.expected.as_ref().unwrap_or(&empty) {
         let snapshot: DebugData = if let Some(step) = exp.step {
             if snapshots.len() < (step + test.programs.len()) {
                 Default::default()


### PR DESCRIPTION
1) Add read access and r/w access wat examples.
2) Allow to skip `expected` and `messages` fields in fixtures.
3) A little refactoring in gear-test