### PR TITLE
Add block weight dependency from block time

### DIFF
--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -23,7 +23,6 @@ mod apis;
 pub use frame_support::{
     parameter_types,
     traits::{Currency, OnUnbalanced},
-    weights::constants::WEIGHT_PER_SECOND,
 };
 use runtime_primitives::{AccountId, Balance, BlockNumber};
 use sp_runtime::{Perbill, Percent};

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -28,15 +28,16 @@ pub use frame_support::{
 use runtime_primitives::{AccountId, Balance, BlockNumber};
 use sp_runtime::{Perbill, Percent};
 
+pub const NORMAL_DISPATCH_RATIO_NUM: u8 = 25;
+pub const GAS_LIMIT_MIN_PERCENTAGE_NUM: u8 = 100 - NORMAL_DISPATCH_RATIO_NUM;
+
 // Extrinsics with DispatchClass::Normal only account for user messages
 // TODO: consider making the normal extrinsics share adjustable in runtime
-const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(25);
+pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(NORMAL_DISPATCH_RATIO_NUM as u32);
 
 parameter_types! {
     pub const BlockHashCount: BlockNumber = 2400;
-    /// We allow for 1/3 of a second of compute with a 2 second average block time.
-    pub BlockWeights: frame_system::limits::BlockWeights = frame_system::limits::BlockWeights
-        ::with_sensible_defaults(WEIGHT_PER_SECOND / 3, NORMAL_DISPATCH_RATIO);
+
     pub BlockLength: frame_system::limits::BlockLength = frame_system::limits::BlockLength
         ::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
 }
@@ -47,8 +48,7 @@ impl gear_common::GasPrice for GasConverter {
 }
 
 parameter_types! {
-    pub const GasLimitMaxPercentage: Percent = Percent::from_percent(75);
-    pub BlockGasLimit: u64 = GasLimitMaxPercentage::get() * BlockWeights::get().max_block.ref_time();
+    pub const GasLimitMaxPercentage: Percent = Percent::from_percent(GAS_LIMIT_MIN_PERCENTAGE_NUM);
 
     pub const TransactionByteFee: Balance = 1;
     pub const QueueLengthStep: u128 = 10;

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -24,6 +24,7 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
+use frame_support::weights::constants::WEIGHT_PER_MILLIS;
 pub use frame_support::{
     construct_runtime, parameter_types,
     traits::{
@@ -38,9 +39,9 @@ use pallet_grandpa::{
 };
 pub use pallet_transaction_payment::{CurrencyAdapter, Multiplier};
 use runtime_common::{
-    impl_runtime_apis_plus_common, BlockGasLimit, BlockHashCount, BlockLength, BlockWeights,
-    DealWithFees, MailboxCost, MailboxThreshold, OperationalFeeMultiplier, OutgoingLimit,
-    QueueLengthStep, ReserveThreshold, WaitlistCost,
+    impl_runtime_apis_plus_common, BlockHashCount, BlockLength, DealWithFees,
+    GasLimitMaxPercentage, MailboxCost, MailboxThreshold, OperationalFeeMultiplier, OutgoingLimit,
+    QueueLengthStep, ReserveThreshold, WaitlistCost, NORMAL_DISPATCH_RATIO,
 };
 pub use runtime_primitives::{AccountId, Signature};
 use runtime_primitives::{Balance, BlockNumber, Hash, Index, Moment};
@@ -114,12 +115,18 @@ pub fn native_version() -> NativeVersion {
 }
 
 parameter_types! {
+    /// We allow for 1/3 of block time for computations.
+    /// It's 1/3 sec for gear runtime with 1 second block duration.
+    pub BlockWeights: frame_system::limits::BlockWeights = frame_system::limits::BlockWeights
+        ::with_sensible_defaults(MILLISECS_PER_BLOCK * WEIGHT_PER_MILLIS / 3, NORMAL_DISPATCH_RATIO);
+
+    pub BlockGasLimit: u64 = GasLimitMaxPercentage::get() * BlockWeights::get().max_block.ref_time();
+
     pub const Version: RuntimeVersion = VERSION;
     pub const SS58Prefix: u8 = 42;
 }
 
 // Configure FRAME pallets to include in runtime.
-
 impl frame_system::Config for Runtime {
     /// The basic call filter to use in dispatchable.
     type BaseCallFilter = frame_support::traits::Everything;

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -116,6 +116,7 @@ pub fn native_version() -> NativeVersion {
 
 parameter_types! {
     /// We allow for 1/3 of block time for computations.
+    ///
     /// It's 1/3 sec for gear runtime with 1 second block duration.
     pub BlockWeights: frame_system::limits::BlockWeights = frame_system::limits::BlockWeights
         ::with_sensible_defaults(MILLISECS_PER_BLOCK * WEIGHT_PER_MILLIS / 3, NORMAL_DISPATCH_RATIO);

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -31,7 +31,10 @@ use frame_support::weights::Weight;
 use frame_support::{
     construct_runtime, parameter_types,
     traits::{ConstU128, ConstU32, Contains, KeyOwnerProofSystem, U128CurrencyToVote},
-    weights::{constants::RocksDbWeight, IdentityFee},
+    weights::{
+        constants::{RocksDbWeight, WEIGHT_PER_MILLIS},
+        IdentityFee,
+    },
 };
 use frame_system::EnsureRoot;
 pub use pallet_gear::manager::{ExtManager, HandleKind};
@@ -42,9 +45,9 @@ use pallet_session::historical::{self as pallet_session_historical};
 pub use pallet_timestamp::Call as TimestampCall;
 pub use pallet_transaction_payment::{CurrencyAdapter, Multiplier};
 use runtime_common::{
-    impl_runtime_apis_plus_common, BlockGasLimit, BlockHashCount, BlockLength, BlockWeights,
-    DealWithFees, MailboxCost, MailboxThreshold, OperationalFeeMultiplier, OutgoingLimit,
-    QueueLengthStep, ReserveThreshold, WaitlistCost,
+    impl_runtime_apis_plus_common, BlockHashCount, BlockLength, DealWithFees,
+    GasLimitMaxPercentage, MailboxCost, MailboxThreshold, OperationalFeeMultiplier, OutgoingLimit,
+    QueueLengthStep, ReserveThreshold, WaitlistCost, NORMAL_DISPATCH_RATIO,
 };
 pub use runtime_primitives::{AccountId, Signature};
 use runtime_primitives::{Balance, BlockNumber, Hash, Index, Moment};
@@ -178,6 +181,14 @@ impl SignedExtension for DisableValueTransfers {
 }
 
 parameter_types! {
+    /// We allow for 1/3 of block time for computations.
+    ///
+    /// It's 2/3 sec for vara runtime with 2 second block duration.
+    pub BlockWeights: frame_system::limits::BlockWeights = frame_system::limits::BlockWeights
+        ::with_sensible_defaults(MILLISECS_PER_BLOCK * WEIGHT_PER_MILLIS / 3, NORMAL_DISPATCH_RATIO);
+
+    pub BlockGasLimit: u64 = GasLimitMaxPercentage::get() * BlockWeights::get().max_block.ref_time();
+
     pub const Version: RuntimeVersion = VERSION;
     pub const SS58Prefix: u8 = 42;
 }


### PR DESCRIPTION
It turned out, that with increase of block production time by twice, block gas limit and weight at all hasn't changed.
This PR fixes this bug defining ration between MILLISECONDS_PER_BLOCK and BlockWeights & BlockGasLimit

ATTENTION: Such changes may be not allowed for runtime upgrade, so we need to restart vara network.