### PR TITLE
fix signal handler for `wasmer`

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -174,7 +174,7 @@ jobs:
       - name: "Install: Build deps"
         run: |
           sudo apt update
-          sudo apt install -y git clang curl libssl-dev llvm libudev-dev cmake
+          sudo apt install -y git clang curl libssl-dev llvm libudev-dev cmake wabt
           sudo wget -c https://github.com/WebAssembly/binaryen/releases/download/version_105/binaryen-version_105-x86_64-linux.tar.gz -O - | sudo tar -xz -C .
           cp binaryen-version_105/bin/wasm-opt /usr/bin/
 
@@ -201,6 +201,9 @@ jobs:
         run: ./scripts/gear.sh build gear --locked --release
         env:
           RUSTFLAGS: -Cinstrument-coverage
+
+      - name: "Build: WAT examples"
+        run: ./scripts/gear.sh build wat-examples
 
       - name: Check runtime imports
         run: ./target/release/wasm-proc --check-runtime-imports --path target/release/wbuild/gear-runtime/gear_runtime.wasm

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -113,6 +113,7 @@ pub(crate) fn charge_gas_for_pages(
     } else {
         // Charging gas for initial pages
         let amount = settings.init_cost * static_pages.0 as u64;
+        log::trace!("Charge {} for initial pages", amount);
 
         if gas_allowance_counter.charge(amount) != ChargeResult::Enough {
             return Err(ExecutionErrorReason::InitialMemoryBlockGasExceeded);

--- a/examples/wat-examples/wrong_load.wat
+++ b/examples/wat-examples/wrong_load.wat
@@ -1,0 +1,9 @@
+(module
+    (import "env" "memory" (memory 1))
+    (export "init" (func $init))
+    (func $init
+        i32.const 0x10000
+        i32.load
+        drop
+    )
+)

--- a/lazy-pages/src/sys/unix.rs
+++ b/lazy-pages/src/sys/unix.rs
@@ -58,7 +58,9 @@ extern "C" fn handle_sigsegv(sig: i32, info: *mut siginfo_t, ucontext: *mut c_vo
             } else {
                 false
             };
-            assert!(old_sig_handler_works, "Signal handler failed: {}", err);
+            if !old_sig_handler_works {
+                panic!("Signal handler failed: {}", err);
+            }
         }
     }
 }

--- a/lazy-pages/src/sys/unix.rs
+++ b/lazy-pages/src/sys/unix.rs
@@ -63,8 +63,6 @@ extern "C" fn handle_sigsegv(sig: i32, info: *mut siginfo_t, ucontext: *mut c_vo
             };
             assert!(old_sig_handler_works, "Signal handler failed: {}", err);
         }
-        // .map_err(|err| err.to_string())
-        // .expect("Signal handler failed")
     }
 }
 
@@ -84,11 +82,6 @@ pub unsafe fn setup_signal_handler() -> io::Result<()> {
 
     let old_sigaction = signal::sigaction(signal, &sig_action).map_err(io::Error::from)?;
     OLD_SIG_HANDLER.with(|sh| *sh.borrow_mut() = old_sigaction.handler());
-    // log::info!("old sigaction: {:?}", old_sigaction);
-
-    // let x = old_sigaction.handler();
-    // x(1, 2, 3);
-
     Ok(())
 }
 

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear-node"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 1650,
+    spec_version: 1660,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -86,7 +86,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1650,
+    spec_version: 1660,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/scripts/src/test.sh
+++ b/scripts/src/test.sh
@@ -95,7 +95,7 @@ runtime_upgrade_test() {
 
   # Run node
   RUST_LOG="pallet_gear=debug,runtime::gear=debug" $ROOT_DIR/target/release/gear-node \
-  --dev --tmp --unsafe-ws-external --unsafe-rpc-external --rpc-methods Unsafe --rpc-cors all & sleep 7
+  --dev --tmp --unsafe-ws-external --unsafe-rpc-external --rpc-methods Unsafe --rpc-cors all & sleep 3
 
   # Change dir to the js script dir
   cd "$TEST_SCRIPT_PATH"

--- a/scripts/src/test.sh
+++ b/scripts/src/test.sh
@@ -91,6 +91,7 @@ runtime_upgrade_test() {
   TEST_SCRIPT_PATH="$ROOT_DIR/scripts/test-utils"
   RUNTIME_PATH="$ROOT_DIR/scripts/test-utils/gear_runtime.compact.compressed.wasm"
   DEMO_PING_PATH="$ROOT_DIR/target/wasm32-unknown-unknown/release/demo_ping.opt.wasm"
+  DEMO_WRONG_LOAD_PATH="$ROOT_DIR/target/wat-examples/wrong_load.wasm"
 
   # Run node
   RUST_LOG="pallet_gear=debug,runtime::gear=debug" $ROOT_DIR/target/release/gear-node \
@@ -100,7 +101,7 @@ runtime_upgrade_test() {
   cd "$TEST_SCRIPT_PATH"
 
   # Run test
-  npm run upgrade "$RUNTIME_PATH" "$DEMO_PING_PATH"
+  npm run upgrade "$RUNTIME_PATH" "$DEMO_PING_PATH" "$DEMO_WRONG_LOAD_PATH"
 
   # Killing node process added in js script
 }

--- a/scripts/test-utils/processingMessageWithRuntimeUpgrade.js
+++ b/scripts/test-utils/processingMessageWithRuntimeUpgrade.js
@@ -97,6 +97,7 @@ const pathToRuntimeCode = args[0];
 assert.notStrictEqual(pathToRuntimeCode, undefined, `Path to runtime code is not specified`);
 const pathToDemoPing = args[1];
 assert.notStrictEqual(pathToDemoPing, undefined, `Path to demo ping is not specified`);
+// TODO: tmp add demo wrong load here, make separate test (issue #1378).
 const pathToDemoWrongLoad = args[2];
 assert.notStrictEqual(pathToDemoWrongLoad, undefined, `Path to demo ping is not specified`);
 let exitCode = undefined;

--- a/scripts/test-utils/processingMessageWithRuntimeUpgrade.js
+++ b/scripts/test-utils/processingMessageWithRuntimeUpgrade.js
@@ -32,7 +32,7 @@ function getMessageEnqueuedBlock(api, { events, status }) {
   return blockHash;
 };
 
-async function main(pathToRuntimeCode, pathToDemoPing) {
+async function main(pathToRuntimeCode, pathToDemoPing, pathToDemoWrongLoad) {
   // Create connection
   const provider = new WsProvider('ws://127.0.0.1:9944');
   const api = await ApiPromise.create({ provider });
@@ -43,10 +43,14 @@ async function main(pathToRuntimeCode, pathToDemoPing) {
   assert.ok((await api.query.sudo.key()).eq(account.addressRaw));
 
   const isInitialized = checkInit(api);
+  // Upload demo_wrong_load
+  await upload_program(api, account, pathToDemoWrongLoad);
+
   // Upload demo_ping
   const [programId, messageId] = await upload_program(api, account, pathToDemoPing);
   // Check that demo_ping was initialized
   await isInitialized(messageId);
+
 
   // Take runtime code
   const code = readFileSync(pathToRuntimeCode);
@@ -90,16 +94,15 @@ async function main(pathToRuntimeCode, pathToDemoPing) {
 };
 
 const args = process.argv.slice(2);
-
 const pathToRuntimeCode = args[0];
 assert.notStrictEqual(pathToRuntimeCode, undefined, `Path to runtime code is not specified`);
-
 const pathToDemoPing = args[1];
 assert.notStrictEqual(pathToDemoPing, undefined, `Path to demo ping is not specified`);
-
+const pathToDemoWrongLoad = args[2];
+assert.notStrictEqual(pathToDemoWrongLoad, undefined, `Path to demo ping is not specified`);
 let exitCode = undefined;
 
-main(pathToRuntimeCode, pathToDemoPing)
+main(pathToRuntimeCode, pathToDemoPing, pathToDemoWrongLoad)
   .then(() => {
     exitCode = 0;
   })

--- a/scripts/test-utils/processingMessageWithRuntimeUpgrade.js
+++ b/scripts/test-utils/processingMessageWithRuntimeUpgrade.js
@@ -5,8 +5,8 @@ const assert = require('assert/strict');
 const { exec } = require('child_process');
 const { messageDispatchedIsOccurred, getBlockNumber, getNextBlock, checkInit } = require('./util.js');
 
-function upload_program(api, account, pathToDemoPing) {
-  const code = readFileSync(pathToDemoPing);
+function upload_program(api, account, pathToDemo) {
+  const code = readFileSync(pathToDemo);
   const codeBytes = api.createType('Bytes', Array.from(code));
   const program = api.tx.gear.uploadProgram(codeBytes, randomAsHex(20), '0x00', 100_000_000_000, 0);
   return new Promise((resolve, reject) => {
@@ -43,7 +43,7 @@ async function main(pathToRuntimeCode, pathToDemoPing, pathToDemoWrongLoad) {
   assert.ok((await api.query.sudo.key()).eq(account.addressRaw));
 
   const isInitialized = checkInit(api);
-  // Upload demo_wrong_load
+  // Upload demo_wrong_load, just check that node won't panic
   await upload_program(api, account, pathToDemoWrongLoad);
 
   // Upload demo_ping

--- a/scripts/test-utils/processingMessageWithRuntimeUpgrade.js
+++ b/scripts/test-utils/processingMessageWithRuntimeUpgrade.js
@@ -51,7 +51,6 @@ async function main(pathToRuntimeCode, pathToDemoPing, pathToDemoWrongLoad) {
   // Check that demo_ping was initialized
   await isInitialized(messageId);
 
-
   // Take runtime code
   const code = readFileSync(pathToRuntimeCode);
   const setCode = api.tx.system.setCode(api.createType('Bytes', Array.from(code)));


### PR DESCRIPTION
`wasmer` uses signals to identify wrong memory operation that try to access memory outside of memory bounds. To support it we call old sighandler (which has been set before we set our sig handler for lazy pages) if signal came from unknown address.

Without patch node will panic in the case contract would like to access wrong memory. 

### TODO
This patch do not fix problem for `windows` OS. #1377 
Add also small test which checks that node does not panic in the case. Currently add it inside `runtime-update` test. #1378 