### PR TITLE
Restore custom transaction fees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,7 +2500,7 @@ dependencies = [
  "gear-runtime-common",
  "gear-runtime-test-cli",
  "gear-service",
- "pallet-transaction-payment",
+ "pallet-gear-payment",
  "sc-cli",
  "sc-client-api",
  "sc-service",

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -16,6 +16,7 @@ scale-info = { version = "2.1.1", default-features = false, features = ["derive"
 gear-node-primitives = { path = "../primitives" }
 gear-runtime-test-cli = { path = "../../utils/gear-runtime-test-cli" }
 service = { package = "gear-service", path = "../service", default-features = false, optional = true }
+pallet-gear-payment = { version = "0.1.0", path = "../../pallets/payment" }
 
 # Gear Runtimes
 gear-runtime = { path = "../../runtime/gear", optional = true }
@@ -37,9 +38,6 @@ sp-inherents = { version = "4.0.0-dev", git = "https://github.com/gear-tech/subs
 sp-keyring = { version = "6.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 sp-runtime = { version = "6.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
-
-# Frame pallets
-pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 
 # Substrate other (benchmarking etc)
 frame-system = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }

--- a/node/cli/src/benchmarking.rs
+++ b/node/cli/src/benchmarking.rs
@@ -118,7 +118,7 @@ macro_rules! signed_payload {
             ),
             frame_system::CheckNonce::<runtime::Runtime>::from($nonce),
             frame_system::CheckWeight::<runtime::Runtime>::new(),
-            pallet_transaction_payment::ChargeTransactionPayment::<runtime::Runtime>::from($tip),
+            pallet_gear_payment::CustomChargeTransactionPayment::<runtime::Runtime>::from($tip),
         );
 
         let $raw_payload = runtime::SignedPayload::from_raw(

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear-node"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 1530,
+    spec_version: 1540,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,
@@ -417,7 +417,7 @@ pub type SignedExtra = (
     frame_system::CheckEra<Runtime>,
     frame_system::CheckNonce<Runtime>,
     frame_system::CheckWeight<Runtime>,
-    pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+    pallet_gear_payment::CustomChargeTransactionPayment<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -86,7 +86,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1530,
+    spec_version: 1540,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -455,7 +455,7 @@ pub type SignedExtra = (
     frame_system::CheckEra<Runtime>,
     frame_system::CheckNonce<Runtime>,
     frame_system::CheckWeight<Runtime>,
-    pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+    pallet_gear_payment::CustomChargeTransactionPayment<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;


### PR DESCRIPTION
Apparently, one of the recent upgrades of Substrate has led to these changes having been reverted so that the default `pallet_transaction_payment` was used to calculate fees. Restoring our custom way of modifying fees that was introduced together with the `gear-payment` pallet