### PR TITLE
add stack pages support for lazy pages in runtime

### DIFF
--- a/common/src/lazy_pages.rs
+++ b/common/src/lazy_pages.rs
@@ -71,17 +71,26 @@ pub fn is_lazy_pages_enabled() -> bool {
 }
 
 /// Protect and save storage keys for pages which has no data
-pub fn protect_pages_and_init_info(mem: &impl Memory, prog_id: ProgramId) -> Result<(), Error> {
+pub fn init_for_program(
+    mem: &impl Memory,
+    prog_id: ProgramId,
+    stack_end: Option<WasmPageNumber>,
+) -> Result<(), Error> {
     let program_prefix = crate::pages_prefix(prog_id.into_origin());
     let wasm_mem_addr = mem.get_buffer_host_addr();
     let wasm_mem_size = mem.size();
+    let stack_end_page = stack_end.map(|p| p.0);
 
     // Cannot panic unless OS allocates buffer in not aligned by native page addr, or
     // something goes wrong with pages protection.
-    // TODO: currently set stack pages as None, should be resolved (issue #1253).
-    gear_ri::initialize_for_program(wasm_mem_addr, wasm_mem_size.0, None, program_prefix)
-        .map_err(|err| err.to_string())
-        .expect("Cannot initialize lazy pages for current program");
+    gear_ri::initialize_for_program(
+        wasm_mem_addr,
+        wasm_mem_size.0,
+        stack_end_page,
+        program_prefix,
+    )
+    .map_err(|err| err.to_string())
+    .expect("Cannot initialize lazy pages for current program");
 
     Ok(())
 }

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -110,11 +110,7 @@ pub struct ExtInfo {
 }
 
 pub trait IntoExtInfo {
-    fn into_ext_info(
-        self,
-        memory: &impl Memory,
-        stack_page_count: WasmPageNumber,
-    ) -> Result<ExtInfo, (MemoryError, GasAmount)>;
+    fn into_ext_info(self, memory: &impl Memory) -> Result<ExtInfo, (MemoryError, GasAmount)>;
 
     fn into_gas_amount(self) -> GasAmount;
 
@@ -149,7 +145,6 @@ where
 pub struct BackendReport<T> {
     pub termination_reason: TerminationReason,
     pub memory_wrap: T,
-    pub stack_end_page: Option<WasmPageNumber>,
 }
 
 #[derive(Debug, derive_more::Display)]

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -179,7 +179,7 @@ pub trait Environment<E: Ext + IntoExtInfo + 'static>: Sized {
         pre_execution_handler: F,
     ) -> Result<BackendReport<Self::Memory>, BackendError<Self::Error>>
     where
-        F: FnOnce(&mut Self::Memory) -> Result<(), T>,
+        F: FnOnce(&mut Self::Memory, Option<WasmPageNumber>) -> Result<(), T>,
         T: fmt::Display;
 }
 

--- a/core-backend/common/src/utils.rs
+++ b/core-backend/common/src/utils.rs
@@ -1,4 +1,6 @@
+use crate::StackEndError;
 use alloc::string::String;
+use gear_core::memory::WasmPageNumber;
 
 #[macro_export]
 macro_rules! assert_ok {
@@ -30,6 +32,20 @@ pub(crate) fn smart_truncate(s: &mut String, max_bytes: usize) {
         }
 
         s.truncate(last_byte);
+    }
+}
+pub fn calc_stack_end(stack_end: Option<i32>) -> Result<Option<WasmPageNumber>, StackEndError> {
+    use StackEndError::*;
+    if let Some(stack_end) = stack_end {
+        if stack_end < 0 {
+            return Err(IsNegative(stack_end));
+        }
+        if stack_end as usize % WasmPageNumber::size() != 0 {
+            return Err(IsNotAligned(stack_end));
+        }
+        Ok(Some(WasmPageNumber::new_from_addr(stack_end as usize)))
+    } else {
+        Ok(None)
     }
 }
 

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -29,18 +29,19 @@ use alloc::{
 };
 use core::fmt;
 use gear_backend_common::{
-    error_processor::IntoExtError, AsTerminationReason, BackendError, BackendReport, Environment,
-    IntoExtInfo, TerminationReason, TrapExplanation,
+    calc_stack_end, error_processor::IntoExtError, AsTerminationReason, BackendReport, Environment,
+    IntoExtInfo, StackEndError, TerminationReason, TrapExplanation, STACK_END_EXPORT_NAME,
 };
 use gear_core::{env::Ext, memory::WasmPageNumber, message::DispatchKind};
-use gear_core_errors::MemoryError;
 use sp_sandbox::{
     default_executor::{EnvironmentDefinitionBuilder, Instance, Memory as DefaultExecutorMemory},
     HostFuncType, ReturnValue, SandboxEnvironmentBuilder, SandboxInstance, SandboxMemory,
 };
 
-#[derive(Debug, derive_more::Display)]
+#[derive(Debug, derive_more::Display, derive_more::From)]
 pub enum SandboxEnvironmentError {
+    #[display(fmt = "Failed to create env memory: {:?}", _0)]
+    CreateEnvMemory(sp_sandbox::Error),
     #[display(fmt = "Unable to instantiate module: {:?}", _0)]
     ModuleInstantiation(sp_sandbox::Error),
     #[display(fmt = "Unable to get wasm module exports: {}", _0)]
@@ -49,12 +50,10 @@ pub enum SandboxEnvironmentError {
     SetModuleMemoryData,
     #[display(fmt = "Unable to save static pages initial data")]
     SaveStaticPagesInitialData,
-    #[display(fmt = "Failed to create env memory: {:?}", _0)]
-    CreateEnvMemory(sp_sandbox::Error),
-    #[display(fmt = "{}", _0)]
-    Memory(MemoryError),
     #[display(fmt = "{}", _0)]
     PreExecutionHandler(String),
+    #[from]
+    StackEnd(StackEndError),
 }
 
 /// Environment to run one module at a time providing Ext.
@@ -102,11 +101,13 @@ where
         mem_size: WasmPageNumber,
         entry_point: &DispatchKind,
         pre_execution_handler: F,
-    ) -> Result<BackendReport<Self::Memory>, BackendError<Self::Error>>
+    ) -> Result<BackendReport<Self::Memory>, Self::Error>
     where
         F: FnOnce(&mut Self::Memory, Option<WasmPageNumber>) -> Result<(), T>,
         T: fmt::Display,
     {
+        use SandboxEnvironmentError::*;
+
         let mut builder = EnvBuilder::<E> {
             env_def_builder: EnvironmentDefinitionBuilder::new(),
             forbidden_funcs: &ext.forbidden_funcs().clone(),
@@ -148,11 +149,7 @@ where
 
         let mem: DefaultExecutorMemory = match SandboxMemory::new(mem_size.0, None) {
             Ok(mem) => mem,
-            Err(e) => {
-                return Err(BackendError {
-                    reason: SandboxEnvironmentError::CreateEnvMemory(e),
-                })
-            }
+            Err(e) => return Err(CreateEnvMemory(e)),
         };
 
         env_builder.add_memory("env", "memory", mem.clone());
@@ -170,31 +167,16 @@ where
 
         let mut instance = match Instance::new(binary, &env_builder, &mut runtime) {
             Ok(inst) => inst,
-            Err(e) => {
-                return Err(BackendError {
-                    reason: SandboxEnvironmentError::ModuleInstantiation(e),
-                })
-            }
+            Err(e) => return Err(ModuleInstantiation(e)),
         };
 
-        // '__gear_stack_end' export is inserted in wasm-proc or wasm-builder
-        let stack_end_page = instance
-            .get_global_val("__gear_stack_end")
-            .and_then(|global| {
-                global.as_i32().and_then(|addr| {
-                    if addr < 0 {
-                        None
-                    } else {
-                        Some(WasmPageNumber(
-                            (addr as usize / WasmPageNumber::size()) as u32,
-                        ))
-                    }
-                })
-            });
+        let stack_end = instance
+            .get_global_val(STACK_END_EXPORT_NAME)
+            .and_then(|global| global.as_i32());
+        let stack_end_page = calc_stack_end(stack_end)?;
 
-        pre_execution_handler(runtime.memory_wrap, stack_end_page).map_err(|e| BackendError {
-            reason: SandboxEnvironmentError::PreExecutionHandler(e.to_string()),
-        })?;
+        pre_execution_handler(runtime.memory_wrap, stack_end_page)
+            .map_err(|e| PreExecutionHandler(e.to_string()))?;
 
         let res = if entries.contains(entry_point) {
             instance.invoke(entry_point.into_entry(), &[], &mut runtime)

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -227,7 +227,6 @@ where
         Ok(BackendReport {
             termination_reason: termination,
             memory_wrap,
-            stack_end_page,
         })
     }
 }

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -450,7 +450,6 @@ where
         Ok(BackendReport {
             termination_reason: termination,
             memory_wrap,
-            stack_end_page,
         })
     }
 }

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -360,6 +360,16 @@ pub enum ExecutionErrorReason {
     /// Initial pages data must be empty when execute with lazy pages
     #[display(fmt = "Initial pages data must be empty when execute with lazy pages")]
     InitialPagesContainsDataInLazyPagesMode,
+    /// Stack end page, which value is specified in WASM code, cannot be bigger than static memory size.
+    #[display(
+        fmt = "Stack end page {:?} is bigger then WASM static memory size {:?}",
+        _0,
+        _1
+    )]
+    StackEndPageBiggerWasmMemSize(WasmPageNumber, WasmPageNumber),
+    /// It's not allowed to set initial data for stack memory pages, if they are specified in WASM code.
+    #[display(fmt = "Set initial data for stack pages is restricted")]
+    StackPagesHaveInitialData,
 }
 
 /// Actor.

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -357,7 +357,7 @@ pub enum ExecutionErrorReason {
     /// Message killed from storage as out of rent.
     #[display(fmt = "Out of rent")]
     OutOfRent,
-    /// Initial pages data must be empty when execute with lazy pages
+    /// Initial pages data must be empty in lazy pages mode
     #[display(fmt = "Initial pages data must be empty when execute with lazy pages")]
     InitialPagesContainsDataInLazyPagesMode,
     /// Stack end page, which value is specified in WASM code, cannot be bigger than static memory size.

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -159,14 +159,9 @@ fn prepare_memory<A: ProcessorExt, M: Memory>(
         // If we executes without lazy pages, then we have to save all initial data for static pages,
         // in order to be able to identify pages, which has been changed during execution.
         // Skip stack page if they are specified.
-        let begin = stack_end.unwrap_or(0.into());
+        let begin = stack_end.unwrap_or(WasmPageNumber(0));
 
-        if pages_data
-            .keys()
-            .filter(|&&p| p < begin.to_gear_page())
-            .next()
-            .is_some()
-        {
+        if pages_data.keys().any(|&p| p < begin.to_gear_page()) {
             return Err(ExecutionErrorReason::StackPagesHaveInitialData);
         }
 

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -359,7 +359,6 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
         })?;
 
     if A::is_lazy_pages_enabled() && !pages_initial_data.is_empty() {
-        // Something wrong in runtime logic - when lazy pages, `pages_initial_data` must be always empty.
         return Err(ExecutionError {
             program_id,
             gas_amount: info.gas_amount,

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -33,7 +33,7 @@ use gear_core::{
     env::Ext as EnvExt,
     gas::{ChargeResult, GasAllowanceCounter, GasAmount, GasCounter, ValueCounter},
     ids::{CodeId, MessageId, ProgramId},
-    memory::{AllocationsContext, Memory, PageBuf, PageNumber, WasmPageNumber},
+    memory::{AllocationsContext, Memory, PageBuf, WasmPageNumber},
     message::{ExitCode, GasLimit, HandlePacket, InitPacket, MessageContext, Packet, ReplyPacket},
 };
 use gear_core_errors::{CoreError, ExecutionError, ExtError, MemoryError, MessageError};
@@ -88,16 +88,14 @@ pub trait ProcessorExt {
     fn check_lazy_pages_consistent_state() -> bool;
 
     /// Protect and save storage keys for pages which has no data
-    fn lazy_pages_protect_and_init_info(
+    fn lazy_pages_init_for_program(
         mem: &impl Memory,
         prog_id: ProgramId,
+        stack_end: Option<WasmPageNumber>,
     ) -> Result<(), Self::Error>;
 
     /// Lazy pages contract post execution actions
-    fn lazy_pages_post_execution_actions(
-        mem: &impl Memory,
-        memory_pages: &mut BTreeMap<PageNumber, PageBuf>,
-    ) -> Result<(), Self::Error>;
+    fn lazy_pages_post_execution_actions(mem: &impl Memory) -> Result<(), Self::Error>;
 }
 
 /// [`Ext`](Ext)'s error
@@ -198,17 +196,15 @@ impl ProcessorExt for Ext {
         true
     }
 
-    fn lazy_pages_protect_and_init_info(
+    fn lazy_pages_init_for_program(
         _mem: &impl Memory,
         _prog_id: ProgramId,
+        _stack_end: Option<WasmPageNumber>,
     ) -> Result<(), Self::Error> {
         unreachable!()
     }
 
-    fn lazy_pages_post_execution_actions(
-        _mem: &impl Memory,
-        _memory_pages: &mut BTreeMap<PageNumber, PageBuf>,
-    ) -> Result<(), Self::Error> {
+    fn lazy_pages_post_execution_actions(_mem: &impl Memory) -> Result<(), Self::Error> {
         unreachable!()
     }
 }

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -210,11 +210,7 @@ impl ProcessorExt for Ext {
 }
 
 impl IntoExtInfo for Ext {
-    fn into_ext_info(
-        self,
-        memory: &impl Memory,
-        stack_page_count: WasmPageNumber,
-    ) -> Result<ExtInfo, (MemoryError, GasAmount)> {
+    fn into_ext_info(self, memory: &impl Memory) -> Result<ExtInfo, (MemoryError, GasAmount)> {
         let ProcessorContext {
             allocations_context,
             message_context,
@@ -229,7 +225,6 @@ impl IntoExtInfo for Ext {
         for page in (0..static_pages.0)
             .map(WasmPageNumber)
             .chain(wasm_pages.iter().copied())
-            .skip_while(|page| *page < stack_page_count)
             .flat_map(|p| p.to_gear_pages_iter())
         {
             let mut buf = PageBuf::new_zeroed();

--- a/core/src/ids.rs
+++ b/core/src/ids.rs
@@ -172,7 +172,7 @@ impl MessageId {
         hash(&argument).into()
     }
 
-    /// Generate MessageId for reply message depent on exit code
+    /// Generate MessageId for reply message depend on exit code
     pub fn generate_reply(origin_msg_id: MessageId, exit_code: ExitCode) -> MessageId {
         let unique_flag = b"reply";
 

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -67,9 +67,6 @@ pub struct FixtureLogger {
 impl FixtureLogger {
     fn new(map: Arc<RwLock<HashMap<ThreadId, Vec<String>>>>) -> FixtureLogger {
         let mut builder = Builder::from_env(FILTER_ENV);
-        builder.parse(
-            "gear_test=debug,gear_core=debug,gear_backend_common=debug,gear_backend_wasmtime=debug,gear_backend_sandbox=debug,gear_core_processor=debug,gwasm=debug",
-        );
 
         FixtureLogger {
             inner: builder.build(),

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -146,7 +146,7 @@ thread_local! {
 
     /// Identify whether signal handler is set for current thread.
     static LAZY_PAGES_ENABLED: RefCell<bool> = RefCell::new(false);
-    /// Lazy pages impl version. Different runtimes may require different impl of lazy pages functionallity.
+    /// Lazy pages impl version. Different runtimes may require different impl of lazy pages functionality.
     static LAZY_PAGES_VERSION: RefCell<LazyPagesVersion> = RefCell::new(LazyPagesVersion::Version1);
     /// Lazy pages context for current execution.
     static LAZY_PAGES_CONTEXT: RefCell<LazyPagesExecutionContext> = RefCell::new(Default::default());

--- a/lazy-pages/src/sys.rs
+++ b/lazy-pages/src/sys.rs
@@ -283,7 +283,7 @@ unsafe fn user_signal_handler_internal_v2(
             let buffer_as_slice = std::slice::from_raw_parts_mut(page_buffer_ptr, gear_ps as usize);
             let res = sp_io::storage::read(prefix.calc_key_for_page(gear_page), buffer_as_slice, 0);
 
-            log::trace!("{:?} has data in storage: {}", gear_page, res.is_none());
+            log::trace!("{:?} has data in storage: {}", gear_page, res.is_some());
 
             if let Some(size) = res.filter(|&size| size as usize != PageNumber::size()) {
                 return Err(Error::InvalidPageDataSize {

--- a/pallets/gear-debug/src/tests.rs
+++ b/pallets/gear-debug/src/tests.rs
@@ -790,7 +790,7 @@ fn check_gear_stack_end() {
         let origin = Origin::signed(1);
 
         assert_ok!(PalletGear::<Test>::upload_program(
-            origin.clone(),
+            origin,
             code.clone(),
             b"salt".to_vec(),
             Vec::new(),

--- a/pallets/gear-debug/src/tests.rs
+++ b/pallets/gear-debug/src/tests.rs
@@ -407,7 +407,7 @@ fn check_not_allocated_pages() {
                     unreachable
                 )
 
-                ;; store 1 to the begin of memomry to identify that test goes right
+                ;; store 1 to the begin of memory to identify that test goes right
                 i32.const 0
                 i32.const 1
                 i32.store

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -69,11 +69,7 @@ pub struct LazyPagesExt {
 }
 
 impl IntoExtInfo for LazyPagesExt {
-    fn into_ext_info(
-        self,
-        memory: &impl Memory,
-        stack_page_count: WasmPageNumber,
-    ) -> Result<ExtInfo, (MemoryError, GasAmount)> {
+    fn into_ext_info(self, memory: &impl Memory) -> Result<ExtInfo, (MemoryError, GasAmount)> {
         let ProcessorContext {
             allocations_context,
             message_context,
@@ -88,8 +84,7 @@ impl IntoExtInfo for LazyPagesExt {
         let mut accessed_pages = lazy_pages::get_released_pages();
         accessed_pages.retain(|p| {
             let wasm_page = p.to_wasm_page();
-            let not_stack_page = wasm_page >= stack_page_count;
-            not_stack_page && (wasm_page < static_pages || allocations.contains(&wasm_page))
+            wasm_page < static_pages || allocations.contains(&wasm_page)
         });
 
         log::trace!("accessed pages numbers = {:?}", accessed_pages);

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -27,7 +27,7 @@ use gear_core::{
     env::Ext as EnvExt,
     gas::GasAmount,
     ids::{MessageId, ProgramId},
-    memory::{Memory, PageBuf, PageNumber, WasmPageNumber},
+    memory::{Memory, PageBuf, WasmPageNumber},
     message::{ExitCode, HandlePacket, ReplyPacket},
 };
 use gear_core_errors::{CoreError, ExtError, MemoryError};
@@ -149,9 +149,10 @@ impl ProcessorExt for LazyPagesExt {
         lazy_pages::is_lazy_pages_enabled()
     }
 
-    fn lazy_pages_protect_and_init_info(
+    fn lazy_pages_init_for_program(
         mem: &impl Memory,
         prog_id: ProgramId,
+        stack_end: Option<WasmPageNumber>,
     ) -> Result<(), Self::Error> {
         lazy_pages::protect_pages_and_init_info(mem, prog_id).map_err(Into::into)
     }

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -154,13 +154,10 @@ impl ProcessorExt for LazyPagesExt {
         prog_id: ProgramId,
         stack_end: Option<WasmPageNumber>,
     ) -> Result<(), Self::Error> {
-        lazy_pages::protect_pages_and_init_info(mem, prog_id).map_err(Into::into)
+        lazy_pages::init_for_program(mem, prog_id, stack_end).map_err(Into::into)
     }
 
-    fn lazy_pages_post_execution_actions(
-        mem: &impl Memory,
-        _memory_pages: &mut BTreeMap<PageNumber, PageBuf>, // TODO: remove it (issue #1273)
-    ) -> Result<(), Self::Error> {
+    fn lazy_pages_post_execution_actions(mem: &impl Memory) -> Result<(), Self::Error> {
         lazy_pages::remove_lazy_pages_prot(mem).map_err(Into::into)
     }
 }

--- a/runtime-interface/src/deprecated.rs
+++ b/runtime-interface/src/deprecated.rs
@@ -90,7 +90,7 @@ pub(crate) unsafe fn sys_mprotect_wasm_pages(
     _prot_write: bool,
     _prot_exec: bool,
 ) -> Result<(), MprotectError> {
-    log::error!("unsupported OS for pages protectection");
+    log::error!("unsupported OS for pages protection");
     Err(MprotectError::OsError)
 }
 

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -48,7 +48,7 @@ mod tests;
 // TODO: issue #1147. Make this error for mprotection and for internal use only.
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, derive_more::Display)]
 pub enum RIError {
-    #[display(fmt = "Cannot mprotect interval: {:?}, mask = {}", interval, mask)]
+    #[display(fmt = "Cannot mprotect interval {:#x?}, mask = {}", interval, mask)]
     MprotectError {
         interval: RangeInclusive<u64>,
         mask: u64,
@@ -303,7 +303,10 @@ pub trait GearRI {
         .expect("Cannot initialize lazy pages for current program");
 
         if let Some(addr) = wasm_mem_addr {
-            unsafe { sys_mprotect_interval(addr, wasm_mem_size.offset(), false, false, false) }
+            let stack_end = stack_end_page.map(|p| p.offset()).unwrap_or(0);
+            let size = wasm_mem_size.offset();
+            let except_pages = std::iter::empty::<PageNumber>();
+            mprotect_mem_interval_except_pages(addr, stack_end, size, except_pages, true)
         } else {
             Ok(())
         }

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear-node"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 1520,
+    spec_version: 1530,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -86,7 +86,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1520,
+    spec_version: 1530,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Resolves #1253.
- Now virtual stack pages will be skipped in lazy pages: they won't be protected and handled as lazy.