### PR TITLE
Update metadata after introducing `LimitedVec`

### DIFF
--- a/core/src/message/mod.rs
+++ b/core/src/message/mod.rs
@@ -44,7 +44,7 @@ use core::fmt::Display;
 
 use super::buffer::LimitedVec;
 
-/// Max payload size which one message can have.
+/// Max payload size which one message can have (8 MiB).
 const MAX_PAYLOAD_SIZE: usize = 8 * 1024 * 1024;
 
 /// Payload size exceed error

--- a/gclient/src/api/listener/mod.rs
+++ b/gclient/src/api/listener/mod.rs
@@ -156,8 +156,8 @@ pub trait EventProcessor {
                 reply_to.eq(&message_id).then(|| {
                     let res = exit_code
                         .eq(&0)
-                        .then_some(payload.clone())
-                        .ok_or_else(|| String::from_utf8(payload).expect("Infallible"));
+                        .then_some(payload.0.clone())
+                        .ok_or_else(|| String::from_utf8(payload.0).expect("Infallible"));
 
                     (id.into(), res, value)
                 })
@@ -186,7 +186,7 @@ pub trait EventProcessor {
                 ..
             }) => {
                 if reply_to == message_id && exit_code != 0 {
-                    Some(Some(String::from_utf8(payload).expect("Infallible")))
+                    Some(Some(String::from_utf8(payload.0).expect("Infallible")))
                 } else {
                     None
                 }
@@ -229,7 +229,7 @@ pub trait EventProcessor {
                         if message_ids.contains(&reply_to) && exit_code != 0 {
                             Some(vec![(
                                 reply_to.into(),
-                                Some(String::from_utf8(payload).expect("Infallible")),
+                                Some(String::from_utf8(payload.0).expect("Infallible")),
                             )])
                         } else {
                             None

--- a/program/scripts/generate-api.sh
+++ b/program/scripts/generate-api.sh
@@ -99,8 +99,6 @@ function main() {
     # 1. Run gear-node and capture spec version
     spec_version="$(spec-version)"
 
-    echo "a"
-
     # 2. generate code
     sleep 5
     generate-header "${spec_version}" > "${GENERATED_RS}"

--- a/program/src/api/generated/metadata.rs
+++ b/program/src/api/generated/metadata.rs
@@ -2,7 +2,7 @@
 //!
 //! subxt codegen | rustfmt --edition=2021
 //!
-//! spec_version: 260
+//! spec_version: 290
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(dead_code, unused_imports, non_camel_case_types)]
@@ -1163,10 +1163,10 @@ pub mod api {
                         };
                         if runtime_storage_hash
                             == [
-                                243u8, 96u8, 72u8, 23u8, 92u8, 188u8, 176u8, 16u8, 184u8, 209u8,
-                                68u8, 202u8, 218u8, 218u8, 31u8, 12u8, 250u8, 27u8, 32u8, 59u8,
-                                30u8, 35u8, 229u8, 61u8, 251u8, 99u8, 139u8, 207u8, 86u8, 16u8,
-                                3u8, 240u8,
+                                136u8, 207u8, 240u8, 92u8, 212u8, 155u8, 87u8, 39u8, 67u8, 255u8,
+                                9u8, 26u8, 225u8, 160u8, 216u8, 113u8, 104u8, 214u8, 156u8, 99u8,
+                                149u8, 16u8, 123u8, 4u8, 127u8, 159u8, 34u8, 63u8, 56u8, 228u8,
+                                208u8, 178u8,
                             ]
                         {
                             let entry = Events;
@@ -1549,9 +1549,10 @@ pub mod api {
                     let metadata = locked_metadata.read();
                     if metadata.constant_hash("System", "Version")?
                         == [
-                            52u8, 145u8, 0u8, 229u8, 101u8, 129u8, 175u8, 42u8, 187u8, 104u8, 43u8,
-                            119u8, 216u8, 141u8, 190u8, 210u8, 152u8, 24u8, 101u8, 4u8, 98u8, 89u8,
-                            32u8, 23u8, 111u8, 235u8, 176u8, 250u8, 225u8, 91u8, 29u8, 73u8,
+                            71u8, 133u8, 254u8, 122u8, 33u8, 118u8, 166u8, 49u8, 52u8, 207u8,
+                            175u8, 169u8, 232u8, 187u8, 38u8, 255u8, 160u8, 131u8, 211u8, 113u8,
+                            174u8, 254u8, 16u8, 94u8, 99u8, 164u8, 231u8, 168u8, 202u8, 114u8, 7u8,
+                            224u8,
                         ]
                     {
                         let pallet = metadata.pallet("System")?;
@@ -5528,9 +5529,10 @@ pub mod api {
                     };
                     if runtime_call_hash
                         == [
-                            64u8, 130u8, 172u8, 59u8, 32u8, 206u8, 207u8, 21u8, 220u8, 253u8, 91u8,
-                            207u8, 77u8, 98u8, 68u8, 10u8, 46u8, 0u8, 107u8, 220u8, 254u8, 47u8,
-                            195u8, 150u8, 140u8, 245u8, 130u8, 123u8, 128u8, 80u8, 19u8, 134u8,
+                            64u8, 170u8, 95u8, 159u8, 242u8, 20u8, 118u8, 117u8, 225u8, 25u8,
+                            237u8, 177u8, 249u8, 76u8, 251u8, 194u8, 201u8, 37u8, 107u8, 104u8,
+                            87u8, 128u8, 141u8, 111u8, 20u8, 178u8, 20u8, 122u8, 81u8, 206u8, 49u8,
+                            80u8,
                         ]
                     {
                         let call = Sudo {
@@ -5573,9 +5575,10 @@ pub mod api {
                     };
                     if runtime_call_hash
                         == [
-                            12u8, 224u8, 23u8, 6u8, 238u8, 107u8, 8u8, 66u8, 201u8, 73u8, 101u8,
-                            50u8, 17u8, 167u8, 124u8, 180u8, 86u8, 254u8, 64u8, 115u8, 214u8,
-                            206u8, 192u8, 28u8, 212u8, 242u8, 6u8, 227u8, 208u8, 31u8, 72u8, 157u8,
+                            178u8, 163u8, 213u8, 159u8, 122u8, 202u8, 238u8, 103u8, 213u8, 201u8,
+                            156u8, 58u8, 9u8, 106u8, 67u8, 130u8, 84u8, 136u8, 124u8, 45u8, 246u8,
+                            103u8, 17u8, 2u8, 124u8, 127u8, 110u8, 121u8, 202u8, 209u8, 26u8,
+                            206u8,
                         ]
                     {
                         let call = SudoUncheckedWeight {
@@ -5654,10 +5657,9 @@ pub mod api {
                     };
                     if runtime_call_hash
                         == [
-                            111u8, 183u8, 184u8, 81u8, 232u8, 192u8, 75u8, 153u8, 55u8, 58u8,
-                            128u8, 17u8, 198u8, 88u8, 19u8, 157u8, 253u8, 172u8, 96u8, 211u8,
-                            145u8, 197u8, 87u8, 86u8, 70u8, 36u8, 0u8, 253u8, 60u8, 52u8, 140u8,
-                            58u8,
+                            116u8, 210u8, 85u8, 128u8, 129u8, 23u8, 59u8, 87u8, 50u8, 108u8, 90u8,
+                            64u8, 169u8, 165u8, 29u8, 121u8, 133u8, 42u8, 42u8, 212u8, 185u8,
+                            152u8, 63u8, 51u8, 25u8, 66u8, 115u8, 217u8, 115u8, 111u8, 27u8, 115u8,
                         ]
                     {
                         let call = SudoAs {
@@ -5857,9 +5859,10 @@ pub mod api {
                     };
                     if runtime_call_hash
                         == [
-                            8u8, 193u8, 230u8, 201u8, 222u8, 71u8, 32u8, 213u8, 52u8, 241u8, 109u8,
-                            151u8, 212u8, 63u8, 180u8, 166u8, 220u8, 194u8, 156u8, 135u8, 60u8,
-                            243u8, 55u8, 168u8, 156u8, 112u8, 136u8, 97u8, 5u8, 254u8, 6u8, 9u8,
+                            179u8, 30u8, 228u8, 208u8, 15u8, 250u8, 186u8, 141u8, 181u8, 207u8,
+                            18u8, 141u8, 131u8, 151u8, 184u8, 164u8, 60u8, 217u8, 18u8, 115u8,
+                            76u8, 6u8, 228u8, 194u8, 89u8, 141u8, 125u8, 54u8, 179u8, 55u8, 221u8,
+                            204u8,
                         ]
                     {
                         let call = Batch { calls };
@@ -5903,9 +5906,10 @@ pub mod api {
                     };
                     if runtime_call_hash
                         == [
-                            234u8, 113u8, 244u8, 13u8, 185u8, 82u8, 218u8, 159u8, 124u8, 24u8,
-                            210u8, 194u8, 26u8, 195u8, 151u8, 99u8, 33u8, 121u8, 199u8, 45u8, 57u8,
-                            65u8, 111u8, 169u8, 58u8, 78u8, 123u8, 198u8, 13u8, 225u8, 205u8, 43u8,
+                            237u8, 4u8, 81u8, 41u8, 146u8, 200u8, 197u8, 176u8, 53u8, 222u8, 75u8,
+                            52u8, 135u8, 204u8, 131u8, 103u8, 230u8, 40u8, 171u8, 192u8, 80u8,
+                            136u8, 132u8, 46u8, 176u8, 224u8, 199u8, 58u8, 116u8, 111u8, 147u8,
+                            125u8,
                         ]
                     {
                         let call = AsDerivative {
@@ -5952,9 +5956,10 @@ pub mod api {
                     };
                     if runtime_call_hash
                         == [
-                            108u8, 218u8, 246u8, 42u8, 66u8, 16u8, 72u8, 210u8, 244u8, 8u8, 32u8,
-                            131u8, 38u8, 59u8, 135u8, 95u8, 94u8, 183u8, 25u8, 207u8, 90u8, 210u8,
-                            194u8, 192u8, 88u8, 151u8, 29u8, 182u8, 50u8, 46u8, 223u8, 92u8,
+                            244u8, 237u8, 223u8, 245u8, 86u8, 167u8, 45u8, 163u8, 17u8, 86u8,
+                            215u8, 148u8, 118u8, 48u8, 91u8, 102u8, 186u8, 49u8, 193u8, 219u8,
+                            33u8, 251u8, 111u8, 25u8, 170u8, 223u8, 133u8, 160u8, 185u8, 215u8,
+                            215u8, 0u8,
                         ]
                     {
                         let call = BatchAll { calls };
@@ -5995,10 +6000,10 @@ pub mod api {
                     };
                     if runtime_call_hash
                         == [
-                            91u8, 146u8, 44u8, 3u8, 211u8, 212u8, 64u8, 151u8, 133u8, 53u8, 93u8,
-                            137u8, 169u8, 105u8, 245u8, 113u8, 161u8, 251u8, 193u8, 4u8, 11u8,
-                            109u8, 44u8, 110u8, 203u8, 153u8, 161u8, 230u8, 73u8, 176u8, 0u8,
-                            145u8,
+                            115u8, 43u8, 188u8, 6u8, 165u8, 236u8, 168u8, 123u8, 49u8, 152u8,
+                            243u8, 113u8, 34u8, 218u8, 210u8, 167u8, 35u8, 181u8, 20u8, 209u8,
+                            161u8, 219u8, 136u8, 249u8, 207u8, 198u8, 133u8, 128u8, 249u8, 79u8,
+                            128u8, 182u8,
                         ]
                     {
                         let call = DispatchAs {
@@ -6045,10 +6050,9 @@ pub mod api {
                     };
                     if runtime_call_hash
                         == [
-                            36u8, 220u8, 159u8, 181u8, 124u8, 97u8, 24u8, 158u8, 40u8, 165u8,
-                            199u8, 254u8, 175u8, 237u8, 97u8, 36u8, 147u8, 69u8, 119u8, 114u8,
-                            20u8, 234u8, 144u8, 67u8, 206u8, 82u8, 76u8, 229u8, 204u8, 108u8, 61u8,
-                            132u8,
+                            58u8, 110u8, 203u8, 171u8, 84u8, 144u8, 9u8, 92u8, 41u8, 242u8, 154u8,
+                            92u8, 151u8, 219u8, 168u8, 103u8, 97u8, 234u8, 10u8, 207u8, 162u8,
+                            24u8, 76u8, 108u8, 55u8, 86u8, 154u8, 196u8, 24u8, 85u8, 200u8, 97u8,
                         ]
                     {
                         let call = ForceBatch { calls };
@@ -6228,10 +6232,10 @@ pub mod api {
                     };
                     if runtime_call_hash
                         == [
-                            186u8, 177u8, 162u8, 70u8, 137u8, 93u8, 68u8, 252u8, 165u8, 26u8,
-                            154u8, 230u8, 141u8, 195u8, 252u8, 65u8, 245u8, 89u8, 219u8, 119u8,
-                            170u8, 68u8, 13u8, 248u8, 82u8, 110u8, 143u8, 244u8, 17u8, 63u8, 254u8,
-                            214u8,
+                            236u8, 193u8, 197u8, 130u8, 111u8, 232u8, 39u8, 144u8, 186u8, 211u8,
+                            86u8, 86u8, 112u8, 138u8, 253u8, 207u8, 32u8, 160u8, 133u8, 43u8, 82u8,
+                            78u8, 192u8, 38u8, 241u8, 226u8, 84u8, 48u8, 173u8, 141u8, 193u8,
+                            162u8,
                         ]
                     {
                         let call = ResumeProgram {
@@ -6781,10 +6785,10 @@ pub mod api {
                         };
                         if runtime_storage_hash
                             == [
-                                13u8, 90u8, 218u8, 85u8, 131u8, 173u8, 149u8, 233u8, 100u8, 187u8,
-                                126u8, 95u8, 131u8, 91u8, 198u8, 105u8, 147u8, 169u8, 42u8, 121u8,
-                                167u8, 245u8, 184u8, 142u8, 83u8, 3u8, 177u8, 43u8, 24u8, 32u8,
-                                115u8, 50u8,
+                                145u8, 42u8, 250u8, 81u8, 66u8, 241u8, 227u8, 134u8, 233u8, 64u8,
+                                200u8, 29u8, 218u8, 173u8, 117u8, 130u8, 255u8, 220u8, 28u8, 158u8,
+                                164u8, 64u8, 83u8, 210u8, 202u8, 59u8, 20u8, 52u8, 178u8, 139u8,
+                                101u8, 112u8,
                             ]
                         {
                             let entry = Dispatches(_0);
@@ -6815,10 +6819,10 @@ pub mod api {
                         };
                         if runtime_storage_hash
                             == [
-                                13u8, 90u8, 218u8, 85u8, 131u8, 173u8, 149u8, 233u8, 100u8, 187u8,
-                                126u8, 95u8, 131u8, 91u8, 198u8, 105u8, 147u8, 169u8, 42u8, 121u8,
-                                167u8, 245u8, 184u8, 142u8, 83u8, 3u8, 177u8, 43u8, 24u8, 32u8,
-                                115u8, 50u8,
+                                145u8, 42u8, 250u8, 81u8, 66u8, 241u8, 227u8, 134u8, 233u8, 64u8,
+                                200u8, 29u8, 218u8, 173u8, 117u8, 130u8, 255u8, 220u8, 28u8, 158u8,
+                                164u8, 64u8, 83u8, 210u8, 202u8, 59u8, 20u8, 52u8, 178u8, 139u8,
+                                101u8, 112u8,
                             ]
                         {
                             client.storage().iter(block_hash).await
@@ -6921,10 +6925,10 @@ pub mod api {
                         };
                         if runtime_storage_hash
                             == [
-                                190u8, 152u8, 202u8, 137u8, 146u8, 197u8, 18u8, 85u8, 176u8, 157u8,
-                                208u8, 115u8, 75u8, 193u8, 199u8, 77u8, 25u8, 110u8, 144u8, 209u8,
-                                138u8, 98u8, 105u8, 3u8, 146u8, 221u8, 76u8, 213u8, 20u8, 157u8,
-                                216u8, 23u8,
+                                134u8, 95u8, 76u8, 93u8, 170u8, 132u8, 43u8, 135u8, 216u8, 62u8,
+                                229u8, 186u8, 54u8, 211u8, 111u8, 229u8, 85u8, 105u8, 27u8, 39u8,
+                                162u8, 65u8, 123u8, 115u8, 38u8, 198u8, 129u8, 221u8, 164u8, 126u8,
+                                64u8, 173u8,
                             ]
                         {
                             let entry = Mailbox(_0, _1);
@@ -6955,10 +6959,10 @@ pub mod api {
                         };
                         if runtime_storage_hash
                             == [
-                                190u8, 152u8, 202u8, 137u8, 146u8, 197u8, 18u8, 85u8, 176u8, 157u8,
-                                208u8, 115u8, 75u8, 193u8, 199u8, 77u8, 25u8, 110u8, 144u8, 209u8,
-                                138u8, 98u8, 105u8, 3u8, 146u8, 221u8, 76u8, 213u8, 20u8, 157u8,
-                                216u8, 23u8,
+                                134u8, 95u8, 76u8, 93u8, 170u8, 132u8, 43u8, 135u8, 216u8, 62u8,
+                                229u8, 186u8, 54u8, 211u8, 111u8, 229u8, 85u8, 105u8, 27u8, 39u8,
+                                162u8, 65u8, 123u8, 115u8, 38u8, 198u8, 129u8, 221u8, 164u8, 126u8,
+                                64u8, 173u8,
                             ]
                         {
                             client.storage().iter(block_hash).await
@@ -7097,10 +7101,10 @@ pub mod api {
                         };
                         if runtime_storage_hash
                             == [
-                                230u8, 23u8, 65u8, 9u8, 236u8, 28u8, 131u8, 44u8, 224u8, 158u8,
-                                80u8, 139u8, 218u8, 178u8, 42u8, 215u8, 28u8, 223u8, 226u8, 167u8,
-                                123u8, 200u8, 242u8, 213u8, 236u8, 2u8, 217u8, 143u8, 109u8, 187u8,
-                                82u8, 185u8,
+                                195u8, 250u8, 250u8, 143u8, 242u8, 163u8, 111u8, 49u8, 94u8, 164u8,
+                                38u8, 83u8, 9u8, 15u8, 14u8, 51u8, 86u8, 238u8, 51u8, 55u8, 186u8,
+                                169u8, 245u8, 218u8, 108u8, 140u8, 153u8, 12u8, 67u8, 198u8, 145u8,
+                                151u8,
                             ]
                         {
                             let entry = Waitlist(_0, _1);
@@ -7131,10 +7135,10 @@ pub mod api {
                         };
                         if runtime_storage_hash
                             == [
-                                230u8, 23u8, 65u8, 9u8, 236u8, 28u8, 131u8, 44u8, 224u8, 158u8,
-                                80u8, 139u8, 218u8, 178u8, 42u8, 215u8, 28u8, 223u8, 226u8, 167u8,
-                                123u8, 200u8, 242u8, 213u8, 236u8, 2u8, 217u8, 143u8, 109u8, 187u8,
-                                82u8, 185u8,
+                                195u8, 250u8, 250u8, 143u8, 242u8, 163u8, 111u8, 49u8, 94u8, 164u8,
+                                38u8, 83u8, 9u8, 15u8, 14u8, 51u8, 86u8, 238u8, 51u8, 55u8, 186u8,
+                                169u8, 245u8, 218u8, 108u8, 140u8, 153u8, 12u8, 67u8, 198u8, 145u8,
+                                151u8,
                             ]
                         {
                             client.storage().iter(block_hash).await
@@ -7242,10 +7246,10 @@ pub mod api {
                         };
                         if runtime_storage_hash
                             == [
-                                92u8, 50u8, 199u8, 84u8, 178u8, 213u8, 235u8, 130u8, 173u8, 175u8,
-                                203u8, 201u8, 95u8, 187u8, 163u8, 143u8, 15u8, 251u8, 128u8, 87u8,
-                                140u8, 187u8, 16u8, 126u8, 105u8, 33u8, 184u8, 163u8, 104u8, 114u8,
-                                189u8, 70u8,
+                                5u8, 140u8, 200u8, 253u8, 35u8, 112u8, 147u8, 219u8, 113u8, 57u8,
+                                98u8, 224u8, 160u8, 157u8, 0u8, 197u8, 219u8, 193u8, 31u8, 82u8,
+                                60u8, 128u8, 232u8, 0u8, 152u8, 202u8, 216u8, 178u8, 169u8, 229u8,
+                                203u8, 224u8,
                             ]
                         {
                             let entry = TaskPool(_0, _1);
@@ -7276,10 +7280,10 @@ pub mod api {
                         };
                         if runtime_storage_hash
                             == [
-                                92u8, 50u8, 199u8, 84u8, 178u8, 213u8, 235u8, 130u8, 173u8, 175u8,
-                                203u8, 201u8, 95u8, 187u8, 163u8, 143u8, 15u8, 251u8, 128u8, 87u8,
-                                140u8, 187u8, 16u8, 126u8, 105u8, 33u8, 184u8, 163u8, 104u8, 114u8,
-                                189u8, 70u8,
+                                5u8, 140u8, 200u8, 253u8, 35u8, 112u8, 147u8, 219u8, 113u8, 57u8,
+                                98u8, 224u8, 160u8, 157u8, 0u8, 197u8, 219u8, 193u8, 31u8, 82u8,
+                                60u8, 128u8, 232u8, 0u8, 152u8, 202u8, 216u8, 178u8, 169u8, 229u8,
+                                203u8, 224u8,
                             ]
                         {
                             client.storage().iter(block_hash).await
@@ -8965,6 +8969,8 @@ pub mod api {
                             runtime_types::gear_core::ids::ProgramId,
                             runtime_types::gear_core::ids::MessageId,
                         ),
+                        #[codec(index = 6)]
+                        SendDispatch(runtime_types::gear_core::message::stored::StoredDispatch),
                     }
                 }
             }
@@ -9017,6 +9023,14 @@ pub mod api {
         }
         pub mod gear_core {
             use super::runtime_types;
+            pub mod buffer {
+                use super::runtime_types;
+                #[derive(:: subxt :: codec :: Decode, :: subxt :: codec :: Encode, Debug)]
+                pub struct LimitedVec<_0, _1>(
+                    pub ::std::vec::Vec<_0>,
+                    #[codec(skip)] pub ::core::marker::PhantomData<_1>,
+                );
+            }
             pub mod code {
                 use super::runtime_types;
                 #[derive(:: subxt :: codec :: Decode, :: subxt :: codec :: Encode, Debug)]
@@ -9071,9 +9085,19 @@ pub mod api {
                     pub struct ContextStore {
                         pub outgoing: ::subxt::KeyedVec<
                             ::core::primitive::u32,
-                            ::core::option::Option<::std::vec::Vec<::core::primitive::u8>>,
+                            ::core::option::Option<
+                                runtime_types::gear_core::buffer::LimitedVec<
+                                    ::core::primitive::u8,
+                                    runtime_types::gear_core::message::PayloadSizeError,
+                                >,
+                            >,
                         >,
-                        pub reply: ::core::option::Option<::std::vec::Vec<::core::primitive::u8>>,
+                        pub reply: ::core::option::Option<
+                            runtime_types::gear_core::buffer::LimitedVec<
+                                ::core::primitive::u8,
+                                runtime_types::gear_core::message::PayloadSizeError,
+                            >,
+                        >,
                         pub initialized: ::std::vec::Vec<runtime_types::gear_core::ids::ProgramId>,
                         pub awaken: ::std::vec::Vec<runtime_types::gear_core::ids::MessageId>,
                         pub reply_sent: ::core::primitive::bool,
@@ -9094,7 +9118,10 @@ pub mod api {
                         pub id: runtime_types::gear_core::ids::MessageId,
                         pub source: runtime_types::gear_core::ids::ProgramId,
                         pub destination: runtime_types::gear_core::ids::ProgramId,
-                        pub payload: ::std::vec::Vec<::core::primitive::u8>,
+                        pub payload: runtime_types::gear_core::buffer::LimitedVec<
+                            ::core::primitive::u8,
+                            runtime_types::gear_core::message::PayloadSizeError,
+                        >,
                         #[codec(compact)]
                         pub value: ::core::primitive::u128,
                         pub reply: ::core::option::Option<
@@ -9113,6 +9140,8 @@ pub mod api {
                     #[codec(index = 3)]
                     Signal,
                 }
+                #[derive(:: subxt :: codec :: Decode, :: subxt :: codec :: Encode, Debug)]
+                pub struct PayloadSizeError;
             }
         }
         pub mod gear_runtime {
@@ -11698,9 +11727,9 @@ pub mod api {
             };
             if runtime_metadata_hash
                 != [
-                    47u8, 187u8, 231u8, 137u8, 118u8, 207u8, 46u8, 167u8, 154u8, 34u8, 253u8, 94u8,
-                    135u8, 204u8, 17u8, 174u8, 113u8, 252u8, 249u8, 61u8, 142u8, 211u8, 97u8,
-                    170u8, 84u8, 59u8, 101u8, 25u8, 59u8, 252u8, 136u8, 232u8,
+                    187u8, 95u8, 24u8, 14u8, 223u8, 129u8, 178u8, 104u8, 49u8, 218u8, 181u8, 169u8,
+                    68u8, 38u8, 28u8, 67u8, 12u8, 193u8, 163u8, 177u8, 139u8, 253u8, 212u8, 6u8,
+                    152u8, 180u8, 92u8, 88u8, 80u8, 251u8, 30u8, 207u8,
                 ]
             {
                 Err(::subxt::MetadataError::IncompatibleMetadata)

--- a/program/src/api/generated/metadata.rs
+++ b/program/src/api/generated/metadata.rs
@@ -2,7 +2,7 @@
 //!
 //! subxt codegen | rustfmt --edition=2021
 //!
-//! spec_version: 290
+//! spec_version: 300
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(dead_code, unused_imports, non_camel_case_types)]

--- a/program/src/api/generated/mod.rs
+++ b/program/src/api/generated/mod.rs
@@ -61,7 +61,8 @@ impl From<generated_message::stored::StoredMessage> for message::StoredMessage {
             other.id.into(),
             other.source.into(),
             other.destination.into(),
-            other.payload.try_into().unwrap(),
+            // converting data from the same type
+            other.payload.0.try_into().expect("Infallible"),
             other.value,
             other.reply.map(Into::into),
         )

--- a/program/src/cmd/info.rs
+++ b/program/src/cmd/info.rs
@@ -107,7 +107,7 @@ impl fmt::Debug for Mail {
             )
             .field(
                 "payload",
-                &["0x", &hex::encode(&self.message.payload)].concat(),
+                &["0x", &hex::encode(&self.message.payload.0)].concat(),
             )
             .field("value", &self.message.value)
             .field("reply", &self.message.reply.as_ref().map(DebugReplyDetails))

--- a/program/tests/cmd/reply.rs
+++ b/program/tests/cmd/reply.rs
@@ -17,7 +17,7 @@ async fn test_command_reply_works() -> Result<()> {
     let _ = common::gear(&["-e", &node.ws(), "reply", &id, "0x", "20000000000"])?;
     let mailbox = api.mailbox(common::alice_account_id(), 10).await?;
     assert_eq!(mailbox.len(), 1);
-    assert_eq!(mailbox[0].0.payload, messager::REPLY_REPLY.encode());
+    assert_eq!(mailbox[0].0.payload.0, messager::REPLY_REPLY.encode());
 
     Ok(())
 }

--- a/program/tests/cmd/send.rs
+++ b/program/tests/cmd/send.rs
@@ -19,7 +19,7 @@ async fn test_command_send_works() -> Result<()> {
     assert_eq!(mailbox.len(), 2);
     assert!(mailbox
         .iter()
-        .any(|mail| mail.0.payload == messager::SEND_REPLY.encode()));
+        .any(|mail| mail.0.payload.0 == messager::SEND_REPLY.encode()));
 
     Ok(())
 }

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -91,7 +91,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 290,
+    spec_version: 300,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 290,
+    spec_version: 300,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
No update occurred after merging #1587 , which caused some problems in `gear-node-loader`