### PR TITLE
Waitlist holding duration control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,6 +1525,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "demo-waiter"
+version = "0.1.0"
+dependencies = [
+ "gear-wasm-builder",
+ "gstd",
+ "parity-scale-codec",
+]
+
+[[package]]
 name = "demo-waiting-proxy"
 version = "0.1.0"
 dependencies = [
@@ -5067,6 +5076,7 @@ dependencies = [
  "demo-proxy",
  "demo-proxy-with-gas",
  "demo-value-sender",
+ "demo-waiter",
  "demo-waiting-proxy",
  "derive_more",
  "env_logger",

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -81,7 +81,7 @@ pub enum TerminationReason {
     Leave,
     Success,
     Trap(TrapExplanation),
-    Wait,
+    Wait(Option<u32>),
     GasAllowanceExceeded,
 }
 

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -144,8 +144,8 @@ where
         builder.add_func("gr_value", Funcs::value);
         builder.add_func("gr_value_available", Funcs::value_available);
         builder.add_func("gr_wait", Funcs::wait);
-        builder.add_func("gr_wait_no_more", Funcs::wait_no_more);
         builder.add_func("gr_wait_for", Funcs::wait_for);
+        builder.add_func("gr_wait_no_more", Funcs::wait_no_more);
         builder.add_func("gr_wake", Funcs::wake);
         let mut env_builder: EnvironmentDefinitionBuilder<_> = builder.into();
 

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -144,6 +144,8 @@ where
         builder.add_func("gr_value", Funcs::value);
         builder.add_func("gr_value_available", Funcs::value_available);
         builder.add_func("gr_wait", Funcs::wait);
+        builder.add_func("gr_wait_no_more", Funcs::wait_no_more);
+        builder.add_func("gr_wait_for", Funcs::wait_for);
         builder.add_func("gr_wake", Funcs::wake);
         let mut env_builder: EnvironmentDefinitionBuilder<_> = builder.into();
 

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -754,14 +754,14 @@ where
         Err(HostError)
     }
 
-    pub fn wait_no_more(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
+    pub fn wait_for(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
         let mut args = args.iter();
 
         let duration_ptr = pop_i32(&mut args)?;
 
         let mut f = || {
             let duration: u32 = ctx.read_memory_as(duration_ptr)?;
-            ctx.ext.wait_no_more(duration).map_err(FuncError::Core)?;
+            ctx.ext.wait_for(duration).map_err(FuncError::Core)?;
             Ok(Some(duration))
         };
 
@@ -772,14 +772,14 @@ where
         Err(HostError)
     }
 
-    pub fn wait_for(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
+    pub fn wait_no_more(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
         let mut args = args.iter();
 
         let duration_ptr = pop_i32(&mut args)?;
 
         let mut f = || {
             let duration: u32 = ctx.read_memory_as(duration_ptr)?;
-            ctx.ext.wait_for(duration).map_err(FuncError::Core)?;
+            ctx.ext.wait_no_more(duration).map_err(FuncError::Core)?;
             Ok(Some(duration))
         };
 

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -749,7 +749,7 @@ where
             .wait()
             .map_err(FuncError::Core)
             .err()
-            .unwrap_or(FuncError::Terminated(TerminationReason::Wait));
+            .unwrap_or(FuncError::Terminated(TerminationReason::Wait(None)));
         ctx.err = err;
         Err(HostError)
     }

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -761,7 +761,7 @@ where
 
         let mut f = || {
             let duration: u32 = ctx.read_memory_as(duration_ptr)?;
-            ctx.ext.wait().map_err(FuncError::Core)?;
+            ctx.ext.wait_no_more(duration).map_err(FuncError::Core)?;
             Ok(Some(duration))
         };
 

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -351,6 +351,8 @@ where
         builder.add_host_func("env", "gr_value", Funcs::value);
         builder.add_host_func("env", "gr_value_available", Funcs::value_available);
         builder.add_host_func("env", "gr_wait", Funcs::wait);
+        builder.add_host_func("env", "gr_wait_no_more", Funcs::wait_no_more);
+        builder.add_host_func("env", "gr_wait_for", Funcs::wait_for);
         builder.add_host_func("env", "gr_wake", Funcs::wake);
 
         let mem: MemoryRef = match MemoryInstance::alloc(Pages(mem_size.0 as usize), None) {

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -351,8 +351,8 @@ where
         builder.add_host_func("env", "gr_value", Funcs::value);
         builder.add_host_func("env", "gr_value_available", Funcs::value_available);
         builder.add_host_func("env", "gr_wait", Funcs::wait);
-        builder.add_host_func("env", "gr_wait_no_more", Funcs::wait_no_more);
         builder.add_host_func("env", "gr_wait_for", Funcs::wait_for);
+        builder.add_host_func("env", "gr_wait_no_more", Funcs::wait_no_more);
         builder.add_host_func("env", "gr_wake", Funcs::wake);
 
         let mem: MemoryRef = match MemoryInstance::alloc(Pages(mem_size.0 as usize), None) {

--- a/core-backend/wasmi/src/funcs.rs
+++ b/core-backend/wasmi/src/funcs.rs
@@ -773,7 +773,7 @@ where
             .wait()
             .map_err(FuncError::Core)
             .err()
-            .unwrap_or(FuncError::Terminated(TerminationReason::Wait));
+            .unwrap_or(FuncError::Terminated(TerminationReason::Wait(None)));
         ctx.err = err;
         Err(FuncError::HostError)
     }

--- a/core-backend/wasmi/src/funcs.rs
+++ b/core-backend/wasmi/src/funcs.rs
@@ -778,6 +778,42 @@ where
         Err(FuncError::HostError)
     }
 
+    pub fn wait_no_more(ctx: &mut Runtime<E>, args: &[RuntimeValue]) -> SyscallOutput<E::Error> {
+        let mut args = args.iter();
+
+        let duration_ptr = pop_i32(&mut args).map_err(|_| FuncError::HostError)?;
+
+        let mut f = || {
+            let duration: u32 = ctx.read_memory_as(duration_ptr)?;
+            ctx.ext.wait().map_err(FuncError::Core)?;
+            Ok(Some(duration))
+        };
+
+        ctx.err = match f() {
+            Ok(duration) => FuncError::Terminated(TerminationReason::Wait(duration)),
+            Err(e) => e,
+        };
+        Err(FuncError::HostError)
+    }
+
+    pub fn wait_for(ctx: &mut Runtime<E>, args: &[RuntimeValue]) -> SyscallOutput<E::Error> {
+        let mut args = args.iter();
+
+        let duration_ptr = pop_i32(&mut args).map_err(|_| FuncError::HostError)?;
+
+        let mut f = || {
+            let duration: u32 = ctx.read_memory_as(duration_ptr)?;
+            ctx.ext.wait_for(duration).map_err(FuncError::Core)?;
+            Ok(Some(duration))
+        };
+
+        ctx.err = match f() {
+            Ok(duration) => FuncError::Terminated(TerminationReason::Wait(duration)),
+            Err(e) => e,
+        };
+        Err(FuncError::HostError)
+    }
+
     pub fn wake(ctx: &mut Runtime<E>, args: &[RuntimeValue]) -> SyscallOutput<E::Error> {
         let mut args = args.iter();
 

--- a/core-backend/wasmi/src/funcs.rs
+++ b/core-backend/wasmi/src/funcs.rs
@@ -778,14 +778,14 @@ where
         Err(FuncError::HostError)
     }
 
-    pub fn wait_no_more(ctx: &mut Runtime<E>, args: &[RuntimeValue]) -> SyscallOutput<E::Error> {
+    pub fn wait_for(ctx: &mut Runtime<E>, args: &[RuntimeValue]) -> SyscallOutput<E::Error> {
         let mut args = args.iter();
 
         let duration_ptr = pop_i32(&mut args).map_err(|_| FuncError::HostError)?;
 
         let mut f = || {
             let duration: u32 = ctx.read_memory_as(duration_ptr)?;
-            ctx.ext.wait_no_more(duration).map_err(FuncError::Core)?;
+            ctx.ext.wait_for(duration).map_err(FuncError::Core)?;
             Ok(Some(duration))
         };
 
@@ -796,14 +796,14 @@ where
         Err(FuncError::HostError)
     }
 
-    pub fn wait_for(ctx: &mut Runtime<E>, args: &[RuntimeValue]) -> SyscallOutput<E::Error> {
+    pub fn wait_no_more(ctx: &mut Runtime<E>, args: &[RuntimeValue]) -> SyscallOutput<E::Error> {
         let mut args = args.iter();
 
         let duration_ptr = pop_i32(&mut args).map_err(|_| FuncError::HostError)?;
 
         let mut f = || {
             let duration: u32 = ctx.read_memory_as(duration_ptr)?;
-            ctx.ext.wait_for(duration).map_err(FuncError::Core)?;
+            ctx.ext.wait_no_more(duration).map_err(FuncError::Core)?;
             Ok(Some(duration))
         };
 

--- a/core-backend/wasmi/src/funcs.rs
+++ b/core-backend/wasmi/src/funcs.rs
@@ -785,7 +785,7 @@ where
 
         let mut f = || {
             let duration: u32 = ctx.read_memory_as(duration_ptr)?;
-            ctx.ext.wait().map_err(FuncError::Core)?;
+            ctx.ext.wait_no_more(duration).map_err(FuncError::Core)?;
             Ok(Some(duration))
         };
 

--- a/core-errors/src/lib.rs
+++ b/core-errors/src/lib.rs
@@ -112,6 +112,18 @@ pub enum MessageError {
     },
 }
 
+/// Error using waiting syscalls.
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, derive_more::Display)]
+#[cfg_attr(feature = "codec", derive(Encode, Decode, TypeInfo))]
+pub enum WaitError {
+    /// An error occurs in attempt to wait duration greater than could be payed.
+    #[display(fmt = "Not enough gas to cover holding in waitlist")]
+    NotEnoughGas,
+    /// An error occurs in attempt to wait duration greater than could be payed.
+    #[display(fmt = "Provided incorrect argument for wait (zero case)")]
+    InvalidArgument,
+}
+
 /// Memory error.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, derive_more::Display)]
 #[cfg_attr(feature = "codec", derive(Encode, Decode, TypeInfo))]
@@ -146,9 +158,6 @@ pub enum ExecutionError {
     /// An error occurs in attempt to refund more gas than burned one.
     #[display(fmt = "Too many gas refunded")]
     TooManyGasAdded,
-    /// An error occurs in attempt to wait duration greater than could be payed.
-    #[display(fmt = "Not enough gas to cover holding in waitlist")]
-    NotEnoughGasToCoverWait,
 }
 
 /// An error occurred in API.
@@ -166,6 +175,9 @@ pub enum ExtError {
     /// Message error.
     #[display(fmt = "Message error: {}", _0)]
     Message(MessageError),
+    /// Waiting error.
+    #[display(fmt = "Waiting error: {}", _0)]
+    Wait(WaitError),
     /// Execution error.
     #[display(fmt = "Execution error: {}", _0)]
     Execution(ExecutionError),

--- a/core-errors/src/lib.rs
+++ b/core-errors/src/lib.rs
@@ -146,6 +146,9 @@ pub enum ExecutionError {
     /// An error occurs in attempt to refund more gas than burned one.
     #[display(fmt = "Too many gas refunded")]
     TooManyGasAdded,
+    /// An error occurs in attempt to wait duration greater than could be payed.
+    #[display(fmt = "Not enough gas to cover holding in waitlist")]
+    NotEnoughGasToCoverWait,
 }
 
 /// An error occurred in API.

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -43,7 +43,7 @@ pub enum DispatchResultKind {
     /// Trap dispatch.
     Trap(TrapExplanation),
     /// Wait dispatch.
-    Wait,
+    Wait(Option<u32>),
     /// Exit dispatch.
     Exit(ProgramId),
     /// Gas allowance exceed.
@@ -191,7 +191,12 @@ pub enum JournalNote {
         dispatch: Dispatch,
     },
     /// Put this dispatch in the wait list.
-    WaitDispatch(StoredDispatch),
+    WaitDispatch {
+        /// Stored dispatch to be inserted into Waitlist.
+        dispatch: StoredDispatch,
+        /// Expected duration of holding.
+        duration: Option<u32>,
+    },
     /// Wake particular message.
     WakeMessage {
         /// Message which has initiated wake.
@@ -263,7 +268,7 @@ pub trait JournalHandler {
     /// Process send dispatch.
     fn send_dispatch(&mut self, message_id: MessageId, dispatch: Dispatch);
     /// Process send message.
-    fn wait_dispatch(&mut self, dispatch: StoredDispatch);
+    fn wait_dispatch(&mut self, dispatch: StoredDispatch, duration: Option<u32>);
     /// Process send message.
     fn wake_message(
         &mut self,

--- a/core-processor/src/configs.rs
+++ b/core-processor/src/configs.rs
@@ -81,28 +81,13 @@ pub struct ExecutionSettings {
     pub forbidden_funcs: BTreeSet<&'static str>,
     /// Threshold for inserting into mailbox
     pub mailbox_threshold: u64,
+    /// Cost for single block waitlist holding.
+    pub waitlist_cost: u64,
+    /// Reserve for parameter of scheduling.
+    pub reserve_for: u32,
 }
 
 impl ExecutionSettings {
-    /// New execution settings with default allocation config.
-    pub fn new(
-        block_info: BlockInfo,
-        existential_deposit: u128,
-        allocations_config: AllocationsConfig,
-        host_fn_weights: HostFnWeights,
-        forbidden_funcs: BTreeSet<&'static str>,
-        mailbox_threshold: u64,
-    ) -> Self {
-        Self {
-            block_info,
-            existential_deposit,
-            allocations_config,
-            host_fn_weights,
-            forbidden_funcs,
-            mailbox_threshold,
-        }
-    }
-
     /// Max amount of pages.
     pub fn max_pages(&self) -> WasmPageNumber {
         self.allocations_config.max_pages
@@ -126,6 +111,10 @@ pub struct BlockConfig {
     pub forbidden_funcs: BTreeSet<&'static str>,
     /// Mailbox threshold.
     pub mailbox_threshold: u64,
+    /// Cost for single block waitlist holding.
+    pub waitlist_cost: u64,
+    /// Reserve for parameter of scheduling.
+    pub reserve_for: u32,
 }
 
 /// Unstable parameters for message execution across processing runs.

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -371,7 +371,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
 
             DispatchResultKind::Trap(explanation)
         }
-        TerminationReason::Wait => DispatchResultKind::Wait,
+        TerminationReason::Wait(duration) => DispatchResultKind::Wait(duration),
         TerminationReason::GasAllowanceExceeded => DispatchResultKind::GasAllowanceExceed,
     };
 

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -292,6 +292,8 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
         host_fn_weights: settings.host_fn_weights,
         forbidden_funcs: settings.forbidden_funcs,
         mailbox_threshold: settings.mailbox_threshold,
+        waitlist_cost: settings.waitlist_cost,
+        reserve_for: settings.reserve_for,
     };
 
     // Creating externalities.

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -561,12 +561,6 @@ impl EnvExt for Ext {
         Ok(())
     }
 
-    fn wait_no_more(&mut self, _duration: u32) -> Result<(), Self::Error> {
-        // TODO: Provide RuntimeCosts::WaitNoMore.
-        self.charge_gas_runtime(RuntimeCosts::Wait)?;
-        Ok(())
-    }
-
     fn wait_for(&mut self, duration: u32) -> Result<(), Self::Error> {
         // TODO: Provide RuntimeCosts::WaitFor.
         self.charge_gas_runtime(RuntimeCosts::Wait)?;
@@ -578,6 +572,12 @@ impl EnvExt for Ext {
             return self.return_and_store_err(Err(ExecutionError::NotEnoughGasToCoverWait));
         }
 
+        Ok(())
+    }
+
+    fn wait_no_more(&mut self, _duration: u32) -> Result<(), Self::Error> {
+        // TODO: Provide RuntimeCosts::WaitNoMore.
+        self.charge_gas_runtime(RuntimeCosts::Wait)?;
         Ok(())
     }
 

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -576,8 +576,7 @@ impl EnvExt for Ext {
     }
 
     fn wait_for(&mut self, duration: u32) -> Result<(), Self::Error> {
-        // TODO: Provide RuntimeCosts::WaitFor.
-        self.charge_gas_runtime(RuntimeCosts::Wait)?;
+        self.charge_gas_runtime(RuntimeCosts::WaitFor)?;
 
         if duration == 0 {
             return self.return_and_store_err(Err(WaitError::InvalidArgument));
@@ -594,8 +593,7 @@ impl EnvExt for Ext {
     }
 
     fn wait_no_more(&mut self, duration: u32) -> Result<(), Self::Error> {
-        // TODO: Provide RuntimeCosts::WaitNoMore.
-        self.charge_gas_runtime(RuntimeCosts::Wait)?;
+        self.charge_gas_runtime(RuntimeCosts::WaitNoMore)?;
 
         if duration == 0 {
             return self.return_and_store_err(Err(WaitError::InvalidArgument));

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -561,6 +561,12 @@ impl EnvExt for Ext {
         Ok(())
     }
 
+    fn wait_no_more(&mut self, _duration: u32) -> Result<(), Self::Error> {
+        // TODO: Provide RuntimeCosts::WaitNoMore.
+        self.charge_gas_runtime(RuntimeCosts::Wait)?;
+        Ok(())
+    }
+
     fn wait_for(&mut self, duration: u32) -> Result<(), Self::Error> {
         // TODO: Provide RuntimeCosts::WaitFor.
         self.charge_gas_runtime(RuntimeCosts::Wait)?;

--- a/core-processor/src/handler.rs
+++ b/core-processor/src/handler.rs
@@ -45,7 +45,9 @@ pub fn handle_journal(
                 message_id,
                 dispatch,
             } => handler.send_dispatch(message_id, dispatch),
-            JournalNote::WaitDispatch(dispatch) => handler.wait_dispatch(dispatch),
+            JournalNote::WaitDispatch { dispatch, duration } => {
+                handler.wait_dispatch(dispatch, duration)
+            }
             JournalNote::WakeMessage {
                 message_id,
                 program_id,

--- a/core-processor/src/processor.rs
+++ b/core-processor/src/processor.rs
@@ -182,16 +182,20 @@ pub fn process<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environment<
         host_fn_weights,
         forbidden_funcs,
         mailbox_threshold,
+        waitlist_cost,
+        reserve_for,
     } = block_config.clone();
 
-    let execution_settings = ExecutionSettings::new(
+    let execution_settings = ExecutionSettings {
         block_info,
         existential_deposit,
         allocations_config,
         host_fn_weights,
         forbidden_funcs,
         mailbox_threshold,
-    );
+        waitlist_cost,
+        reserve_for,
+    };
 
     let dispatch = execution_context.dispatch;
     let balance = execution_context.balance;

--- a/core/src/costs.rs
+++ b/core/src/costs.rs
@@ -109,6 +109,12 @@ pub struct HostFnWeights {
     /// Weight of calling `gr_wait`.
     pub gr_wait: u64,
 
+    /// Weight of calling `gr_wait_for`.
+    pub gr_wait_for: u64,
+
+    /// Weight of calling `gr_wait_no_more`.
+    pub gr_wait_no_more: u64,
+
     /// Weight of calling `gr_wake`.
     pub gr_wake: u64,
 
@@ -199,6 +205,10 @@ pub enum RuntimeCosts {
     Leave,
     /// Weight of calling `gr_wait`.
     Wait,
+    /// Weight of calling `gr_wait_for`.
+    WaitFor,
+    /// Weight of calling `gr_wait_no_more`.
+    WaitNoMore,
     /// Weight of calling `gr_wake`.
     Wake,
     /// Weight of calling `gr_create_program_wgas`.
@@ -244,6 +254,8 @@ impl RuntimeCosts {
             Exit => s.gr_exit,
             Leave => s.gr_leave,
             Wait => s.gr_wait,
+            WaitFor => s.gr_wait_for,
+            WaitNoMore => s.gr_wait_no_more,
             Wake => s.gr_wake,
             CreateProgram(len) => s
                 .gr_create_program_wgas

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -148,12 +148,12 @@ pub trait Ext {
     /// Interrupt the program and reschedule execution for maximum.
     fn wait(&mut self) -> Result<(), Self::Error>;
 
+    /// Interrupt the program and reschedule execution in duration.
+    fn wait_for(&mut self, duration: u32) -> Result<(), Self::Error>;
+
     /// Interrupt the program and reschedule execution for maximum,
     /// but not more than duration.
     fn wait_no_more(&mut self, duration: u32) -> Result<(), Self::Error>;
-
-    /// Interrupt the program and reschedule execution in duration.
-    fn wait_for(&mut self, duration: u32) -> Result<(), Self::Error>;
 
     /// Wake the waiting message and move it to the processing queue.
     fn wake(&mut self, waker_id: MessageId) -> Result<(), Self::Error>;
@@ -278,10 +278,10 @@ mod tests {
         fn wait(&mut self) -> Result<(), Self::Error> {
             Ok(())
         }
-        fn wait_no_more(&mut self, _duration: u32) -> Result<(), Self::Error> {
+        fn wait_for(&mut self, _duration: u32) -> Result<(), Self::Error> {
             Ok(())
         }
-        fn wait_for(&mut self, _duration: u32) -> Result<(), Self::Error> {
+        fn wait_no_more(&mut self, _duration: u32) -> Result<(), Self::Error> {
             Ok(())
         }
         fn wake(&mut self, _waker_id: MessageId) -> Result<(), Self::Error> {

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -145,8 +145,12 @@ pub trait Ext {
     /// Tell how much value is left in running context.
     fn value_available(&mut self) -> Result<u128, Self::Error>;
 
-    /// Interrupt the program and reschedule execution.
+    /// Interrupt the program and reschedule execution for maximum.
     fn wait(&mut self) -> Result<(), Self::Error>;
+
+    /// Interrupt the program and reschedule execution for maximum,
+    /// but not more than duration.
+    fn wait_no_more(&mut self, duration: u32) -> Result<(), Self::Error>;
 
     /// Interrupt the program and reschedule execution in duration.
     fn wait_for(&mut self, duration: u32) -> Result<(), Self::Error>;
@@ -272,6 +276,9 @@ mod tests {
             Ok(())
         }
         fn wait(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+        fn wait_no_more(&mut self, _duration: u32) -> Result<(), Self::Error> {
             Ok(())
         }
         fn wait_for(&mut self, _duration: u32) -> Result<(), Self::Error> {

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -148,6 +148,9 @@ pub trait Ext {
     /// Interrupt the program and reschedule execution.
     fn wait(&mut self) -> Result<(), Self::Error>;
 
+    /// Interrupt the program and reschedule execution in duration.
+    fn wait_for(&mut self, duration: u32) -> Result<(), Self::Error>;
+
     /// Wake the waiting message and move it to the processing queue.
     fn wake(&mut self, waker_id: MessageId) -> Result<(), Self::Error>;
 
@@ -269,6 +272,9 @@ mod tests {
             Ok(())
         }
         fn wait(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+        fn wait_for(&mut self, _duration: u32) -> Result<(), Self::Error> {
             Ok(())
         }
         fn wake(&mut self, _waker_id: MessageId) -> Result<(), Self::Error> {

--- a/examples/binaries/waiter/Cargo.toml
+++ b/examples/binaries/waiter/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "demo-waiter"
+version = "0.1.0"
+authors = ["Gear Technologies"]
+edition = "2018"
+license = "GPL-3.0"
+workspace = "../../../"
+
+[dependencies]
+gstd = { path = "../../../gstd", features = ["debug"] }
+codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive"] }
+
+[build-dependencies]
+gear-wasm-builder = { path = "../../../utils/wasm-builder" }
+
+[dev-dependencies]
+
+[lib]
+
+[features]
+std = ["codec/std"]
+default = ["std"]

--- a/examples/binaries/waiter/build.rs
+++ b/examples/binaries/waiter/build.rs
@@ -1,0 +1,21 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+fn main() {
+    gear_wasm_builder::build();
+}

--- a/examples/binaries/waiter/src/code.rs
+++ b/examples/binaries/waiter/src/code.rs
@@ -1,0 +1,14 @@
+use crate::Command;
+
+use gstd::{exec, msg};
+
+#[no_mangle]
+unsafe extern "C" fn handle() {
+    let cmd: Command = msg::load().unwrap();
+
+    match cmd {
+        Command::Wait => exec::wait(),
+        Command::WaitFor(duration) => exec::wait_for(duration),
+        Command::WaitNoMore(duration) => exec::wait_no_more(duration),
+    }
+}

--- a/examples/binaries/waiter/src/lib.rs
+++ b/examples/binaries/waiter/src/lib.rs
@@ -1,0 +1,40 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+#![no_std]
+
+use codec::{Decode, Encode};
+
+#[cfg(feature = "std")]
+mod code {
+    include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+}
+
+#[cfg(feature = "std")]
+pub use code::WASM_BINARY_OPT as WASM_BINARY;
+
+#[cfg(not(feature = "std"))]
+mod wasm {
+    include! {"./code.rs"}
+}
+
+#[derive(Debug, Encode, Decode)]
+pub enum Command {
+    Wait,
+    WaitFor(u32),
+    WaitNoMore(u32),
+}

--- a/gcore/src/exec.rs
+++ b/gcore/src/exec.rs
@@ -33,6 +33,8 @@ mod sys {
         pub fn gr_leave() -> !;
         pub fn gr_value_available(val: *mut u8);
         pub fn gr_wait() -> !;
+        pub fn gr_wait_no_more(duration: *const u8) -> !;
+        pub fn gr_wait_for(duration: *const u8) -> !;
         pub fn gr_wake(waker_id_ptr: *const u8);
     }
 }
@@ -174,6 +176,9 @@ pub fn value_available() -> u128 {
 /// function later. All gas that hasn't yet been spent is attributed to the
 /// message in the *waiting queue*.
 ///
+/// This call delays message execution for maximal amount of blocks
+/// that could be payed.
+///
 /// # Examples
 ///
 /// ```
@@ -186,6 +191,19 @@ pub fn value_available() -> u128 {
 /// ```
 pub fn wait() -> ! {
     unsafe { sys::gr_wait() }
+}
+
+/// Same as [`wait`], but delays handling for given specific amount of blocks.
+///
+/// NOTE: It panics, if given duration couldn't be totally payed.
+pub fn wait_for(duration: u32) -> ! {
+    unsafe { sys::gr_wait_for(duration.to_le_bytes().as_ptr()) }
+}
+
+/// Same as [`wait`], but delays handling for maximal amount of blocks
+/// that could be payed, that doesn't exceed given duration.
+pub fn wait_no_more(duration: u32) -> ! {
+    unsafe { sys::gr_wait_no_more(duration.to_le_bytes().as_ptr()) }
 }
 
 /// Resume previously paused message handling.

--- a/gcore/src/exec.rs
+++ b/gcore/src/exec.rs
@@ -82,7 +82,7 @@ pub fn block_timestamp() -> u64 {
 }
 
 /// Terminate the execution of a program. The program and all corresponding data
-/// are removed from the storage. This is similiar to
+/// are removed from the storage. This is similar to
 /// `std::process::exit`. `value_destination` specifies the address where all
 /// available to the program value should be transferred to.
 /// Maybe called in `init` method as well.

--- a/gear-test/src/manager.rs
+++ b/gear-test/src/manager.rs
@@ -265,7 +265,7 @@ impl JournalHandler for InMemoryExtManager {
             self.log.push(dispatch.into_parts().1.into_stored());
         }
     }
-    fn wait_dispatch(&mut self, dispatch: StoredDispatch) {
+    fn wait_dispatch(&mut self, dispatch: StoredDispatch, _duration: Option<u32>) {
         self.message_consumed(dispatch.id());
         self.wait_list
             .insert((dispatch.destination(), dispatch.id()), dispatch);

--- a/gear-test/src/proc.rs
+++ b/gear-test/src/proc.rs
@@ -40,6 +40,8 @@ use wasm_instrument::gas_metering::ConstantCostRules;
 pub const EXISTENTIAL_DEPOSIT: u128 = 500;
 pub const OUTGOING_LIMIT: u32 = 1024;
 pub const MAILBOX_THRESHOLD: u64 = 3000;
+pub const WAITLIST_COST: u64 = 100;
+pub const RESERVE_FOR: u32 = 1;
 
 pub fn parse_payload(payload: String) -> String {
     let program_id_regex = Regex::new(r"\{(?P<id>[0-9]+)\}").unwrap();
@@ -89,11 +91,11 @@ where
     JH: JournalHandler + CollectState + ExecutionContext,
 {
     let code = Code::try_new(message.code.clone(), 1, |_| ConstantCostRules::default())
-        .map_err(|e| anyhow::anyhow!("Error initialisation: {:?}", &e))?;
+        .map_err(|e| anyhow::anyhow!("Error initialization: {:?}", &e))?;
 
     if code.static_pages() > AllocationsConfig::default().max_pages {
         return Err(anyhow::anyhow!(
-            "Error initialisation: memory limit exceeded"
+            "Error initialization: memory limit exceeded"
         ));
     }
 
@@ -146,7 +148,7 @@ where
             let code_bytes = std::fs::read(&code.path)
                 .map_err(|e| IoError::new(IoErrorKind::Other, format!("`{}': {}", code.path, e)))?;
             let code = Code::try_new(code_bytes.clone(), 1, |_| ConstantCostRules::default())
-                .map_err(|e| anyhow::anyhow!("Error initialisation: {:?}", &e))?;
+                .map_err(|e| anyhow::anyhow!("Error initialization: {:?}", &e))?;
 
             let (code, code_id) = CodeAndId::new(code).into_parts();
 
@@ -383,5 +385,7 @@ fn test_block_config(block_info: BlockInfo) -> BlockConfig {
         host_fn_weights: Default::default(),
         forbidden_funcs: Default::default(),
         mailbox_threshold: MAILBOX_THRESHOLD,
+        waitlist_cost: WAITLIST_COST,
+        reserve_for: RESERVE_FOR,
     }
 }

--- a/gstd/src/async_runtime/futures.rs
+++ b/gstd/src/async_runtime/futures.rs
@@ -67,6 +67,7 @@ where
     if Pin::new(&mut task.future).poll(&mut cx).is_ready() {
         super::futures().remove(&crate::msg::id());
     } else {
-        crate::exec::wait()
+        // TODO: make this call configurable.
+        crate::exec::wait_no_more(100)
     }
 }

--- a/gstd/src/exec.rs
+++ b/gstd/src/exec.rs
@@ -78,13 +78,19 @@
 //! }
 //! ```
 use crate::{ActorId, MessageId};
-pub use gcore::exec::{block_height, block_timestamp, gas_available, value_available};
+pub use gcore::exec::{
+    block_height, block_timestamp, gas_available, leave, value_available, wait, wait_for,
+    wait_no_more,
+};
 
-/// Terminate the execution of a program. The program and all corresponding data
-/// are removed from the storage. This is similiar to
-/// `std::process::exit`. `value_destination` specifies the address where all
-/// available to the program value should be transferred to.
-/// Maybe called in `init` method as well.
+/// Terminate the execution of a program.
+///
+/// The program and all corresponding data
+/// are removed from the storage. This is similar to `std::process::exit`.
+/// `value_destination` specifies the address where all associated with
+/// the program value should be transferred to.
+///
+/// May be called in `init` method as well.
 ///
 /// # Examples
 ///
@@ -98,48 +104,6 @@ pub use gcore::exec::{block_height, block_timestamp, gas_available, value_availa
 /// ```
 pub fn exit(value_destination: ActorId) -> ! {
     gcore::exec::exit(value_destination.into())
-}
-
-/// Terminate the current message handling.
-///
-/// For cases when the message handling needs to be terminated with state
-/// saving.
-///
-/// # Examples
-///
-/// ```
-/// use gstd::exec;
-///
-/// unsafe extern "C" fn handle() {
-///     // ...
-///     exec::leave();
-/// }
-/// ```
-pub fn leave() -> ! {
-    gcore::exec::leave()
-}
-
-/// Pause the current message handling.
-///
-/// If the message handling needs to be paused, i.e. to wait for another
-/// execution to finish, this function should be used. [`wait`] finishes current
-/// message handle execution with a special result and puts the current message
-/// into the *waiting queue* to be awakened using the correspondent [`wake`]
-/// function later. All gas that hasn't yet been spent is attributed to the
-/// message in the *waiting queue*.
-///
-/// # Examples
-///
-/// ```
-/// use gstd::exec;
-///
-/// unsafe extern "C" fn handle() {
-///     // ...
-///     exec::wait();
-/// }
-/// ```
-pub fn wait() -> ! {
-    gcore::exec::wait()
 }
 
 /// Resume previously paused message handling.

--- a/gtest/src/lib.rs
+++ b/gtest/src/lib.rs
@@ -31,3 +31,5 @@ pub use system::System;
 
 pub const EXISTENTIAL_DEPOSIT: u128 = 500;
 pub const MAILBOX_THRESHOLD: u64 = 3000;
+pub const WAITLIST_COST: u64 = 100;
+pub const RESERVE_FOR: u32 = 1;

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -316,7 +316,7 @@ impl ExtManager {
                     .entry(dest)
                     .or_default()
                     .push(message_id);
-                self.wait_dispatch(dispatch);
+                self.wait_dispatch(dispatch, None);
 
                 continue;
             }
@@ -709,7 +709,7 @@ impl JournalHandler for ExtManager {
         }
     }
 
-    fn wait_dispatch(&mut self, dispatch: StoredDispatch) {
+    fn wait_dispatch(&mut self, dispatch: StoredDispatch, _duration: Option<u32>) {
         self.message_consumed(dispatch.id());
         self.wait_list
             .insert((dispatch.destination(), dispatch.id()), dispatch);

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -20,7 +20,7 @@ use crate::{
     log::{CoreLog, RunResult},
     program::{Gas, WasmProgram},
     wasm_executor::WasmExecutor,
-    Result, TestError, EXISTENTIAL_DEPOSIT, MAILBOX_THRESHOLD,
+    Result, TestError, EXISTENTIAL_DEPOSIT, MAILBOX_THRESHOLD, RESERVE_FOR, WAITLIST_COST,
 };
 use core_processor::{
     common::*,
@@ -581,6 +581,8 @@ impl ExtManager {
             host_fn_weights: Default::default(),
             forbidden_funcs: Default::default(),
             mailbox_threshold: MAILBOX_THRESHOLD,
+            waitlist_cost: WAITLIST_COST,
+            reserve_for: RESERVE_FOR,
         };
         let message_execution_context = MessageExecutionContext {
             actor: Actor {

--- a/gtest/src/wasm_executor.rs
+++ b/gtest/src/wasm_executor.rs
@@ -34,7 +34,9 @@ use gear_core::{
 use std::{collections::BTreeMap, mem};
 use wasmi::{memory_units::Pages, MemoryInstance, MemoryRef, ModuleInstance, RuntimeValue};
 
-use crate::{manager::ExtManager, Result, TestError, MAILBOX_THRESHOLD};
+use crate::{
+    manager::ExtManager, Result, TestError, MAILBOX_THRESHOLD, RESERVE_FOR, WAITLIST_COST,
+};
 
 /// Binary meta-functions executor for testing purposes
 pub(crate) struct WasmExecutor;
@@ -171,6 +173,8 @@ impl WasmExecutor {
             host_fn_weights: Default::default(),
             forbidden_funcs: Default::default(),
             mailbox_threshold: MAILBOX_THRESHOLD,
+            waitlist_cost: WAITLIST_COST,
+            reserve_for: RESERVE_FOR,
         })
     }
 

--- a/pallets/gear/Cargo.toml
+++ b/pallets/gear/Cargo.toml
@@ -78,6 +78,7 @@ demo-calc-hash-in-one-block = { path = "../../examples/binaries/calc-hash/in-one
 demo-compose = { path = "../../examples/binaries/compose" }
 demo-mul-by-const = { path = "../../examples/binaries/mul-by-const" }
 demo-value-sender = { path = "../../examples/binaries/value-sender" }
+demo-waiter = { path = "../../examples/binaries/waiter" }
 page_size = "0.4.2"
 pallet-gear-gas = { path = "../gas" }
 pallet-gear-messenger = { path = "../gear-messenger" }

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -289,6 +289,8 @@ where
 
     let existential_deposit = CurrencyOf::<T>::minimum_balance().unique_saturated_into();
     let mailbox_threshold = <T as Config>::MailboxThreshold::get();
+    let waitlist_cost = CostsPerBlockOf::<T>::waitlist();
+    let reserve_for = CostsPerBlockOf::<T>::reserve_for().unique_saturated_into();
 
     let block_config = BlockConfig {
         block_info,
@@ -304,6 +306,8 @@ where
         host_fn_weights: Default::default(),
         forbidden_funcs: Default::default(),
         mailbox_threshold,
+        waitlist_cost,
+        reserve_for,
     };
 
     if let Some(queued_dispatch) = QueueOf::<T>::dequeue().map_err(|_| "MQ storage corrupted")? {

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -1540,6 +1540,70 @@ benchmarks! {
         >(&block_config, context, memory_pages);
     }
 
+    // We cannot call `gr_wait_for` multiple times. Therefore our weight determination is not
+    // as precise as with other APIs.
+    gr_wait_for {
+        let r in 0 .. 1;
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec![ImportedFunction {
+                module: "env",
+                name: "gr_wait_for",
+                params: vec![ValueType::I32],
+                return_type: None,
+            }],
+            handle_body: Some(body::repeated(r, &[
+                Instruction::I32Const(100),
+                Instruction::Call(0),
+            ])),
+            .. Default::default()
+        });
+        let instance = Program::<T>::new(code, vec![])?;
+        let Exec {
+            ext_manager,
+            block_config,
+            context,
+            memory_pages,
+        } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 0u32.into())?;
+    }: {
+        core_processor::process::<
+            ext::LazyPagesExt,
+            SandboxEnvironment,
+        >(&block_config, context, memory_pages);
+    }
+
+    // We cannot call `gr_wait_no_more` multiple times. Therefore our weight determination is not
+    // as precise as with other APIs.
+    gr_wait_no_more {
+        let r in 0 .. 1;
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec![ImportedFunction {
+                module: "env",
+                name: "gr_wait_no_more",
+                params: vec![ValueType::I32],
+                return_type: None,
+            }],
+            handle_body: Some(body::repeated(r, &[
+                Instruction::I32Const(100),
+                Instruction::Call(0),
+            ])),
+            .. Default::default()
+        });
+        let instance = Program::<T>::new(code, vec![])?;
+        let Exec {
+            ext_manager,
+            block_config,
+            context,
+            memory_pages,
+        } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 0u32.into())?;
+    }: {
+        core_processor::process::<
+            ext::LazyPagesExt,
+            SandboxEnvironment,
+        >(&block_config, context, memory_pages);
+    }
+
     gr_wake {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let message_ids = (0..r * API_BENCHMARK_BATCH_SIZE)

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -323,6 +323,10 @@ impl EnvExt for LazyPagesExt {
         self.inner.wait().map_err(Error::Processor)
     }
 
+    fn wait_for(&mut self, duration: u32) -> Result<(), Self::Error> {
+        self.inner.wait_for(duration).map_err(Error::Processor)
+    }
+
     fn wake(&mut self, waker_id: MessageId) -> Result<(), Self::Error> {
         self.inner.wake(waker_id).map_err(Error::Processor)
     }

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -323,6 +323,10 @@ impl EnvExt for LazyPagesExt {
         self.inner.wait().map_err(Error::Processor)
     }
 
+    fn wait_no_more(&mut self, duration: u32) -> Result<(), Self::Error> {
+        self.inner.wait_no_more(duration).map_err(Error::Processor)
+    }
+
     fn wait_for(&mut self, duration: u32) -> Result<(), Self::Error> {
         self.inner.wait_for(duration).map_err(Error::Processor)
     }

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -323,12 +323,12 @@ impl EnvExt for LazyPagesExt {
         self.inner.wait().map_err(Error::Processor)
     }
 
-    fn wait_no_more(&mut self, duration: u32) -> Result<(), Self::Error> {
-        self.inner.wait_no_more(duration).map_err(Error::Processor)
-    }
-
     fn wait_for(&mut self, duration: u32) -> Result<(), Self::Error> {
         self.inner.wait_for(duration).map_err(Error::Processor)
+    }
+
+    fn wait_no_more(&mut self, duration: u32) -> Result<(), Self::Error> {
+        self.inner.wait_no_more(duration).map_err(Error::Processor)
     }
 
     fn wake(&mut self, waker_id: MessageId) -> Result<(), Self::Error> {

--- a/pallets/gear/src/internal.rs
+++ b/pallets/gear/src/internal.rs
@@ -341,6 +341,7 @@ where
         // `HoldBound` cost builder.
         let hold_builder = HoldBound::<T>::by(CostsPerBlockOf::<T>::waitlist());
 
+        // Maximal hold bound for the message.
         let maximal_hold = hold_builder.clone().maximum_for_message(dispatch.id());
 
         // Figuring out correct hold bound.
@@ -358,14 +359,6 @@ where
             log::error!("Failed to figure out correct wait hold bound");
             return;
         }
-
-        // // TODO: remove, once duration-control added inside programs (#1173).
-        // //
-        // // This need in async scenarios, while we send gasless message and it
-        // // goes into waitlist: then all funds become locked for storing in
-        // // waitlist, instead of distribute for execution and storing.
-        // let hold = HoldBound::<T>::by(CostsPerBlockOf::<T>::waitlist())
-        //     .duration(hold.expected_duration().min(500u32.unique_saturated_into()));
 
         // Locking funds for holding.
         GasHandlerOf::<T>::lock(dispatch.id(), hold.lock())

--- a/pallets/gear/src/internal.rs
+++ b/pallets/gear/src/internal.rs
@@ -355,7 +355,6 @@ where
         if hold.expected_duration().is_zero() {
             // TODO: Replace with unreachable call after:
             // - `HoldBound` safety usage stabilized;
-            // - Issue #1173 solved.
             log::error!("Failed to figure out correct wait hold bound");
             return;
         }

--- a/pallets/gear/src/internal.rs
+++ b/pallets/gear/src/internal.rs
@@ -359,13 +359,13 @@ where
             return;
         }
 
-        // TODO: remove, once duration-control added inside programs (#1173).
-        //
-        // This need in async scenarios, while we send gasless message and it
-        // goes into waitlist: then all funds become locked for storing in
-        // waitlist, instead of distribute for execution and storing.
-        let hold = HoldBound::<T>::by(CostsPerBlockOf::<T>::waitlist())
-            .duration(hold.expected_duration().min(500u32.unique_saturated_into()));
+        // // TODO: remove, once duration-control added inside programs (#1173).
+        // //
+        // // This need in async scenarios, while we send gasless message and it
+        // // goes into waitlist: then all funds become locked for storing in
+        // // waitlist, instead of distribute for execution and storing.
+        // let hold = HoldBound::<T>::by(CostsPerBlockOf::<T>::waitlist())
+        //     .duration(hold.expected_duration().min(500u32.unique_saturated_into()));
 
         // Locking funds for holding.
         GasHandlerOf::<T>::lock(dispatch.id(), hold.lock())

--- a/pallets/gear/src/internal.rs
+++ b/pallets/gear/src/internal.rs
@@ -33,6 +33,7 @@ use common::{
     storage::*,
     GasPrice, GasTree, Origin,
 };
+use core::cmp::{Ord, Ordering};
 use core_processor::common::ExecutionErrorReason;
 use frame_support::traits::{
     BalanceStatus, Currency, ExistenceRequirement, Imbalance, ReservableCurrency,
@@ -101,7 +102,7 @@ impl<T: Config> HoldBoundCost<T> {
 
 /// Hold bound, specifying cost of storing, expected block number for task to
 /// create on it, deadlines and durations of holding.
-#[derive(Clone, Debug, Decode, Encode, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
 pub(crate) struct HoldBound<T: Config> {
     /// Cost of storing per block.
     cost: SchedulingCostOf<T>,
@@ -155,6 +156,21 @@ impl<T: Config> HoldBound<T> {
         self.deadline_duration()
             .saturated_into::<GasBalanceOf<T>>()
             .saturating_mul(self.cost())
+    }
+}
+
+impl<T: Config> PartialOrd for HoldBound<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.expected.partial_cmp(&other.expected)
+    }
+}
+
+impl<T: Config> Ord for HoldBound<T>
+where
+    BlockNumberFor<T>: PartialOrd,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.expected.cmp(&other.expected)
     }
 }
 
@@ -317,10 +333,22 @@ where
     }
 
     /// Adds dispatch into waitlist, deposits event and adds task for waking it.
-    pub(crate) fn wait_dispatch(dispatch: StoredDispatch, reason: MessageWaitedReason) {
-        // Figuring out maximal deadline of holding.
-        let hold =
-            HoldBound::<T>::by(CostsPerBlockOf::<T>::waitlist()).maximum_for_message(dispatch.id());
+    pub(crate) fn wait_dispatch(
+        dispatch: StoredDispatch,
+        duration: Option<BlockNumberFor<T>>,
+        reason: MessageWaitedReason,
+    ) {
+        // `HoldBound` cost builder.
+        let hold_builder = HoldBound::<T>::by(CostsPerBlockOf::<T>::waitlist());
+
+        let maximal_hold = hold_builder.clone().maximum_for_message(dispatch.id());
+
+        // Figuring out correct hold bound.
+        let hold = if let Some(duration) = duration {
+            hold_builder.duration(duration).min(maximal_hold)
+        } else {
+            maximal_hold
+        };
 
         // Validating duration.
         if hold.expected_duration().is_zero() {

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -796,6 +796,8 @@ pub mod pallet {
                 host_fn_weights: schedule.host_fn_weights.into_core(),
                 forbidden_funcs: ["gr_gas_available"].into(),
                 mailbox_threshold: T::MailboxThreshold::get(),
+                waitlist_cost: CostsPerBlockOf::<T>::waitlist(),
+                reserve_for: CostsPerBlockOf::<T>::reserve_for().unique_saturated_into(),
             };
 
             let mut min_limit = 0;
@@ -1143,6 +1145,8 @@ pub mod pallet {
                 host_fn_weights: schedule.host_fn_weights.into_core(),
                 forbidden_funcs: Default::default(),
                 mailbox_threshold: T::MailboxThreshold::get(),
+                waitlist_cost: CostsPerBlockOf::<T>::waitlist(),
+                reserve_for: CostsPerBlockOf::<T>::reserve_for().unique_saturated_into(),
             };
 
             if T::DebugInfo::is_remap_id_enabled() {

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -1221,6 +1221,7 @@ pub mod pallet {
 
                                 Self::wait_dispatch(
                                     dispatch,
+                                    None,
                                     MessageWaitedSystemReason::ProgramIsNotInitialized
                                         .into_reason(),
                                 );

--- a/pallets/gear/src/manager/journal.rs
+++ b/pallets/gear/src/manager/journal.rs
@@ -259,7 +259,7 @@ where
         }
     }
 
-    fn wait_dispatch(&mut self, dispatch: StoredDispatch) {
+    fn wait_dispatch(&mut self, dispatch: StoredDispatch, _duration: Option<u32>) {
         Pallet::<T>::wait_dispatch(
             dispatch,
             MessageWaitedRuntimeReason::WaitCalled.into_reason(),

--- a/pallets/gear/src/manager/journal.rs
+++ b/pallets/gear/src/manager/journal.rs
@@ -259,9 +259,10 @@ where
         }
     }
 
-    fn wait_dispatch(&mut self, dispatch: StoredDispatch, _duration: Option<u32>) {
+    fn wait_dispatch(&mut self, dispatch: StoredDispatch, duration: Option<u32>) {
         Pallet::<T>::wait_dispatch(
             dispatch,
+            duration.map(UniqueSaturatedInto::unique_saturated_into),
             MessageWaitedRuntimeReason::WaitCalled.into_reason(),
         )
     }

--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -342,6 +342,12 @@ pub struct HostFnWeights<T: Config> {
     /// Weight of calling `gr_wait`.
     pub gr_wait: Weight,
 
+    /// Weight of calling `gr_wait_for`.
+    pub gr_wait_for: Weight,
+
+    /// Weight of calling `gr_wait_no_more`.
+    pub gr_wait_no_more: Weight,
+
     /// Weight of calling `gr_wake`.
     pub gr_wake: Weight,
 
@@ -572,6 +578,8 @@ impl<T: Config> HostFnWeights<T> {
             gr_exit: self.gr_exit,
             gr_leave: self.gr_leave,
             gr_wait: self.gr_wait,
+            gr_wait_for: self.gr_wait_for,
+            gr_wait_no_more: self.gr_wait_no_more,
             gr_wake: self.gr_wake,
             gr_create_program_wgas: self.gr_create_program_wgas,
             gr_create_program_wgas_per_byte: self.gr_create_program_wgas_per_byte,
@@ -611,6 +619,8 @@ impl<T: Config> Default for HostFnWeights<T> {
             gr_exit: cost!(gr_exit),
             gr_leave: cost!(gr_leave),
             gr_wait: cost!(gr_wait),
+            gr_wait_for: cost!(gr_wait_for),
+            gr_wait_no_more: cost!(gr_wait_no_more),
             gr_wake: cost_batched!(gr_wake),
             gr_create_program_wgas: cost!(gr_create_program_wgas),
             gr_create_program_wgas_per_byte: cost_byte_batched!(gr_create_program_wgas_per_kb),

--- a/pallets/gear/src/weights.rs
+++ b/pallets/gear/src/weights.rs
@@ -77,6 +77,8 @@ pub trait WeightInfo {
 	fn gr_exit(r: u32, ) -> Weight;
 	fn gr_leave(r: u32, ) -> Weight;
 	fn gr_wait(r: u32, ) -> Weight;
+	fn gr_wait_for(r: u32, ) -> Weight;
+	fn gr_wait_no_more(r: u32, ) -> Weight;
 	fn gr_wake(r: u32, ) -> Weight;
 	fn gr_create_program_wgas(r: u32, ) -> Weight;
 	fn gr_create_program_wgas_per_kb(n: u32, ) -> Weight;
@@ -365,6 +367,18 @@ impl<T: frame_system::Config> WeightInfo for GearWeight<T> {
 		(112_271_000 as Weight)
 			// Standard Error: 280_000
 			.saturating_add((23_250_000 as Weight).saturating_mul(r as Weight))
+	}
+	fn gr_wait_for(r: u32, ) -> Weight {
+		(72_800_000 as Weight)
+			// Standard Error: 851_000
+			.saturating_add((41_000_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(T::DbWeight::get().reads((4 as Weight).saturating_mul(r as Weight)))
+	}
+	fn gr_wait_no_more(r: u32, ) -> Weight {
+		(74_000_000 as Weight)
+			// Standard Error: 611_000
+			.saturating_add((43_200_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(T::DbWeight::get().reads((4 as Weight).saturating_mul(r as Weight)))
 	}
 	fn gr_wake(r: u32, ) -> Weight {
 		(170_137_000 as Weight)
@@ -867,6 +881,18 @@ impl WeightInfo for () {
 		(112_271_000 as Weight)
 			// Standard Error: 280_000
 			.saturating_add((23_250_000 as Weight).saturating_mul(r as Weight))
+	}
+	fn gr_wait_for(r: u32, ) -> Weight {
+		(72_800_000 as Weight)
+			// Standard Error: 851_000
+			.saturating_add((41_000_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(RocksDbWeight::get().reads((4 as Weight).saturating_mul(r as Weight)))
+	}
+	fn gr_wait_no_more(r: u32, ) -> Weight {
+		(74_000_000 as Weight)
+			// Standard Error: 611_000
+			.saturating_add((43_200_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(RocksDbWeight::get().reads((4 as Weight).saturating_mul(r as Weight)))
 	}
 	fn gr_wake(r: u32, ) -> Weight {
 		(170_137_000 as Weight)

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear-node"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 1640,
+    spec_version: 1650,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -86,7 +86,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1640,
+    spec_version: 1650,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/utils/wasm-proc/metadata-js/index.js
+++ b/utils/wasm-proc/metadata-js/index.js
@@ -40,6 +40,8 @@ exports.getWasmMetadata = async (wasmBytes) => {
             gr_reply_to: () => { },
             gr_value: () => { },
             gr_wait: () => { },
+            gr_wait_for: () => { },
+            gr_wait_no_more: () => { },
             gr_wake: () => { },
             gr_error: () => { },
         }


### PR DESCRIPTION
Resolves #1173.
Part of #349.

This PR adds functionality to limit holding in waitlist from contracts side:
`gr_wait` - wait as much as possible
`gr_wait_for` - wait exactly for duration
`gr_wait_no_more` - wait as much as possible, but not more than given duration

**Release notes:** see changes and related issues above.

