### PR TITLE
Revert "Run perf check tests in 1 thread (#1509)"

### DIFF
--- a/.github/workflows/test-measurements.yaml
+++ b/.github/workflows/test-measurements.yaml
@@ -84,7 +84,7 @@ jobs:
         run: |
           mkdir ./target/tests/
           mkdir ./target/tests-output/
-          for i in `seq 1 $COUNT`; do echo $i; ./scripts/gear.sh test gear --release -- --test-threads 1 > ./target/tests-output/$i ; mv ./target/nextest/ci/junit.xml ./target/tests/$i; done
+          for i in `seq 1 $COUNT`; do echo $i; ./scripts/gear.sh test gear --release -j1 > ./target/tests-output/$i ; mv ./target/nextest/ci/junit.xml ./target/tests/$i; done
           ./target/release/regression-analysis collect-data --data-folder-path ./target/tests/ --output-path ./target/pallet-tests.json
 
       - name: "Collect: Node runtime tests"


### PR DESCRIPTION
I forgot we use `cargo nextest` (not `cargo test`) in test measurements so flags were correct