### PR TITLE
Bugfix: `gr_read`, `gr_size` economic and memory

### DIFF
--- a/core-backend/sandbox/src/runtime.rs
+++ b/core-backend/sandbox/src/runtime.rs
@@ -17,15 +17,32 @@ pub(crate) struct Runtime<'a, E: Ext> {
     pub err: FuncError<E::Error>,
 }
 
+impl<'a, E: Ext> Runtime<'a, E>
+where
+    E: Ext + IntoExtInfo + 'static,
+    E::Error: AsTerminationReason + IntoExtError,
+{
+    pub(crate) fn write_validated_output(
+        &mut self,
+        out_ptr: u32,
+        f: impl FnOnce(&mut E) -> Result<&[u8], FuncError<E::Error>>,
+    ) -> Result<(), FuncError<E::Error>> {
+        let buf = f(self.ext)?;
+
+        self.memory
+            .set(out_ptr, buf)
+            .map_err(|_| MemoryError::OutOfBounds)?;
+
+        Ok(())
+    }
+}
+
 impl<'a, E> RuntimeCtx<E> for Runtime<'a, E>
 where
     E: Ext + IntoExtInfo + 'static,
     E::Error: AsTerminationReason + IntoExtError,
 {
-    fn alloc(
-        &mut self,
-        pages: u32,
-    ) -> Result<gear_core::memory::WasmPageNumber, <E as Ext>::Error> {
+    fn alloc(&mut self, pages: u32) -> Result<gear_core::memory::WasmPageNumber, E::Error> {
         self.ext.alloc(pages.into(), self.memory_wrap)
     }
 

--- a/core-backend/wasmi/src/funcs.rs
+++ b/core-backend/wasmi/src/funcs.rs
@@ -330,26 +330,36 @@ where
         let len: usize = pop_i32(&mut args).map_err(|_| FuncError::HostError)?;
         let dest = pop_i32(&mut args).map_err(|_| FuncError::HostError)?;
 
-        let mut f = || {
-            let msg = ctx.ext.msg().to_vec();
+        ctx.write_validated_output(dest, |ext| {
+            let msg = ext.read().map_err(FuncError::Core)?;
+
             let last_idx = at
                 .checked_add(len)
                 .ok_or(FuncError::ReadLenOverflow(at, len))?;
+
             if last_idx > msg.len() {
                 return Err(FuncError::ReadWrongRange(at..last_idx, msg.len()));
             }
-            // `[..]` is safe, because we check borders above.
-            ctx.write_output(dest, &msg[at..last_idx])
-                .map_err(Into::into)
-        };
-        f().map(|()| ReturnValue::Unit).map_err(|err| {
+
+            Ok(&msg[at..last_idx])
+        })
+        .map(|()| ReturnValue::Unit)
+        .map_err(|err| {
             ctx.err = err;
             FuncError::HostError
         })
     }
 
     pub fn size(ctx: &mut Runtime<E>, _args: &[RuntimeValue]) -> SyscallOutput<E::Error> {
-        return_i32(ctx.ext.msg().len()).map_err(|_| FuncError::HostError)
+        let size = ctx.ext.size().map_err(FuncError::Core);
+
+        match size {
+            Ok(size) => return_i32(size).map_err(|_| FuncError::HostError),
+            Err(err) => {
+                ctx.err = err;
+                Err(FuncError::HostError)
+            }
+        }
     }
 
     pub fn exit(ctx: &mut Runtime<E>, args: &[RuntimeValue]) -> SyscallOutput<E::Error> {
@@ -394,7 +404,6 @@ where
                 if let Some(TerminationReason::GasAllowanceExceeded) = e
                     .as_core()
                     .and_then(AsTerminationReason::as_termination_reason)
-                    .cloned()
                 {
                     ctx.err = FuncError::Terminated(TerminationReason::GasAllowanceExceeded);
                 }

--- a/core-backend/wasmi/src/runtime.rs
+++ b/core-backend/wasmi/src/runtime.rs
@@ -17,16 +17,33 @@ pub struct Runtime<'a, E: Ext> {
     pub err: FuncError<E::Error>,
 }
 
+impl<'a, E: Ext> Runtime<'a, E>
+where
+    E: Ext + IntoExtInfo + 'static,
+    E::Error: AsTerminationReason + IntoExtError,
+{
+    pub(crate) fn write_validated_output(
+        &mut self,
+        out_ptr: u32,
+        f: impl FnOnce(&mut E) -> Result<&[u8], FuncError<E::Error>>,
+    ) -> Result<(), FuncError<E::Error>> {
+        let buf = f(self.ext)?;
+
+        self.memory
+            .set(out_ptr, buf)
+            .map_err(|_| MemoryError::OutOfBounds)?;
+
+        Ok(())
+    }
+}
+
 impl<'a, E> RuntimeCtx<E> for Runtime<'a, E>
 where
     E: Ext + IntoExtInfo + 'static,
     E::Error: AsTerminationReason + IntoExtError,
 {
-    fn alloc(
-        &mut self,
-        pages: u32,
-    ) -> Result<gear_core::memory::WasmPageNumber, <E as Ext>::Error> {
-        self.ext.alloc(pages.into(), self.memory_wrap)
+    fn alloc(&mut self, pages: u32) -> Result<gear_core::memory::WasmPageNumber, E::Error> {
+        (self.ext).alloc(pages.into(), self.memory_wrap)
     }
 
     fn read_memory(&self, ptr: u32, len: u32) -> Result<Vec<u8>, MemoryError> {

--- a/core-backend/wasmi/src/runtime.rs
+++ b/core-backend/wasmi/src/runtime.rs
@@ -17,7 +17,7 @@ pub struct Runtime<'a, E: Ext> {
     pub err: FuncError<E::Error>,
 }
 
-impl<'a, E: Ext> Runtime<'a, E>
+impl<'a, E> Runtime<'a, E>
 where
     E: Ext + IntoExtInfo + 'static,
     E::Error: AsTerminationReason + IntoExtError,

--- a/core-errors/src/lib.rs
+++ b/core-errors/src/lib.rs
@@ -110,6 +110,10 @@ pub enum MessageError {
         /// Amount of available value.
         value_left: u128,
     },
+
+    /// The error occurs when program receives too big payload.
+    #[display(fmt = "Received message with abnormal payload size")]
+    IncomingPayloadTooBig,
 }
 
 /// Memory error.

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -122,7 +122,10 @@ pub trait Ext {
     fn leave(&mut self) -> Result<(), Self::Error>;
 
     /// Access currently handled message payload.
-    fn msg(&mut self) -> &[u8];
+    fn read(&mut self) -> Result<&[u8], Self::Error>;
+
+    /// Size of currently handled message payload.
+    fn size(&mut self) -> Result<usize, Self::Error>;
 
     /// Default gas host call.
     fn gas(&mut self, amount: u32) -> Result<(), Self::Error>;
@@ -241,8 +244,11 @@ mod tests {
         fn debug(&mut self, _data: &str) -> Result<(), Self::Error> {
             Ok(())
         }
-        fn msg(&mut self) -> &[u8] {
-            &[]
+        fn read(&mut self) -> Result<&[u8], Self::Error> {
+            Ok(&[])
+        }
+        fn size(&mut self) -> Result<usize, Self::Error> {
+            Ok(0)
         }
         fn gas(&mut self, _amount: u32) -> Result<(), Self::Error> {
             Ok(())

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -291,8 +291,12 @@ impl EnvExt for LazyPagesExt {
         self.inner.debug(data).map_err(Error::Processor)
     }
 
-    fn msg(&mut self) -> &[u8] {
-        self.inner.msg()
+    fn read(&mut self) -> Result<&[u8], Self::Error> {
+        self.inner.read().map_err(Error::Processor)
+    }
+
+    fn size(&mut self) -> Result<usize, Self::Error> {
+        self.inner.size().map_err(Error::Processor)
     }
 
     fn charge_gas(&mut self, val: u64) -> Result<(), Self::Error> {

--- a/pallets/gear/src/weights.rs
+++ b/pallets/gear/src/weights.rs
@@ -260,19 +260,19 @@ impl<T: frame_system::Config> WeightInfo for GearWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 	}
 	fn gr_size(r: u32, ) -> Weight {
-		(115_701_000 as Weight)
-			// Standard Error: 91_000
-			.saturating_add((48_724_000 as Weight).saturating_mul(r as Weight))
+		(113_701_000 as Weight)
+			// Standard Error: 330_000
+			.saturating_add((51_210_000 as Weight).saturating_mul(r as Weight))
 	}
 	fn gr_read(r: u32, ) -> Weight {
-		(159_796_000 as Weight)
-			// Standard Error: 220_000
-			.saturating_add((69_793_000 as Weight).saturating_mul(r as Weight))
+		(140_564_000 as Weight)
+			// Standard Error: 305_000
+			.saturating_add((73_728_000 as Weight).saturating_mul(r as Weight))
 	}
 	fn gr_read_per_kb(n: u32, ) -> Weight {
-		(197_916_000 as Weight)
-			// Standard Error: 94_000
-			.saturating_add((30_106_000 as Weight).saturating_mul(n as Weight))
+		(207_021_000 as Weight)
+			// Standard Error: 75_000
+			.saturating_add((15_007_000 as Weight).saturating_mul(n as Weight))
 			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
 	}
 	fn gr_block_height(r: u32, ) -> Weight {

--- a/pallets/gear/src/weights.rs
+++ b/pallets/gear/src/weights.rs
@@ -260,19 +260,20 @@ impl<T: frame_system::Config> WeightInfo for GearWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 	}
 	fn gr_size(r: u32, ) -> Weight {
-		(116_813_000 as Weight)
-			// Standard Error: 200_000
-			.saturating_add((51_107_000 as Weight).saturating_mul(r as Weight))
+		(115_701_000 as Weight)
+			// Standard Error: 91_000
+			.saturating_add((48_724_000 as Weight).saturating_mul(r as Weight))
 	}
 	fn gr_read(r: u32, ) -> Weight {
-		(148_006_000 as Weight)
-			// Standard Error: 163_000
-			.saturating_add((71_441_000 as Weight).saturating_mul(r as Weight))
+		(159_796_000 as Weight)
+			// Standard Error: 220_000
+			.saturating_add((69_793_000 as Weight).saturating_mul(r as Weight))
 	}
 	fn gr_read_per_kb(n: u32, ) -> Weight {
-		(176_272_000 as Weight)
-			// Standard Error: 162_000
-			.saturating_add((33_383_000 as Weight).saturating_mul(n as Weight))
+		(197_916_000 as Weight)
+			// Standard Error: 94_000
+			.saturating_add((30_106_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
 	}
 	fn gr_block_height(r: u32, ) -> Weight {
 		(117_042_000 as Weight)

--- a/pallets/gear/src/weights.rs
+++ b/pallets/gear/src/weights.rs
@@ -273,7 +273,7 @@ impl<T: frame_system::Config> WeightInfo for GearWeight<T> {
 		(207_021_000 as Weight)
 			// Standard Error: 75_000
 			.saturating_add((15_007_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 	}
 	fn gr_block_height(r: u32, ) -> Weight {
 		(117_042_000 as Weight)
@@ -763,19 +763,20 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 	}
 	fn gr_size(r: u32, ) -> Weight {
-		(116_813_000 as Weight)
-			// Standard Error: 200_000
-			.saturating_add((51_107_000 as Weight).saturating_mul(r as Weight))
+		(113_701_000 as Weight)
+			// Standard Error: 330_000
+			.saturating_add((51_210_000 as Weight).saturating_mul(r as Weight))
 	}
 	fn gr_read(r: u32, ) -> Weight {
-		(148_006_000 as Weight)
-			// Standard Error: 163_000
-			.saturating_add((71_441_000 as Weight).saturating_mul(r as Weight))
+		(140_564_000 as Weight)
+			// Standard Error: 305_000
+			.saturating_add((73_728_000 as Weight).saturating_mul(r as Weight))
 	}
 	fn gr_read_per_kb(n: u32, ) -> Weight {
-		(176_272_000 as Weight)
-			// Standard Error: 162_000
-			.saturating_add((33_383_000 as Weight).saturating_mul(n as Weight))
+		(207_021_000 as Weight)
+			// Standard Error: 75_000
+			.saturating_add((15_007_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
 	}
 	fn gr_block_height(r: u32, ) -> Weight {
 		(117_042_000 as Weight)

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear-node"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 1660,
+    spec_version: 1670,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -86,7 +86,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1660,
+    spec_version: 1670,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Resolves #1359.

Also fixed bug, that we were allocating vector and copying elements every time we call `gr_read` (line 316):
https://github.com/gear-tech/gear/blob/d51697ce38daadf85942f1d11d8a9c95670f62f1/core-backend/sandbox/src/funcs.rs#L315-L326

Benchmark result of fixing mentioned above bug:
`gr_read_per_kb: 30_106_000 -> 15_007_000`

Resolving initial feature a bit increased `gr_read` + `gr_size` but its like 2-5%