### PR TITLE
Make pallet gear benchmarking able to run without lazy-pages

### DIFF
--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -36,12 +36,15 @@ use crate::{
     manager::{ExtManager, HandleKind},
     pallet,
     schedule::{API_BENCHMARK_BATCH_SIZE, INSTR_BENCHMARK_BATCH_SIZE},
-    BTreeMap, BalanceOf, BlockGasLimitOf, Call, Config, CurrencyOf, Ext as Externalities,
-    GasHandlerOf, MailboxOf, Pallet as Gear, Pallet, QueueOf, SandboxEnvironment, Schedule,
-    WaitlistOf,
+    BTreeMap, BalanceOf, BlockGasLimitOf, Call, Config, CostsPerBlockOf, CurrencyOf,
+    Ext as Externalities, GasHandlerOf, MailboxOf, Pallet as Gear, Pallet, QueueOf,
+    SandboxEnvironment, Schedule, WaitlistOf,
 };
 use codec::Encode;
-use common::{benchmarking, storage::*, CodeMetadata, CodeStorage, GasPrice, GasTree, Origin};
+use common::{
+    benchmarking, scheduler::SchedulingCostsPerBlock, storage::*, CodeMetadata, CodeStorage,
+    GasPrice, GasTree, Origin,
+};
 use core_processor::{
     configs::{AllocationsConfig, BlockConfig, BlockInfo, MessageExecutionContext},
     PrepareResult, PreparedMessageExecutionContext,
@@ -1569,7 +1572,7 @@ benchmarks! {
         } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 0u32.into())?;
     }: {
         core_processor::process::<
-            ext::LazyPagesExt,
+            Externalities,
             SandboxEnvironment,
         >(&block_config, context, memory_pages);
     }
@@ -1601,7 +1604,7 @@ benchmarks! {
         } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 0u32.into())?;
     }: {
         core_processor::process::<
-            ext::LazyPagesExt,
+            Externalities,
             SandboxEnvironment,
         >(&block_config, context, memory_pages);
     }

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear-node"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 1670,
+    spec_version: 1680,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -86,7 +86,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1670,
+    spec_version: 1680,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Resolves #1402 

- make explicit imports in benchmakring/mod.rs
- use corresponding externalities for core_processor

@gear-tech/dev 
