### PR TITLE
make big signal alt stack to be able run lazy pages in debug mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2658,7 +2658,9 @@ version = "0.1.0"
 dependencies = [
  "cfg-if",
  "derive_more",
+ "errno",
  "gear-core",
+ "libc",
  "log",
  "nix 0.25.0",
  "once_cell",

--- a/lazy-pages/Cargo.toml
+++ b/lazy-pages/Cargo.toml
@@ -21,6 +21,8 @@ static_assertions = "1.1"
 [target.'cfg(unix)'.dependencies]
 nix = "0.25"
 once_cell = "1.14"
+libc = "0.2"
+errno = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["excpt", "memoryapi"] }

--- a/lazy-pages/Cargo.toml
+++ b/lazy-pages/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gear-lazy-pages"
 version = "0.1.0"
 authors = ["Gear Technologies"]
-description = "Gear lazy pages support"
+description = "Gear lazy-pages support"
 edition = "2018"
 license = "GPL-3.0"
 homepage = "https://gear-tech.io"

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -252,7 +252,7 @@ pub enum InitError {
     CanNotSetUpSignalHandler(String),
 }
 
-/// Initialize lazy pages:
+/// Initialize lazy-pages once for process:
 /// 1) checks whether lazy pages is supported in current environment
 /// 2) set signals handler
 ///

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -282,6 +282,8 @@ unsafe fn init_internal<H: UserSignalHandler>(version: LazyPagesVersion) -> Resu
         return Err(NativePageSizeIsNotSuitable(ps));
     }
 
+    sys::init_for_thread();
+
     if let Err(err) = sys::setup_signal_handler::<H>() {
         return Err(CanNotSetUpSignalHandler(err.to_string()));
     }

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! Lazy pages support.
+//! Lazy-pages support.
 //! In runtime data for contract wasm memory pages can be loaded in lazy manner.
 //! All pages, which is supposed to be lazy, must be mprotected before contract execution.
 //! During execution data from storage is loaded for all pages, which has been accessed.
@@ -108,12 +108,12 @@ pub(crate) struct LazyPagesExecutionContext {
     pub wasm_mem_size: Option<u32>,
     /// Current program prefix in storage
     pub program_storage_prefix: Option<Vec<u8>>,
-    /// Wasm addresses of lazy pages, that have been read or write accessed at least once.
+    /// Wasm addresses of lazy-pages, that have been read or write accessed at least once.
     /// Lazy page here is page, which has `size = max(native_page_size, gear_page_size)`.
     pub accessed_pages_addrs: BTreeSet<WasmAddr>,
     /// End of stack wasm address. Default is `0`, which means,
     /// that wasm data has no stack region. It's not necessary to specify
-    /// this value, `lazy pages` uses it to identify memory, for which we
+    /// this value, `lazy-pages` uses it to identify memory, for which we
     /// can skip processing and this memory won't be protected. So, pages
     /// which lies before this value will never get into `released_pages`,
     /// which means that they will never be updated in storage.
@@ -126,10 +126,10 @@ thread_local! {
     // NOTE: here we suppose, that each contract is executed in separate thread.
     // Or may be in one thread but consequentially.
 
-    /// Lazy pages impl version. Different runtimes may require different impl of lazy pages functionality.
+    /// Lazy-pages impl version. Different runtimes may require different impl of lazy-pages functionality.
     /// NOTE: be dangerous when use it and pay attention process and thread initialization.
     static LAZY_PAGES_VERSION: RefCell<LazyPagesVersion> = RefCell::new(LazyPagesVersion::Version1);
-    /// Lazy pages context for current execution.
+    /// Lazy-pages context for current execution.
     static LAZY_PAGES_CONTEXT: RefCell<LazyPagesExecutionContext> = RefCell::new(Default::default());
 }
 
@@ -183,7 +183,7 @@ pub fn initialize_for_program(
 
         ctx.program_storage_prefix = Some(program_prefix);
 
-        log::trace!("Initialize lazy pages for current program: {:?}", ctx);
+        log::trace!("Initialize lazy-pages for current program: {:?}", ctx);
 
         Ok(())
     })
@@ -239,21 +239,21 @@ pub fn set_wasm_mem_size(size: WasmPageNumber) -> Result<(), WasmMemSizeError> {
     Ok(())
 }
 
-/// Returns vec of lazy pages which has been accessed
+/// Returns vec of lazy-pages which has been accessed
 pub fn get_released_pages() -> Vec<PageNumber> {
     LAZY_PAGES_CONTEXT.with(|ctx| ctx.borrow().released_pages.iter().copied().collect())
 }
 
 #[derive(Debug, Clone, derive_more::Display)]
 pub enum InitError {
-    #[display(fmt = "Native page size {:#x} is not suitable for lazy pages", _0)]
+    #[display(fmt = "Native page size {:#x} is not suitable for lazy-pages", _0)]
     NativePageSizeIsNotSuitable(usize),
     #[display(fmt = "Can not set signal handler: {}", _0)]
     CanNotSetUpSignalHandler(String),
 }
 
 /// Initialize lazy-pages once for process:
-/// 1) checks whether lazy pages is supported in current environment
+/// 1) checks whether lazy-pages is supported in current environment
 /// 2) set signals handler
 ///
 /// # Safety
@@ -283,18 +283,18 @@ unsafe fn init_for_process<H: UserSignalHandler>() -> Result<(), InitError> {
         .clone()
 }
 
-/// Initialize lazy pages for current thread.
+/// Initialize lazy-pages for current thread.
 pub fn init<H: UserSignalHandler>(version: LazyPagesVersion) -> bool {
     // Set version even if it has been already set, because it can be changed after runtime upgrade.
     LAZY_PAGES_VERSION.with(|v| *v.borrow_mut() = version);
 
     if let Err(err) = unsafe { init_for_process::<H>() } {
-        log::debug!("Cannot initialize lazy pages for process: {}", err);
+        log::debug!("Cannot initialize lazy-pages for process: {}", err);
         return false;
     }
 
     if let Err(err) = unsafe { sys::init_for_thread() } {
-        log::debug!("Cannot initialize lazy pages for thread: {}", err);
+        log::debug!("Cannot initialize lazy-pages for thread: {}", err);
         return false;
     }
 

--- a/lazy-pages/src/sys.rs
+++ b/lazy-pages/src/sys.rs
@@ -328,7 +328,7 @@ unsafe fn user_signal_handler_internal(
 }
 
 /// User signal handler. Logic depends on lazy pages version.
-/// For the most recent logic see "self::user_signal_handler_internal_v2"
+/// For the most recent logic see "self::user_signal_handler_internal"
 pub unsafe fn user_signal_handler(info: ExceptionInfo) -> Result<(), Error> {
     log::debug!("Interrupted, exception info = {:?}", info);
     LAZY_PAGES_CONTEXT.with(|ctx| user_signal_handler_internal(ctx.borrow_mut(), info))

--- a/lazy-pages/src/sys.rs
+++ b/lazy-pages/src/sys.rs
@@ -37,10 +37,10 @@ static_assertions::const_assert_eq!(PAGE_STORAGE_GRANULARITY, 0x4000);
 cfg_if! {
     if #[cfg(windows)] {
         mod windows;
-        pub use windows::*;
+        pub(crate) use windows::*;
     } else if #[cfg(unix)] {
         mod unix;
-        pub use unix::*;
+        pub(crate) use unix::*;
     } else {
         compile_error!("lazy pages are not supported on your system. Disable `lazy-pages` feature");
     }

--- a/lazy-pages/src/sys.rs
+++ b/lazy-pages/src/sys.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! Lazy pages signal handler functionality.
+//! Lazy-pages signal handler functionality.
 
 use cfg_if::cfg_if;
 use region::Protection;
@@ -30,7 +30,7 @@ use gear_core::memory::{PageNumber, PAGE_STORAGE_GRANULARITY};
 // so we make here additional checks. If somebody would change these values
 // in runtime, then he also should pay attention to support new values here:
 // 1) must rebuild node after that.
-// 2) must support old runtimes: need to make lazy pages version with old constants values.
+// 2) must support old runtimes: need to make lazy-pages version with old constants values.
 static_assertions::const_assert_eq!(PageNumber::size(), 0x1000);
 static_assertions::const_assert_eq!(PAGE_STORAGE_GRANULARITY, 0x4000);
 
@@ -42,7 +42,7 @@ cfg_if! {
         mod unix;
         pub(crate) use unix::*;
     } else {
-        compile_error!("lazy pages are not supported on your system. Disable `lazy-pages` feature");
+        compile_error!("lazy-pages are not supported on your system. Disable `lazy-pages` feature");
     }
 }
 
@@ -327,7 +327,7 @@ unsafe fn user_signal_handler_internal(
     Ok(())
 }
 
-/// User signal handler. Logic depends on lazy pages version.
+/// User signal handler. Logic depends on lazy-pages version.
 /// For the most recent logic see "self::user_signal_handler_internal"
 pub unsafe fn user_signal_handler(info: ExceptionInfo) -> Result<(), Error> {
     log::debug!("Interrupted, exception info = {:?}", info);

--- a/lazy-pages/src/sys/unix.rs
+++ b/lazy-pages/src/sys/unix.rs
@@ -124,7 +124,7 @@ enum ThreadInitError {
 fn init_for_thread_internal() -> Result<(), ThreadInitError> {
     use core::{mem, ptr};
 
-    // Should be enought for lazy pages signal handler
+    // Should be enough for lazy pages signal handler
     const STACK_SIZE: usize = 0x20000;
 
     enum StackInfo {
@@ -204,11 +204,11 @@ fn init_for_thread_internal() -> Result<(), ThreadInitError> {
     TLS.with(|tls| tls.as_ref().map(|_| ()).map_err(|err| *err))
 }
 
-pub(crate) unsafe fn init_for_thread() {
-    init_for_thread_internal().expect("Cannot initialize for thread");
+pub(crate) unsafe fn init_for_thread() -> Result<(), String> {
+    init_for_thread_internal().map_err(|err| err.to_string())
 }
 
-pub unsafe fn setup_signal_handler<H>() -> io::Result<()>
+pub(crate) unsafe fn setup_signal_handler<H>() -> io::Result<()>
 where
     H: UserSignalHandler,
 {

--- a/lazy-pages/src/sys/unix.rs
+++ b/lazy-pages/src/sys/unix.rs
@@ -189,7 +189,11 @@ fn init_for_thread_internal() -> Result<(), ThreadInitError> {
             return Err(ThreadInitError::SigAltStack(errno::errno()));
         }
 
-        log::debug!("Set new signal stack: ptr = {:?}, size = {:#x}", ptr, STACK_SIZE);
+        log::debug!(
+            "Set new signal stack: ptr = {:?}, size = {:#x}",
+            ptr,
+            STACK_SIZE
+        );
 
         Ok(StackInfo::NewStack {
             mmap_ptr: ptr,

--- a/lazy-pages/src/sys/windows.rs
+++ b/lazy-pages/src/sys/windows.rs
@@ -71,7 +71,7 @@ where
 
 pub(crate) fn init_for_thread() {}
 
-pub unsafe fn setup_signal_handler<H>() -> io::Result<()>
+pub(crate) unsafe fn setup_signal_handler<H>() -> io::Result<()>
 where
     H: UserSignalHandler,
 {

--- a/lazy-pages/src/sys/windows.rs
+++ b/lazy-pages/src/sys/windows.rs
@@ -50,11 +50,11 @@ where
     let is_write = match (*exception_record).ExceptionInformation[0] {
         0 /* read */ => Some(false),
         1 /* write */ => Some(true),
-        // we work with WASM memory which is handled by WASM executor 
+        // we work with WASM memory which is handled by WASM executor
         // (e.g. it reads and writes, but doesn't execute as native code)
         // that's why the case is impossible
         8 /* DEP */ => unreachable!("data execution prevention"),
-        // existence of other values is undocumented and I expect they should be treated as reserved 
+        // existence of other values is undocumented and I expect they should be treated as reserved
         _ => None,
     };
     let info = ExceptionInfo {
@@ -68,6 +68,8 @@ where
 
     EXCEPTION_CONTINUE_EXECUTION
 }
+
+pub(crate) fn init_for_thread() {}
 
 pub unsafe fn setup_signal_handler<H>() -> io::Result<()>
 where

--- a/lazy-pages/src/sys/windows.rs
+++ b/lazy-pages/src/sys/windows.rs
@@ -69,7 +69,9 @@ where
     EXCEPTION_CONTINUE_EXECUTION
 }
 
-pub(crate) fn init_for_thread() {}
+pub(crate) unsafe fn init_for_thread() -> Result<(), String> {
+    Ok(())
+}
 
 pub(crate) unsafe fn setup_signal_handler<H>() -> io::Result<()>
 where


### PR DESCRIPTION
Rust on linux allocates only 0x2000 bytes for signal alternative stack (equal to libc::SIGSTKSZ). This is not enough for debug build, because in debug code use too much of stack. So, we create our own alternative signal stack if existed stack is not big enough for lazy pages signal handler (suppose that signal stack size for macos M1 0x20000 is big enough).