### PR TITLE
remove pages compare after execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5027,6 +5027,7 @@ dependencies = [
  "demo-proxy-with-gas",
  "demo-value-sender",
  "demo-waiting-proxy",
+ "derive_more",
  "env_logger",
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,6 +2605,7 @@ dependencies = [
  "region 3.0.0",
  "sp-io",
  "sp-std",
+ "static_assertions",
  "winapi",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,18 +948,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.85.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749d0d6022c9038dccf480bdde2a38d435937335bf2bb0f14e815d94517cdce8"
+checksum = "529ffacce2249ac60edba2941672dfedf3d96558b415d0d8083cd007456e0f55"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.85.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94370cc7b37bf652ccd8bb8f09bd900997f7ccf97520edfc75554bb5c4abbea"
+checksum = "427d105f617efc8cb55f8d036a7fded2e227892d8780b4985e5551f8d27c4a92"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
@@ -975,33 +975,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.85.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a3cea8fdab90e44018c5b9a1dfd460d8ee265ac354337150222a354628bdb6"
+checksum = "551674bed85b838d45358e3eab4f0ffaa6790c70dc08184204b9a54b41cdb7d1"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.85.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac72f76f2698598951ab26d8c96eaa854810e693e7dd52523958b5909fde6b2"
+checksum = "2b3a63ae57498c3eb495360944a33571754241e15e47e3bcae6082f40fec5866"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.85.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09eaeacfcd2356fe0e66b295e8f9d59fdd1ac3ace53ba50de14d628ec902f72d"
+checksum = "11aa8aa624c72cc1c94ea3d0739fa61248260b5b14d3646f51593a88d67f3e6e"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.85.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba69c9980d5ffd62c18a2bde927855fcd7c8dc92f29feaf8636052662cbd99c"
+checksum = "544ee8f4d1c9559c9aa6d46e7aaeac4a13856d620561094f35527356c7d21bd0"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1011,15 +1011,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.85.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2920dc1e05cac40304456ed3301fde2c09bd6a9b0210bcfa2f101398d628d5b"
+checksum = "ed16b14363d929b8c37e3c557d0a7396791b383ecc302141643c054343170aad"
 
 [[package]]
 name = "cranelift-native"
-version = "0.85.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04dfa45f9b2a6f587c564d6b63388e00cd6589d2df6ea2758cf79e1a13285e6"
+checksum = "51617cf8744634f2ed3c989c3c40cd6444f63377c6d994adab0d85807f3eb682"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1028,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.85.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31a46513ae6f26f3f267d8d75b5373d555fbbd1e68681f348d99df43f747ec54"
+checksum = "e5a8073a41efc173fd19bad3f725c170c705df6da999fc47a738ff310225dd63"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1038,7 +1038,7 @@ dependencies = [
  "itertools",
  "log",
  "smallvec",
- "wasmparser 0.85.0",
+ "wasmparser 0.86.0",
  "wasmtime-types",
 ]
 
@@ -2034,7 +2034,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2052,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2074,7 +2074,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "Inflector",
  "chrono",
@@ -2125,7 +2125,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2153,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -2183,7 +2183,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -2195,7 +2195,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -2207,7 +2207,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2217,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "frame-support",
  "log",
@@ -2234,7 +2234,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2249,7 +2249,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2258,7 +2258,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "frame-support",
  "sp-api",
@@ -3343,12 +3343,6 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec58677acfea8a15352d42fc87d11d63596ade9239e0a7c9352914417515dbe6"
-
-[[package]]
-name = "io-lifetimes"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24c3f4eff5495aee4c0399d7b6a0dc2b6e81be84242ffbfcf253ebacccc1d0cb"
@@ -4312,12 +4306,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
@@ -4454,11 +4442,11 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memfd"
-version = "0.4.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6627dc657574b49d6ad27105ed671822be56e0d2547d413bfbf3e8d8fa92e7a"
+checksum = "480b5a5de855d11ff13195950bdc8b98b5e942ef47afc447f6615cdcc4e15d80"
 dependencies = [
- "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -4949,7 +4937,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4965,7 +4953,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4980,7 +4968,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5004,7 +4992,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5276,7 +5264,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5299,7 +5287,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5335,7 +5323,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5349,7 +5337,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5367,7 +5355,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5383,7 +5371,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -5398,7 +5386,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -5409,7 +5397,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6228,9 +6216,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.2.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a8d23b35d7177df3b9d31ed8a9ab4bf625c668be77a319d4f5efd4a5257701c"
+checksum = "d43a209257d978ef079f3d446331d0f1794f5e0fc19b306a199983857833a779"
 dependencies = [
  "fxhash",
  "log",
@@ -6303,7 +6291,7 @@ dependencies = [
 [[package]]
 name = "remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "env_logger",
  "jsonrpsee",
@@ -6466,29 +6454,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.33.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938a344304321a9da4973b9ff4f9f8db9caf4597dfd9dda6a60b523340a0fff0"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes 0.5.3",
- "libc",
- "linux-raw-sys 0.0.42",
- "winapi",
-]
-
-[[package]]
-name = "rustix"
 version = "0.35.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51cc38aa10f6bbb377ed28197aa052aa4e2b762c22be9d3153d01822587e787"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes 0.7.2",
+ "io-lifetimes",
  "libc",
- "linux-raw-sys 0.0.46",
+ "linux-raw-sys",
  "windows-sys 0.36.1",
 ]
 
@@ -6581,7 +6555,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "log",
  "sp-core",
@@ -6592,7 +6566,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6615,7 +6589,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -6631,7 +6605,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "impl-trait-for-tuples",
  "memmap2 0.5.5",
@@ -6648,7 +6622,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6659,7 +6633,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "chrono",
  "clap",
@@ -6698,7 +6672,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "fnv",
  "futures",
@@ -6726,7 +6700,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -6751,7 +6725,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "async-trait",
  "futures",
@@ -6775,7 +6749,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "async-trait",
  "futures",
@@ -6804,7 +6778,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -6847,7 +6821,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -6869,7 +6843,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -6882,7 +6856,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "async-trait",
  "futures",
@@ -6907,7 +6881,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "lazy_static",
  "lru",
@@ -6934,7 +6908,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "environmental",
  "log",
@@ -6955,7 +6929,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6970,7 +6944,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "cfg-if",
  "libc",
@@ -6978,7 +6952,7 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "parity-wasm 0.45.0",
- "rustix 0.35.7",
+ "rustix",
  "sc-allocator",
  "sc-executor-common",
  "sp-runtime-interface",
@@ -6990,7 +6964,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "ahash",
  "async-trait",
@@ -7031,7 +7005,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "ansi_term",
  "futures",
@@ -7048,7 +7022,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "async-trait",
  "hex",
@@ -7063,7 +7037,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -7112,7 +7086,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "bitflags",
  "futures",
@@ -7130,7 +7104,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "ahash",
  "futures",
@@ -7147,7 +7121,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "futures",
  "libp2p",
@@ -7167,7 +7141,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "fork-tree",
  "futures",
@@ -7194,7 +7168,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "bytes",
  "fnv",
@@ -7222,7 +7196,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "futures",
  "libp2p",
@@ -7235,7 +7209,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -7244,7 +7218,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "futures",
  "hash-db",
@@ -7274,7 +7248,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -7297,7 +7271,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -7310,7 +7284,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "async-trait",
  "directories",
@@ -7377,7 +7351,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7391,7 +7365,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "futures",
  "libc",
@@ -7410,7 +7384,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "chrono",
  "futures",
@@ -7428,7 +7402,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "ansi_term",
  "atty",
@@ -7459,7 +7433,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7470,7 +7444,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7497,7 +7471,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "futures",
  "log",
@@ -7510,7 +7484,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7955,7 +7929,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "hash-db",
  "log",
@@ -7972,7 +7946,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -7984,7 +7958,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7997,7 +7971,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "5.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -8012,7 +7986,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8024,7 +7998,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8036,7 +8010,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "futures",
  "log",
@@ -8054,7 +8028,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "async-trait",
  "futures",
@@ -8073,7 +8047,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8091,7 +8065,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "async-trait",
  "merlin",
@@ -8114,7 +8088,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8128,7 +8102,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8141,7 +8115,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "base58",
  "bitflags",
@@ -8187,7 +8161,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "blake2",
  "byteorder",
@@ -8201,7 +8175,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8212,7 +8186,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -8221,7 +8195,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "4.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8231,7 +8205,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.12.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -8242,7 +8216,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -8260,7 +8234,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -8274,7 +8248,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "futures",
  "hash-db",
@@ -8299,7 +8273,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -8310,7 +8284,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.12.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "async-trait",
  "futures",
@@ -8327,7 +8301,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "thiserror",
  "zstd",
@@ -8336,7 +8310,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -8346,7 +8320,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "4.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -8356,7 +8330,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -8366,7 +8340,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -8388,7 +8362,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8405,7 +8379,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -8417,7 +8391,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8431,7 +8405,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -8440,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8454,7 +8428,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8465,7 +8439,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.12.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "hash-db",
  "log",
@@ -8487,12 +8461,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 
 [[package]]
 name = "sp-storage"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8505,7 +8479,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "log",
  "sp-core",
@@ -8518,7 +8492,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -8534,7 +8508,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "5.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -8546,7 +8520,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -8555,7 +8529,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "async-trait",
  "log",
@@ -8571,7 +8545,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -8587,7 +8561,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8604,7 +8578,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -8615,7 +8589,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -8721,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "platforms",
 ]
@@ -8729,7 +8703,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -8750,7 +8724,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "futures-util",
  "hyper",
@@ -8763,7 +8737,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -9244,7 +9218,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#afd2e78fc4a6e7d61497815505329015d7507eef"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#abc134523a276ba867ec4ebd10dc16069401a9ed"
 dependencies = [
  "clap",
  "jsonrpsee",
@@ -9977,9 +9951,9 @@ checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wasmparser"
-version = "0.85.0"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570460c58b21e9150d2df0eaaedbb7816c34bcec009ae0dcc976e40ba81463e7"
+checksum = "4bcbfe95447da2aa7ff171857fc8427513eb57c75a729bb190e974dc695e8f5c"
 dependencies = [
  "indexmap",
 ]
@@ -10005,9 +9979,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "0.38.3"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f50eadf868ab6a04b7b511460233377d0bfbb92e417b2f6a98b98fef2e098f5"
+checksum = "0d10a6853d64e99fffdae80f93a45080475c9267f87743060814dc1186d74618"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -10025,20 +9999,20 @@ dependencies = [
  "region 2.2.0",
  "serde",
  "target-lexicon",
- "wasmparser 0.85.0",
+ "wasmparser 0.86.0",
  "wasmtime-cache",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "wasmtime-jit",
  "wasmtime-runtime",
- "winapi",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "0.38.3"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1df23c642e1376892f3b72f311596976979cbf8b85469680cdd3a8a063d12a2"
+checksum = "0617b2f4c897b6a89b9d143466f3c724b9a36c6eabc443bf463f4e1ad48a2ccd"
 dependencies = [
  "anyhow",
  "base64",
@@ -10046,19 +10020,19 @@ dependencies = [
  "directories-next",
  "file-per-thread-logger",
  "log",
- "rustix 0.33.7",
+ "rustix",
  "serde",
  "sha2 0.9.9",
  "toml",
- "winapi",
+ "windows-sys 0.36.1",
  "zstd",
 ]
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.38.3"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f264ff6b4df247d15584f2f53d009fbc90032cfdc2605b52b961bffc71b6eccd"
+checksum = "3302b33d919e8e33f1717d592c10c3cddccb318d0e1e0bef75178f579686ba94"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -10072,15 +10046,15 @@ dependencies = [
  "object 0.28.4",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.85.0",
+ "wasmparser 0.86.0",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.38.3"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839d2820e4b830f4b9e7aa08d4c0acabf4a5036105d639f6dfa1c6891c73bdc6"
+checksum = "7c50fb925e8eaa9f8431f9b784ea89a13c703cb445ddfe51cb437596fc34e734"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -10092,15 +10066,15 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.85.0",
+ "wasmparser 0.86.0",
  "wasmtime-types",
 ]
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.38.3"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef0a0bcbfa18b946d890078ba0e1bc76bcc53eccfb40806c0020ec29dcd1bd49"
+checksum = "cad81635f33ab69aa04b386c9d954aef9f6230059f66caf67e55fb65bfd2f3e0"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -10112,32 +10086,32 @@ dependencies = [
  "object 0.28.4",
  "region 2.2.0",
  "rustc-demangle",
- "rustix 0.33.7",
+ "rustix",
  "serde",
  "target-lexicon",
  "thiserror",
  "wasmtime-environ",
  "wasmtime-jit-debug",
  "wasmtime-runtime",
- "winapi",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "0.38.3"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4779d976206c458edd643d1ac622b6c37e4a0800a8b1d25dfbf245ac2f2cac"
+checksum = "55e23273fddce8cab149a0743c46932bf4910268641397ed86b46854b089f38f"
 dependencies = [
  "lazy_static",
  "object 0.28.4",
- "rustix 0.33.7",
+ "rustix",
 ]
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.38.3"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7eb6ffa169eb5dcd18ac9473c817358cd57bc62c244622210566d473397954a"
+checksum = "36b8aafb292502d28dc2d25f44d4a81e229bb2e0cc14ca847dde4448a1a62ae4"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -10152,23 +10126,23 @@ dependencies = [
  "more-asserts",
  "rand 0.8.5",
  "region 2.2.0",
- "rustix 0.33.7",
+ "rustix",
  "thiserror",
  "wasmtime-environ",
  "wasmtime-jit-debug",
- "winapi",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
 name = "wasmtime-types"
-version = "0.38.3"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d932b0ac5336f7308d869703dd225610a6a3aeaa8e968c52b43eed96cefb1c2"
+checksum = "dd7edc34f358fc290d12e326de81884422cb94cf74cc305b27979569875332d6"
 dependencies = [
  "cranelift-entity",
  "serde",
  "thiserror",
- "wasmparser 0.85.0",
+ "wasmparser 0.86.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Modern blockchains solve many issues of the older blockchain networks, such as:
  - Lack of scalability, low transaction speed, high transaction costs
  - Domain-specific development language (high barrier to entry)
  - Complex and inefficient native consensus protocols
- - Absence of intercommunication tool asdiis
+ - Absence of intercommunication tools
 
 But still have room for improvements due to:
  - Fixated, rigid native consensus protocols

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Modern blockchains solve many issues of the older blockchain networks, such as:
  - Lack of scalability, low transaction speed, high transaction costs
  - Domain-specific development language (high barrier to entry)
  - Complex and inefficient native consensus protocols
- - Absence of intercommunication tools
+ - Absence of intercommunication tool asdiis
 
 But still have room for improvements due to:
  - Fixated, rigid native consensus protocols

--- a/common/src/lazy_pages.rs
+++ b/common/src/lazy_pages.rs
@@ -19,6 +19,7 @@
 //! Lazy pages support runtime functions
 
 use crate::Origin;
+use alloc::string::ToString;
 use core::fmt;
 use gear_core::{
     ids::ProgramId,
@@ -78,9 +79,9 @@ pub fn protect_pages_and_init_info(mem: &impl Memory, prog_id: ProgramId) -> Res
     // Cannot panic unless OS allocates buffer in not aligned by native page addr, or
     // something goes wrong with pages protection.
     // TODO: currently set stack pages as None, should be resolved (issue #1253).
-    gear_ri::initilize_for_program(wasm_mem_addr, wasm_mem_size.0, None, program_prefix)
+    gear_ri::initialize_for_program(wasm_mem_addr, wasm_mem_size.0, None, program_prefix)
         .map_err(|err| err.to_string())
-        .expect("Cannot initilize lazy pages for current program");
+        .expect("Cannot initialize lazy pages for current program");
 
     Ok(())
 }

--- a/common/src/lazy_pages.rs
+++ b/common/src/lazy_pages.rs
@@ -22,10 +22,10 @@ use crate::Origin;
 use core::{convert::TryFrom, fmt};
 use gear_core::{
     ids::ProgramId,
-    memory::{HostPointer, Memory, PageBuf, PageNumber, WasmPageNumber},
+    memory::{HostPointer, Memory, PageNumber, WasmPageNumber},
 };
 use gear_runtime_interface::{gear_ri, RIError};
-use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
+use sp_std::vec::Vec;
 
 extern crate alloc;
 use alloc::string::ToString;
@@ -105,10 +105,7 @@ pub fn protect_pages_and_init_info(mem: &impl Memory, prog_id: ProgramId) -> Res
 }
 
 /// Lazy pages contract post execution actions
-pub fn post_execution_actions(
-    mem: &impl Memory,
-    _pages_data: &mut BTreeMap<PageNumber, PageBuf>,
-) -> Result<(), Error> {
+pub fn post_execution_actions(mem: &impl Memory) -> Result<(), Error> {
     // Removes protections from lazy pages
     mprotect_lazy_pages(mem, false)
 }

--- a/common/src/lazy_pages.rs
+++ b/common/src/lazy_pages.rs
@@ -19,7 +19,7 @@
 //! Lazy pages support runtime functions
 
 use crate::Origin;
-use core::{convert::TryFrom, fmt};
+use core::fmt;
 use gear_core::{
     ids::ProgramId,
     memory::{HostPointer, Memory, PageNumber, WasmPageNumber},
@@ -59,15 +59,6 @@ fn mprotect_lazy_pages(mem: &impl Memory, protect: bool) -> Result<(), Error> {
     gear_ri::mprotect_lazy_pages(protect).expect("Cannot set/unset protection for wasm mem");
 
     Ok(())
-}
-
-fn get_memory_size_in_bytes(size_in_wasm_pages: WasmPageNumber) -> Result<u32, Error> {
-    size_in_wasm_pages
-        .0
-        .checked_add(1)
-        .ok_or(Error::WasmMemorySizeOverflow)?
-        .checked_mul(WasmPageNumber::size() as u32)
-        .ok_or(Error::WasmMemorySizeOverflow)
 }
 
 /// Try to enable and initialize lazy pages env

--- a/common/src/lazy_pages.rs
+++ b/common/src/lazy_pages.rs
@@ -27,9 +27,6 @@ use gear_core::{
 use gear_runtime_interface::{gear_ri, RIError};
 use sp_std::vec::Vec;
 
-extern crate alloc;
-use alloc::string::ToString;
-
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::Display)]
 pub enum Error {
     #[display(fmt = "{}", _0)]

--- a/common/src/lazy_pages.rs
+++ b/common/src/lazy_pages.rs
@@ -34,14 +34,8 @@ use alloc::string::ToString;
 pub enum Error {
     #[display(fmt = "{}", _0)]
     RIError(RIError),
-    #[display(fmt = "{:?} has no released data", _0)]
-    ReleasedPageHasNoData(PageNumber),
-    #[display(fmt = "Released page {:?} has initial data", _0)]
-    ReleasedPageHasInitialData(PageNumber),
-    #[display(fmt = "Wasm memory buffer is undefined")]
+    #[display(fmt = "Wasm memory buffer is undefined after wasm memory relocation")]
     WasmMemBufferIsUndefined,
-    #[display(fmt = "Wasm memory buffer size is bigger then u32::MAX")]
-    WasmMemorySizeOverflow,
 }
 
 impl From<RIError> for Error {
@@ -92,12 +86,6 @@ pub fn protect_pages_and_init_info(mem: &impl Memory, prog_id: ProgramId) -> Res
         .expect("Cannot initilize lazy pages for current program");
 
     Ok(())
-}
-
-/// Lazy pages contract post execution actions
-pub fn post_execution_actions(mem: &impl Memory) -> Result<(), Error> {
-    // Removes protections from lazy pages
-    mprotect_lazy_pages(mem, false)
 }
 
 /// Remove lazy-pages protection, returns wasm memory begin addr

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -54,6 +54,7 @@ use sp_std::{
     prelude::*,
 };
 use storage::ValueStorage;
+extern crate alloc;
 
 pub use gas_provider::{Provider as GasProvider, Tree as GasTree};
 

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -173,20 +173,10 @@ fn get_pages_to_be_updated<A: ProcessorExt>(
     let mut page_update = BTreeMap::new();
     for (page, new_data) in new_pages_data {
         if A::is_lazy_pages_enabled() {
-            if let Some(initial_data) = old_pages_data.remove(&page) {
-                if new_data != initial_data {
-                    page_update.insert(page, new_data);
-                    log::trace!(
-                        "Page {} has been changed - will be updated in storage",
-                        page.0
-                    );
-                } else {
-                    log::trace!("Page {} is accessed but has not been changed", page.0);
-                }
-            } else {
-                log::trace!("{:?} has been write accessed, update it in storage", page);
-                page_update.insert(page, new_data);
-            }
+            // TODO: remove assert and make proper handling (issue #1273)
+            assert!(old_pages_data.is_empty());
+            log::trace!("{:?} has been write accessed, update it in storage", page);
+            page_update.insert(page, new_data);
         } else {
             let initial_data = if let Some(initial_data) = old_pages_data.remove(&page) {
                 initial_data

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -183,6 +183,9 @@ fn get_pages_to_be_updated<A: ProcessorExt>(
                 } else {
                     log::trace!("Page {} is accessed but has not been changed", page.0);
                 }
+            } else {
+                log::trace!("{:?} has been write accessed, update it in storage", page);
+                page_update.insert(page, new_data);
             }
         } else {
             let initial_data = if let Some(initial_data) = old_pages_data.remove(&page) {

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -43,7 +43,22 @@ const WASM_PAGE_SIZE: usize = 0x10000;
 /// native page size, so can vary.
 const GEAR_PAGE_SIZE: usize = 0x1000;
 
-/// TODO
+/// Pages data storage granularity (PSG) is a size and wasm addr alignemnt
+/// of a memory interval, for which the following conditions must be met:
+/// if some gear page has data in storage, then all gear
+/// pages, that are in the same granularity interval, must contain
+/// data in storage. For example:
+/// ````
+///   granularity interval no.0       interval no.1        interval no.2
+///                |                    |                    |
+///                {====|====|====|====}{====|====|====|====}{====|====|====|====}
+///               /     |     \
+///    gear-page 0    page 1   page 2 ...
+/// ````
+/// In this example each PSG page contains 4 gear-pages. So, if gear-page `2`
+/// has data in storage, then gear-page `0`,`1`,`3` also has data in storage.
+/// This constant is necessary for consensus between nodes with different
+/// native page sizes. You can see an example of using in crate `gear-lazy-pages`.
 pub const PAGE_STORAGE_GRANULARITY: usize = 0x4000;
 
 /// Number of gear pages in one wasm page

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -43,8 +43,15 @@ const WASM_PAGE_SIZE: usize = 0x10000;
 /// native page size, so can vary.
 const GEAR_PAGE_SIZE: usize = 0x1000;
 
+/// TODO
+pub const PAGE_STORAGE_GRANULARITY: usize = 0x4000;
+
 /// Number of gear pages in one wasm page
 const GEAR_PAGES_IN_ONE_WASM: u32 = (WASM_PAGE_SIZE / GEAR_PAGE_SIZE) as u32;
+
+static_assertions::const_assert_eq!(WASM_PAGE_SIZE % GEAR_PAGE_SIZE, 0);
+static_assertions::const_assert_eq!(WASM_PAGE_SIZE % PAGE_STORAGE_GRANULARITY, 0);
+static_assertions::const_assert_eq!(PAGE_STORAGE_GRANULARITY % GEAR_PAGE_SIZE, 0);
 
 /// Buffer for gear page data.
 #[derive(Clone, Encode, Decode, PartialEq, Eq)]

--- a/lazy-pages/Cargo.toml
+++ b/lazy-pages/Cargo.toml
@@ -16,6 +16,7 @@ sp-std = { version = "4.0.0", git = "https://github.com/gear-tech/substrate.git"
 cfg-if = "1.0.0"
 region = "3.0.0"
 derive_more = "0.99.17"
+static_assertions = "1.1"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.23.1"

--- a/lazy-pages/src/deprecated.rs
+++ b/lazy-pages/src/deprecated.rs
@@ -1,0 +1,129 @@
+// This file is part of Gear.
+
+// Copyright (C) 2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use region::Protection;
+use std::cell::RefMut;
+
+use crate::{sys::ExceptionInfo, Error, LazyPagesExecutionContext, PageBuf, PageNumber};
+
+/// Returns key which `page` has in storage.
+/// `prefix` is current program prefix in storage.
+#[deprecated]
+fn page_key_in_storage(prefix: &Vec<u8>, page: PageNumber) -> Vec<u8> {
+    let mut key = Vec::with_capacity(prefix.len() + std::mem::size_of::<u32>());
+    key.extend(prefix);
+    key.extend(page.0.to_le_bytes());
+    key
+}
+
+#[deprecated]
+pub(crate) unsafe fn user_signal_handler_internal_v1(
+    mut ctx: RefMut<LazyPagesExecutionContext>,
+    info: ExceptionInfo,
+) -> Result<(), Error> {
+    let native_ps = region::page::size();
+    let gear_ps = PageNumber::size();
+
+    log::debug!("Interrupted, exception info = {:?}", info);
+
+    let mem = info.fault_addr;
+    let native_page = region::page::floor(mem) as usize;
+    let wasm_mem_begin = ctx.wasm_mem_addr.ok_or(Error::WasmMemAddrIsNotSet)? as usize;
+
+    if wasm_mem_begin > native_page {
+        return Err(Error::SignalAddrIsLessThenWasmMemAddr {
+            addr: native_page,
+            wasm_mem_addr: wasm_mem_begin,
+        });
+    }
+
+    // First gear page which must be unprotected
+    let gear_page = PageNumber(((native_page - wasm_mem_begin) / gear_ps) as u32);
+
+    let (gear_page, gear_pages_num, unprot_addr) = if native_ps > gear_ps {
+        assert_eq!(native_ps % gear_ps, 0);
+        (gear_page, native_ps / gear_ps, native_page)
+    } else {
+        assert_eq!(gear_ps % native_ps, 0);
+        (gear_page, 1usize, wasm_mem_begin + gear_page.offset())
+    };
+
+    let accessed_page = PageNumber(((mem as usize - wasm_mem_begin) / gear_ps) as u32);
+    log::debug!(
+        "mem={:?} accessed={:?},{:?} pages={:?} page_native_addr={:#x}",
+        mem,
+        accessed_page,
+        accessed_page.to_wasm_page(),
+        gear_page.0..gear_page.0 + gear_pages_num as u32,
+        unprot_addr
+    );
+
+    let unprot_size = gear_pages_num * gear_ps;
+
+    region::protect(unprot_addr as *mut (), unprot_size, Protection::READ_WRITE)?;
+
+    for idx in 0..gear_pages_num as u32 {
+        let page = gear_page + idx.into();
+
+        let ptr = (unprot_addr as *mut u8).add(idx as usize * gear_ps);
+        let buffer_as_slice = std::slice::from_raw_parts_mut(ptr, gear_ps);
+
+        // TODO: simplify before release (issue #1147). Currently we must support here all old runtimes.
+        // For new runtimes we have to calc page key from program pages prefix.
+        let page_key = if let Some(prefix) = &ctx.program_storage_prefix {
+            page_key_in_storage(prefix, page)
+        } else {
+            // This case is for old runtimes support
+            ctx.lazy_pages_info
+                .remove(&page)
+                .ok_or(Error::LazyPageNotExistForSignalAddr(mem, page))?
+        };
+        let res = sp_io::storage::read(&page_key, buffer_as_slice, 0);
+
+        if res.is_none() {
+            log::trace!(
+                "{:?} has no data in storage, so just save current page data to released pages",
+                page
+            );
+        } else {
+            log::trace!(
+                "{:?} has data in storage, so set this data for page and save it in released pages",
+                page
+            );
+        }
+
+        if let Some(size) = res.filter(|&size| size as usize != PageNumber::size()) {
+            return Err(Error::InvalidPageDataSize {
+                expected: PageNumber::size(),
+                actual: size,
+            });
+        }
+
+        let page_buf = PageBuf::new_from_vec(buffer_as_slice.to_vec())
+            .expect("Cannot panic here, because we create slice with PageBuf size");
+
+        if ctx
+            .released_lazy_pages
+            .insert(page, Some(page_buf))
+            .is_some()
+        {
+            return Err(Error::DoubleRelease(page));
+        }
+    }
+    Ok(())
+}

--- a/lazy-pages/src/deprecated.rs
+++ b/lazy-pages/src/deprecated.rs
@@ -16,6 +16,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+//! Deprecated lazy-pages impl to support old runtimes.
+
 use region::Protection;
 use std::cell::RefMut;
 
@@ -117,8 +119,9 @@ pub(crate) unsafe fn user_signal_handler_internal_v1(
         let page_buf = PageBuf::new_from_vec(buffer_as_slice.to_vec())
             .expect("Cannot panic here, because we create slice with PageBuf size");
 
+        let _ = ctx.released_lazy_pages.insert(page);
         if ctx
-            .released_lazy_pages
+            .released_lazy_pages_old
             .insert(page, Some(page_buf))
             .is_some()
         {

--- a/lazy-pages/src/deprecated.rs
+++ b/lazy-pages/src/deprecated.rs
@@ -85,7 +85,6 @@ pub(crate) unsafe fn user_signal_handler_internal_v1(
         let ptr = (unprot_addr as *mut u8).add(idx as usize * gear_ps);
         let buffer_as_slice = std::slice::from_raw_parts_mut(ptr, gear_ps);
 
-        // TODO: simplify before release (issue #1147). Currently we must support here all old runtimes.
         // For new runtimes we have to calc page key from program pages prefix.
         let page_key = if let Some(prefix) = &ctx.program_storage_prefix {
             page_key_in_storage(prefix, page)
@@ -119,9 +118,9 @@ pub(crate) unsafe fn user_signal_handler_internal_v1(
         let page_buf = PageBuf::new_from_vec(buffer_as_slice.to_vec())
             .expect("Cannot panic here, because we create slice with PageBuf size");
 
-        let _ = ctx.released_lazy_pages.insert(page);
+        let _ = ctx.released_pages.insert(page);
         if ctx
-            .released_lazy_pages_old
+            .released_lazy_pages
             .insert(page, Some(page_buf))
             .is_some()
         {

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -158,15 +158,15 @@ pub fn get_lazy_pages_numbers() -> Vec<PageNumber> {
 }
 
 #[derive(Debug, derive_more::Display)]
-pub enum InitForProgramError {
+pub enum InitializeForProgramError {
     #[display(
-        fmt = "Wasm mem native addr {:#x} is not aligned to the native page size",
+        fmt = "WASM memory native address {:#x} is not aligned to the native page size",
         _0
     )]
     WasmMemAddrIsNotAligned(usize),
-    #[display(fmt = "Wasm mem size {:?} is bigger than u32::MAX bytes", _0)]
+    #[display(fmt = "WASM memory size {:?} is bigger than u32::MAX bytes", _0)]
     WasmMemSizeBiggerThenU32Max(WasmPageNumber),
-    #[display(fmt = "Wasm stack end addr {:?} > wasm mem size {:?}", _0, _1)]
+    #[display(fmt = "WASM stack end addr {:?} > wasm mem size {:?}", _0, _1)]
     StackEndAddrBiggerThenSize(WasmPageNumber, WasmPageNumber),
 }
 
@@ -175,8 +175,8 @@ pub fn initialize_for_program(
     wasm_mem_size: WasmPageNumber,
     stack_end_page: Option<WasmPageNumber>,
     program_prefix: Vec<u8>,
-) -> Result<(), InitForProgramError> {
-    use InitForProgramError::*;
+) -> Result<(), InitializeForProgramError> {
+    use InitializeForProgramError::*;
     LAZY_PAGES_CONTEXT.with(|ctx| {
         let mut ctx = ctx.borrow_mut();
         ctx.accessed_pages_addrs.clear();

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -19,11 +19,11 @@
 //! Lazy pages support.
 //! In runtime data for contract wasm memory pages can be loaded in lazy manner.
 //! All pages, which is supposed to be lazy, must be mprotected before contract execution.
-//! During execution data from storage is loaded for all pages, which has been accesed.
+//! During execution data from storage is loaded for all pages, which has been accessed.
 //! See also `sys::user_signal_handler` in the source code.
 //!
 //! Currently we restrict twice write signal from same page during one execution.
-//! It's not necessary behaviour, but more simple and safe.
+//! It's not necessary behavior, but more simple and safe.
 
 // TODO: remove all deprecated code before release (issue #1147)
 #![allow(useless_deprecated, deprecated)]
@@ -170,7 +170,7 @@ pub enum InitForProgramError {
     StackEndAddrBiggerThenSize(WasmPageNumber, WasmPageNumber),
 }
 
-pub fn initilize_for_program(
+pub fn initialize_for_program(
     wasm_mem_addr: Option<usize>,
     wasm_mem_size: WasmPageNumber,
     stack_end_page: Option<WasmPageNumber>,

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -45,7 +45,7 @@ pub enum Error {
     WasmMemAddrIsNotSet,
     #[display(fmt = "WASM memory size is not set")]
     WasmMemSizeIsNotSet,
-    #[display(fmt = "Overflow of addr arith operation")]
+    #[display(fmt = "Overflow of address arithmetic operation")]
     AddrArithOverflow,
     #[display(fmt = "Program pages prefix in storage is not set")]
     ProgramPrefixIsNotSet,
@@ -61,7 +61,7 @@ pub enum Error {
         wasm_mem_end_addr: usize,
     },
     #[display(
-        fmt = "Signal addr {:#x} is from wasm program virt-stack memory [0, {:#x})",
+        fmt = "Signal addr {:#x} is from WASM program virtual stack memory [0, {:#x})",
         wasm_addr,
         stack_end
     )]
@@ -70,7 +70,7 @@ pub enum Error {
         stack_end: WasmAddr,
     },
     #[display(
-        fmt = "Accessed pages are not lies in wasm memory: [{:#x}, {:#x}) not in [{:#x}, {:#x})",
+        fmt = "Accessed pages do not lay in WASM memory: [{:#x}, {:#x}) not in [{:#x}, {:#x})",
         begin_addr,
         end_addr,
         wasm_mem_addr,
@@ -158,7 +158,7 @@ pub fn get_lazy_pages_numbers() -> Vec<PageNumber> {
 }
 
 #[derive(Debug, derive_more::Display)]
-pub enum InitForProgramErr {
+pub enum InitForProgramError {
     #[display(
         fmt = "Wasm mem native addr {:#x} is not aligned to the native page size",
         _0
@@ -175,8 +175,8 @@ pub fn initilize_for_program(
     wasm_mem_size: WasmPageNumber,
     stack_end_page: Option<WasmPageNumber>,
     program_prefix: Vec<u8>,
-) -> Result<(), InitForProgramErr> {
-    use InitForProgramErr::*;
+) -> Result<(), InitForProgramError> {
+    use InitForProgramError::*;
     LAZY_PAGES_CONTEXT.with(|ctx| {
         let mut ctx = ctx.borrow_mut();
         ctx.accessed_pages_addrs.clear();

--- a/lazy-pages/src/sys.rs
+++ b/lazy-pages/src/sys.rs
@@ -33,7 +33,7 @@ use gear_core::memory::{PageNumber, PAGE_STORAGE_GRANULARITY};
 // so we make here additional checks. If somebody would change these values
 // in runtime, then he also should pay attention to support new values here:
 // 1) must rebuild node after that.
-// 2) must support old runtimes: need to make lazy pages version with old constatns values.
+// 2) must support old runtimes: need to make lazy pages version with old constants values.
 static_assertions::const_assert_eq!(PageNumber::size(), 0x1000);
 static_assertions::const_assert_eq!(PAGE_STORAGE_GRANULARITY, 0x4000);
 
@@ -224,13 +224,13 @@ unsafe fn user_signal_handler_internal_v2(
     // of the accessed gear page, if native page size is smaller then gear page size.
     wasm_addr.align_down(lazy_page_size);
 
-    // If `is_write` is Some, than we definitly know whether it's `write` or `read` access.
+    // If `is_write` is Some, than we definitely know whether it's `write` or `read` access.
     // In other case we handle first access as it's `read`.
     // This also means that we will set read protection for the accessed interval after handling.
     // If in reality it's `write` access, then right after return from signal handler,
     // another signal will appear from the same instruction and for the same address.
     // Because we insert accessed pages in `accessed_pages_addrs`, then handling second signal
-    // we can definitly identify that this signal from `write` access.
+    // we can definitely identify that this signal from `write` access.
     let is_definitely_write =
         ctx.accessed_pages_addrs.contains(&wasm_addr.get()) || info.is_write.unwrap_or(false);
 
@@ -259,7 +259,7 @@ unsafe fn user_signal_handler_internal_v2(
     let fist_gear_page = wasm_addr.as_page_number();
 
     for idx in 0..unprot_size / lazy_page_size {
-        // Arithmetic opertaions are safe here, because this values represents, address and
+        // Arithmetic operations are safe here, because this values represents, address and
         // pages, for which we have already checked, that they are inside wasm memory.
         let lazy_page_wasm_addr = wasm_addr.get() + idx * lazy_page_size;
         let begin = fist_gear_page.0 + idx * num_of_gear_pages_in_one_lazy;

--- a/lazy-pages/src/sys/unix.rs
+++ b/lazy-pages/src/sys/unix.rs
@@ -23,16 +23,34 @@ use nix::{
     libc::{c_void, siginfo_t},
     sys::signal,
 };
-use std::io::{self};
+use std::io;
 
-extern "C" fn handle_sigsegv(_sig: i32, info: *mut siginfo_t, _ucontext: *mut c_void) {
+extern "C" fn handle_sigsegv(_sig: i32, info: *mut siginfo_t, ucontext: *mut c_void) {
     unsafe {
+        #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+        let is_write = {
+            let ucontext = ucontext as *const nix::libc::ucontext_t;
+            let error_reg = nix::libc::REG_ERR as usize;
+            let error_code = (*ucontext).uc_mcontext.gregs[error_reg];
+            // Use second bit from err reg. See https://git.io/JEQn3
+            Some(error_code & 0b10 == 0b10)
+        };
+
+        #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+        let is_write = {
+            let _unused_warning_resolver = ucontext;
+            None
+        };
+
         let addr = (*info).si_addr();
         let info = ExceptionInfo {
             fault_addr: addr as *mut _,
+            is_write,
         };
 
-        super::user_signal_handler(info).expect("Memory exception handler");
+        super::user_signal_handler(info)
+            .map_err(|err| format!("Signal handler failed: {}", err))
+            .unwrap()
     }
 }
 

--- a/lazy-pages/src/sys/unix.rs
+++ b/lazy-pages/src/sys/unix.rs
@@ -49,8 +49,8 @@ extern "C" fn handle_sigsegv(_sig: i32, info: *mut siginfo_t, ucontext: *mut c_v
         };
 
         super::user_signal_handler(info)
-            .map_err(|err| format!("Signal handler failed: {}", err))
-            .unwrap()
+            .map_err(|err| err.to_string())
+            .expect("Signal handler failed")
     }
 }
 

--- a/lazy-pages/src/sys/windows.rs
+++ b/lazy-pages/src/sys/windows.rs
@@ -46,9 +46,12 @@ unsafe extern "system" fn exception_handler(exception_info: *mut EXCEPTION_POINT
     let addr = (*exception_record).ExceptionInformation[1];
     let info = ExceptionInfo {
         fault_addr: addr as *mut _,
+        is_write: None,
     };
 
-    super::user_signal_handler(info).expect("Memory exception handler");
+    super::user_signal_handler(info)
+        .map_err(|err| format!("Memory exception handler failed: {}", err))
+        .unwrap();
 
     EXCEPTION_CONTINUE_EXECUTION
 }

--- a/lazy-pages/src/sys/windows.rs
+++ b/lazy-pages/src/sys/windows.rs
@@ -50,8 +50,8 @@ unsafe extern "system" fn exception_handler(exception_info: *mut EXCEPTION_POINT
     };
 
     super::user_signal_handler(info)
-        .map_err(|err| format!("Memory exception handler failed: {}", err))
-        .unwrap();
+        .map_err(|err| err.to_string())
+        .expect("Memory exception handler failed");
 
     EXCEPTION_CONTINUE_EXECUTION
 }

--- a/pallets/gear-debug/Cargo.toml
+++ b/pallets/gear-debug/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pallet-gear-debug"
 version = "2.0.0"
 authors = ['Gear Technologies']
-edition = '2018'
+edition = '2021'
 license = "GPL-3.0"
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"

--- a/pallets/gear-debug/src/tests.rs
+++ b/pallets/gear-debug/src/tests.rs
@@ -628,7 +628,7 @@ fn check_changed_pages_in_storage() {
                 ;; change page 3 and 4
                 ;; because we store 0x00_00_00_42 then bits will be changed
                 ;; in 3th page only. But because we store by write access, then
-                ;; both data will be for some gear pages from 3th and 4th page.
+                ;; both data will be for gear pages from 3th and 4th wasm page.
                 i32.const 0x3fffd
                 i32.const 0x42
                 i32.store

--- a/pallets/gear-debug/src/tests.rs
+++ b/pallets/gear-debug/src/tests.rs
@@ -19,7 +19,7 @@
 use super::*;
 use crate::mock::*;
 use common::{self, Origin as _};
-#[allow(unused)]
+#[cfg(feature = "lazy-pages")]
 use frame_support::assert_ok;
 use frame_system::Pallet as SystemPallet;
 use gear_core::{
@@ -285,7 +285,7 @@ fn get_last_message_id() -> MessageId {
     }
 }
 
-#[allow(unused)]
+#[cfg(feature = "lazy-pages")]
 fn append_rest_psg_pages(page: PageNumber, pages_data: &mut BTreeMap<PageNumber, Vec<u8>>) {
     let first_in_psg = PageNumber::new_from_addr((page.offset() as usize / PSG) * PSG);
     (0..(PSG / PageNumber::size()) as u32)
@@ -452,8 +452,7 @@ fn check_not_allocated_pages() {
         // For all pages, which is write accessed, and has no data in storage yet,
         // we must upload to storage all pages from [PAGE_STORAGE_GRANULARITY] interval.
         [gear_page0, gear_page7]
-            .iter()
-            .copied()
+            .into_iter()
             .for_each(|page| append_rest_psg_pages(page, &mut persistent_pages));
 
         System::assert_last_event(
@@ -691,8 +690,7 @@ fn check_changed_pages_in_storage() {
         // For all pages, which is write accessed, and has no data in storage yet,
         // we must upload to storage all pages from [PAGE_STORAGE_GRANULARITY] interval.
         [gear_page1, gear_page8, gear_page9]
-            .iter()
-            .copied()
+            .into_iter()
             .for_each(|page| append_rest_psg_pages(page, &mut persistent_pages));
 
         System::assert_last_event(
@@ -732,8 +730,7 @@ fn check_changed_pages_in_storage() {
         persistent_pages.insert(gear_page4, empty_data.to_vec());
 
         [gear_page3, gear_page4]
-            .iter()
-            .copied()
+            .into_iter()
             .for_each(|page| append_rest_psg_pages(page, &mut persistent_pages));
 
         System::assert_last_event(

--- a/pallets/gear/Cargo.toml
+++ b/pallets/gear/Cargo.toml
@@ -18,6 +18,7 @@ scale-info = { version = "2.1.1", default-features = false, features = ["derive"
 log = { version = "0.4.17", default-features = false }
 primitive-types = { version = "0.11.1", default-features = false, features = ["scale-info"] }
 wasm-instrument = { version = "0.2", default-features = false }
+derive_more = "0.99.17"
 
 # Internal deps
 common = { package = "gear-common", path = "../../common", default-features = false }

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -18,7 +18,6 @@
 
 use alloc::collections::BTreeSet;
 use common::lazy_pages;
-use core::fmt;
 use core_processor::{Ext, ProcessorContext, ProcessorError, ProcessorExt};
 use gear_backend_common::{
     error_processor::IntoExtError, AsTerminationReason, ExtInfo, IntoExtInfo, TerminationReason,
@@ -34,9 +33,13 @@ use gear_core::{
 use gear_core_errors::{CoreError, ExtError, MemoryError};
 use sp_std::collections::btree_map::BTreeMap;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, derive_more::Display, derive_more::From)]
 pub enum Error {
+    #[from]
+    #[display(fmt = "{}", _0)]
     Processor(ProcessorError),
+    #[from]
+    #[display(fmt = "{}", _0)]
     LazyPages(lazy_pages::Error),
 }
 
@@ -56,27 +59,6 @@ impl AsTerminationReason for Error {
         match self {
             Error::Processor(err) => err.as_termination_reason(),
             Error::LazyPages(_) => None,
-        }
-    }
-}
-
-impl From<ProcessorError> for Error {
-    fn from(err: ProcessorError) -> Self {
-        Self::Processor(err)
-    }
-}
-
-impl From<lazy_pages::Error> for Error {
-    fn from(err: lazy_pages::Error) -> Self {
-        Self::LazyPages(err)
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Error::Processor(err) => fmt::Display::fmt(err, f),
-            Error::LazyPages(err) => fmt::Display::fmt(err, f),
         }
     }
 }
@@ -171,14 +153,14 @@ impl ProcessorExt for LazyPagesExt {
         mem: &impl Memory,
         prog_id: ProgramId,
     ) -> Result<(), Self::Error> {
-        lazy_pages::protect_pages_and_init_info(mem, prog_id).map_err(Error::LazyPages)
+        lazy_pages::protect_pages_and_init_info(mem, prog_id).map_err(Into::into)
     }
 
     fn lazy_pages_post_execution_actions(
         mem: &impl Memory,
         _memory_pages: &mut BTreeMap<PageNumber, PageBuf>, // TODO: remove it (issue #1273)
     ) -> Result<(), Self::Error> {
-        lazy_pages::post_execution_actions(mem).map_err(Error::LazyPages)
+        lazy_pages::remove_lazy_pages_prot(mem).map_err(Into::into)
     }
 }
 

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -176,9 +176,9 @@ impl ProcessorExt for LazyPagesExt {
 
     fn lazy_pages_post_execution_actions(
         mem: &impl Memory,
-        memory_pages: &mut BTreeMap<PageNumber, PageBuf>,
+        _memory_pages: &mut BTreeMap<PageNumber, PageBuf>, // TODO: remove it (issue #1273)
     ) -> Result<(), Self::Error> {
-        lazy_pages::post_execution_actions(mem, memory_pages).map_err(Error::LazyPages)
+        lazy_pages::post_execution_actions(mem).map_err(Error::LazyPages)
     }
 }
 

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -841,6 +841,7 @@ fn restrict_start_section() {
     });
 }
 
+#[cfg(feature = "lazy-pages")]
 #[test]
 fn memory_access_cases() {
     // This test access different pages in wasm linear memory.
@@ -1079,7 +1080,7 @@ fn memory_access_cases() {
 #[cfg(feature = "lazy-pages")]
 #[test]
 fn lazy_pages() {
-    use gear_core::memory::PageNumber;
+    use gear_core::memory::{PageNumber, PAGE_STORAGE_GRANULARITY};
     use gear_runtime_interface as gear_ri;
     use std::collections::BTreeSet;
 
@@ -1097,6 +1098,7 @@ fn lazy_pages() {
             i32.const 0x0
             i32.const 0x9
             call $alloc
+            ;; store alloc result to 0x0 addr, so 0 page will be already accessed in handle
             i32.store
         )
         (func $handle
@@ -1144,7 +1146,6 @@ fn lazy_pages() {
         };
 
         run_to_block(2, None);
-        log::debug!("submit done {:?}", pid);
         assert_last_dequeued(1);
 
         let res = GearPallet::<Test>::send_message(
@@ -1154,7 +1155,6 @@ fn lazy_pages() {
             10_000_000_000,
             1000,
         );
-        log::debug!("res = {:?}", res);
         assert_ok!(res);
 
         run_to_block(3, None);
@@ -1162,50 +1162,85 @@ fn lazy_pages() {
         // Dirty hack: lazy pages info is stored in thread local static variables,
         // so after contract execution lazy-pages information
         // remains correct and we can use it here.
-        let released_pages: BTreeSet<PageNumber> = gear_ri::gear_ri::get_released_pages()
-            .iter()
-            .map(|p| PageNumber(*p))
-            .collect();
+        let released_pages: BTreeSet<u32> =
+            gear_ri::gear_ri::get_released_pages().into_iter().collect();
 
         // checks accessed pages set
         let native_size = page_size::get();
-        let mut expected_accessed = BTreeSet::new();
+        let mut expected_released = BTreeSet::new();
 
-        let page_to_accessed = |p: u32| {
-            if native_size > PageNumber::size() {
-                // `x` is number of gear pages in one native page for current host
-                let x = (native_size / PageNumber::size()) as u32;
-                // each native page contains several gear pages
-                let first_accessed_gear_page = (p / x) * x;
+        let page_to_released = |p: u32, is_first_access: bool| {
+            // is the minimum memory interval, which must be in storage for any page.
+            let granularity = if is_first_access {
+                PAGE_STORAGE_GRANULARITY
+            } else {
+                native_size
+            };
+            if granularity > PageNumber::size() {
+                // `x` is a number of gear pages in granularity
+                let x = (granularity / PageNumber::size()) as u32;
+                // is first gear page in granularity interval
+                let first_gear_page = (p / x) * x;
                 // accessed gear pages range:
-                first_accessed_gear_page..=first_accessed_gear_page + x - 1
+                first_gear_page..=first_gear_page + x - 1
             } else {
                 p..=p
             }
         };
 
-        // accessed from 0 wasm page:
-        expected_accessed.extend(page_to_accessed(0));
+        // released from 0 wasm page:
+        expected_released.extend(page_to_released(0, false));
 
-        // accessed from 2 wasm page, can be several gear and native pages:
+        // released from 2 wasm page:
         let first_page = (0x23ffe / PageNumber::size()) as u32;
         let second_page = (0x24001 / PageNumber::size()) as u32;
-        expected_accessed.extend(page_to_accessed(first_page));
-        expected_accessed.extend(page_to_accessed(second_page));
+        expected_released.extend(page_to_released(first_page, true));
+        expected_released.extend(page_to_released(second_page, true));
 
-        // accessed from 5 wasm page:
-        expected_accessed.extend(page_to_accessed((0x50000 / PageNumber::size()) as u32));
+        // nothing for 5 wasm page, because it's just read access
 
-        // accessed from 8 and 9 wasm pages, must be several gear pages:
+        // released from 8 and 9 wasm pages, must be several gear pages:
         let first_page = (0x8fffc / PageNumber::size()) as u32;
         let second_page = (0x90003 / PageNumber::size()) as u32;
-        expected_accessed.extend(page_to_accessed(first_page));
-        expected_accessed.extend(page_to_accessed(second_page));
+        expected_released.extend(page_to_released(first_page, true));
+        expected_released.extend(page_to_released(second_page, true));
 
-        assert_eq!(
-            released_pages,
-            expected_accessed.into_iter().map(PageNumber).collect()
+        assert_eq!(released_pages, expected_released);
+
+        // For second message handle we will touch the same memory, but because
+        // some pages are already in storage, then we can skip page storage granularity
+        // when uploads pages to storage, so released pages can be different.
+        let res = GearPallet::<Test>::send_message(
+            Origin::signed(USER_1),
+            pid,
+            EMPTY_PAYLOAD.to_vec(),
+            10_000_000_000,
+            1000,
         );
+        assert_ok!(res);
+
+        run_to_block(4, None);
+
+        let released_pages: BTreeSet<u32> =
+            gear_ri::gear_ri::get_released_pages().into_iter().collect();
+        let mut expected_released = BTreeSet::new();
+
+        // released from 0 wasm page:
+        expected_released.extend(page_to_released(0, false));
+
+        // released from 2 wasm page:
+        let first_page = (0x23ffe / PageNumber::size()) as u32;
+        let second_page = (0x24001 / PageNumber::size()) as u32;
+        expected_released.extend(page_to_released(first_page, false));
+        expected_released.extend(page_to_released(second_page, false));
+
+        // released from 8 and 9 wasm pages, must be several gear pages:
+        let first_page = (0x8fffc / PageNumber::size()) as u32;
+        let second_page = (0x90003 / PageNumber::size()) as u32;
+        expected_released.extend(page_to_released(first_page, false));
+        expected_released.extend(page_to_released(second_page, false));
+
+        assert_eq!(released_pages, expected_released);
     });
 }
 

--- a/runtime-interface/src/deprecated.rs
+++ b/runtime-interface/src/deprecated.rs
@@ -104,7 +104,7 @@ pub(crate) fn mprotect_pages_slice(
     let mprotect = |start: PageNumber, count, protect: bool| unsafe {
         let addr = mem_addr + (start.0 as usize * PageNumber::size()) as HostPointer;
         let size = count as usize * PageNumber::size();
-        sys_mprotect_interval(addr, size, !protect, !protect, false)
+        sys_mprotect_interval(addr as usize, size, !protect, !protect, false)
     };
 
     // Collects continuous intervals of memory from lazy pages to protect them.

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -282,7 +282,7 @@ pub trait GearRI {
         lazy_pages::set_wasm_mem_size(size_in_bytes);
     }
 
-    fn initilize_for_program(
+    fn initialize_for_program(
         wasm_mem_addr: Option<HostPointer>,
         wasm_mem_size: u32,
         stack_end_page: Option<u32>,
@@ -293,14 +293,14 @@ pub trait GearRI {
 
         let wasm_mem_addr = wasm_mem_addr
             .map(|addr| usize::try_from(addr).expect("Cannot cast wasm mem addr to `usize`"));
-        lazy_pages::initilize_for_program(
+        lazy_pages::initialize_for_program(
             wasm_mem_addr,
             wasm_mem_size,
             stack_end_page,
             program_prefix,
         )
         .map_err(|e| e.to_string())
-        .expect("Cannot initilize lazy pages for current program");
+        .expect("Cannot initialize lazy pages for current program");
 
         if let Some(addr) = wasm_mem_addr {
             unsafe { sys_mprotect_interval(addr, wasm_mem_size.offset(), false, false, false) }

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -297,17 +297,6 @@ pub trait GearRI {
         }
     }
 
-    // fn set_lazy_pages_addresses(stack_end_wasm_addr: WasmAddr) -> Result<(), RIError> {
-    //     // TODO: remove this panic before release and make an error (issue #1147)
-    //     assert_eq!(
-    //         stack_end_wasm_addr as usize % WasmPageNumber::size(),
-    //         0,
-    //         "Stack end addr must be multiple of wasm page size"
-    //     );
-    //     lazy_pages::set_stack_end_wasm_addr(stack_end_wasm_addr);
-    //     Ok(())
-    // }
-
     fn set_program_prefix(prefix: Vec<u8>) {
         lazy_pages::set_program_prefix(prefix);
     }

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -25,7 +25,7 @@
 
 use codec::{Decode, Encode};
 use core::ops::RangeInclusive;
-use gear_core::memory::{HostPointer, PageBuf};
+use gear_core::memory::{HostPointer, PageBuf, WasmPageNumber};
 use sp_runtime_interface::runtime_interface;
 
 mod deprecated;
@@ -40,11 +40,12 @@ use gear_core::memory::PageNumber;
 #[cfg(feature = "std")]
 use gear_lazy_pages as lazy_pages;
 
-pub use sp_std::{result::Result, vec::Vec};
+pub use sp_std::{convert::TryFrom, result::Result, vec::Vec};
 
 #[cfg(test)]
 mod tests;
 
+// TODO: issue #1147. Make this error for mprotection and for internal use only.
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, derive_more::Display)]
 pub enum RIError {
     #[display(fmt = "Cannot mprotect interval: {:?}, mask = {}", interval, mask)]
@@ -72,7 +73,7 @@ pub enum RIError {
 /// Protection mask is set according to protection arguments.
 #[cfg(feature = "std")]
 pub(crate) unsafe fn sys_mprotect_interval(
-    addr: HostPointer,
+    addr: usize,
     size: usize,
     prot_read: bool,
     prot_write: bool,
@@ -105,7 +106,7 @@ pub(crate) unsafe fn sys_mprotect_interval(
             err,
         );
         return Err(RIError::MprotectError {
-            interval: addr..=addr + size as u64,
+            interval: addr as u64..=addr as u64 + size as u64,
             mask: prot_mask.bits() as u64,
         });
     }
@@ -122,19 +123,18 @@ pub(crate) unsafe fn sys_mprotect_interval(
 /// If `protect` is true then restrict read/write access, else allow them.
 #[cfg(feature = "std")]
 fn mprotect_mem_interval_except_pages(
-    mem_addr: HostPointer,
-    start_offset: u32,
+    mem_addr: usize,
+    start_offset: usize,
     mem_size: usize,
     except_pages: impl Iterator<Item = PageNumber>,
     protect: bool,
 ) -> Result<(), RIError> {
     let mprotect = |start, end| {
-        let addr = mem_addr + start as HostPointer;
+        let addr = mem_addr + start;
         let size = end - start;
         unsafe { sys_mprotect_interval(addr, size, !protect, !protect, false) }
     };
 
-    // TODO: remove panics and make an errors (issue #1147)
     assert!(start_offset as usize <= mem_size);
 
     let mut interval_offset = start_offset as usize;
@@ -204,10 +204,9 @@ pub trait GearRI {
     fn mprotect_lazy_pages(protect: bool) -> Result<(), RIError> {
         log::trace!("mem size = {:?}", lazy_pages::get_wasm_mem_size());
         mprotect_mem_interval_except_pages(
-            // TODO: remove panics and make an errors (issue #1147)
             lazy_pages::get_wasm_mem_addr()
                 .expect("Wasm mem addr must be set before using this method"),
-            lazy_pages::get_stack_end_wasm_addr(),
+            lazy_pages::get_stack_end_wasm_addr() as usize,
             lazy_pages::get_wasm_mem_size()
                 .expect("Wasm mem size must be set before using this method") as usize,
             lazy_pages::get_released_pages().iter().copied(),
@@ -246,7 +245,7 @@ pub trait GearRI {
 
     #[deprecated]
     fn set_wasm_mem_begin_addr(addr: u64) {
-        lazy_pages::set_wasm_mem_begin_addr(addr);
+        lazy_pages::set_wasm_mem_begin_addr(addr as usize);
     }
 
     #[version(2)]
@@ -258,13 +257,13 @@ pub trait GearRI {
             });
         }
 
-        gear_lazy_pages::set_wasm_mem_begin_addr(addr);
+        gear_lazy_pages::set_wasm_mem_begin_addr(addr as usize);
 
         Ok(())
     }
 
+    #[deprecated]
     fn set_wasm_mem_size(size: u32) -> Result<(), RIError> {
-        // TODO: remove this panic before release and make an error (issue #1147)
         assert_eq!(
             size as usize % region::page::size(),
             0,
@@ -275,23 +274,36 @@ pub trait GearRI {
         Ok(())
     }
 
+    #[version(2)]
+    fn set_wasm_mem_size(size_in_wasm_pages: u32) {
+        let size = WasmPageNumber(size_in_wasm_pages);
+        let size_in_bytes =
+            u32::try_from(size.offset()).expect("Wasm memory size is bigger then u32::MAX bytes");
+        lazy_pages::set_wasm_mem_size(size_in_bytes);
+    }
+
     fn initilize_for_program(
         wasm_mem_addr: Option<HostPointer>,
         wasm_mem_size: u32,
-        stack_end_wasm_addr: Option<u32>,
+        stack_end_page: Option<u32>,
         program_prefix: Vec<u8>,
     ) -> Result<(), RIError> {
-        // TODO: remove this panic before release and make an error (issue #1147)
+        let wasm_mem_size = wasm_mem_size.into();
+        let stack_end_page = stack_end_page.map(Into::into);
+
+        let wasm_mem_addr = wasm_mem_addr
+            .map(|addr| usize::try_from(addr).expect("Cannot cast wasm mem addr to `usize`"));
         lazy_pages::initilize_for_program(
             wasm_mem_addr,
             wasm_mem_size,
-            stack_end_wasm_addr,
+            stack_end_page,
             program_prefix,
         )
+        .map_err(|e| e.to_string())
         .expect("Cannot initilize lazy pages for current program");
 
         if let Some(addr) = wasm_mem_addr {
-            unsafe { sys_mprotect_interval(addr, wasm_mem_size as usize, false, false, false) }
+            unsafe { sys_mprotect_interval(addr, wasm_mem_size.offset(), false, false, false) }
         } else {
             Ok(())
         }

--- a/runtime-interface/src/tests.rs
+++ b/runtime-interface/src/tests.rs
@@ -109,6 +109,7 @@ fn test_mprotect_pages() {
 
     mprotect_mem_interval_except_pages(
         page_begin,
+        0,
         mem_size,
         pages_unprotected.iter().copied(),
         true,
@@ -133,6 +134,7 @@ fn test_mprotect_pages() {
 
     mprotect_mem_interval_except_pages(
         page_begin,
+        0,
         mem_size,
         pages_unprotected.iter().copied(),
         false,

--- a/runtime-interface/src/tests.rs
+++ b/runtime-interface/src/tests.rs
@@ -86,8 +86,8 @@ fn test_mprotect_pages() {
 
     let mut v = vec![0u8; 3 * WasmPageNumber::size()];
     let buff = v.as_mut_ptr() as usize;
-    let page_begin = (((buff + WasmPageNumber::size()) / WasmPageNumber::size())
-        * WasmPageNumber::size()) as u64;
+    let page_begin =
+        ((buff + WasmPageNumber::size()) / WasmPageNumber::size()) * WasmPageNumber::size();
     let mem_size = 2 * WasmPageNumber::size();
 
     // Gear pages in 2 wasm pages. Randomly choose pages, which will be protected,


### PR DESCRIPTION
Resolves #1123

1) In lazy pages mode we upload page data to the storage in case it has been `write` accessed. Old logic is to compare pages data before and after execution and upload data if it has been changed. So, now in lazy pages mode comparing is removed. In executor I leave logic with comparing in case we works without lazy-pages: gtest/gear-test.
Removing pages comparing brings some performance changes. I've measured how execution time for function `gear_core_processor::execute_wasm` is changed for wat examples:
```
read_access.wat T(master)/T(patch) = 1.63
read_write_access.wat T(master)/T(patch) = 1
```
As you can see `read_write` access has no performance changes - this is because we must handle signal twice: one for read and second for write. This lead to 3 times more mprotection calls. 

2) Add page storage granularity:
```rust
/// Pages data storage granularity (PSG) is a size and wasm addr alignemnt
/// of a memory interval, for which the following conditions must be met:
/// if some gear page has data in storage, then all gear
/// pages, that are in the same granularity interval, must contain
/// data in storage. For example:
/// ````
///   granularity interval no.0       interval no.1        interval no.2
///                |                    |                    |
///                {====|====|====|====}{====|====|====|====}{====|====|====|====}
///               /     |     \
///    gear-page 0    page 1   page 2 ...
/// ````
/// In this example each PSG page contains 4 gear-pages. So, if gear-page `2`
/// has data in storage, then gear-page `0`,`1`,`3` also has data in storage.
/// This constant is necessary for consensus between nodes with different
/// native page sizes. You can see an example of using in crate `gear-lazy-pages`.

/// [PAGE_STORAGE_GRANULARITY] (PSG) case - if page is write accessed
/// first time in program live, then this page has no data in storage yet.
/// This also means that all pages from the same PSG interval has no data in storage.
/// So, in this case we have to insert in `released_lazy_pages` all pages from the same
/// PSG interval, in order to upload their data to storage later in runtime.
/// We have to make separate logic for this case in order to support consensus
/// between nodes with different native page sizes. For example, if one node
/// has native page size 4kBit and other 16kBit, then (without PSG logic)
/// for first one gear page will be uploaded and for second 4 gear pages.
/// This can cause conflicts in data about pages that have data in storage.
/// So, to avoid this we upload all pages from PSG interval (which is 16kBit now),
/// and restrict to run node on machines, that have native page number bigger than PSG.
```

3) Fix and add test cases.

### Tested
1) Test that if one node change data for some `key` in storage to the same value, which was before. And other node does not do this in the same block finalisation, then this nodes generates equal blocks and consensus is not failed between them.
2) Test that this patch works on chain in old test-net and in new test-net

### IMPORTANT
In case of runtime upgrade to current patch - need to rebuild nodes in test net