### PR TITLE
Check runtime WASM imports for being allowed

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -202,6 +202,9 @@ jobs:
         env:
           RUSTFLAGS: -Cinstrument-coverage
 
+      - name: Check runtime imports
+        run: ./target/release/wasm-proc --check-runtime-imports --path target/release/wbuild/gear-runtime/gear_runtime.wasm
+
       - name: "Build: Examples (WASM)"
         run: ./scripts/gear.sh build examples --locked
 
@@ -367,9 +370,6 @@ jobs:
           tar -cf /tmp/build_cache.tar /tmp/cachepot
           tar -cf /tmp/build_cargo_registry.tar /tmp/cargo/bin /tmp/cargo/registry/cache /tmp/cargo/registry/index /tmp/cargo/git
           mkdir -p /root/cache/${{ github.event.pull_request.number }} && mv /tmp/*.tar /root/cache/${{ github.event.pull_request.number }}/
-
-      - name: Check runtime imports
-        run: ./target/release/wasm-proc --check-runtime-imports --path target/production/wbuild/gear-runtime/gear_runtime.wasm
 
       - name: Prepare artifacts
         if: github.event_name == 'push'

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -368,6 +368,9 @@ jobs:
           tar -cf /tmp/build_cargo_registry.tar /tmp/cargo/bin /tmp/cargo/registry/cache /tmp/cargo/registry/index /tmp/cargo/git
           mkdir -p /root/cache/${{ github.event.pull_request.number }} && mv /tmp/*.tar /root/cache/${{ github.event.pull_request.number }}/
 
+      - name: Check runtime imports
+        run: ./target/release/wasm-proc --check-runtime-imports --path target/production/wbuild/gear-runtime/gear_runtime.wasm
+
       - name: Prepare artifacts
         if: github.event_name == 'push'
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9675,6 +9675,7 @@ dependencies = [
  "env_logger",
  "gear-wasm-builder",
  "log",
+ "parity-wasm 0.45.0",
  "thiserror",
 ]
 

--- a/utils/wasm-proc/Cargo.toml
+++ b/utils/wasm-proc/Cargo.toml
@@ -9,3 +9,4 @@ log = "0.4.17"
 env_logger = "0.9.0"
 thiserror = "1.0.32"
 gear-wasm-builder = { path = "../wasm-builder" }
+parity-wasm = "0.45.0"

--- a/utils/wasm-proc/src/main.rs
+++ b/utils/wasm-proc/src/main.rs
@@ -22,8 +22,10 @@ use parity_wasm::elements::External;
 use std::{collections::HashSet, fs, path::PathBuf};
 
 const RT_ALLOWED_IMPORTS: [&str; 49] = [
+    // From `Allocator` (substrate/primitives/io/src/lib.rs)
     "ext_allocator_free_version_1",
     "ext_allocator_malloc_version_1",
+    // From `Crypto` (substrate/primitives/io/src/lib.rs)
     "ext_crypto_ed25519_generate_version_1",
     "ext_crypto_ed25519_verify_version_1",
     "ext_crypto_finish_batch_verify_version_1",
@@ -31,6 +33,7 @@ const RT_ALLOWED_IMPORTS: [&str; 49] = [
     "ext_crypto_sr25519_generate_version_1",
     "ext_crypto_sr25519_verify_version_2",
     "ext_crypto_start_batch_verify_version_1",
+    // From `GearRI` (runtime-interface/scr/lib.rs)
     "ext_gear_ri_get_released_pages_version_1",
     "ext_gear_ri_init_lazy_pages_version_2",
     "ext_gear_ri_initialize_for_program_version_1",
@@ -38,15 +41,19 @@ const RT_ALLOWED_IMPORTS: [&str; 49] = [
     "ext_gear_ri_mprotect_lazy_pages_version_3",
     "ext_gear_ri_set_wasm_mem_begin_addr_version_2",
     "ext_gear_ri_set_wasm_mem_size_version_2",
+    // From `Hashing` (substrate/primitives/io/src/lib.rs)
     "ext_hashing_blake2_128_version_1",
     "ext_hashing_blake2_256_version_1",
     "ext_hashing_twox_128_version_1",
     "ext_hashing_twox_64_version_1",
+    // From `Logging` (substrate/primitives/io/src/lib.rs)
     "ext_logging_log_version_1",
     "ext_logging_max_level_version_1",
+    // From `Misc` (substrate/primitives/io/src/lib.rs)
     "ext_misc_print_hex_version_1",
     "ext_misc_print_utf8_version_1",
     "ext_misc_runtime_version_version_1",
+    // From `Sandbox` (substrate/primitives/io/src/lib.rs)
     "ext_sandbox_get_buff_version_1",
     "ext_sandbox_get_global_val_version_1",
     "ext_sandbox_instance_teardown_version_1",
@@ -58,6 +65,7 @@ const RT_ALLOWED_IMPORTS: [&str; 49] = [
     "ext_sandbox_memory_set_version_1",
     "ext_sandbox_memory_size_version_1",
     "ext_sandbox_memory_teardown_version_1",
+    // From `Storage` (substrate/primitives/io/src/lib.rs)
     "ext_storage_append_version_1",
     "ext_storage_clear_prefix_version_2",
     "ext_storage_clear_version_1",
@@ -70,6 +78,7 @@ const RT_ALLOWED_IMPORTS: [&str; 49] = [
     "ext_storage_root_version_2",
     "ext_storage_set_version_1",
     "ext_storage_start_transaction_version_1",
+    // From `Trie` (substrate/primitives/io/src/lib.rs)
     "ext_trie_blake2_256_ordered_root_version_2",
 ];
 


### PR DESCRIPTION
- Added to `wasm-proc` a functionality for checking runtime imports against the whitelist.
- Added a correspondent stage to CI.

@gear-tech/dev 
