### PR TITLE
fix wrong block panic in node

### DIFF
--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -353,8 +353,8 @@ pub enum InitError {
 unsafe fn init_internal(version: LazyPagesVersion) -> Result<(), InitError> {
     use InitError::*;
 
-    // Set version even if it has been already set, because runtime upgrade and then contracts
-    // execution can be done in the same thread.
+    // Set version even if it has been already set, because `on_idle` calls can be
+    // in the same thread, even after runtime upgrade, which can change version.
     LAZY_PAGES_VERSION.with(|v| *v.borrow_mut() = version);
 
     if LAZY_PAGES_ENABLED.with(|x| *x.borrow()) {

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -254,6 +254,27 @@ pub fn get_released_pages() -> Vec<PageNumber> {
     LAZY_PAGES_CONTEXT.with(|ctx| ctx.borrow().released_pages.iter().copied().collect())
 }
 
+pub fn get_released_pages_patch() -> Vec<PageNumber> {
+    LAZY_PAGES_CONTEXT.with(|ctx| {
+        let ctx = ctx.borrow_mut();
+        if ctx.program_storage_prefix.as_ref().unwrap()
+            == &vec![
+                103, 58, 58, 112, 97, 103, 101, 115, 58, 58, 37, 234, 245, 189, 198, 95, 86, 8,
+                181, 243, 151, 188, 58, 173, 35, 83, 155, 213, 81, 68, 52, 30, 26, 95, 37, 155,
+                148, 43, 94, 120, 61, 188, 58, 58,
+            ]
+        {
+            ctx.released_pages
+                .iter()
+                .copied()
+                .filter(|&p| p.0 != 259)
+                .collect()
+        } else {
+            ctx.released_pages.iter().copied().collect()
+        }
+    })
+}
+
 /// Returns whether lazy pages env is enabled
 pub fn is_enabled() -> bool {
     LAZY_PAGES_ENABLED.with(|x| *x.borrow())
@@ -330,6 +351,10 @@ pub enum InitError {
 unsafe fn init_internal(version: LazyPagesVersion) -> Result<(), InitError> {
     use InitError::*;
 
+    // Set version even if it has been already set, because runtime upgrade and then contracts
+    // execution can be done in the same thread.
+    LAZY_PAGES_VERSION.with(|v| *v.borrow_mut() = version);
+
     if LAZY_PAGES_ENABLED.with(|x| *x.borrow()) {
         log::trace!("Lazy-pages has been already enabled for current thread");
         return Ok(());
@@ -352,7 +377,6 @@ unsafe fn init_internal(version: LazyPagesVersion) -> Result<(), InitError> {
         return Err(CanNotSetUpSignalHandler(err.to_string()));
     }
 
-    LAZY_PAGES_VERSION.with(|v| *v.borrow_mut() = version);
     LAZY_PAGES_ENABLED.with(|x| *x.borrow_mut() = true);
 
     Ok(())

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -256,7 +256,7 @@ pub fn get_released_pages() -> Vec<PageNumber> {
 
 /// TODO: remove this after current test-net chain will be dropped (issue #1317).
 /// This patch solves the problem for block `#866245`, see more in issue.
-pub fn get_released_pages_patch() -> Vec<PageNumber> {
+pub fn get_released_pages_patched() -> Vec<PageNumber> {
     LAZY_PAGES_CONTEXT.with(|ctx| {
         let ctx = ctx.borrow_mut();
         if ctx.program_storage_prefix.as_ref().unwrap()

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -254,6 +254,8 @@ pub fn get_released_pages() -> Vec<PageNumber> {
     LAZY_PAGES_CONTEXT.with(|ctx| ctx.borrow().released_pages.iter().copied().collect())
 }
 
+/// TODO: remove this after current test-net chain will be dropped (issue #1317).
+/// This patch solves the problem for block `#866245`, see more in issue.
 pub fn get_released_pages_patch() -> Vec<PageNumber> {
     LAZY_PAGES_CONTEXT.with(|ctx| {
         let ctx = ctx.borrow_mut();

--- a/lazy-pages/src/sys.rs
+++ b/lazy-pages/src/sys.rs
@@ -312,6 +312,8 @@ unsafe fn user_signal_handler_internal_v2(
         log::trace!("Is write access - keep r/w prot");
     }
 
+    log::debug!("prefix = {:?}", ctx.program_storage_prefix.as_ref().unwrap());
+
     Ok(())
 }
 

--- a/lazy-pages/src/sys.rs
+++ b/lazy-pages/src/sys.rs
@@ -312,8 +312,6 @@ unsafe fn user_signal_handler_internal_v2(
         log::trace!("Is write access - keep r/w prot");
     }
 
-    log::debug!("prefix = {:?}", ctx.program_storage_prefix.as_ref().unwrap());
-
     Ok(())
 }
 

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -317,7 +317,7 @@ pub trait GearRI {
     }
 
     fn get_released_pages() -> Vec<u32> {
-        lazy_pages::get_released_pages()
+        lazy_pages::get_released_pages_patch()
             .into_iter()
             .map(|p| p.0)
             .collect()

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -317,7 +317,7 @@ pub trait GearRI {
     }
 
     fn get_released_pages() -> Vec<u32> {
-        lazy_pages::get_released_pages_patch()
+        lazy_pages::get_released_pages_patched()
             .into_iter()
             .map(|p| p.0)
             .collect()

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear-node"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 1540,
+    spec_version: 1550,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -86,7 +86,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1540,
+    spec_version: 1550,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/scripts/check-spec.sh
+++ b/scripts/check-spec.sh
@@ -33,7 +33,7 @@ check_spec() {
     fi
 }
 
-PACKAGES_REQUIRE_BUMP_SPEC="common core core-backend core-processor node pallets runtime-interface lazy-pages"
+PACKAGES_REQUIRE_BUMP_SPEC="common core core-backend core-processor node pallets runtime-interface"
 
 SPEC_ON_MASTER="$(git diff origin/master | sed -n -r "s/^\-[[:space:]]+spec_version: +([0-9]+),$/\1/p")"
 ACTUAL_SPEC_GEAR="$(cat $ROOT_DIR/runtime/gear/src/lib.rs | grep "spec_version: " | awk -F " " '{print substr($2, 1, length($2)-1)}')"


### PR DESCRIPTION
See issue #1317 

### Test
Run test net sync for mac and for linux, all goes OK.

### Other
Removes `lazy-pages` from list of crates to update runtime spec version, because lazy-pages crate code is restricted to be in runtime.