### PR TITLE
Use wasmi backend for std builds of pallet gear

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6182,6 +6182,7 @@ dependencies = [
  "frame-system",
  "gear-backend-common",
  "gear-backend-sandbox",
+ "gear-backend-wasmi",
  "gear-common",
  "gear-core",
  "gear-core-errors",

--- a/core-backend/wasmi/Cargo.toml
+++ b/core-backend/wasmi/Cargo.toml
@@ -18,4 +18,4 @@ codec = { package = "parity-scale-codec", version = "3.1.2", default-features = 
 
 [features]
 default = ["std"]
-std = ["wasmi/std", "parity-wasm/std", "log/std"]
+std = ["wasmi/virtual_memory", "parity-wasm/std", "log/std"]

--- a/pallets/gear/Cargo.toml
+++ b/pallets/gear/Cargo.toml
@@ -28,6 +28,7 @@ gear-core = { path = "../../core", default-features = false }
 gear-core-errors = { path = "../../core-errors", default-features = false }
 gear-backend-common = { path = "../../core-backend/common", default-features = false }
 gear-backend-sandbox = { path = "../../core-backend/sandbox", default-features = false }
+gear-backend-wasmi = { path = "../../core-backend/wasmi", default-features = false, optional = true }
 pallet-gear-proc-macro = { version = "2.0.0", path = "proc-macro" }
 
 # Substrate deps
@@ -96,6 +97,7 @@ std = [
 	"frame-system/std",
 	"wasm-instrument/std",
 	"gear-backend-sandbox/std",
+	"gear-backend-wasmi/std",
 	"scale-info/std",
 	"sp-io/std",
 	"sp-std/std",

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -37,8 +37,8 @@ use crate::{
     pallet,
     schedule::{API_BENCHMARK_BATCH_SIZE, INSTR_BENCHMARK_BATCH_SIZE},
     BTreeMap, BalanceOf, BlockGasLimitOf, Call, Config, CostsPerBlockOf, CurrencyOf,
-    Ext as Externalities, GasHandlerOf, MailboxOf, Pallet as Gear, Pallet, QueueOf,
-    SandboxEnvironment, Schedule, WaitlistOf,
+    ExecutionEnvironment, Ext as Externalities, GasHandlerOf, MailboxOf, Pallet as Gear, Pallet,
+    QueueOf, Schedule, WaitlistOf,
 };
 use codec::Encode;
 use common::{
@@ -588,7 +588,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -652,7 +652,7 @@ benchmarks! {
 
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -682,7 +682,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -700,7 +700,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -718,7 +718,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -736,7 +736,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -755,7 +755,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -773,7 +773,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -791,7 +791,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -821,7 +821,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -862,7 +862,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -907,7 +907,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -937,7 +937,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -967,7 +967,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -998,7 +998,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1040,7 +1040,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1082,7 +1082,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1135,7 +1135,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1188,7 +1188,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1231,7 +1231,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1272,7 +1272,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1314,7 +1314,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1354,7 +1354,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1388,7 +1388,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1419,7 +1419,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1452,7 +1452,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1492,7 +1492,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1523,7 +1523,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1554,7 +1554,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1586,7 +1586,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1618,7 +1618,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1664,7 +1664,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1728,7 +1728,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 
@@ -1792,7 +1792,7 @@ benchmarks! {
     }: {
         core_processor::process::<
             Externalities,
-            SandboxEnvironment,
+            ExecutionEnvironment,
         >(&block_config, context, memory_pages);
     }
 

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -54,7 +54,10 @@ use frame_support::{
     traits::{Currency, StorageVersion},
     weights::Weight,
 };
-use gear_backend_sandbox::SandboxEnvironment;
+#[cfg(not(feature = "std"))]
+use gear_backend_sandbox::SandboxEnvironment as ExecutionEnvironment;
+#[cfg(feature = "std")]
+use gear_backend_wasmi::WasmiEnvironment as ExecutionEnvironment;
 use gear_core::{
     code::{Code, CodeAndId, InstrumentedCode, InstrumentedCodeAndId},
     ids::{CodeId, MessageId, ProgramId, ReservationId},
@@ -878,7 +881,7 @@ pub mod pallet {
                                 })
                                 .unwrap_or(0);
 
-                            core_processor::process::<Ext, SandboxEnvironment>(
+                            core_processor::process::<Ext, ExecutionEnvironment>(
                                 &block_config,
                                 context,
                                 memory_pages,
@@ -1298,7 +1301,7 @@ pub mod pallet {
 
                                 ext_manager.insert_program_id_loaded_pages(program_id);
 
-                                core_processor::process::<Ext, SandboxEnvironment>(
+                                core_processor::process::<Ext, ExecutionEnvironment>(
                                     &block_config,
                                     context,
                                     memory_pages,

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -91,7 +91,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 310,
+    spec_version: 320,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 310,
+    spec_version: 320,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Resolves #1604 

- Enable the backend instead of sp-sandbox embedded executor which is also a wrapper around wasmi. This step allows us to update wasmi independently later.

@gear-tech/dev 
