### PR TITLE
Refactor `node-loader` to make it ready for multiple tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,6 +2835,7 @@ dependencies = [
 name = "gear-node-loader"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arbitrary",
  "color-eyre",
  "futures",

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -727,7 +727,7 @@ where
                         .unwrap()
                         .iter()
                         .for_each(|line| {
-                            println!("{}", line);
+                            println!("OK LOG from {:?}- {}", &thread::current().id(), line);
                         });
                 }
                 println!(

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -727,7 +727,7 @@ where
                         .unwrap()
                         .iter()
                         .for_each(|line| {
-                            println!("OK LOG from {:?}- {}", &thread::current().id(), line);
+                            println!("{}", &thread::current().id(), line);
                         });
                 }
                 println!(

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -727,7 +727,7 @@ where
                         .unwrap()
                         .iter()
                         .for_each(|line| {
-                            println!("{}", &thread::current().id(), line);
+                            println!("{}", line);
                         });
                 }
                 println!(

--- a/utils/node-loader/Cargo.toml
+++ b/utils/node-loader/Cargo.toml
@@ -21,3 +21,4 @@ structopt = "0.3.26"
 rand = { version = "0.8.0", features = ["small_rng"] }
 futures = "0.3.24"
 parking_lot = "0.12.1"
+anyhow = "1.0.65"

--- a/utils/node-loader/src/args.rs
+++ b/utils/node-loader/src/args.rs
@@ -1,5 +1,6 @@
 //! CLI args for the `gear-node-loader`
 
+use anyhow::Error;
 use std::str::FromStr;
 use structopt::StructOpt;
 
@@ -50,23 +51,23 @@ pub(crate) enum SeedVariant {
 }
 
 impl FromStr for SeedVariant {
-    type Err = String;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = s.to_lowercase();
         let input = s.split('=').collect::<Vec<_>>();
         if input.len() != 2 {
-            return Err(format!(
+            return Err(anyhow::anyhow!(
                 "Invalid seed argument format {s:?}. Must be 'seed_variant=num'"
             ));
         }
 
         let variant = input[0];
-        let num = input[1].parse::<u64>().map_err(|e| e.to_string())?;
+        let num = input[1].parse::<u64>()?;
         match variant {
             "start" => Ok(SeedVariant::Dynamic(num)),
             "constant" => Ok(SeedVariant::Constant(num)),
-            v => Err(format!("Invalid variant {v}")),
+            v => Err(anyhow::anyhow!("Invalid variant {v}")),
         }
     }
 }

--- a/utils/node-loader/src/args.rs
+++ b/utils/node-loader/src/args.rs
@@ -1,7 +1,6 @@
 //! CLI args for the `gear-node-loader`
 
 use std::str::FromStr;
-
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -29,8 +28,9 @@ pub(crate) struct LoadParams {
     /// start or constant. Start sets starting seed value for the generator.
     /// Constant sets constant seed which will be used in every test, therefore
     /// generated input data (for example, program) for each test will be the same.
-    #[structopt(long, short, default_value = "start=0")]
-    pub(crate) seed: SeedVariant,
+    /// Example value: `<seed_variant>=<seed_u64_value>`.
+    #[structopt(long, short)]
+    pub(crate) seed: Option<SeedVariant>,
 
     /// Desirable amount of threads.
     #[structopt(long, short, default_value = "1")]

--- a/utils/node-loader/src/args.rs
+++ b/utils/node-loader/src/args.rs
@@ -31,6 +31,10 @@ pub(crate) struct LoadParams {
     /// generated input data (for example, program) for each test will be the same.
     #[structopt(long, short, default_value = "start=0")]
     pub(crate) seed: SeedVariant,
+
+    /// Desirable amount of threads.
+    #[structopt(long, short, default_value = "1")]
+    pub(crate) threads: usize,
 }
 
 pub(crate) fn parse_cli_params() -> Params {

--- a/utils/node-loader/src/args.rs
+++ b/utils/node-loader/src/args.rs
@@ -3,7 +3,7 @@
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "node-hacker")]
+#[structopt(name = "node-loader")]
 pub(crate) struct Params {
     /// rpc node addr
     #[structopt(long, default_value = "ws://localhost:9944")]

--- a/utils/node-loader/src/args.rs
+++ b/utils/node-loader/src/args.rs
@@ -24,17 +24,19 @@ pub(crate) struct LoadParams {
     #[structopt(long, default_value = "//Alice")]
     pub(crate) user: String,
 
-    /// Seed for random seeds generation. There are either 2 seed variants:
-    /// start or constant. Start sets starting seed value for the generator.
-    /// Constant sets constant seed which will be used in every test, therefore
-    /// generated input data (for example, program) for each test will be the same.
+    /// Seed used to generate random seeds for various internal generators.
+    /// If the parameter isn't provided, then timestamp will be used by default.
+    /// There are either 2 seed variants: start or constant. Start sets starting
+    ///  seed value for the generator. Constant sets constant seed which will be
+    /// used in every test, therefore generated input data (for example, program)
+    /// for each test will be the same.
     /// Example value: `<seed_variant>=<seed_u64_value>`.
     #[structopt(long, short)]
     pub(crate) seed: Option<SeedVariant>,
 
-    /// Desirable amount of threads.
+    /// Desirable amount of workers in task pool.
     #[structopt(long, short, default_value = "1")]
-    pub(crate) threads: usize,
+    pub(crate) workers: usize,
 }
 
 pub(crate) fn parse_cli_params() -> Params {
@@ -43,7 +45,7 @@ pub(crate) fn parse_cli_params() -> Params {
 
 #[derive(Debug)]
 pub(crate) enum SeedVariant {
-    Start(u64),
+    Dynamic(u64),
     Constant(u64),
 }
 
@@ -62,7 +64,7 @@ impl FromStr for SeedVariant {
         let variant = input[0];
         let num = input[1].parse::<u64>().map_err(|e| e.to_string())?;
         match variant {
-            "start" => Ok(SeedVariant::Start(num)),
+            "start" => Ok(SeedVariant::Dynamic(num)),
             "constant" => Ok(SeedVariant::Constant(num)),
             v => Err(format!("Invalid variant {v}")),
         }

--- a/utils/node-loader/src/main.rs
+++ b/utils/node-loader/src/main.rs
@@ -5,21 +5,19 @@
 //! gets properly structured data acceptable by the gear node and randomizes it's "fields".
 //! That's why generated data is called semi-random.
 
-use std::{fs::File, io::Write, sync::Arc};
+use std::{fs::File, io::Write};
 
-use arbitrary::Unstructured;
-use gear_program::api::{generated::api::gear::calls::UploadProgram, Api};
-use gear_wasm_gen::GearConfig;
-use parking_lot::Mutex;
-use rand::{rngs::SmallRng, RngCore, SeedableRng};
+use rand::rngs::SmallRng;
 
-use args::{parse_cli_params, LoadParams, Params, SeedVariant};
-use reporter::Reporter;
-use task::TaskPool;
+use args::{parse_cli_params, LoadParams, Params};
+use task::{generators, TaskPool};
+
+use utils::Rng;
 
 mod args;
 mod reporter;
 mod task;
+mod utils;
 
 /// Main entry-point
 #[tokio::main]
@@ -40,71 +38,24 @@ async fn run() -> Result<(), String> {
 
 // todo use anyhow?
 fn dump_with_seed(seed: u64) -> Result<(), String> {
-    let code = gen_code_for_seed(seed);
+    let code = generators::generate_gear_program::<SmallRng>(seed);
     let mut file = File::create("out.wasm").map_err(|e| e.to_string())?;
     file.write_all(&code).map_err(|e| e.to_string())?;
     Ok(())
 }
 
 async fn load_node(params: LoadParams) -> Result<(), String> {
-    gear_program::keystore::login(&params.user, None).unwrap();
+    let gear_api = utils::obtain_gear_api(&params.endpoint, &params.user).await?;
+    let mut task_pool = TaskPool::<SmallRng>::try_new(params.threads, params.seed, gear_api)?;
 
-    let params = Arc::new(params);
-    let gear_api = gear_program::api::Api::new(Some(&params.endpoint))
-        .await
-        .unwrap();
-    let salt = Arc::new(Mutex::new(0));
-
-    let mut task_pool = TaskPool::try_new(params.threads)?;
     loop {
         let reporters = task_pool
-            .run(|| load_node_task(gear_api.clone(), Arc::clone(&salt), Arc::clone(&params)))
+            .run()
             .await
-            .expect("tmp");
-        reporters.into_iter().for_each(Reporter::report);
-    }
+            .map_err(|_| format!("Task pool run failed"))?;
 
-    Ok(())
-}
-
-async fn load_node_task(gear_api: Api, salt: Arc<Mutex<u32>>, params: Arc<LoadParams>) -> Reporter {
-    let signer = gear_api.try_signer(None).unwrap();
-    let (seed, salt) = match params.seed {
-        SeedVariant::Start(seed) => (SmallRng::seed_from_u64(seed).next_u64(), 0),
-        SeedVariant::Constant(num) => {
-            *salt.lock() += 1;
-            (num, *salt.lock())
+        for r in reporters {
+            r.report()?;
         }
-    };
-
-    let mut reporter = Reporter::new(seed);
-    let salt = format!("{:02}", salt);
-    reporter.record(format!("Run with salt = {}", salt));
-
-    let code = gen_code_for_seed(seed);
-    reporter.record(format!("Gen code size = {}", code.len()));
-
-    let params = UploadProgram {
-        code: code.clone(),
-        salt: hex::decode(salt.as_str()).unwrap(),
-        init_payload: hex::decode("00").unwrap(),
-        gas_limit: 250_000_000_000,
-        value: 0,
-    };
-
-    if let Err(e) = signer.submit_program(params).await {
-        reporter.record(format!("ERROR: {}", e));
-    } else {
-        reporter.record("Successfully receive response");
     }
-
-    reporter
-}
-
-fn gen_code_for_seed(seed: u64) -> Vec<u8> {
-    let mut rng = SmallRng::seed_from_u64(seed);
-    let mut buf = vec![0; 100_000];
-    rng.fill_bytes(&mut buf);
-    let mut u = Unstructured::new(&buf);
-    gear_wasm_gen::gen_gear_program_code(&mut u, GearConfig::default())
 }

--- a/utils/node-loader/src/main.rs
+++ b/utils/node-loader/src/main.rs
@@ -8,15 +8,12 @@
 use std::{fs::File, io::Write, sync::Arc};
 
 use arbitrary::Unstructured;
-use gear_program::{
-    api::{generated::api::gear::calls::UploadProgram, Api},
-    result::Result,
-};
+use gear_program::api::{generated::api::gear::calls::UploadProgram, Api};
 use gear_wasm_gen::GearConfig;
 use parking_lot::Mutex;
 use rand::{rngs::SmallRng, RngCore, SeedableRng};
 
-use args::{parse_cli_params, Params};
+use args::{parse_cli_params, LoadParams, Params, SeedVariant};
 use reporter::Reporter;
 use task::TaskPool;
 
@@ -24,23 +21,32 @@ mod args;
 mod reporter;
 mod task;
 
+/// Main entry-point
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() {
+    if let Err(e) = run().await {
+        eprintln!("{e:}");
+    }
+}
+
+async fn run() -> Result<(), String> {
     let params = parse_cli_params();
 
-    if let Some(seed) = params.dump_seed {
-        let code = gen_code_for_seed(seed);
-        let mut file = File::create("out.wasm").expect("Cannot create out.wasm file");
-        file.write_all(&code).expect("Cannot write bytes into file");
-        return Ok(());
+    match params {
+        Params::Dump { seed } => dump_with_seed(seed),
+        Params::Load(load_params) => load_node(load_params).await,
     }
+}
 
-    load_node(params).await;
-
+// todo use anyhow?
+fn dump_with_seed(seed: u64) -> Result<(), String> {
+    let code = gen_code_for_seed(seed);
+    let mut file = File::create("out.wasm").map_err(|e| e.to_string())?;
+    file.write_all(&code).map_err(|e| e.to_string())?;
     Ok(())
 }
 
-async fn load_node(params: Params) {
+async fn load_node(params: LoadParams) -> Result<(), String> {
     gear_program::keystore::login(&params.user, None).unwrap();
 
     let params = Arc::new(params);
@@ -48,37 +54,27 @@ async fn load_node(params: Params) {
         .await
         .unwrap();
     let salt = Arc::new(Mutex::new(0));
-    let seed_gen = Arc::new(Mutex::new(SmallRng::seed_from_u64(params.seed)));
 
-    let mut task_pool = TaskPool::new(&params);
+    let mut task_pool = TaskPool::new();
     loop {
         let reporters = task_pool
-            .run(|| {
-                load_node_task(
-                    gear_api.clone(),
-                    Arc::clone(&salt),
-                    Arc::clone(&seed_gen),
-                    Arc::clone(&params),
-                )
-            })
+            .run(|| load_node_task(gear_api.clone(), Arc::clone(&salt), Arc::clone(&params)))
             .await
             .expect("tmp");
         reporters.into_iter().for_each(Reporter::report);
     }
+
+    Ok(())
 }
 
-async fn load_node_task(
-    gear_api: Api,
-    salt: Arc<Mutex<u32>>,
-    seed_gen: Arc<Mutex<SmallRng>>,
-    params: Arc<Params>,
-) -> Reporter {
+async fn load_node_task(gear_api: Api, salt: Arc<Mutex<u32>>, params: Arc<LoadParams>) -> Reporter {
     let signer = gear_api.try_signer(None).unwrap();
-    let (seed, salt) = if let Some(seed) = params.only_seed {
-        *salt.lock() += 1;
-        (seed, *salt.lock())
-    } else {
-        (seed_gen.lock().next_u64(), 0)
+    let (seed, salt) = match params.seed {
+        SeedVariant::Start(seed) => (SmallRng::seed_from_u64(seed).next_u64(), 0),
+        SeedVariant::Constant(num) => {
+            *salt.lock() += 1;
+            (num, *salt.lock())
+        }
     };
 
     let mut reporter = Reporter::new(seed);

--- a/utils/node-loader/src/main.rs
+++ b/utils/node-loader/src/main.rs
@@ -46,7 +46,7 @@ fn dump_with_seed(seed: u64) -> Result<(), String> {
 
 async fn load_node(params: LoadParams) -> Result<(), String> {
     let gear_api = utils::obtain_gear_api(&params.endpoint, &params.user).await?;
-    let mut task_pool = TaskPool::<SmallRng>::try_new(params.threads, params.seed, gear_api)?;
+    let mut task_pool = TaskPool::<SmallRng>::try_new(params.workers, params.seed, gear_api)?;
 
     loop {
         let reporters = task_pool

--- a/utils/node-loader/src/main.rs
+++ b/utils/node-loader/src/main.rs
@@ -36,7 +36,6 @@ async fn run(params: Params) -> Result<()> {
     }
 }
 
-// todo use anyhow?
 fn dump_with_seed(seed: u64) -> Result<()> {
     let code = generators::generate_gear_program::<SmallRng>(seed);
     let mut file = File::create("out.wasm")?;

--- a/utils/node-loader/src/main.rs
+++ b/utils/node-loader/src/main.rs
@@ -24,6 +24,7 @@ mod utils;
 async fn main() {
     if let Err(e) = run().await {
         eprintln!("{e:}");
+        std::process::exit(1);
     }
 }
 

--- a/utils/node-loader/src/main.rs
+++ b/utils/node-loader/src/main.rs
@@ -55,7 +55,7 @@ async fn load_node(params: LoadParams) -> Result<(), String> {
         .unwrap();
     let salt = Arc::new(Mutex::new(0));
 
-    let mut task_pool = TaskPool::new();
+    let mut task_pool = TaskPool::try_new(params.threads)?;
     loop {
         let reporters = task_pool
             .run(|| load_node_task(gear_api.clone(), Arc::clone(&salt), Arc::clone(&params)))

--- a/utils/node-loader/src/reporter.rs
+++ b/utils/node-loader/src/reporter.rs
@@ -1,0 +1,35 @@
+//! Reporter for each task used as an in-memory
+//! logger to solve logs jumbling problem in a
+//! multithreaded environment.
+
+// todo use cow?
+// todo make macro to use "{}" stuff instead of data argument in `record`
+#[derive(Debug)]
+pub(crate) struct Reporter {
+    seed: u64,
+    reports: Vec<String>
+}
+
+impl Reporter {
+    pub(crate) fn new(id: u64) -> Self {
+        Self {
+            seed: id,
+            reports: Vec::new(),
+        }
+    }
+
+    pub(crate) fn record(&mut self, data: impl ToString) {
+        self.reports.push(data.to_string());
+    }
+
+    pub(crate) fn report(self) {
+        println!("Reporter with seed {} reports:", self.seed);
+        println!("==============================================");
+        self.reports.into_iter().for_each(|record| {
+            println!("{record:?}");
+        });
+        println!("==============================================\n");
+    }
+}
+
+

--- a/utils/node-loader/src/reporter.rs
+++ b/utils/node-loader/src/reporter.rs
@@ -7,7 +7,7 @@
 #[derive(Debug)]
 pub(crate) struct Reporter {
     seed: u64,
-    reports: Vec<String>
+    reports: Vec<String>,
 }
 
 impl Reporter {
@@ -31,5 +31,3 @@ impl Reporter {
         println!("==============================================\n");
     }
 }
-
-

--- a/utils/node-loader/src/reporter.rs
+++ b/utils/node-loader/src/reporter.rs
@@ -13,7 +13,6 @@ pub(crate) trait Reporter: Send {
     fn report(&self) -> Result<(), String>;
 }
 
-// todo use cow?
 // todo make macro to use "{}" stuff instead of data argument in `record`
 #[derive(Debug)]
 pub(crate) struct StdoutReporter {

--- a/utils/node-loader/src/reporter.rs
+++ b/utils/node-loader/src/reporter.rs
@@ -2,15 +2,17 @@
 //! logger to solve logs jumbling problem in a
 //! multithreaded environment.
 
+use anyhow::Result;
+
 pub(crate) type SomeReporter = Box<dyn Reporter>;
 
 pub(crate) trait Reporter: Send {
     /// Save data to reported later.
-    fn record(&mut self, data: String) -> Result<(), String>;
+    fn record(&mut self, data: String) -> Result<()>;
 
     /// Report saved data into any destination either file, socket
     /// or stdout.
-    fn report(&self) -> Result<(), String>;
+    fn report(&self) -> Result<()>;
 }
 
 // todo make macro to use "{}" stuff instead of data argument in `record`
@@ -30,12 +32,12 @@ impl StdoutReporter {
 }
 
 impl Reporter for StdoutReporter {
-    fn record(&mut self, data: String) -> Result<(), String> {
+    fn record(&mut self, data: String) -> Result<()> {
         self.reports.push(data);
         Ok(())
     }
 
-    fn report(&self) -> Result<(), String> {
+    fn report(&self) -> Result<()> {
         println!("Reporter with seed {} reports:", self.id);
         println!("==============================================");
         self.reports.iter().for_each(|record| {

--- a/utils/node-loader/src/task.rs
+++ b/utils/node-loader/src/task.rs
@@ -6,10 +6,20 @@ use tokio::task::JoinHandle;
 pub(crate) struct TaskPool<T>(Vec<JoinHandle<T>>);
 
 impl<T> TaskPool<T> {
-    const POOL_SIZE: usize = 100;
+    pub(crate) const MIN_SIZE: usize = 1;
+    pub(crate) const MAX_SIZE: usize = 100;
 
-    pub(crate) fn new() -> Self {
-        Self(Vec::with_capacity(Self::POOL_SIZE))
+    pub(crate) fn try_new(size: usize) -> Result<Self, String> {
+        if size >= Self::MIN_SIZE && size <= Self::MAX_SIZE {
+            Ok(Self(Vec::with_capacity(size)))
+        } else {
+            Err(format!(
+                "Can't create task pool with such size {size:?}. \
+                Allowed minimum size is {:?} and maximum {:?}",
+                Self::MIN_SIZE,
+                Self::MAX_SIZE,
+            ))
+        }
     }
 
     pub(crate) async fn run<Job>(&mut self, job_wrap: impl Fn() -> Job) -> Result<Vec<T>, ()>

--- a/utils/node-loader/src/task.rs
+++ b/utils/node-loader/src/task.rs
@@ -1,0 +1,36 @@
+use std::fmt::Debug;
+
+use tokio::task::JoinHandle;
+use futures::Future;
+
+use super::args::Params;
+
+pub(crate) struct TaskPool<T>(Vec<JoinHandle<T>>);
+
+impl<T> TaskPool<T> {
+    pub(crate) fn new(params: &Params) -> Self {
+        Self(Vec::with_capacity(params.workers as usize))
+    }
+
+    pub(crate) async fn run<Job>(&mut self, job_wrap: impl Fn() -> Job) -> Result<Vec<T>, ()>
+    where
+        Job: Future<Output = T> + Send + 'static,
+        T: Debug + Send + 'static,
+    {
+        let Self(tasks) = self;
+        let mut results = Vec::with_capacity(tasks.capacity());
+
+        tasks.clear();
+        while tasks.len() != tasks.capacity() {
+            let task = tokio::spawn(job_wrap());
+            tasks.push(task)
+        }
+
+        for task in tasks {
+            let res = task.await.map_err(|_| ())?;
+            results.push(res);
+        }
+
+        Ok(results)
+    }
+}

--- a/utils/node-loader/src/task.rs
+++ b/utils/node-loader/src/task.rs
@@ -12,7 +12,7 @@ mod upload_program;
 pub(crate) struct TaskPool<Rng: crate::Rng> {
     up_task_gen: UploadProgramTaskGen,
     tasks: Vec<JoinHandle<SomeReporter>>,
-    _phantom: PhantomData<Rng>
+    _phantom: PhantomData<Rng>,
 }
 
 impl<Rng: crate::Rng> TaskPool<Rng> {
@@ -23,8 +23,7 @@ impl<Rng: crate::Rng> TaskPool<Rng> {
         size: usize,
         seed_variant: Option<SeedVariant>,
         gear_api: Api,
-    ) -> Result<Self, String> 
-    {
+    ) -> Result<Self, String> {
         if size >= Self::MIN_SIZE && size <= Self::MAX_SIZE {
             Ok(Self {
                 up_task_gen: UploadProgramTaskGen::try_new(
@@ -32,7 +31,7 @@ impl<Rng: crate::Rng> TaskPool<Rng> {
                     generators::get_some_seed_generator::<Rng>(seed_variant),
                 ),
                 tasks: Vec::with_capacity(size),
-                _phantom: PhantomData
+                _phantom: PhantomData,
             })
         } else {
             Err(format!(

--- a/utils/node-loader/src/task.rs
+++ b/utils/node-loader/src/task.rs
@@ -1,15 +1,15 @@
 use std::fmt::Debug;
 
-use tokio::task::JoinHandle;
 use futures::Future;
-
-use super::args::Params;
+use tokio::task::JoinHandle;
 
 pub(crate) struct TaskPool<T>(Vec<JoinHandle<T>>);
 
 impl<T> TaskPool<T> {
-    pub(crate) fn new(params: &Params) -> Self {
-        Self(Vec::with_capacity(params.workers as usize))
+    const POOL_SIZE: usize = 100;
+
+    pub(crate) fn new() -> Self {
+        Self(Vec::with_capacity(Self::POOL_SIZE))
     }
 
     pub(crate) async fn run<Job>(&mut self, job_wrap: impl Fn() -> Job) -> Result<Vec<T>, ()>

--- a/utils/node-loader/src/task/generators.rs
+++ b/utils/node-loader/src/task/generators.rs
@@ -1,0 +1,47 @@
+use arbitrary::Unstructured;
+use rand::RngCore;
+
+use crate::{args::SeedVariant, utils::{now, self}};
+
+pub(crate) fn get_some_seed_generator<Rng: utils::Rng>(seed_variant: Option<SeedVariant>) -> Box<dyn RngCore> {
+    match seed_variant {
+        None => Box::new(Rng::seed_from_u64(now())) as Box<dyn RngCore>,
+        Some(SeedVariant::Start(v)) => Box::new(Rng::seed_from_u64(v)) as Box<dyn RngCore>,
+        Some(SeedVariant::Constant(v)) => Box::new(ConstantGenerator::new(v)) as Box<dyn RngCore>,
+    }
+}
+
+pub(crate) fn generate_gear_program<Rng: utils::Rng>(seed: u64) -> Vec<u8> {
+    let mut rng = Rng::seed_from_u64(seed);
+    let mut buf = vec![0; 100_000];
+    rng.fill_bytes(&mut buf);
+    let mut u = Unstructured::new(&buf);
+    gear_wasm_gen::gen_gear_program_code(&mut u, gear_wasm_gen::GearConfig::default())
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ConstantGenerator(u64);
+
+impl ConstantGenerator {
+    pub(crate) fn new(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+impl RngCore for ConstantGenerator {
+    fn next_u32(&mut self) -> u32 {
+        self.0 as u32
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0
+    }
+
+    fn fill_bytes(&mut self, _dest: &mut [u8]) {
+        unimplemented!()
+    }
+
+    fn try_fill_bytes(&mut self, _dest: &mut [u8]) -> Result<(), rand::Error> {
+        unimplemented!()
+    }
+}

--- a/utils/node-loader/src/task/generators.rs
+++ b/utils/node-loader/src/task/generators.rs
@@ -1,12 +1,17 @@
 use arbitrary::Unstructured;
 use rand::RngCore;
 
-use crate::{args::SeedVariant, utils::{now, self}};
+use crate::{
+    args::SeedVariant,
+    utils::{self, now},
+};
 
-pub(crate) fn get_some_seed_generator<Rng: utils::Rng>(seed_variant: Option<SeedVariant>) -> Box<dyn RngCore> {
+pub(crate) fn get_some_seed_generator<Rng: utils::Rng>(
+    seed_variant: Option<SeedVariant>,
+) -> Box<dyn RngCore> {
     match seed_variant {
         None => Box::new(Rng::seed_from_u64(now())) as Box<dyn RngCore>,
-        Some(SeedVariant::Start(v)) => Box::new(Rng::seed_from_u64(v)) as Box<dyn RngCore>,
+        Some(SeedVariant::Dynamic(v)) => Box::new(Rng::seed_from_u64(v)) as Box<dyn RngCore>,
         Some(SeedVariant::Constant(v)) => Box::new(ConstantGenerator::new(v)) as Box<dyn RngCore>,
     }
 }

--- a/utils/node-loader/src/task/upload_program.rs
+++ b/utils/node-loader/src/task/upload_program.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use futures::Future;
 use gear_program::api::{generated::api::gear::calls::UploadProgram, Api};
 use rand::RngCore;
@@ -14,7 +15,7 @@ pub(crate) struct UploadProgramTaskGen {
 }
 
 impl UploadProgramTaskGen {
-    pub(super) fn try_new(gear_api: Api, code_rand_gen: Box<dyn RngCore>) -> Self {
+    pub(super) fn new(gear_api: Api, code_rand_gen: Box<dyn RngCore>) -> Self {
         Self {
             code_seed_gen: code_rand_gen,
             gear_api,
@@ -23,14 +24,16 @@ impl UploadProgramTaskGen {
 
     pub(super) fn gen<Rng: utils::Rng>(
         &mut self,
-    ) -> impl Future<Output = SomeReporter> + Send + 'static {
+    ) -> impl Future<Output = Result<SomeReporter>> + Send + 'static {
         upload_program_task::<Rng>(self.gear_api.clone(), self.code_seed_gen.next_u64())
     }
 }
 
-async fn upload_program_task<Rng: utils::Rng>(gear_api: Api, code_gen_seed: u64) -> SomeReporter {
-    // todo avoid panics
-    let signer = gear_api.try_signer(None).unwrap();
+async fn upload_program_task<Rng: utils::Rng>(
+    gear_api: Api,
+    code_gen_seed: u64,
+) -> Result<SomeReporter> {
+    let signer = gear_api.try_signer(None)?;
 
     let mut reporter = StdoutReporter::new(code_gen_seed);
 
@@ -48,8 +51,8 @@ async fn upload_program_task<Rng: utils::Rng>(gear_api: Api, code_gen_seed: u64)
     if let Err(e) = signer.submit_program(payload).await {
         let _ = reporter.record(format!("ERROR: {}", e));
     } else {
-        let _ = reporter.record("Successfully receive response".into());
+        let _ = reporter.record("Successfully received response".into());
     }
 
-    Box::new(reporter)
+    Ok(Box::new(reporter))
 }

--- a/utils/node-loader/src/task/upload_program.rs
+++ b/utils/node-loader/src/task/upload_program.rs
@@ -1,6 +1,6 @@
 use futures::Future;
-use rand::RngCore;
 use gear_program::api::{generated::api::gear::calls::UploadProgram, Api};
+use rand::RngCore;
 
 use crate::{
     reporter::{Reporter, SomeReporter, StdoutReporter},
@@ -21,7 +21,9 @@ impl UploadProgramTaskGen {
         }
     }
 
-    pub(super) fn gen<Rng: utils::Rng>(&mut self) -> impl Future<Output = SomeReporter> + Send + 'static {
+    pub(super) fn gen<Rng: utils::Rng>(
+        &mut self,
+    ) -> impl Future<Output = SomeReporter> + Send + 'static {
         upload_program_task::<Rng>(self.gear_api.clone(), self.code_seed_gen.next_u64())
     }
 }

--- a/utils/node-loader/src/task/upload_program.rs
+++ b/utils/node-loader/src/task/upload_program.rs
@@ -1,0 +1,53 @@
+use futures::Future;
+use rand::RngCore;
+use gear_program::api::{generated::api::gear::calls::UploadProgram, Api};
+
+use crate::{
+    reporter::{Reporter, SomeReporter, StdoutReporter},
+    task::generators,
+    utils,
+};
+
+pub(crate) struct UploadProgramTaskGen {
+    gear_api: Api,
+    code_seed_gen: Box<dyn RngCore>,
+}
+
+impl UploadProgramTaskGen {
+    pub(super) fn try_new(gear_api: Api, code_rand_gen: Box<dyn RngCore>) -> Self {
+        Self {
+            code_seed_gen: code_rand_gen,
+            gear_api,
+        }
+    }
+
+    pub(super) fn gen<Rng: utils::Rng>(&mut self) -> impl Future<Output = SomeReporter> + Send + 'static {
+        upload_program_task::<Rng>(self.gear_api.clone(), self.code_seed_gen.next_u64())
+    }
+}
+
+async fn upload_program_task<Rng: utils::Rng>(gear_api: Api, code_gen_seed: u64) -> SomeReporter {
+    // todo avoid panics
+    let signer = gear_api.try_signer(None).unwrap();
+
+    let mut reporter = StdoutReporter::new(code_gen_seed);
+
+    let code = generators::generate_gear_program::<Rng>(code_gen_seed);
+    let _ = reporter.record(format!("Gen code size = {}", code.len()));
+
+    let payload = UploadProgram {
+        code: code.clone(),
+        salt: hex::decode("00").unwrap(),
+        init_payload: hex::decode("00").unwrap(),
+        gas_limit: 250_000_000_000,
+        value: 0,
+    };
+
+    if let Err(e) = signer.submit_program(payload).await {
+        let _ = reporter.record(format!("ERROR: {}", e));
+    } else {
+        let _ = reporter.record("Successfully receive response".into());
+    }
+
+    Box::new(reporter)
+}

--- a/utils/node-loader/src/utils.rs
+++ b/utils/node-loader/src/utils.rs
@@ -16,4 +16,3 @@ pub(crate) async fn obtain_gear_api(endpoint: &str, user: &str) -> Result<Api, S
 
 pub(crate) trait Rng: RngCore + SeedableRng + 'static {}
 impl<T: RngCore + SeedableRng + 'static> Rng for T {}
-

--- a/utils/node-loader/src/utils.rs
+++ b/utils/node-loader/src/utils.rs
@@ -1,6 +1,8 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
 use gear_program::{api::Api, keystore};
 use rand::{RngCore, SeedableRng};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 pub(crate) fn now() -> u64 {
     let time_since_epoch = SystemTime::now()
@@ -9,9 +11,9 @@ pub(crate) fn now() -> u64 {
     time_since_epoch.as_millis() as u64
 }
 
-pub(crate) async fn obtain_gear_api(endpoint: &str, user: &str) -> Result<Api, String> {
-    keystore::login(user, None).map_err(|e| e.to_string())?;
-    Api::new(Some(endpoint)).await.map_err(|e| e.to_string())
+pub(crate) async fn obtain_gear_api(endpoint: &str, user: &str) -> Result<Api> {
+    keystore::login(user, None)?;
+    Api::new(Some(endpoint)).await.map_err(|e| e.into())
 }
 
 pub(crate) trait Rng: RngCore + SeedableRng + 'static {}

--- a/utils/node-loader/src/utils.rs
+++ b/utils/node-loader/src/utils.rs
@@ -1,0 +1,19 @@
+use gear_program::{api::Api, keystore};
+use rand::{RngCore, SeedableRng};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub(crate) fn now() -> u64 {
+    let time_since_epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("internal error: current time before UNIX Epoch");
+    time_since_epoch.as_millis() as u64
+}
+
+pub(crate) async fn obtain_gear_api(endpoint: &str, user: &str) -> Result<Api, String> {
+    keystore::login(user, None).map_err(|e| e.to_string())?;
+    Api::new(Some(endpoint)).await.map_err(|e| e.to_string())
+}
+
+pub(crate) trait Rng: RngCore + SeedableRng + 'static {}
+impl<T: RngCore + SeedableRng + 'static> Rng for T {}
+


### PR DESCRIPTION
Resolves #1502 .

- Separate models and logic into corresponding types and modules
- Implement in-memory logger which avoids logs jumbling  
