### PR TITLE
beautify runtime logs

### DIFF
--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -422,14 +422,14 @@ pub mod pallet {
 
         /// Initialization
         fn on_initialize(bn: BlockNumberFor<T>) -> Weight {
-            log::debug!(target: "runtime::gear", "⚙️ Initialization of block #{:?}", bn);
+            log::debug!(target: "runtime::gear", "⚙️  Initialization of block #{:?}", bn);
 
             Weight::zero()
         }
 
         /// Finalization
         fn on_finalize(bn: BlockNumberFor<T>) {
-            log::debug!(target: "runtime::gear", "⚙️ Finalization of block #{:?}", bn);
+            log::debug!(target: "runtime::gear", "⚙️  Finalization of block #{:?}", bn);
         }
 
         /// Queue processing occurs after all normal extrinsics in the block
@@ -438,7 +438,7 @@ pub mod pallet {
         fn on_idle(bn: BlockNumberFor<T>, remaining_weight: Weight) -> Weight {
             log::debug!(
                 target: "runtime::gear",
-                "⚙️ Queue and tasks processing of block #{:?} with weight='{:?}'",
+                "⚙️  Queue and tasks processing of block #{:?} with {}",
                 bn,
                 remaining_weight,
             );
@@ -466,7 +466,7 @@ pub mod pallet {
 
             log::debug!(
                 target: "runtime::gear",
-                "⚙️ Weight '{:?}' burned in block #{:?}",
+                "⚙️  {} burned in block #{:?}",
                 weight,
                 bn,
             );

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -91,7 +91,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 300,
+    spec_version: 310,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 300,
+    spec_version: 310,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
before:
```sh
 runtime::gear: ⚙️Initialization of block #1
 runtime::gear: ⚙️Queue and tasks processing of block #1 with weight='<wasm:stripped>'
 runtime::gear: ⚙️Weight '<wasm:stripped>' burned in block #1
 runtime::gear: ⚙️Finalization of block #1
```

after:
```sh
runtime::gear: ⚙️ Initialization of block #1
runtime::gear: ⚙️ Queue and tasks processing of block #1 with Weight(ref_time: 327333086333)
runtime::gear: ⚙️ Weight(ref_time: 25000000) burned in block #1
runtime::gear: ⚙️ Finalization of block #1
```