### PR TITLE
Fix integer overflow in syscalls return value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,6 +1684,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "demo-overflow"
+version = "0.1.0"
+dependencies = [
+ "gear-wasm-builder",
+ "gstd",
+ "gtest",
+]
+
+[[package]]
 name = "demo-program-factory"
 version = "0.1.0"
 dependencies = [

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -474,32 +474,35 @@ where
         }
     }
 
-    pub fn block_height(ctx: &mut Runtime<E>, _args: &[Value]) -> SyscallOutput {
+    pub fn block_height(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
         log::trace!(target: "syscall::gear", "block_height");
-        let block_height = ctx
-            .ext
-            .block_height()
-            .map_err(FuncError::Core)
-            .map_err(|err| {
-                ctx.err = err;
-                HostError
-            })?;
+        let mut args = args.iter();
+        let height_ptr = pop_i32(&mut args)?;
 
-        return_i32(block_height)
+        let mut f = || {
+            let block_height = ctx.ext.block_height().map_err(FuncError::Core)?;
+            ctx.write_output(height_ptr, &block_height.to_le_bytes())
+                .map_err(Into::into)
+        };
+        f().map(|()| ReturnValue::Unit).map_err(|err| {
+            ctx.err = err;
+            HostError
+        })
     }
 
-    pub fn block_timestamp(ctx: &mut Runtime<E>, _args: &[Value]) -> SyscallOutput {
+    pub fn block_timestamp(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
         log::trace!(target: "syscall::gear", "block_timestamp");
-        let block_timestamp =
-            ctx.ext
-                .block_timestamp()
-                .map_err(FuncError::Core)
-                .map_err(|err| {
-                    ctx.err = err;
-                    HostError
-                })?;
-
-        return_i64(block_timestamp)
+        let mut args = args.iter();
+        let timestamp_ptr = pop_i32(&mut args)?;
+        let mut f = || {
+            let block_timestamp = ctx.ext.block_timestamp().map_err(FuncError::Core)?;
+            ctx.write_output(timestamp_ptr, &block_timestamp.to_le_bytes())
+                .map_err(Into::into)
+        };
+        f().map(|()| ReturnValue::Unit).map_err(|err| {
+            ctx.err = err;
+            HostError
+        })
     }
 
     pub fn origin(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {

--- a/core-backend/wasmi/src/funcs.rs
+++ b/core-backend/wasmi/src/funcs.rs
@@ -458,33 +458,34 @@ where
         }
     }
 
-    pub fn block_height(ctx: &mut Runtime<E>, _args: &[RuntimeValue]) -> SyscallOutput<E::Error> {
-        let block_height = ctx
-            .ext
-            .block_height()
-            .map_err(FuncError::Core)
-            .map_err(|err| {
-                ctx.err = err;
-                FuncError::HostError
-            })?;
+    pub fn block_height(ctx: &mut Runtime<E>, args: &[RuntimeValue]) -> SyscallOutput<E::Error> {
+        let mut args = args.iter();
+        let height_ptr = pop_i32(&mut args).map_err(|_| FuncError::HostError)?;
 
-        return_i32(block_height).map_err(|_| FuncError::HostError)
+        let mut f = || {
+            let block_height = ctx.ext.block_height().map_err(FuncError::Core)?;
+            ctx.write_output(height_ptr, &block_height.to_le_bytes())
+                .map_err(Into::into)
+        };
+        f().map(|()| ReturnValue::Unit).map_err(|err| {
+            ctx.err = err;
+            FuncError::HostError
+        })
     }
 
-    pub fn block_timestamp(
-        ctx: &mut Runtime<E>,
-        _args: &[RuntimeValue],
-    ) -> SyscallOutput<E::Error> {
-        let block_timestamp =
-            ctx.ext
-                .block_timestamp()
-                .map_err(FuncError::Core)
-                .map_err(|err| {
-                    ctx.err = err;
-                    FuncError::HostError
-                })?;
+    pub fn block_timestamp(ctx: &mut Runtime<E>, args: &[RuntimeValue]) -> SyscallOutput<E::Error> {
+        let mut args = args.iter();
+        let timestamp_ptr = pop_i32(&mut args).map_err(|_| FuncError::HostError)?;
 
-        return_i64(block_timestamp).map_err(|_| FuncError::HostError)
+        let mut f = || {
+            let block_timestamp = ctx.ext.block_timestamp().map_err(FuncError::Core)?;
+            ctx.write_output(timestamp_ptr, &block_timestamp.to_le_bytes())
+                .map_err(Into::into)
+        };
+        f().map(|()| ReturnValue::Unit).map_err(|err| {
+            ctx.err = err;
+            FuncError::HostError
+        })
     }
 
     pub fn origin(ctx: &mut Runtime<E>, args: &[RuntimeValue]) -> SyscallOutput<E::Error> {

--- a/examples/binaries/overflow/Cargo.toml
+++ b/examples/binaries/overflow/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "demo-overflow"
+version = "0.1.0"
+authors = ["Gear Technologies"]
+edition = "2021"
+license = "MIT"
+workspace = "../../../"
+
+[dependencies]
+gstd = { path = "../../../gstd", features = ["debug"] }
+
+[dev-dependencies]
+gtest = { path = "../../../gtest" }
+
+[build-dependencies]
+gear-wasm-builder = { path = "../../../utils/wasm-builder" }

--- a/examples/binaries/overflow/build.rs
+++ b/examples/binaries/overflow/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    gear_wasm_builder::build();
+}

--- a/examples/binaries/overflow/src/lib.rs
+++ b/examples/binaries/overflow/src/lib.rs
@@ -1,0 +1,28 @@
+#![no_std]
+
+use gstd::exec;
+
+#[no_mangle]
+extern "C" fn handle() {
+    let bh = exec::block_height();
+    gstd::debug!("Block height: {}", bh);
+}
+
+#[cfg(test)]
+mod tests {
+    use gtest::{Program, System};
+    #[test]
+    fn overflow() {
+        let sys = System::new();
+        sys.init_logger();
+
+        let prog = Program::current(&sys);
+        let res = prog.send_bytes(42, "INIT");
+        assert!(res.log().is_empty());
+
+        sys.spend_blocks(u32::MAX / 2 + 1);
+
+        let res = prog.send_bytes(42, "HANDLE");
+        assert!(res.main_failed());
+    }
+}

--- a/gcore/src/exec.rs
+++ b/gcore/src/exec.rs
@@ -24,8 +24,8 @@ use crate::{ActorId, MessageId};
 
 mod sys {
     extern "C" {
-        pub fn gr_block_height() -> u32;
-        pub fn gr_block_timestamp() -> u64;
+        pub fn gr_block_height(height_ptr: *mut u8);
+        pub fn gr_block_timestamp(timestamp_ptr: *mut u8);
         pub fn gr_exit(value_dest_ptr: *const u8) -> !;
         pub fn gr_gas_available() -> u64;
         pub fn gr_program_id(val: *mut u8);
@@ -58,7 +58,11 @@ mod sys {
 /// }
 /// ```
 pub fn block_height() -> u32 {
-    unsafe { sys::gr_block_height() }
+    let mut bytes = [0u8; 4];
+    unsafe {
+        sys::gr_block_height(bytes.as_mut_ptr());
+    }
+    u32::from_le_bytes(bytes)
 }
 
 /// Get the current block timestamp.
@@ -78,7 +82,11 @@ pub fn block_height() -> u32 {
 /// }
 /// ```
 pub fn block_timestamp() -> u64 {
-    unsafe { sys::gr_block_timestamp() }
+    let mut bytes = [0u8; 8];
+    unsafe {
+        sys::gr_block_timestamp(bytes.as_mut_ptr());
+    }
+    u64::from_le_bytes(bytes)
 }
 
 /// Terminate the execution of a program. The program and all corresponding data

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -91,7 +91,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 310,
+    spec_version: 320,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 310,
+    spec_version: 320,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Resolves #1208.

Changed syscalls:
- [x] `gr_block_height`
- [x] `gr_block_timestamp`
- [ ] `gr_gas_available`
- [ ] ? `gr_size`

