### PR TITLE
Remove deprecated functions from `gstd` and rename syscall

### DIFF
--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -145,7 +145,7 @@ where
         builder.add_func("gr_value_available", Funcs::value_available);
         builder.add_func("gr_wait", Funcs::wait);
         builder.add_func("gr_wait_for", Funcs::wait_for);
-        builder.add_func("gr_wait_no_more", Funcs::wait_no_more);
+        builder.add_func("gr_wait_up_to", Funcs::wait_up_to);
         builder.add_func("gr_wake", Funcs::wake);
         let mut env_builder: EnvironmentDefinitionBuilder<_> = builder.into();
 

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -782,14 +782,14 @@ where
         Err(HostError)
     }
 
-    pub fn wait_no_more(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
+    pub fn wait_up_to(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
         let mut args = args.iter();
 
         let duration_ptr = pop_i32(&mut args)?;
 
         let mut f = || {
             let duration: u32 = ctx.read_memory_as(duration_ptr)?;
-            ctx.ext.wait_no_more(duration).map_err(FuncError::Core)?;
+            ctx.ext.wait_up_to(duration).map_err(FuncError::Core)?;
             Ok(Some(duration))
         };
 

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -352,7 +352,7 @@ where
         builder.add_host_func("env", "gr_value_available", Funcs::value_available);
         builder.add_host_func("env", "gr_wait", Funcs::wait);
         builder.add_host_func("env", "gr_wait_for", Funcs::wait_for);
-        builder.add_host_func("env", "gr_wait_no_more", Funcs::wait_no_more);
+        builder.add_host_func("env", "gr_wait_up_to", Funcs::wait_up_to);
         builder.add_host_func("env", "gr_wake", Funcs::wake);
 
         let mem: MemoryRef = match MemoryInstance::alloc(Pages(mem_size.0 as usize), None) {

--- a/core-backend/wasmi/src/funcs.rs
+++ b/core-backend/wasmi/src/funcs.rs
@@ -805,14 +805,14 @@ where
         Err(FuncError::HostError)
     }
 
-    pub fn wait_no_more(ctx: &mut Runtime<E>, args: &[RuntimeValue]) -> SyscallOutput<E::Error> {
+    pub fn wait_up_to(ctx: &mut Runtime<E>, args: &[RuntimeValue]) -> SyscallOutput<E::Error> {
         let mut args = args.iter();
 
         let duration_ptr = pop_i32(&mut args).map_err(|_| FuncError::HostError)?;
 
         let mut f = || {
             let duration: u32 = ctx.read_memory_as(duration_ptr)?;
-            ctx.ext.wait_no_more(duration).map_err(FuncError::Core)?;
+            ctx.ext.wait_up_to(duration).map_err(FuncError::Core)?;
             Ok(Some(duration))
         };
 

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -621,7 +621,7 @@ impl EnvExt for Ext {
         Ok(())
     }
 
-    fn wait_no_more(&mut self, duration: u32) -> Result<(), Self::Error> {
+    fn wait_up_to(&mut self, duration: u32) -> Result<(), Self::Error> {
         self.charge_gas_runtime(RuntimeCosts::WaitNoMore)?;
 
         if duration == 0 {

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -622,7 +622,7 @@ impl EnvExt for Ext {
     }
 
     fn wait_up_to(&mut self, duration: u32) -> Result<(), Self::Error> {
-        self.charge_gas_runtime(RuntimeCosts::WaitNoMore)?;
+        self.charge_gas_runtime(RuntimeCosts::WaitUpTo)?;
 
         if duration == 0 {
             return self.return_and_store_err(Err(WaitError::InvalidArgument));

--- a/core/src/costs.rs
+++ b/core/src/costs.rs
@@ -112,8 +112,8 @@ pub struct HostFnWeights {
     /// Weight of calling `gr_wait_for`.
     pub gr_wait_for: u64,
 
-    /// Weight of calling `gr_wait_no_more`.
-    pub gr_wait_no_more: u64,
+    /// Weight of calling `gr_wait_up_to`.
+    pub gr_wait_up_to: u64,
 
     /// Weight of calling `gr_wake`.
     pub gr_wake: u64,
@@ -207,7 +207,7 @@ pub enum RuntimeCosts {
     Wait,
     /// Weight of calling `gr_wait_for`.
     WaitFor,
-    /// Weight of calling `gr_wait_no_more`.
+    /// Weight of calling `gr_wait_up_to`.
     WaitNoMore,
     /// Weight of calling `gr_wake`.
     Wake,
@@ -255,7 +255,7 @@ impl RuntimeCosts {
             Leave => s.gr_leave,
             Wait => s.gr_wait,
             WaitFor => s.gr_wait_for,
-            WaitNoMore => s.gr_wait_no_more,
+            WaitNoMore => s.gr_wait_up_to,
             Wake => s.gr_wake,
             CreateProgram(len) => s
                 .gr_create_program_wgas

--- a/core/src/costs.rs
+++ b/core/src/costs.rs
@@ -208,7 +208,7 @@ pub enum RuntimeCosts {
     /// Weight of calling `gr_wait_for`.
     WaitFor,
     /// Weight of calling `gr_wait_up_to`.
-    WaitNoMore,
+    WaitUpTo,
     /// Weight of calling `gr_wake`.
     Wake,
     /// Weight of calling `gr_create_program_wgas`.
@@ -255,7 +255,7 @@ impl RuntimeCosts {
             Leave => s.gr_leave,
             Wait => s.gr_wait,
             WaitFor => s.gr_wait_for,
-            WaitNoMore => s.gr_wait_up_to,
+            WaitUpTo => s.gr_wait_up_to,
             Wake => s.gr_wake,
             CreateProgram(len) => s
                 .gr_create_program_wgas

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -156,7 +156,7 @@ pub trait Ext {
 
     /// Interrupt the program and reschedule execution for maximum,
     /// but not more than duration.
-    fn wait_no_more(&mut self, duration: u32) -> Result<(), Self::Error>;
+    fn wait_up_to(&mut self, duration: u32) -> Result<(), Self::Error>;
 
     /// Wake the waiting message and move it to the processing queue.
     fn wake(&mut self, waker_id: MessageId) -> Result<(), Self::Error>;
@@ -291,7 +291,7 @@ mod tests {
         fn wait_for(&mut self, _duration: u32) -> Result<(), Self::Error> {
             Ok(())
         }
-        fn wait_no_more(&mut self, _duration: u32) -> Result<(), Self::Error> {
+        fn wait_up_to(&mut self, _duration: u32) -> Result<(), Self::Error> {
             Ok(())
         }
         fn wake(&mut self, _waker_id: MessageId) -> Result<(), Self::Error> {

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -10,12 +10,6 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
@@ -33,23 +27,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
  "generic-array",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
 ]
 
 [[package]]
@@ -73,12 +55,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c5fdd0166095e1d463fc6cc01aa8ce547ad77a4e84d42eb6762b084e28067e"
 
 [[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,21 +73,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "curve25519-dalek"
-version = "2.1.3"
+name = "curve25519-dalek-ng"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b85542f99a2dfa2a1b8e192662741c9859a846b296bef1c92ef9b58b5a216"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
 dependencies = [
  "byteorder",
  "digest",
  "rand_core",
- "subtle",
+ "subtle-ng",
  "zeroize",
 ]
 
@@ -413,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
 ]
@@ -431,12 +416,6 @@ dependencies = [
  "static_assertions",
  "str-buf",
 ]
-
-[[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fixed-hash"
@@ -557,11 +536,12 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.4"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -659,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "merlin"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e261cf0f8b3c42ded9f7d2bb59dea03aa52bc8a1cbc7482f9fc3fd1229d3b42"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
@@ -671,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "page_size"
@@ -691,7 +671,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8b44461635bbb1a0300f100a841e571e7d919c81c73075ef5d152ffdb521066"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
@@ -763,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "room"
@@ -810,17 +790,17 @@ dependencies = [
 
 [[package]]
 name = "schnorrkel"
-version = "0.9.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021b403afe70d81eea68f6ea12f6b3c9588e5d536a94c3bf80f15e7faa267862"
+checksum = "844b7645371e6ecdf61ff246ba1958c29e802881a749ae3fb1993675d210d28d"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
- "curve25519-dalek",
+ "arrayvec",
+ "curve25519-dalek-ng",
  "merlin",
  "rand_core",
  "sha2",
- "subtle",
+ "subtle-ng",
  "zeroize",
 ]
 
@@ -838,13 +818,14 @@ checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 
 [[package]]
 name = "sha2"
-version = "0.8.2"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer",
+ "cfg-if",
+ "cpufeatures",
  "digest",
- "fake-simd",
  "opaque-debug",
 ]
 
@@ -861,10 +842,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0873cb29201126440dcc78d0b1f5a13d917e78831778429a7920ca9c7f3dae1e"
 
 [[package]]
-name = "subtle"
-version = "2.4.1"
+name = "subtle-ng"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
@@ -959,6 +940,12 @@ name = "unicode-xid"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "winapi"

--- a/examples/binaries/waiter/src/code.rs
+++ b/examples/binaries/waiter/src/code.rs
@@ -9,6 +9,6 @@ unsafe extern "C" fn handle() {
     match cmd {
         Command::Wait => exec::wait(),
         Command::WaitFor(duration) => exec::wait_for(duration),
-        Command::WaitNoMore(duration) => exec::wait_up_to(duration),
+        Command::WaitUpTo(duration) => exec::wait_up_to(duration),
     }
 }

--- a/examples/binaries/waiter/src/code.rs
+++ b/examples/binaries/waiter/src/code.rs
@@ -9,6 +9,6 @@ unsafe extern "C" fn handle() {
     match cmd {
         Command::Wait => exec::wait(),
         Command::WaitFor(duration) => exec::wait_for(duration),
-        Command::WaitNoMore(duration) => exec::wait_no_more(duration),
+        Command::WaitNoMore(duration) => exec::wait_up_to(duration),
     }
 }

--- a/examples/binaries/waiter/src/lib.rs
+++ b/examples/binaries/waiter/src/lib.rs
@@ -36,5 +36,5 @@ mod wasm {
 pub enum Command {
     Wait,
     WaitFor(u32),
-    WaitNoMore(u32),
+    WaitUpTo(u32),
 }

--- a/examples/light_sr25519/Cargo.toml
+++ b/examples/light_sr25519/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies.schnorrkel]
 version = "0.10.2"
 features = [
-	"preaudit_deprecated",
-	"u64_backend",
+    "preaudit_deprecated",
+    "u64_backend",
 ]
 default-features = false

--- a/examples/light_sr25519/Cargo.toml
+++ b/examples/light_sr25519/Cargo.toml
@@ -4,8 +4,10 @@ version = "0.1.0"
 authors = ["Gear Technologies"]
 edition = "2018"
 
-[dependencies]
-schnorrkel = { version = "0.9.1", features = [
+[dependencies.schnorrkel]
+version = "0.10.2"
+features = [
 	"preaudit_deprecated",
 	"u64_backend",
-], default-features = false }
+]
+default-features = false

--- a/gcore/src/exec.rs
+++ b/gcore/src/exec.rs
@@ -33,7 +33,7 @@ mod sys {
         pub fn gr_leave() -> !;
         pub fn gr_value_available(val: *mut u8);
         pub fn gr_wait() -> !;
-        pub fn gr_wait_no_more(duration: *const u8) -> !;
+        pub fn gr_wait_up_to(duration: *const u8) -> !;
         pub fn gr_wait_for(duration: *const u8) -> !;
         pub fn gr_wake(waker_id_ptr: *const u8);
     }
@@ -202,8 +202,8 @@ pub fn wait_for(duration: u32) -> ! {
 
 /// Same as [`wait`], but delays handling for maximal amount of blocks
 /// that could be payed, that doesn't exceed given duration.
-pub fn wait_no_more(duration: u32) -> ! {
-    unsafe { sys::gr_wait_no_more(duration.to_le_bytes().as_ptr()) }
+pub fn wait_up_to(duration: u32) -> ! {
+    unsafe { sys::gr_wait_up_to(duration.to_le_bytes().as_ptr()) }
 }
 
 /// Resume previously paused message handling.

--- a/gstd/src/async_runtime/futures.rs
+++ b/gstd/src/async_runtime/futures.rs
@@ -68,6 +68,6 @@ where
         super::futures().remove(&crate::msg::id());
     } else {
         // TODO: make this call configurable (#1380)
-        crate::exec::wait_no_more(100)
+        crate::exec::wait_up_to(100)
     }
 }

--- a/gstd/src/exec.rs
+++ b/gstd/src/exec.rs
@@ -80,7 +80,7 @@
 use crate::{ActorId, MessageId};
 pub use gcore::exec::{
     block_height, block_timestamp, gas_available, leave, value_available, wait, wait_for,
-    wait_no_more,
+    wait_up_to,
 };
 
 /// Terminate the execution of a program.

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -1590,15 +1590,15 @@ benchmarks! {
         >(&block_config, context, memory_pages);
     }
 
-    // We cannot call `gr_wait_no_more` multiple times. Therefore our weight determination is not
+    // We cannot call `gr_wait_up_to` multiple times. Therefore our weight determination is not
     // as precise as with other APIs.
-    gr_wait_no_more {
+    gr_wait_up_to {
         let r in 0 .. 1;
         let code = WasmModule::<T>::from(ModuleDefinition {
             memory: Some(ImportedMemory::max::<T>()),
             imported_functions: vec![ImportedFunction {
                 module: "env",
-                name: "gr_wait_no_more",
+                name: "gr_wait_up_to",
                 params: vec![ValueType::I32],
                 return_type: None,
             }],

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -338,8 +338,8 @@ impl EnvExt for LazyPagesExt {
         self.inner.wait_for(duration).map_err(Error::Processor)
     }
 
-    fn wait_no_more(&mut self, duration: u32) -> Result<(), Self::Error> {
-        self.inner.wait_no_more(duration).map_err(Error::Processor)
+    fn wait_up_to(&mut self, duration: u32) -> Result<(), Self::Error> {
+        self.inner.wait_up_to(duration).map_err(Error::Processor)
     }
 
     fn wake(&mut self, waker_id: MessageId) -> Result<(), Self::Error> {

--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -345,8 +345,8 @@ pub struct HostFnWeights<T: Config> {
     /// Weight of calling `gr_wait_for`.
     pub gr_wait_for: u64,
 
-    /// Weight of calling `gr_wait_no_more`.
-    pub gr_wait_no_more: u64,
+    /// Weight of calling `gr_wait_up_to`.
+    pub gr_wait_up_to: u64,
 
     /// Weight of calling `gr_wake`.
     pub gr_wake: u64,
@@ -579,7 +579,7 @@ impl<T: Config> HostFnWeights<T> {
             gr_leave: self.gr_leave,
             gr_wait: self.gr_wait,
             gr_wait_for: self.gr_wait_for,
-            gr_wait_no_more: self.gr_wait_no_more,
+            gr_wait_up_to: self.gr_wait_up_to,
             gr_wake: self.gr_wake,
             gr_create_program_wgas: self.gr_create_program_wgas,
             gr_create_program_wgas_per_byte: self.gr_create_program_wgas_per_byte,
@@ -620,7 +620,7 @@ impl<T: Config> Default for HostFnWeights<T> {
             gr_leave: cost!(gr_leave),
             gr_wait: cost!(gr_wait),
             gr_wait_for: cost!(gr_wait_for),
-            gr_wait_no_more: cost!(gr_wait_no_more),
+            gr_wait_up_to: cost!(gr_wait_up_to),
             gr_wake: cost_batched!(gr_wake),
             gr_create_program_wgas: cost!(gr_create_program_wgas),
             gr_create_program_wgas_per_byte: cost_byte_batched!(gr_create_program_wgas_per_kb),

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -2609,9 +2609,9 @@ fn test_different_waits_success() {
             expiration(duration)
         );
 
-        // Command::WaitNoMore case.
+        // Command::WaitUpTo case.
         let duration = 5;
-        let payload = Command::WaitNoMore(duration).encode();
+        let payload = Command::WaitUpTo(duration).encode();
         let wl_gas = duration_gas(duration) + reserve_gas + 100_000_000;
         let value = 0;
 
@@ -2736,8 +2736,8 @@ fn test_different_waits_fail() {
             ))),
         );
 
-        // Command::WaitNoMore case no gas.
-        let payload = Command::WaitNoMore(10).encode();
+        // Command::WaitUpTo case no gas.
+        let payload = Command::WaitUpTo(10).encode();
         let wl_gas = 0;
         let value = 0;
 
@@ -2807,8 +2807,8 @@ fn test_different_waits_fail() {
             ))),
         );
 
-        // Command::WaitNoMore case invalid argument.
-        let payload = Command::WaitNoMore(0).encode();
+        // Command::WaitUpTo case invalid argument.
+        let payload = Command::WaitUpTo(0).encode();
         let wl_gas = 10_000;
         let value = 0;
 
@@ -2816,7 +2816,7 @@ fn test_different_waits_fail() {
             USER_1.into_origin(),
             HandleKind::Handle(program_id),
             // Hack to avoid calculating gas info fail.
-            Command::WaitNoMore(1).encode(),
+            Command::WaitUpTo(1).encode(),
             value,
             false,
         )

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -2634,12 +2634,12 @@ fn test_different_waits_success() {
             value
         ));
 
-        let wait_no_more_success = get_last_message_id();
+        let wait_up_to_success = get_last_message_id();
 
         run_to_next_block(None);
 
         assert_eq!(
-            get_waitlist_expiration(wait_no_more_success),
+            get_waitlist_expiration(wait_up_to_success),
             expiration(duration)
         );
     });
@@ -2760,12 +2760,12 @@ fn test_different_waits_fail() {
             value
         ));
 
-        let wait_no_more_gas = get_last_message_id();
+        let wait_up_to_gas = get_last_message_id();
 
         run_to_next_block(None);
 
         assert_failed(
-            wait_no_more_gas,
+            wait_up_to_gas,
             ExecutionErrorReason::Ext(TrapExplanation::Core(ExtError::Wait(
                 WaitError::NotEnoughGas,
             ))),
@@ -2832,12 +2832,12 @@ fn test_different_waits_fail() {
             value
         ));
 
-        let wait_no_more_arg = get_last_message_id();
+        let wait_up_to_arg = get_last_message_id();
 
         run_to_next_block(None);
 
         assert_failed(
-            wait_no_more_arg,
+            wait_up_to_arg,
             ExecutionErrorReason::Ext(TrapExplanation::Core(ExtError::Wait(
                 WaitError::InvalidArgument,
             ))),

--- a/pallets/gear/src/weights.rs
+++ b/pallets/gear/src/weights.rs
@@ -79,7 +79,7 @@ pub trait WeightInfo {
     fn gr_leave(r: u32, ) -> Weight;
     fn gr_wait(r: u32, ) -> Weight;
     fn gr_wait_for(r: u32, ) -> Weight;
-    fn gr_wait_no_more(r: u32, ) -> Weight;
+    fn gr_wait_up_to(r: u32, ) -> Weight;
     fn gr_wake(r: u32, ) -> Weight;
     fn gr_create_program_wgas(r: u32, ) -> Weight;
     fn gr_create_program_wgas_per_kb(n: u32, ) -> Weight;
@@ -410,7 +410,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             .saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
     }
     /// The range of component `r` is `[0, 1]`.
-    fn gr_wait_no_more(r: u32, ) -> Weight {
+    fn gr_wait_up_to(r: u32, ) -> Weight {
         Weight::from_ref_time(77_195_000 as u64)
             // Standard Error: 240_822
             .saturating_add(Weight::from_ref_time(38_296_200 as u64).saturating_mul(r as u64))
@@ -1013,7 +1013,7 @@ impl WeightInfo for () {
             .saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
     }
     /// The range of component `r` is `[0, 1]`.
-    fn gr_wait_no_more(r: u32, ) -> Weight {
+    fn gr_wait_up_to(r: u32, ) -> Weight {
         Weight::from_ref_time(77_195_000 as u64)
             // Standard Error: 240_822
             .saturating_add(Weight::from_ref_time(38_296_200 as u64).saturating_mul(r as u64))

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -91,7 +91,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 230,
+    spec_version: 240,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/gear/src/weights/pallet_gear.rs
+++ b/runtime/gear/src/weights/pallet_gear.rs
@@ -79,7 +79,7 @@ pub trait WeightInfo {
     fn gr_leave(r: u32, ) -> Weight;
     fn gr_wait(r: u32, ) -> Weight;
     fn gr_wait_for(r: u32, ) -> Weight;
-    fn gr_wait_no_more(r: u32, ) -> Weight;
+    fn gr_wait_up_to(r: u32, ) -> Weight;
     fn gr_wake(r: u32, ) -> Weight;
     fn gr_create_program_wgas(r: u32, ) -> Weight;
     fn gr_create_program_wgas_per_kb(n: u32, ) -> Weight;
@@ -410,7 +410,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
             .saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
     }
     /// The range of component `r` is `[0, 1]`.
-    fn gr_wait_no_more(r: u32, ) -> Weight {
+    fn gr_wait_up_to(r: u32, ) -> Weight {
         Weight::from_ref_time(77_195_000 as u64)
             // Standard Error: 240_822
             .saturating_add(Weight::from_ref_time(38_296_200 as u64).saturating_mul(r as u64))
@@ -1013,7 +1013,7 @@ impl WeightInfo for () {
             .saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
     }
     /// The range of component `r` is `[0, 1]`.
-    fn gr_wait_no_more(r: u32, ) -> Weight {
+    fn gr_wait_up_to(r: u32, ) -> Weight {
         Weight::from_ref_time(77_195_000 as u64)
             // Standard Error: 240_822
             .saturating_add(Weight::from_ref_time(38_296_200 as u64).saturating_mul(r as u64))

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 230,
+    spec_version: 240,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/vara/src/weights/pallet_gear.rs
+++ b/runtime/vara/src/weights/pallet_gear.rs
@@ -79,7 +79,7 @@ pub trait WeightInfo {
     fn gr_leave(r: u32, ) -> Weight;
     fn gr_wait(r: u32, ) -> Weight;
     fn gr_wait_for(r: u32, ) -> Weight;
-    fn gr_wait_no_more(r: u32, ) -> Weight;
+    fn gr_wait_up_to(r: u32, ) -> Weight;
     fn gr_wake(r: u32, ) -> Weight;
     fn gr_create_program_wgas(r: u32, ) -> Weight;
     fn gr_create_program_wgas_per_kb(n: u32, ) -> Weight;
@@ -410,7 +410,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
             .saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
     }
     /// The range of component `r` is `[0, 1]`.
-    fn gr_wait_no_more(r: u32, ) -> Weight {
+    fn gr_wait_up_to(r: u32, ) -> Weight {
         Weight::from_ref_time(77_345_000 as u64)
             // Standard Error: 188_756
             .saturating_add(Weight::from_ref_time(38_571_100 as u64).saturating_mul(r as u64))
@@ -1013,7 +1013,7 @@ impl WeightInfo for () {
             .saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
     }
     /// The range of component `r` is `[0, 1]`.
-    fn gr_wait_no_more(r: u32, ) -> Weight {
+    fn gr_wait_up_to(r: u32, ) -> Weight {
         Weight::from_ref_time(77_345_000 as u64)
             // Standard Error: 188_756
             .saturating_add(Weight::from_ref_time(38_571_100 as u64).saturating_mul(r as u64))

--- a/utils/regression-analysis/src/main.rs
+++ b/utils/regression-analysis/src/main.rs
@@ -334,7 +334,7 @@ fn weights(kind: WeightsKind, input_file: PathBuf, output_file: PathBuf) {
                     gr_leave,
                     gr_wait,
                     gr_wait_for,
-                    gr_wait_no_more,
+                    gr_wait_up_to,
                     gr_wake,
                     gr_create_program_wgas,
                     gr_create_program_wgas_per_byte,

--- a/utils/wasm-proc/metadata-js/index.js
+++ b/utils/wasm-proc/metadata-js/index.js
@@ -41,7 +41,7 @@ exports.getWasmMetadata = async (wasmBytes) => {
             gr_value: () => { },
             gr_wait: () => { },
             gr_wait_for: () => { },
-            gr_wait_no_more: () => { },
+            gr_wait_up_to: () => { },
             gr_wake: () => { },
             gr_error: () => { },
         }


### PR DESCRIPTION
Part of #1528.

- Removed deprecated `gstd::send_and_wait_for_reply` and `gstd::send_bytes_and_wait_for_reply`.
- Renamed `wait_no_more` (I know it is an allusion to "Faith No More" but ...) to `wait_up_to`.

@gear-tech/dev 
