### PR TITLE
fix bug gas charge for allocated pages

### DIFF
--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -128,13 +128,13 @@ pub trait Ext {
     fn gas(&mut self, amount: u32) -> Result<(), Self::Error>;
 
     /// Charge some extra gas.
-    fn charge_gas(&mut self, amount: u32) -> Result<(), Self::Error>;
+    fn charge_gas(&mut self, amount: u64) -> Result<(), Self::Error>;
 
     /// Charge gas by `RuntimeCosts` token.
     fn charge_gas_runtime(&mut self, costs: RuntimeCosts) -> Result<(), Self::Error>;
 
     /// Refund some gas.
-    fn refund_gas(&mut self, amount: u32) -> Result<(), Self::Error>;
+    fn refund_gas(&mut self, amount: u64) -> Result<(), Self::Error>;
 
     /// Tell how much gas is left in running context.
     fn gas_available(&mut self) -> Result<u64, Self::Error>;
@@ -247,13 +247,13 @@ mod tests {
         fn gas(&mut self, _amount: u32) -> Result<(), Self::Error> {
             Ok(())
         }
-        fn charge_gas(&mut self, _amount: u32) -> Result<(), Self::Error> {
+        fn charge_gas(&mut self, _amount: u64) -> Result<(), Self::Error> {
             Ok(())
         }
         fn charge_gas_runtime(&mut self, _costs: RuntimeCosts) -> Result<(), Self::Error> {
             Ok(())
         }
-        fn refund_gas(&mut self, _amount: u32) -> Result<(), Self::Error> {
+        fn refund_gas(&mut self, _amount: u64) -> Result<(), Self::Error> {
             Ok(())
         }
         fn gas_available(&mut self) -> Result<u64, Self::Error> {

--- a/examples/wat-examples/read_write_access.wat
+++ b/examples/wat-examples/read_write_access.wat
@@ -17,27 +17,20 @@
         ;; make read and then write for all gear pages
         (loop
             local.get $i
-            i32.const 1
-            i32.add
-            local.set $i
-
-            local.get $i
-            i32.const 0x1000
-            i32.mul
             i32.load
             drop
 
             local.get $i
-            i32.const 0x1000
-            i32.mul
-            i32.const 0x800
-            i32.add
-            i32.const 0x42
+            local.get $i
             i32.store
 
+            local.get $i
+            i32.const 0x1000
+            i32.add
+            local.set $i
 
             local.get $i
-            i32.const 0x1fff
+            i32.const 0x2000000
             i32.ne
             br_if 0
         )

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -158,16 +158,10 @@ impl EnvExt for LazyPagesExt {
         mem: &mut impl Memory,
     ) -> Result<WasmPageNumber, Self::Error> {
         // Greedily charge gas for allocations
-        self.charge_gas(
-            pages_num
-                .0
-                .saturating_mul(self.inner.context.config.alloc_cost as u32),
-        )?;
+        self.charge_gas((pages_num.0 as u64).saturating_mul(self.inner.context.config.alloc_cost))?;
         // Greedily charge gas for grow
         self.charge_gas(
-            pages_num
-                .0
-                .saturating_mul(self.inner.context.config.mem_grow_cost as u32),
+            (pages_num.0 as u64).saturating_mul(self.inner.context.config.mem_grow_cost),
         )?;
 
         let old_mem_size = mem.size();
@@ -224,7 +218,7 @@ impl EnvExt for LazyPagesExt {
                 .saturating_mul((pages_num - new_allocated_pages_num).0 as u64),
         );
 
-        self.refund_gas(gas_to_return_back as u32)?;
+        self.refund_gas(gas_to_return_back)?;
 
         Ok(page_number)
     }
@@ -301,11 +295,11 @@ impl EnvExt for LazyPagesExt {
         self.inner.msg()
     }
 
-    fn charge_gas(&mut self, val: u32) -> Result<(), Self::Error> {
+    fn charge_gas(&mut self, val: u64) -> Result<(), Self::Error> {
         self.inner.charge_gas(val).map_err(Error::Processor)
     }
 
-    fn refund_gas(&mut self, val: u32) -> Result<(), Self::Error> {
+    fn refund_gas(&mut self, val: u64) -> Result<(), Self::Error> {
         self.inner.refund_gas(val).map_err(Error::Processor)
     }
 

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -1245,6 +1245,105 @@ fn lazy_pages() {
 }
 
 #[test]
+fn initial_pages_cheaper_than_allocated_pages() {
+    // When contract some amount of the initial pages, then it is simpler
+    // for core processor and executor than process the same contract
+    // but with allocated pages.
+
+    let wat_initial = r#"
+    (module
+        (import "env" "memory" (memory 0x10))
+        (export "init" (func $init))
+        (func $init
+            (local $i i32)
+            ;; make store, so pages are really used
+            (loop
+                local.get $i
+                local.get $i
+                i32.store
+
+                local.get $i
+                i32.const 0x1000
+                i32.add
+                local.set $i
+
+                local.get $i
+                i32.const 0x100000
+                i32.ne
+                br_if 0
+            )
+        )
+    )"#;
+
+    let wat_alloc = r#"
+    (module
+        (import "env" "memory" (memory 0))
+        (import "env" "alloc" (func $alloc (param i32) (result i32)))
+        (export "init" (func $init))
+        (func $init
+            (local $i i32)
+
+            ;; alloc 0x10 pages, so mem pages are: 0..=0xf
+            (block
+                i32.const 0x10
+                call $alloc
+                i32.eqz
+                br_if 0
+                unreachable
+            )
+
+            ;; make store, so pages are really used
+            (loop
+                local.get $i
+                local.get $i
+                i32.store
+
+                local.get $i
+                i32.const 0x1000
+                i32.add
+                local.set $i
+
+                local.get $i
+                i32.const 0x100000
+                i32.ne
+                br_if 0
+            )
+        )
+    )"#;
+
+    init_logger();
+    new_test_ext().execute_with(|| {
+        let mut block_number = 1;
+        let mut gas_spent = |wat| {
+            let res = GearPallet::<Test>::upload_program(
+                Origin::signed(USER_1),
+                ProgramCodeKind::Custom(wat).to_bytes(),
+                DEFAULT_SALT.to_vec(),
+                EMPTY_PAYLOAD.to_vec(),
+                10_000_000_000,
+                0,
+            );
+            assert_ok!(res);
+
+            block_number += 1;
+            run_to_block(block_number, None);
+            assert_last_dequeued(1);
+
+            GasPrice::gas_price(BlockGasLimitOf::<Test>::get() - GasAllowanceOf::<Test>::get())
+        };
+
+        let spent_for_initial_pages = gas_spent(wat_initial);
+        let spent_for_allocated_pages = gas_spent(wat_alloc);
+        assert!(
+            spent_for_initial_pages < spent_for_allocated_pages,
+            "spent {} gas for initial pages, spent {} gas for allocated pages",
+            spent_for_initial_pages,
+            spent_for_allocated_pages
+        );
+    });
+}
+
+#[test]
 fn block_gas_limit_works() {
     // Same as `ProgramCodeKind::OutgoingWithValueInHandle`, but without value sending
     let wat1 = r#"

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -1246,13 +1246,13 @@ fn lazy_pages() {
 
 #[test]
 fn initial_pages_cheaper_than_allocated_pages() {
-    // When contract some amount of the initial pages, then it is simpler
+    // When contract has some amount of the initial pages, then it is simpler
     // for core processor and executor than process the same contract
     // but with allocated pages.
 
     let wat_initial = r#"
     (module
-        (import "env" "memory" (memory 0x10))
+        (import "env" "memory" (memory 0x100))
         (export "init" (func $init))
         (func $init
             (local $i i32)
@@ -1268,7 +1268,7 @@ fn initial_pages_cheaper_than_allocated_pages() {
                 local.set $i
 
                 local.get $i
-                i32.const 0x100000
+                i32.const 0x1000000
                 i32.ne
                 br_if 0
             )
@@ -1283,9 +1283,9 @@ fn initial_pages_cheaper_than_allocated_pages() {
         (func $init
             (local $i i32)
 
-            ;; alloc 0x10 pages, so mem pages are: 0..=0xf
+            ;; alloc 0x100 pages, so mem pages are: 0..=0xff
             (block
-                i32.const 0x10
+                i32.const 0x100
                 call $alloc
                 i32.eqz
                 br_if 0
@@ -1304,7 +1304,7 @@ fn initial_pages_cheaper_than_allocated_pages() {
                 local.set $i
 
                 local.get $i
-                i32.const 0x100000
+                i32.const 0x1000000
                 i32.ne
                 br_if 0
             )
@@ -1320,7 +1320,7 @@ fn initial_pages_cheaper_than_allocated_pages() {
                 ProgramCodeKind::Custom(wat).to_bytes(),
                 DEFAULT_SALT.to_vec(),
                 EMPTY_PAYLOAD.to_vec(),
-                10_000_000_000,
+                100_000_000_000,
                 0,
             );
             assert_ok!(res);


### PR DESCRIPTION
Found a bug, which is caused by `u32` saturating when makes `saturating_mul`, which cause very cheap big number of pages allocation.