### PR TITLE
make macros to print sys-calls

### DIFF
--- a/core-backend/sandbox/Cargo.toml
+++ b/core-backend/sandbox/Cargo.toml
@@ -13,10 +13,11 @@ gear-backend-common = { path = "../common" }
 parity-wasm = { version = "0.45.0", default-features = false }
 sp-sandbox = { version = "0.10.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false, features = ["host-sandbox"] }
 # Use max_level_debug feature to remove tracing in sys-calls by default.
-log = { version = "0.4.17", default-features = false, features = ["max_level_debug"] }
+log = { version = "0.4.17", default-features = false }
 derive_more = "0.99.17"
 codec = { package = "parity-scale-codec", version = "3.1.3", default-features = false }
 
 [features]
 default = ["std"]
 std = ["sp-sandbox/std", "parity-wasm/std", "log/std"]
+sys-trace = []

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -148,13 +148,24 @@ fn args_to_str(args: &[Value]) -> String {
     res
 }
 
+/// We use this macros to avoid perf decrease because of log level comparing.
+/// By default `sys-trace` feature is disabled, so this macros does nothing.
+/// To see sys-calls tracing enable this feature and rebuild node.
+macro_rules! sys_trace {
+    (target: $target:expr, $($arg:tt)+) => (
+        if cfg!(feature = "sys-trace") {
+            log::trace!(target: $target, $($arg)+)
+        }
+    );
+}
+
 impl<E> FuncsHandler<E>
 where
     E: Ext + IntoExtInfo + 'static,
     E::Error: AsTerminationReason + IntoExtError,
 {
     pub fn send(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "send, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "send, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let program_id_ptr = pop_i32(&mut args)?;
@@ -189,7 +200,7 @@ where
     }
 
     pub fn send_wgas(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "send_wgas, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "send_wgas, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let program_id_ptr = pop_i32(&mut args)?;
@@ -227,7 +238,7 @@ where
     }
 
     pub fn send_commit(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "send_commit, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "send_commit, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let handle_ptr = pop_i32(&mut args)?;
@@ -263,7 +274,7 @@ where
     }
 
     pub fn send_commit_wgas(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "send_commit_wgas, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "send_commit_wgas, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let handle_ptr = pop_i32(&mut args)?;
@@ -300,7 +311,7 @@ where
     }
 
     pub fn send_init(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "send_init, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "send_init, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let handle_ptr = pop_i32(&mut args)?;
@@ -324,7 +335,7 @@ where
     }
 
     pub fn send_push(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "send_push, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "send_push, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let handle_ptr = pop_i32(&mut args)?;
@@ -349,7 +360,7 @@ where
     }
 
     pub fn read(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "read, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "read, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let at: usize = pop_i32(&mut args)?;
@@ -377,7 +388,7 @@ where
     }
 
     pub fn size(ctx: &mut Runtime<E>, _args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "size");
+        sys_trace!(target: "syscall::gear", "size");
         let size = ctx.ext.size().map_err(FuncError::Core);
 
         match size {
@@ -391,7 +402,7 @@ where
 
     pub fn exit(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
         let value_dest_ptr = pop_i32(&mut args.iter())?;
-        log::trace!(target: "syscall::gear", "exit, value_dest_ptr = {:#x}", value_dest_ptr);
+        sys_trace!(target: "syscall::gear", "exit, value_dest_ptr = {:#x}", value_dest_ptr);
 
         let mut res = || -> Result<(), _> {
             let value_dest: ProgramId = ctx.read_memory_as(value_dest_ptr)?;
@@ -406,7 +417,7 @@ where
     }
 
     pub fn exit_code(ctx: &mut Runtime<E>, _args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "exit_code");
+        sys_trace!(target: "syscall::gear", "exit_code");
         let exit_code = ctx.ext.exit_code().map_err(FuncError::Core).map_err(|e| {
             ctx.err = e;
             HostError
@@ -421,7 +432,7 @@ where
     }
 
     pub fn gas(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "gas::gear", "gas, args = {}", args_to_str(args));
+        sys_trace!(target: "gas::gear", "gas, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let val = pop_i32(&mut args)?;
@@ -443,7 +454,7 @@ where
     }
 
     pub fn alloc(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "alloc, args = {:#x?}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "alloc, args = {:#x?}", args_to_str(args));
         let mut args = args.iter();
 
         let pages: u32 = pop_i32(&mut args)?;
@@ -459,7 +470,7 @@ where
     }
 
     pub fn free(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "free, args = {:#x?}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "free, args = {:#x?}", args_to_str(args));
         let mut args = args.iter();
 
         let page: u32 = pop_i32(&mut args)?;
@@ -475,7 +486,7 @@ where
     }
 
     pub fn block_height(ctx: &mut Runtime<E>, _args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "block_height");
+        sys_trace!(target: "syscall::gear", "block_height");
         let block_height = ctx
             .ext
             .block_height()
@@ -489,7 +500,7 @@ where
     }
 
     pub fn block_timestamp(ctx: &mut Runtime<E>, _args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "block_timestamp");
+        sys_trace!(target: "syscall::gear", "block_timestamp");
         let block_timestamp =
             ctx.ext
                 .block_timestamp()
@@ -503,7 +514,7 @@ where
     }
 
     pub fn origin(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "origin, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "origin, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let origin_ptr = pop_i32(&mut args)?;
@@ -521,7 +532,7 @@ where
     }
 
     pub fn reply(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "reply, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "reply, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let payload_ptr = pop_i32(&mut args)?;
@@ -553,7 +564,7 @@ where
     }
 
     pub fn reply_wgas(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "reply_wgas, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "reply_wgas, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let payload_ptr = pop_i32(&mut args)?;
@@ -586,7 +597,7 @@ where
     }
 
     pub fn reply_commit(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "reply_commit, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "reply_commit, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let value_ptr = pop_i32(&mut args)?;
@@ -615,7 +626,7 @@ where
     }
 
     pub fn reply_commit_wgas(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "reply_commit_wgas, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "reply_commit_wgas, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let gas_limit = pop_i64(&mut args)?;
@@ -648,7 +659,7 @@ where
     }
 
     pub fn reply_to(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "reply_to, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "reply_to, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let dest = pop_i32(&mut args)?;
@@ -672,7 +683,7 @@ where
     }
 
     pub fn reply_push(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "reply_push, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "reply_push, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let payload_ptr = pop_i32(&mut args)?;
@@ -696,7 +707,7 @@ where
     }
 
     pub fn debug(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "debug, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "debug, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let str_ptr = pop_i32(&mut args)?;
@@ -716,7 +727,7 @@ where
     }
 
     pub fn gas_available(ctx: &mut Runtime<E>, _args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "gas_available");
+        sys_trace!(target: "syscall::gear", "gas_available");
         let gas_available = ctx
             .ext
             .gas_available()
@@ -727,7 +738,7 @@ where
     }
 
     pub fn msg_id(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "msg_id, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "msg_id, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let msg_id_ptr = pop_i32(&mut args)?;
@@ -744,7 +755,7 @@ where
     }
 
     pub fn program_id(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "program_id, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "program_id, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let program_id_ptr = pop_i32(&mut args)?;
@@ -761,7 +772,7 @@ where
     }
 
     pub fn source(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "source, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "source, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let source_ptr = pop_i32(&mut args)?;
@@ -783,7 +794,7 @@ where
     }
 
     pub fn value(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "value, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "value, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let value_ptr = pop_i32(&mut args)?;
@@ -800,7 +811,7 @@ where
     }
 
     pub fn value_available(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "value_available, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "value_available, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let value_ptr = pop_i32(&mut args)?;
@@ -817,7 +828,7 @@ where
     }
 
     pub fn leave(ctx: &mut Runtime<E>, _args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "leave");
+        sys_trace!(target: "syscall::gear", "leave");
         let err = ctx
             .ext
             .leave()
@@ -829,7 +840,7 @@ where
     }
 
     pub fn wait(ctx: &mut Runtime<E>, _args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "wait");
+        sys_trace!(target: "syscall::gear", "wait");
         let err = ctx
             .ext
             .wait()
@@ -841,7 +852,7 @@ where
     }
 
     pub fn wait_for(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "wait_for, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "wait_for, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let duration_ptr = pop_i32(&mut args)?;
@@ -860,7 +871,7 @@ where
     }
 
     pub fn wait_up_to(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "wait_up_to, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "wait_up_to, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let duration_ptr = pop_i32(&mut args)?;
@@ -879,7 +890,7 @@ where
     }
 
     pub fn wake(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "wake, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "wake, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let waker_id_ptr = pop_i32(&mut args)?;
@@ -899,7 +910,7 @@ where
     }
 
     pub fn create_program(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "create_program, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "create_program, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let code_hash_ptr = pop_i32(&mut args)?;
@@ -939,7 +950,7 @@ where
     }
 
     pub fn create_program_wgas(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "create_program_wgas, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "create_program_wgas, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let code_hash_ptr = pop_i32(&mut args)?;
@@ -980,7 +991,7 @@ where
     }
 
     pub fn error(ctx: &mut Runtime<E>, args: &[Value]) -> Result<ReturnValue, HostError> {
-        log::trace!(target: "syscall::gear", "error, args = {}", args_to_str(args));
+        sys_trace!(target: "syscall::gear", "error, args = {}", args_to_str(args));
         let mut args = args.iter();
 
         let data_ptr = pop_i32(&mut args)?;
@@ -1001,7 +1012,7 @@ where
     }
 
     pub fn forbidden(ctx: &mut Runtime<E>, _args: &[Value]) -> SyscallOutput {
-        log::trace!(target: "syscall::gear", "forbidden");
+        sys_trace!(target: "syscall::gear", "forbidden");
         ctx.err = FuncError::Core(E::Error::forbidden_function());
         Err(HostError)
     }

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -91,7 +91,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 310,
+    spec_version: 320,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 310,
+    spec_version: 320,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Using feature = max_level_debug for log dep cause that trace logs disables in all runtime. So, made a macros which enables tracing in sys-calls when self made feature is set.