### PR TITLE
Use reexported `scale_info` and `parity-scale-codec` from `gstd`

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -105,8 +105,6 @@ name = "demo-async"
 version = "0.1.0"
 dependencies = [
  "gstd",
- "parity-scale-codec",
- "scale-info",
 ]
 
 [[package]]
@@ -115,8 +113,6 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "gstd",
- "parity-scale-codec",
- "scale-info",
 ]
 
 [[package]]

--- a/examples/async-init/Cargo.toml
+++ b/examples/async-init/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-gstd = { path = "../../gstd", features = ["debug"] }
+gstd = { path = "../../gstd" }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/examples/async-init/Cargo.toml
+++ b/examples/async-init/Cargo.toml
@@ -8,6 +8,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 gstd = { path = "../../gstd", features = ["debug"] }
-codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive"] }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/examples/async-init/src/lib.rs
+++ b/examples/async-init/src/lib.rs
@@ -11,16 +11,16 @@
  * If an approval is obtained the method replies with "PONG".
  */
 
-use codec::Decode;
 use futures::future;
 use gstd::{msg, prelude::*, ActorId};
-use scale_info::TypeInfo;
 
 static mut APPROVER_FIRST: ActorId = ActorId::new([0u8; 32]);
 static mut APPROVER_SECOND: ActorId = ActorId::new([0u8; 32]);
 static mut APPROVER_THIRD: ActorId = ActorId::new([0u8; 32]);
 
 #[derive(Debug, Decode, TypeInfo)]
+#[codec(crate = gstd)]
+#[scale_info(crate = gstd)]
 pub struct InputArgs {
     pub approver_first: ActorId,
     pub approver_second: ActorId,

--- a/examples/async-init/src/lib.rs
+++ b/examples/async-init/src/lib.rs
@@ -19,8 +19,8 @@ static mut APPROVER_SECOND: ActorId = ActorId::new([0u8; 32]);
 static mut APPROVER_THIRD: ActorId = ActorId::new([0u8; 32]);
 
 #[derive(Debug, Decode, TypeInfo)]
-#[codec(crate = gstd)]
-#[scale_info(crate = gstd)]
+#[codec(crate = gstd::codec)]
+#[scale_info(crate = gstd::scale_info)]
 pub struct InputArgs {
     pub approver_first: ActorId,
     pub approver_second: ActorId,

--- a/examples/async-multisig/Cargo.toml
+++ b/examples/async-multisig/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-gstd = { path = "../../gstd", features = ["debug"] }
+gstd = { path = "../../gstd" }
 codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive"] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -8,6 +8,4 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-gstd = { path = "../../gstd", features = ["debug"] }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive"] }
+gstd = { path = "../../gstd" }

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -49,7 +49,3 @@ pub use prelude::*;
 
 #[cfg(feature = "debug")]
 pub use gcore::ext;
-
-pub mod build {
-    pub use scale_info::build::Fields;
-}

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -49,3 +49,7 @@ pub use prelude::*;
 
 #[cfg(feature = "debug")]
 pub use gcore::ext;
+
+pub mod build {
+    pub use scale_info::build::Fields;
+}

--- a/gstd/src/prelude.rs
+++ b/gstd/src/prelude.rs
@@ -33,9 +33,9 @@ pub use core::{
 pub use alloc::str::FromStr;
 pub use borrow::ToOwned;
 pub use boxed::Box;
-pub use codec::{Decode, Encode, EncodeLike, Error, Input, Output};
+pub use codec::{self, Decode, Encode};
 pub use collections::{BTreeMap, BTreeSet, VecDeque};
 pub use convert::{Into, TryInto};
-pub use scale_info::{Path, Type, TypeInfo};
+pub use scale_info::{self, TypeInfo};
 pub use string::{String, ToString};
 pub use vec::Vec;

--- a/gstd/src/prelude.rs
+++ b/gstd/src/prelude.rs
@@ -33,9 +33,9 @@ pub use core::{
 pub use alloc::str::FromStr;
 pub use borrow::ToOwned;
 pub use boxed::Box;
-pub use codec::{Decode, Encode};
+pub use codec::{Decode, Encode, EncodeLike, Error, Input, Output};
 pub use collections::{BTreeMap, BTreeSet, VecDeque};
 pub use convert::{Into, TryInto};
-pub use scale_info::TypeInfo;
+pub use scale_info::{Path, Type, TypeInfo};
 pub use string::{String, ToString};
 pub use vec::Vec;


### PR DESCRIPTION
Resolves #861.

- [x] Added needed exports to `gstd`
- [x] One example was reworked.

