### PR TITLE
Bump wasm-mutate version to 0.2.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9623,6 +9623,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d443c5a7daae71697d97ec12ad70b4fe8766d3a0f4db16158ac8b781365892f7"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wasm-gc-api"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9644,16 +9653,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-mutate"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e6de18ed96f27d3942041e5ae02177aff18e4425196a3d4b1f14145d027f71"
+checksum = "f04ad5c8a18bf9d8d07ad9df8dea5e8ff701ab3472583a79350c3ab5b4766705"
 dependencies = [
  "egg",
  "log",
  "rand 0.8.5",
  "thiserror",
- "wasm-encoder",
- "wasmparser 0.88.0",
+ "wasm-encoder 0.16.0",
+ "wasmparser 0.89.0",
 ]
 
 [[package]]
@@ -9982,6 +9991,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.89.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e93aca64a4778dde5c48d494a4a0c610ba0f06663798a2c70eaadb1d51460da"
+dependencies = [
+ "indexmap",
+]
+
+[[package]]
 name = "wasmprinter"
 version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10168,7 +10186,7 @@ dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder",
+ "wasm-encoder 0.15.0",
 ]
 
 [[package]]

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -1,18 +1,20 @@
-// Copyright 2019-2022 PureStake Inc.
-// This file is part of Moonbeam.
+// This file is part of Gear.
 
-// Moonbeam is free software: you can redistribute it and/or modify
+// Copyright (C) 2021-2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Moonbeam is distributed in the hope that it will be useful,
+// This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 #[macro_export]
 macro_rules! impl_runtime_apis_plus_common {

--- a/utils/economic-checks/Cargo.toml
+++ b/utils/economic-checks/Cargo.toml
@@ -16,7 +16,7 @@ serde = "1"
 env_logger = "0.9"
 hex = "0.4.3"
 arbitrary = { version = "1" }
-wasm-mutate = "0.2.6"
+wasm-mutate = "0.2.7"
 wasmparser = "0.88.0"
 
 # Internal deps


### PR DESCRIPTION
This will allow unpinning rust compiler version