### PR TITLE
Deny calls with value for `vara-stage-1`

### DIFF
--- a/node/cli/src/benchmarking.rs
+++ b/node/cli/src/benchmarking.rs
@@ -151,7 +151,7 @@ macro_rules! signed_payload {
     $custom_ext:ident
     ) => {
         let $extra: runtime::SignedExtra = (
-            runtime::DisableBalancesCall,
+            runtime::DisableValueTransfers,
             frame_system::CheckNonZeroSender::<runtime::Runtime>::new(),
             frame_system::CheckSpecVersion::<runtime::Runtime>::new(),
             frame_system::CheckTxVersion::<runtime::Runtime>::new(),

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -390,8 +390,6 @@ pub mod pallet {
         FailedToConstructProgram,
         /// Value doesn't cover ExistentialDeposit.
         ValueLessThanMinimal,
-        /// Value is not zero.
-        ValueNotZero,
         /// Unable to instrument program code.
         GasInstrumentationFailed,
         /// No code could be found at the supplied code hash.
@@ -1367,10 +1365,11 @@ pub mod pallet {
                 Error::<T>::GasLimitTooHigh
             );
 
-            // Value transfer prohibited.
+            // Checking that applied value fits existence requirements:
+            // it should be zero or not less than existential deposit.
             ensure!(
-                value.is_zero(),
-                Error::<T>::ValueNotZero
+                value.is_zero() || value >= CurrencyOf::<T>::minimum_balance(),
+                Error::<T>::ValueLessThanMinimal
             );
 
             Ok(())

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -121,9 +121,10 @@ pub fn native_version() -> NativeVersion {
 /// RELEASE: This is only relevant for the initial PoA run-in period and will be removed
 /// from the release runtime.
 #[derive(Default, Encode, Debug, Decode, Clone, Eq, PartialEq, TypeInfo)]
-pub struct DisableBalancesCall;
-impl SignedExtension for DisableBalancesCall {
-    const IDENTIFIER: &'static str = "DisableBalancesCall";
+pub struct DisableValueTransfers;
+
+impl SignedExtension for DisableValueTransfers {
+    const IDENTIFIER: &'static str = "DisableValueTransfers";
     type AccountId = AccountId;
     type Call = Call;
     type AdditionalSigned = ();
@@ -504,7 +505,7 @@ pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
     // RELEASE: remove before final release
-    DisableBalancesCall,
+    DisableValueTransfers,
     frame_system::CheckNonZeroSender<Runtime>,
     frame_system::CheckSpecVersion<Runtime>,
     frame_system::CheckTxVersion<Runtime>,


### PR DESCRIPTION
Reverts [this commit](https://github.com/gear-tech/gear/commit/c40e76860fd0c2515c78f2adade3081c1a85e437) and expands our custom signed extension in order to use the unified mechanic of denying calling extrinsics, that cause balances, instead of somewhere invalidate extrinsics, somewhere return errors.