### PR TITLE
fix panic on big allocations in wasm runtime

### DIFF
--- a/core-backend/sandbox/Cargo.toml
+++ b/core-backend/sandbox/Cargo.toml
@@ -12,7 +12,8 @@ gear-backend-common = { path = "../common" }
 
 parity-wasm = { version = "0.45.0", default-features = false }
 sp-sandbox = { version = "0.10.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false, features = ["host-sandbox"] }
-log = { version = "0.4.17", default-features = false }
+# Use max_level_debug feature to remove tracing in sys-calls by default.
+log = { version = "0.4.17", default-features = false, features = ["max_level_debug"] }
 derive_more = "0.99.17"
 codec = { package = "parity-scale-codec", version = "3.1.3", default-features = false }
 

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -127,7 +127,7 @@ pub(crate) struct FuncsHandler<E: Ext + 'static> {
     _phantom: PhantomData<E>,
 }
 
-fn args_to_str<'a>(args: &[Value]) -> String {
+fn args_to_str(args: &[Value]) -> String {
     let mut res = String::new();
     for val in args {
         match val {

--- a/core-backend/sandbox/src/runtime.rs
+++ b/core-backend/sandbox/src/runtime.rs
@@ -3,7 +3,7 @@ use codec::{Decode, DecodeAll, MaxEncodedLen};
 use gear_backend_common::{
     error_processor::IntoExtError, AsTerminationReason, IntoExtInfo, RuntimeCtx,
 };
-use gear_core::env::Ext;
+use gear_core::{env::Ext, RUNTIME_MAX_ALLOC_SIZE};
 
 use gear_core_errors::MemoryError;
 use sp_sandbox::{default_executor::Memory as DefaultExecutorMemory, SandboxMemory};
@@ -47,6 +47,9 @@ where
     }
 
     fn read_memory(&self, ptr: u32, len: u32) -> Result<Vec<u8>, MemoryError> {
+        if len as usize > RUNTIME_MAX_ALLOC_SIZE {
+            return Err(MemoryError::OutOfBounds);
+        }
         let mut buf = vec![0u8; len as usize];
         self.memory
             .get(ptr, buf.as_mut_slice())

--- a/core/src/code.rs
+++ b/core/src/code.rs
@@ -31,7 +31,7 @@ pub const MAX_WASM_PAGE_COUNT: u32 = 512;
 /// Parse function exports from wasm module into [`DispatchKind`].
 fn get_exports(
     module: &Module,
-    reject_unnececery: bool,
+    reject_unnecessary: bool,
 ) -> Result<BTreeSet<DispatchKind>, CodeError> {
     let mut exports = BTreeSet::<DispatchKind>::new();
 
@@ -50,7 +50,7 @@ fn get_exports(
                 exports.insert(DispatchKind::Reply);
             } else if entry.field() == DispatchKind::Signal.into_entry() {
                 exports.insert(DispatchKind::Signal);
-            } else if reject_unnececery {
+            } else if reject_unnecessary {
                 return Err(CodeError::NonGearExportFnFound);
             }
         }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -25,6 +25,13 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
 #![doc(html_logo_url = "https://docs.gear.rs/logo.svg")]
 
+/// Max memory size, which runtime can allocate at once.
+/// Substrate allocator restrict allocations bigger then 512 wasm pages at once.
+/// See more information about:
+/// https://github.com/paritytech/substrate/blob/cc4d5cc8654d280f03a13421669ba03632e14aa7/client/allocator/src/freeing_bump.rs#L136-L149
+/// https://github.com/paritytech/substrate/blob/cc4d5cc8654d280f03a13421669ba03632e14aa7/primitives/core/src/lib.rs#L385-L388
+pub const RUNTIME_MAX_ALLOC_SIZE: usize = 512 * 0x10000;
+
 extern crate alloc;
 
 pub mod code;

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -91,7 +91,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 240,
+    spec_version: 250,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 240,
+    spec_version: 250,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
1) Add restriction for max allocation in gear runtime, currently check it only in gear_backend_sandbox.
2) Add tracing of sys-calls. To avoid performance decrease  disable them using log feature: max_level_debug