### PR TITLE
[skip ci] Revert "Deploy node binary with `runtime-benchmaks`"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ COPY . /gear
 RUN apt-get update && apt-get install -y libsecp256k1-dev openssl wget
 RUN wget https://static.rust-lang.org/rustup/archive/1.24.3/x86_64-unknown-linux-gnu/rustup-init
 RUN chmod +x rustup-init && ./rustup-init -y
-RUN cargo build -p gear-node --profile $PROFILE --features runtime-benchmarks
+RUN cargo build -p gear-node --profile $PROFILE
 
 # ===== SECOND STAGE ======
 


### PR DESCRIPTION

This reverts commit a4ddad081b191aeedf5ac51aa22c0cb6ed702e6f.

@reviewer-or-team
