### PR TITLE
Handle code re-instrumentation failure in process_queue

### DIFF
--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -372,10 +372,7 @@ where
         };
 
         let defined_host_functions = builder.defined_host_functions.clone();
-        let module = match wasmi::Module::from_buffer(binary) {
-            Ok(module) => module,
-            Err(e) => return Err(ModuleInstantiation(e)),
-        };
+        let module = wasmi::Module::from_buffer(binary).map_err(ModuleInstantiation)?;
         let instance = match ModuleInstance::new(&module, &builder) {
             Ok(inst) => inst.not_started_instance().clone(),
             Err(e) => return Err(ModuleInstantiation(e)),

--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -746,10 +746,155 @@ impl<'a, T: Config> gas_metering::Rules for ScheduleRules<'a, T> {
 mod test {
     use super::*;
     use crate::mock::Test;
+    use gas_metering::Rules;
 
+    fn all_measured_instructions() -> Vec<elements::Instruction> {
+        use elements::{BlockType, BrTableData, Instruction::*};
+        let default_table_data = BrTableData {
+            table: Default::default(),
+            default: 0,
+        };
+
+        // A set of instructions weights for which the Gear provides.
+        // Instruction must not be removed (!), but can be added.
+        vec![
+            End,
+            Unreachable,
+            Return,
+            Else,
+            I32Const(0),
+            I64Const(0),
+            Block(BlockType::NoResult),
+            Loop(BlockType::NoResult),
+            Nop,
+            Drop,
+            I32Load(0, 0),
+            I32Load8S(0, 0),
+            I32Load8U(0, 0),
+            I32Load16S(0, 0),
+            I32Load16U(0, 0),
+            I64Load(0, 0),
+            I64Load8S(0, 0),
+            I64Load8U(0, 0),
+            I64Load16S(0, 0),
+            I64Load16U(0, 0),
+            I64Load32S(0, 0),
+            I64Load32U(0, 0),
+            I32Store(0, 0),
+            I32Store8(0, 0),
+            I32Store16(0, 0),
+            I64Store(0, 0),
+            I64Store8(0, 0),
+            I64Store16(0, 0),
+            I64Store32(0, 0),
+            Select,
+            If(BlockType::NoResult),
+            Br(0),
+            BrIf(0),
+            Call(0),
+            GetLocal(0),
+            SetLocal(0),
+            TeeLocal(0),
+            GetGlobal(0),
+            SetGlobal(0),
+            CurrentMemory(0),
+            CallIndirect(0, 0),
+            BrTable(default_table_data.into()),
+            I32Clz,
+            I64Clz,
+            I32Ctz,
+            I64Ctz,
+            I32Popcnt,
+            I64Popcnt,
+            I32Eqz,
+            I64Eqz,
+            I64ExtendSI32,
+            I64ExtendUI32,
+            I32WrapI64,
+            I32Eq,
+            I64Eq,
+            I32Ne,
+            I64Ne,
+            I32LtS,
+            I64LtS,
+            I32LtU,
+            I64LtU,
+            I32GtS,
+            I64GtS,
+            I32GtU,
+            I64GtU,
+            I32LeS,
+            I64LeS,
+            I32LeU,
+            I64LeU,
+            I32GeS,
+            I64GeS,
+            I32GeU,
+            I64GeU,
+            I32Add,
+            I64Add,
+            I32Sub,
+            I64Sub,
+            I32Mul,
+            I64Mul,
+            I32DivS,
+            I64DivS,
+            I32DivU,
+            I64DivU,
+            I32RemS,
+            I64RemS,
+            I32RemU,
+            I64RemU,
+            I32And,
+            I64And,
+            I32Or,
+            I64Or,
+            I32Xor,
+            I64Xor,
+            I32Shl,
+            I64Shl,
+            I32ShrS,
+            I64ShrS,
+            I32ShrU,
+            I64ShrU,
+            I32Rotl,
+            I64Rotl,
+            I32Rotr,
+            I64Rotr,
+        ]
+    }
+
+    fn default_wasm_module() -> elements::Module {
+        let simple_wat = r#"
+        (module
+            (import "env" "memory" (memory 1))
+            (export "handle" (func $handle))
+            (export "init" (func $init))
+            (func $handle)
+            (func $init)
+        )"#;
+        elements::Module::from_bytes(
+            wabt::Wat2Wasm::new()
+                .validate(false)
+                .convert(simple_wat)
+                .expect("failed to parse module")
+                .as_ref()
+                .to_vec(),
+        )
+        .expect("module instantiation failed")
+    }
+
+    // This test must never fail during local development/release.
+    //
+    // The instruction set in the test mustn't be changed. Test checks
+    // whether no instruction weight was removed from Rules, so backward
+    // compatibility is reached.
     #[test]
-    fn print_test_schedule() {
+    fn instructions_backward_compatibility() {
         let schedule = Schedule::<Test>::default();
-        println!("{:#?}", schedule);
+        let rules = schedule.rules(&default_wasm_module());
+        all_measured_instructions()
+            .iter()
+            .for_each(|i| assert!(rules.instruction_cost(i).is_some()))
     }
 }


### PR DESCRIPTION
Partially resolves #827.

The idea of the current solution is described in the issue's page. However, due to lack of type-level guarantees, that `expect`ing re-instrumentation won't fail, we state another to be considered in the future task to make the solution infallible.

- Introduce test to protect instructions from being accidentally deleted in `Rules::instruction_cost` method implementation.


