### PR TITLE
Make formatters smarter

### DIFF
--- a/core/src/ids.rs
+++ b/core/src/ids.rs
@@ -238,7 +238,7 @@ fn formatting_test() {
     assert_eq!(format!("{id:.2?}"), "0xc15d..fdef");
     // `Debug`/`Display` with precision 4.
     assert_eq!(format!("{id:.4?}"), "0xc15d1549..b936fdef");
-    // `Debug`/`Display` with precision 15 (the same for any case >= 16).
+    // `Debug`/`Display` with precision 15.
     assert_eq!(
         format!("{id:.15?}"),
         "0xc15d1549fa3950c0aa61e14a3ba476..95b4bcc894b9fab09e7fe9b936fdef"

--- a/core/src/ids.rs
+++ b/core/src/ids.rs
@@ -99,15 +99,17 @@ macro_rules! declare_id {
         impl core::fmt::Display for $name {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 let len = self.0.len();
-                let mut e1 = len / 2;
-                let mut s2 = len / 2;
+                let median = (len + 1) / 2;
+
+                let mut e1 = median;
+                let mut s2 = median;
 
                 if let Some(precision) = f.precision() {
-                    let precision = precision.min(len / 2);
-
-                    e1 = precision;
-                    s2 = len - precision;
-                };
+                    if precision < median {
+                        e1 = precision;
+                        s2 = len - precision;
+                    }
+                }
 
                 let p1 = hex::encode(&self.0[..e1]);
                 let p2 = hex::encode(&self.0[s2..]);
@@ -236,6 +238,11 @@ fn formatting_test() {
     assert_eq!(format!("{id:.2?}"), "0xc15d..fdef");
     // `Debug`/`Display` with precision 4.
     assert_eq!(format!("{id:.4?}"), "0xc15d1549..b936fdef");
+    // `Debug`/`Display` with precision 15 (the same for any case >= 16).
+    assert_eq!(
+        format!("{id:.15?}"),
+        "0xc15d1549fa3950c0aa61e14a3ba476..95b4bcc894b9fab09e7fe9b936fdef"
+    );
     // `Debug`/`Display` with precision 30 (the same for any case >= 16).
     assert_eq!(
         format!("{id:.30?}"),

--- a/core/src/ids.rs
+++ b/core/src/ids.rs
@@ -98,17 +98,26 @@ macro_rules! declare_id {
 
         impl core::fmt::Display for $name {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-                let mut end = self.0.len();
+                let len = self.0.len();
+                let mut e1 = len / 2;
+                let mut s2 = len / 2;
 
                 if let Some(precision) = f.precision() {
-                    if precision > end {
-                        return Err(core::fmt::Error);
-                    }
+                    let precision = precision.min(len / 2);
 
-                    end = precision;
+                    e1 = precision;
+                    s2 = len - precision;
                 };
 
-                write!(f, "0x{}", hex::encode(&self.0[..end]))
+                let p1 = hex::encode(&self.0[..e1]);
+                let p2 = hex::encode(&self.0[s2..]);
+                let sep = e1.ne(&s2).then_some("..").unwrap_or_default();
+
+                if f.alternate() {
+                    write!(f, "{}(0x{p1}{sep}{p2})", stringify!($name))
+                } else {
+                    write!(f, "0x{p1}{sep}{p2}")
+                }
             }
         }
 

--- a/core/src/ids.rs
+++ b/core/src/ids.rs
@@ -224,7 +224,10 @@ fn formatting_test() {
     let id = ProgramId::generate(code_id, &[2, 1, 0]);
 
     // `Debug`/`Display`.
-    assert_eq!(format!("{id:?}"), "0xc15d1549fa3950c0aa61e14a3ba476e06c95b4bcc894b9fab09e7fe9b936fdef");
+    assert_eq!(
+        format!("{id:?}"),
+        "0xc15d1549fa3950c0aa61e14a3ba476e06c95b4bcc894b9fab09e7fe9b936fdef"
+    );
     // `Debug`/`Display` with precision 0.
     assert_eq!(format!("{id:.0?}"), "0x..");
     // `Debug`/`Display` with precision 1.
@@ -234,9 +237,15 @@ fn formatting_test() {
     // `Debug`/`Display` with precision 4.
     assert_eq!(format!("{id:.4?}"), "0xc15d1549..b936fdef");
     // `Debug`/`Display` with precision 30 (the same for any case >= 16).
-    assert_eq!(format!("{id:.30?}"), "0xc15d1549fa3950c0aa61e14a3ba476e06c95b4bcc894b9fab09e7fe9b936fdef");
+    assert_eq!(
+        format!("{id:.30?}"),
+        "0xc15d1549fa3950c0aa61e14a3ba476e06c95b4bcc894b9fab09e7fe9b936fdef"
+    );
     // Alternate formatter.
-    assert_eq!(format!("{id:#}"), "ProgramId(0xc15d1549fa3950c0aa61e14a3ba476e06c95b4bcc894b9fab09e7fe9b936fdef)");
+    assert_eq!(
+        format!("{id:#}"),
+        "ProgramId(0xc15d1549fa3950c0aa61e14a3ba476e06c95b4bcc894b9fab09e7fe9b936fdef)"
+    );
     // Alternate formatter with precision 2.
     assert_eq!(format!("{id:#.2}"), "ProgramId(0xc15d..fdef)");
 }

--- a/core/src/ids.rs
+++ b/core/src/ids.rs
@@ -215,3 +215,28 @@ impl ProgramId {
         hash(&argument).into()
     }
 }
+
+#[test]
+fn formatting_test() {
+    use alloc::format;
+
+    let code_id = CodeId::generate(&[0, 1, 2]);
+    let id = ProgramId::generate(code_id, &[2, 1, 0]);
+
+    // `Debug`/`Display`.
+    assert_eq!(format!("{id:?}"), "0xc15d1549fa3950c0aa61e14a3ba476e06c95b4bcc894b9fab09e7fe9b936fdef");
+    // `Debug`/`Display` with precision 0.
+    assert_eq!(format!("{id:.0?}"), "0x..");
+    // `Debug`/`Display` with precision 1.
+    assert_eq!(format!("{id:.1?}"), "0xc1..ef");
+    // `Debug`/`Display` with precision 2.
+    assert_eq!(format!("{id:.2?}"), "0xc15d..fdef");
+    // `Debug`/`Display` with precision 4.
+    assert_eq!(format!("{id:.4?}"), "0xc15d1549..b936fdef");
+    // `Debug`/`Display` with precision 30 (the same for any case >= 16).
+    assert_eq!(format!("{id:.30?}"), "0xc15d1549fa3950c0aa61e14a3ba476e06c95b4bcc894b9fab09e7fe9b936fdef");
+    // Alternate formatter.
+    assert_eq!(format!("{id:#}"), "ProgramId(0xc15d1549fa3950c0aa61e14a3ba476e06c95b4bcc894b9fab09e7fe9b936fdef)");
+    // Alternate formatter with precision 2.
+    assert_eq!(format!("{id:#.2}"), "ProgramId(0xc15d..fdef)");
+}

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear-node"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 1620,
+    spec_version: 1630,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -86,7 +86,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1620,
+    spec_version: 1630,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
- Excluded possibility to fail formatting, except `write!` result
- Precision works with both sides at the same time
- Added alternate `:#` formatter

For details, see test:
https://github.com/gear-tech/gear/blob/5f47966c6624ae72e3102e3dddab11992da0490f/core/src/ids.rs#L219-L242