### PR TITLE
Correct error replies lifecycle

### DIFF
--- a/core-processor/src/processor.rs
+++ b/core-processor/src/processor.rs
@@ -68,7 +68,7 @@ impl PreparedMessageExecutionContext {
 
 /// Defines result variants of the function `prepare`.
 pub enum PrepareResult {
-    /// Successfully precharged for memory pages.
+    /// Successfully pre-charged for memory pages.
     Ok {
         /// A context for `process` function.
         context: Box<PreparedMessageExecutionContext>,
@@ -295,7 +295,7 @@ fn process_error(
         });
     }
 
-    if !dispatch.is_reply() || dispatch.exit_code().expect("Checked before") == 0 {
+    if !dispatch.is_error_reply() {
         // # Safety
         //
         // 1. The dispatch.id() has already been checked
@@ -489,7 +489,7 @@ fn process_non_executable(
     }
 
     // Reply back to the message `source`
-    if !dispatch.is_reply() || dispatch.exit_code().expect("Checked before") == 0 {
+    if !dispatch.is_error_reply() {
         // # Safety
         //
         // 1. The dispatch.id() has already been checked

--- a/core/src/message/common.rs
+++ b/core/src/message/common.rs
@@ -146,6 +146,11 @@ impl Message {
             })
             .map_err(|_| self)
     }
+
+    /// Returns bool defining if message is error reply.
+    pub fn is_error_reply(&self) -> bool {
+        !matches!(self.exit_code(), Some(0) | None)
+    }
 }
 
 /// Reply details data.

--- a/core/src/message/incoming.rs
+++ b/core/src/message/incoming.rs
@@ -122,6 +122,11 @@ impl IncomingMessage {
     pub fn exit_code(&self) -> Option<ExitCode> {
         self.reply.map(|v| v.exit_code())
     }
+
+    /// Returns bool defining if message is error reply.
+    pub fn is_error_reply(&self) -> bool {
+        !matches!(self.exit_code(), Some(0) | None)
+    }
 }
 
 /// Incoming message with entry point and previous execution context, if exists.

--- a/core/src/message/stored.rs
+++ b/core/src/message/stored.rs
@@ -137,6 +137,11 @@ impl StoredMessage {
             })
             .map_err(|_| self)
     }
+
+    /// Returns bool defining if message is error reply.
+    pub fn is_error_reply(&self) -> bool {
+        !matches!(self.exit_code(), Some(0) | None)
+    }
 }
 
 /// Stored message with entry point and previous execution context, if exists.

--- a/pallets/gear/src/internal.rs
+++ b/pallets/gear/src/internal.rs
@@ -531,7 +531,7 @@ where
 
         // If gas limit can cover threshold, message will be added to mailbox,
         // task created and funds reserved.
-        let expiration = if gas_limit >= threshold {
+        let expiration = if !message.is_error_reply() && gas_limit >= threshold {
             // Figuring out hold bound for given gas limit.
             let hold = HoldBound::<T>::by(CostsPerBlockOf::<T>::mailbox()).maximum_for(gas_limit);
 

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -44,7 +44,7 @@ use frame_support::{
     traits::Currency,
 };
 use frame_system::{pallet_prelude::BlockNumberFor, Pallet as SystemPallet};
-use gear_backend_common::TrapExplanation;
+use gear_backend_common::{StackEndError, TrapExplanation};
 use gear_core::{
     code::Code,
     ids::{CodeId, MessageId, ProgramId},
@@ -792,19 +792,13 @@ fn unused_gas_released_back_works() {
 
         assert!(user1_potential_msgs_spends > user1_actual_msgs_spends);
 
-        let mailbox_threshold_gas_limit = <Test as Config>::MailboxThreshold::get();
-        let mailbox_threshold_reserved =
-            <Test as Config>::GasPrice::gas_price(mailbox_threshold_gas_limit);
         assert_eq!(
             Balances::free_balance(USER_1),
-            user1_initial_balance - user1_actual_msgs_spends - mailbox_threshold_reserved
+            user1_initial_balance - user1_actual_msgs_spends
         );
 
         // All created gas cancels out.
-        assert_eq!(
-            GasHandlerOf::<Test>::total_supply(),
-            <Test as Config>::MailboxThreshold::get()
-        );
+        assert!(GasHandlerOf::<Test>::total_supply().is_zero());
     })
 }
 
@@ -1872,16 +1866,8 @@ fn send_reply_failure_to_claim_from_mailbox() {
 
         populate_mailbox_from_program(prog_id, USER_1, 2, 2_000_000_000, 0);
 
-        // Program didn't have enough balance, so it's message produces trap
-        // (and following system reply with error to USER_1 mailbox)
-        assert_eq!(MailboxOf::<Test>::len(&USER_1), 1);
-        assert_eq!(
-            MailboxOf::<Test>::iter_key(USER_1)
-                .next()
-                .and_then(|(msg, _interval)| msg.exit_code())
-                .unwrap(),
-            1
-        );
+        assert_init_success(1);
+        assert_total_dequeued(2);
     })
 }
 
@@ -2101,9 +2087,7 @@ fn distributor_initialize() {
         // and the value unreserved back to the original sender (USER_1)
         let final_balance = Balances::free_balance(USER_1) + Balances::free_balance(BLOCK_AUTHOR);
 
-        let mailbox_threshold_reserved =
-            <Test as Config>::GasPrice::gas_price(<Test as Config>::MailboxThreshold::get());
-        assert_eq!(initial_balance - mailbox_threshold_reserved, final_balance);
+        assert_eq!(initial_balance, final_balance);
     });
 }
 
@@ -2143,7 +2127,7 @@ fn distributor_distribute() {
         // has been refunded to the sender so the free balances should add up
         let final_balance = Balances::free_balance(USER_1) + Balances::free_balance(BLOCK_AUTHOR);
 
-        let mailbox_threshold_gas_limit = <Test as Config>::MailboxThreshold::get() * 2;
+        let mailbox_threshold_gas_limit = <Test as Config>::MailboxThreshold::get();
         let mailbox_threshold_reserved =
             <Test as Config>::GasPrice::gas_price(mailbox_threshold_gas_limit);
         assert_eq!(initial_balance - mailbox_threshold_reserved, final_balance);
@@ -2513,28 +2497,18 @@ fn test_message_processing_for_non_existing_destination() {
             10_000,
             1000
         ));
+
         let skipped_message_id = get_last_message_id();
         assert!(MailboxOf::<Test>::is_empty(&USER_1));
 
         run_to_block(2, None);
-        // system reply message
-        assert!(!MailboxOf::<Test>::is_empty(&USER_1));
-
-        let mailbox_threshold_gas_limit = <Test as Config>::MailboxThreshold::get();
-        let mailbox_threshold_reserved =
-            <Test as Config>::GasPrice::gas_price(mailbox_threshold_gas_limit);
-        let user_balance_after = Balances::free_balance(USER_1);
-        assert_eq!(
-            user_balance_before - mailbox_threshold_reserved,
-            user_balance_after
-        );
 
         assert_not_executed(skipped_message_id);
 
+        assert_eq!(user_balance_before, Balances::free_balance(USER_1));
+
         assert!(Gear::is_terminated(program_id));
-        assert!(<Test as Config>::CodeStorage::exists(CodeId::from_origin(
-            code_hash
-        )));
+        assert!(<Test as Config>::CodeStorage::exists(code_hash));
     })
 }
 
@@ -2956,8 +2930,6 @@ fn test_create_program_duplicate_in_one_execution() {
             0,
         ));
 
-        assert!(MailboxOf::<Test>::is_empty(&USER_1));
-
         run_to_block(3, None);
 
         // Duplicate init fails the call and returns error reply to the caller, which is USER_1.
@@ -2965,10 +2937,7 @@ fn test_create_program_duplicate_in_one_execution() {
         assert_total_dequeued(2); // 2 for extrinsics
         assert_init_success(1); // 1 for creating a factory
 
-        assert!(!MailboxOf::<Test>::is_empty(&USER_1));
-
         System::reset_events();
-        MailboxOf::<Test>::clear();
 
         // Successful child creation
         assert_ok!(Gear::send_message(
@@ -2982,7 +2951,6 @@ fn test_create_program_duplicate_in_one_execution() {
 
         run_to_block(4, None);
 
-        assert!(MailboxOf::<Test>::is_empty(&USER_2));
         assert_total_dequeued(2 + 1); // 1 for extrinsics
         assert_init_success(1);
     });
@@ -3356,14 +3324,13 @@ fn messages_to_paused_program_skipped() {
             1000u128
         ));
 
+        let message_id = get_last_message_id();
+
         run_to_block(3, None);
 
-        let mailbox_threshold_reserved =
-            <Test as Config>::GasPrice::gas_price(<Test as Config>::MailboxThreshold::get());
-        assert_eq!(
-            before_balance - mailbox_threshold_reserved,
-            Balances::free_balance(USER_3)
-        );
+        assert_not_executed(message_id);
+
+        assert_eq!(before_balance, Balances::free_balance(USER_3));
     })
 }
 
@@ -3389,29 +3356,35 @@ fn replies_to_paused_program_skipped() {
 
         run_to_block(2, None);
 
+        // Program sends it in init function, going into waitlist afterward.
+        let mailboxed_ping = get_last_message_id();
+
         assert_ok!(GearProgram::pause_program(program_id));
 
         run_to_block(3, None);
-
-        let message_id = MailboxOf::<Test>::iter_key(USER_1)
-            .next()
-            .map(|(msg, _bn)| msg.id())
-            .expect("Element should be");
 
         let before_balance = Balances::free_balance(USER_1);
 
         assert_ok!(Gear::send_reply(
             Origin::signed(USER_1),
-            message_id,
+            mailboxed_ping,
             b"PONG".to_vec(),
             50_000_000u64,
             1000u128,
         ));
 
-        run_to_block(4, None);
+        let message_id = get_last_message_id();
 
-        let after_hold_balance = before_balance - CostsPerBlockOf::<Test>::mailbox() as u128;
-        assert_eq!(Balances::free_balance(USER_1), after_hold_balance);
+        run_to_block(4, None);
+        assert_not_executed(message_id);
+
+        let actual_balance = Balances::free_balance(USER_1);
+
+        // On message read, USER_1 unlocks mailbox-related funds from initial message.
+        let mb_threshold = <Test as Config>::MailboxThreshold::get() as u128;
+        let burned_in_mb = CostsPerBlockOf::<Test>::mailbox() as u128; // cost of one block holding
+
+        assert_eq!(before_balance + mb_threshold - burned_in_mb, actual_balance);
     })
 }
 
@@ -4038,14 +4011,8 @@ fn test_create_program_with_value_lt_ed() {
         run_to_block(3, None);
 
         // User's message execution will result in trap, because program tries
-        // to send init message with value in invalid range. As a result, 1 dispatch
-        // is dequeued (user's  message) and one message is sent to mailbox.
-        let mailbox_msg_id = get_last_message_id();
-        assert!(MailboxOf::<Test>::contains(&USER_1, &mailbox_msg_id));
-
-        // This check means, that program's invalid init message didn't reach the queue.
+        // to send init message with value in invalid range.
         assert_total_dequeued(1);
-
         assert_failed(
             msg_id,
             ExecutionErrorReason::Ext(TrapExplanation::Core(ExtError::Message(
@@ -4124,14 +4091,8 @@ fn test_create_program_with_exceeding_value() {
         ));
 
         // User's message execution will result in trap, because program tries
-        // to send init message with value more than program has. As a result, 1 dispatch
-        // is dequeued (user's  message) and one message is sent to mailbox.
-        let mailbox_msg_id = get_last_message_id();
-        assert!(MailboxOf::<Test>::contains(&USER_1, &mailbox_msg_id));
-
-        // This check means, that program's invalid init message didn't reach the queue.
+        // to send init message with value more than program has.
         assert_total_dequeued(1);
-
         assert_failed(
             origin_msg_id,
             ExecutionErrorReason::Ext(TrapExplanation::Core(ExtError::Message(
@@ -5499,9 +5460,14 @@ fn check_gear_stack_end_fail() {
         )
         .expect("Failed to upload program");
 
-        run_to_block(2, None);
+        let message_id = get_last_message_id();
+
+        run_to_next_block(None);
         assert_last_dequeued(1);
-        assert_eq!(MailboxOf::<Test>::iter_key(USER_1).count(), 1);
+        assert_failed(
+            message_id,
+            ExecutionErrorReason::StackEndPageBiggerWasmMemSize(5.into(), 4.into()),
+        );
 
         // Check error when stack end is negative
         let wat = format!(wat_template!(), "-0x10000");
@@ -5515,9 +5481,14 @@ fn check_gear_stack_end_fail() {
         )
         .expect("Failed to upload program");
 
-        run_to_block(3, None);
+        let message_id = get_last_message_id();
+
+        run_to_next_block(None);
         assert_last_dequeued(1);
-        assert_eq!(MailboxOf::<Test>::iter_key(USER_1).count(), 2);
+        assert_failed(
+            message_id,
+            ExecutionErrorReason::Backend(StackEndError::IsNegative(-65536).to_string()),
+        );
 
         // Check error when stack end is not aligned
         let wat = format!(wat_template!(), "0x10001");
@@ -5531,9 +5502,14 @@ fn check_gear_stack_end_fail() {
         )
         .expect("Failed to upload program");
 
-        run_to_block(4, None);
+        let message_id = get_last_message_id();
+
+        run_to_next_block(None);
         assert_last_dequeued(1);
-        assert_eq!(MailboxOf::<Test>::iter_key(USER_1).count(), 3);
+        assert_failed(
+            message_id,
+            ExecutionErrorReason::Backend(StackEndError::IsNotAligned(65537).to_string()),
+        );
 
         // Check OK if stack end is suitable
         let wat = format!(wat_template!(), "0x10000");
@@ -5547,8 +5523,10 @@ fn check_gear_stack_end_fail() {
         )
         .expect("Failed to upload program");
 
-        run_to_block(5, None);
+        let message_id = get_last_message_id();
+
+        run_to_next_block(None);
         assert_last_dequeued(1);
-        assert_eq!(MailboxOf::<Test>::iter_key(USER_1).count(), 3);
+        assert_succeed(message_id);
     });
 }

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear-node"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 1600,
+    spec_version: 1610,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -86,7 +86,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1600,
+    spec_version: 1610,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
There is no need to store error replies in mailbox, so this PR removed this possibility.
