### PR TITLE
lazy pages runtime refactoring

### DIFF
--- a/common/lazy-pages/src/lib.rs
+++ b/common/lazy-pages/src/lib.rs
@@ -29,22 +29,13 @@ use gear_core::{
 use gear_runtime_interface::gear_ri;
 use sp_std::vec::Vec;
 
-// TODO: remove this error and refactoring (issue #1390)
-#[derive(Debug, Clone, PartialEq, Eq, derive_more::Display, derive_more::From)]
-pub enum Error {
-    #[display(fmt = "Wasm memory buffer is undefined after wasm memory relocation")]
-    WasmMemBufferIsUndefined,
-}
-
-fn mprotect_lazy_pages(mem: &mut impl Memory, protect: bool) -> Result<(), Error> {
+fn mprotect_lazy_pages(mem: &mut impl Memory, protect: bool) {
     if mem.get_buffer_host_addr().is_none() {
-        return Ok(());
+        return;
     }
 
     // Cannot panic, unless OS has some problems with pages protection.
     gear_ri::mprotect_lazy_pages(protect);
-
-    Ok(())
 }
 
 /// Try to enable and initialize lazy pages env
@@ -57,7 +48,7 @@ pub fn init_for_program(
     mem: &mut impl Memory,
     prog_id: ProgramId,
     stack_end: Option<WasmPageNumber>,
-) -> Result<(), Error> {
+) {
     let program_prefix = crate::pages_prefix(prog_id.into_origin());
     let wasm_mem_addr = mem.get_buffer_host_addr();
     let wasm_mem_size = mem.size();
@@ -71,13 +62,11 @@ pub fn init_for_program(
         stack_end_page,
         program_prefix,
     );
-
-    Ok(())
 }
 
 /// Remove lazy-pages protection, returns wasm memory begin addr
-pub fn remove_lazy_pages_prot(mem: &mut impl Memory) -> Result<(), Error> {
-    mprotect_lazy_pages(mem, false)
+pub fn remove_lazy_pages_prot(mem: &mut impl Memory) {
+    mprotect_lazy_pages(mem, false);
 }
 
 /// Protect lazy-pages and set new wasm mem addr and size,
@@ -86,7 +75,8 @@ pub fn update_lazy_pages_and_protect_again(
     mem: &mut impl Memory,
     old_mem_addr: Option<HostPointer>,
     old_mem_size: WasmPageNumber,
-) -> Result<(), Error> {
+    new_mem_addr: HostPointer,
+) {
     struct PointerDisplay(HostPointer);
 
     impl fmt::Debug for PointerDisplay {
@@ -95,14 +85,15 @@ pub fn update_lazy_pages_and_protect_again(
         }
     }
 
-    let new_mem_addr = mem.get_buffer_host_addr();
-    if new_mem_addr != old_mem_addr {
+    if old_mem_addr
+        .map(|addr| new_mem_addr != addr)
+        .unwrap_or(true)
+    {
         log::debug!(
             "backend executor has changed wasm mem buff: from {:?} to {:?}",
             old_mem_addr.map(PointerDisplay),
-            new_mem_addr.map(PointerDisplay)
+            new_mem_addr
         );
-        let new_mem_addr = new_mem_addr.ok_or(Error::WasmMemBufferIsUndefined)?;
 
         // Cannot panic, unless OS allocates wasm mem buffer
         // in not aligned by native page addr.
@@ -114,7 +105,7 @@ pub fn update_lazy_pages_and_protect_again(
         gear_ri::set_wasm_mem_size(new_mem_size.0);
     }
 
-    mprotect_lazy_pages(mem, true)
+    mprotect_lazy_pages(mem, true);
 }
 
 /// Returns list of released pages numbers.

--- a/core-backend/sandbox/src/memory.rs
+++ b/core-backend/sandbox/src/memory.rs
@@ -70,7 +70,7 @@ impl Memory for MemoryWrap {
 mod tests {
     use super::*;
     use gear_backend_common::{assert_err, assert_ok};
-    use gear_core::memory::AllocationsContext;
+    use gear_core::memory::{AllocationsContext, GrowHandlerNothing};
 
     fn new_test_memory(static_pages: u32, max_pages: u32) -> (AllocationsContext, MemoryWrap) {
         use sp_sandbox::SandboxMemory as WasmMemory;
@@ -89,32 +89,47 @@ mod tests {
     fn smoky() {
         let (mut mem, mut mem_wrap) = new_test_memory(16, 256);
 
-        assert_ok!(mem.alloc(16.into(), &mut mem_wrap), 16.into());
+        assert_ok!(
+            mem.alloc::<GrowHandlerNothing>(16.into(), &mut mem_wrap),
+            16.into()
+        );
 
         // there is a space for 14 more
         for _ in 0..14 {
-            assert_ok!(mem.alloc(16.into(), &mut mem_wrap));
+            assert_ok!(mem.alloc::<GrowHandlerNothing>(16.into(), &mut mem_wrap));
         }
 
         // no more mem!
-        assert_err!(mem.alloc(1.into(), &mut mem_wrap), Error::OutOfBounds);
+        assert_err!(
+            mem.alloc::<GrowHandlerNothing>(1.into(), &mut mem_wrap),
+            Error::OutOfBounds
+        );
 
         // but we free some
         assert_ok!(mem.free(137.into()));
 
         // and now can allocate page that was freed
-        assert_ok!(mem.alloc(1.into(), &mut mem_wrap), 137.into());
+        assert_ok!(
+            mem.alloc::<GrowHandlerNothing>(1.into(), &mut mem_wrap),
+            137.into()
+        );
 
         // if we have 2 in a row we can allocate even 2
         assert_ok!(mem.free(117.into()));
         assert_ok!(mem.free(118.into()));
 
-        assert_ok!(mem.alloc(2.into(), &mut mem_wrap), 117.into());
+        assert_ok!(
+            mem.alloc::<GrowHandlerNothing>(2.into(), &mut mem_wrap),
+            117.into()
+        );
 
         // but if 2 are not in a row, bad luck
         assert_ok!(mem.free(117.into()));
         assert_ok!(mem.free(158.into()));
 
-        assert_err!(mem.alloc(2.into(), &mut mem_wrap), Error::OutOfBounds);
+        assert_err!(
+            mem.alloc::<GrowHandlerNothing>(2.into(), &mut mem_wrap),
+            Error::OutOfBounds
+        );
     }
 }

--- a/core-errors/src/lib.rs
+++ b/core-errors/src/lib.rs
@@ -157,6 +157,10 @@ pub enum MemoryError {
     /// WASM page does not contain all necessary Gear pages.
     #[display(fmt = "Page data has wrong size: {:#x}", _0)]
     InvalidPageDataSize(u64),
+
+    /// Memory size cannot be zero after grow is applied for memory
+    #[display(fmt = "Memory unexpectedly has zero size after grow")]
+    MemSizeIsZeroAfterGrow,
 }
 
 /// Execution error.

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -357,9 +357,6 @@ pub enum ExecutionErrorReason {
     /// Page with data is not allocated for program
     #[display(fmt = "{:?} is not allocated for program", _0)]
     PageIsNotAllocated(PageNumber),
-    /// Lazy pages init failed for current program.
-    #[display(fmt = "Cannot init lazy pages for program: {}", _0)]
-    LazyPagesInitFailed(String),
     /// Cannot read initial memory data from wasm memory.
     #[display(fmt = "Cannot read data for {:?}: {}", _0, _1)]
     InitialMemoryReadFailed(PageNumber, MemoryError),

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -156,8 +156,7 @@ fn prepare_memory<A: ProcessorExt, M: Memory>(
         if !pages_data.is_empty() {
             return Err(ExecutionErrorReason::InitialPagesContainsDataInLazyPagesMode);
         }
-        A::lazy_pages_init_for_program(mem, program_id, stack_end)
-            .map_err(|err| ExecutionErrorReason::LazyPagesInitFailed(err.to_string()))?;
+        A::lazy_pages_init_for_program(mem, program_id, stack_end);
     } else {
         // If we executes without lazy pages, then we have to save all initial data for static pages,
         // in order to be able to identify pages, which has been changed during execution.
@@ -327,13 +326,7 @@ pub fn execute_wasm<A: ProcessorExt + EnvExt + IntoExtInfo + 'static, E: Environ
         }) => {
             // released pages initial data will be added to `pages_initial_data` after execution.
             if A::LAZY_PAGES_ENABLED {
-                if let Err(e) = A::lazy_pages_post_execution_actions(&mut memory) {
-                    return Err(ExecutionError {
-                        program_id,
-                        gas_amount: ext.into_gas_amount(),
-                        reason: ExecutionErrorReason::Backend(e.to_string()),
-                    });
-                }
+                A::lazy_pages_post_execution_actions(&mut memory);
             }
 
             (termination, memory, ext)

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -22,7 +22,6 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use core::fmt;
 use gear_backend_common::{
     error_processor::IntoExtError, AsTerminationReason, ExtInfo, GetGasAmount, IntoExtInfo,
     TerminationReason, TrapExplanation,
@@ -33,7 +32,10 @@ use gear_core::{
     env::Ext as EnvExt,
     gas::{ChargeResult, GasAllowanceCounter, GasAmount, GasCounter, ValueCounter},
     ids::{CodeId, MessageId, ProgramId},
-    memory::{AllocationsContext, Memory, PageBuf, WasmPageNumber},
+    memory::{
+        AllocationsContext, GrowHandler, GrowHandlerNothing, Memory, PageBuf, PageNumber,
+        WasmPageNumber,
+    },
     message::{ExitCode, GasLimit, HandlePacket, InitPacket, MessageContext, Packet, ReplyPacket},
 };
 use gear_core_errors::{CoreError, ExecutionError, ExtError, MemoryError, MessageError, WaitError};
@@ -78,8 +80,6 @@ pub struct ProcessorContext {
 /// Trait to which ext must have to work in processor wasm executor.
 /// Currently used only for lazy-pages support.
 pub trait ProcessorExt {
-    /// An error issues in processor
-    type Error: fmt::Display;
     /// Whether this extension works with lazy pages.
     const LAZY_PAGES_ENABLED: bool;
 
@@ -91,10 +91,10 @@ pub trait ProcessorExt {
         mem: &mut impl Memory,
         prog_id: ProgramId,
         stack_end: Option<WasmPageNumber>,
-    ) -> Result<(), Self::Error>;
+    );
 
     /// Lazy pages contract post execution actions
-    fn lazy_pages_post_execution_actions(mem: &mut impl Memory) -> Result<(), Self::Error>;
+    fn lazy_pages_post_execution_actions(mem: &mut impl Memory);
 }
 
 /// [`Ext`](Ext)'s error
@@ -188,7 +188,6 @@ pub struct Ext {
 
 /// Empty implementation for non-substrate (and non-lazy-pages) using
 impl ProcessorExt for Ext {
-    type Error = ExtError;
     const LAZY_PAGES_ENABLED: bool = false;
 
     fn new(context: ProcessorContext) -> Self {
@@ -202,53 +201,28 @@ impl ProcessorExt for Ext {
         _mem: &mut impl Memory,
         _prog_id: ProgramId,
         _stack_end: Option<WasmPageNumber>,
-    ) -> Result<(), Self::Error> {
+    ) {
         unreachable!()
     }
 
-    fn lazy_pages_post_execution_actions(_mem: &mut impl Memory) -> Result<(), Self::Error> {
+    fn lazy_pages_post_execution_actions(_mem: &mut impl Memory) {
         unreachable!()
     }
 }
 
 impl IntoExtInfo for Ext {
     fn into_ext_info(self, memory: &impl Memory) -> Result<ExtInfo, (MemoryError, GasAmount)> {
-        let ProcessorContext {
-            allocations_context,
-            message_context,
-            gas_counter,
-            program_candidates_data,
-            ..
-        } = self.context;
-
-        let static_pages = allocations_context.static_pages();
-        let (initial_allocations, wasm_pages) = allocations_context.into_parts();
-        let mut pages_data = BTreeMap::new();
-        for page in (0..static_pages.0)
-            .map(WasmPageNumber)
-            .chain(wasm_pages.iter().copied())
-            .flat_map(|p| p.to_gear_pages_iter())
-        {
-            let mut buf = PageBuf::new_zeroed();
-            if let Err(err) = memory.read(page.offset(), buf.as_mut_slice()) {
-                return Err((err, gas_counter.into()));
-            }
-            pages_data.insert(page, buf);
-        }
-
-        let (outcome, context_store) = message_context.drain();
-        let (generated_dispatches, awakening) = outcome.drain();
-
-        let info = ExtInfo {
-            gas_amount: gas_counter.into(),
-            allocations: wasm_pages.ne(&initial_allocations).then_some(wasm_pages),
-            pages_data,
-            generated_dispatches,
-            awakening,
-            context_store,
-            program_candidates_data,
+        let pages_for_data = |static_pages: WasmPageNumber,
+                              allocations: &BTreeSet<WasmPageNumber>|
+         -> Vec<PageNumber> {
+            (0..static_pages.0)
+                .map(WasmPageNumber)
+                .chain(allocations.iter().copied())
+                .flat_map(|p| p.to_gear_pages_iter())
+                .collect()
         };
-        Ok(info)
+
+        self.into_ext_info_inner(memory, pages_for_data)
     }
 
     fn into_gas_amount(self) -> GasAmount {
@@ -348,54 +322,12 @@ impl Ext {
 impl EnvExt for Ext {
     type Error = ProcessorError;
 
-    // !!! Please changing this method do not forget to change `LazyPagesExt` in `pallet/gear/src/ext.rs`.
-    // TODO: make solution, which allows to reuse `alloc` logic in `LazyPagesExt` (issue #1395).
     fn alloc(
         &mut self,
         pages_num: WasmPageNumber,
         mem: &mut impl Memory,
     ) -> Result<WasmPageNumber, Self::Error> {
-        self.charge_gas_runtime(RuntimeCosts::Alloc)?;
-
-        // Greedily charge gas for allocations
-        self.charge_gas((pages_num.0 as u64).saturating_mul(self.context.config.alloc_cost))?;
-        // Greedily charge gas for grow
-        self.charge_gas((pages_num.0 as u64).saturating_mul(self.context.config.mem_grow_cost))?;
-
-        let old_mem_size = mem.size();
-
-        let result = self.context.allocations_context.alloc(pages_num, mem);
-
-        let page_number = self.return_and_store_err(result)?;
-
-        // Returns back greedily used gas for grow
-        let new_mem_size = mem.size();
-        let grow_pages_num = new_mem_size - old_mem_size;
-        let mut gas_to_return_back = self
-            .context
-            .config
-            .mem_grow_cost
-            .saturating_mul((pages_num - grow_pages_num).0 as u64);
-
-        // Returns back greedily used gas for allocations
-        let first_page = page_number;
-        let last_page = first_page + pages_num - 1.into();
-        let mut new_allocated_pages_num = 0;
-        for page in first_page.0..=last_page.0 {
-            if !self.context.allocations_context.is_init_page(page.into()) {
-                new_allocated_pages_num += 1;
-            }
-        }
-        gas_to_return_back = gas_to_return_back.saturating_add(
-            self.context
-                .config
-                .alloc_cost
-                .saturating_mul((pages_num.0 - new_allocated_pages_num) as u64),
-        );
-
-        self.refund_gas(gas_to_return_back)?;
-
-        Ok(page_number)
+        self.alloc_inner::<GrowHandlerNothing>(pages_num, mem)
     }
 
     fn block_height(&mut self) -> Result<u32, Self::Error> {
@@ -690,5 +622,96 @@ impl EnvExt for Ext {
 
     fn forbidden_funcs(&self) -> &BTreeSet<&'static str> {
         &self.context.forbidden_funcs
+    }
+}
+
+impl Ext {
+    /// Inner alloc realization.
+    pub fn alloc_inner<G: GrowHandler>(
+        &mut self,
+        pages_num: WasmPageNumber,
+        mem: &mut impl Memory,
+    ) -> Result<WasmPageNumber, ProcessorError> {
+        self.charge_gas_runtime(RuntimeCosts::Alloc)?;
+
+        // Charge gas for allocations
+        self.charge_gas((pages_num.0 as u64).saturating_mul(self.context.config.alloc_cost))?;
+        // Greedily charge gas for grow
+        self.charge_gas((pages_num.0 as u64).saturating_mul(self.context.config.mem_grow_cost))?;
+
+        let old_mem_size = mem.size();
+
+        let result = self.context.allocations_context.alloc::<G>(pages_num, mem);
+
+        let page_number = self.return_and_store_err(result)?;
+
+        // Returns back greedily used gas for grow
+        let new_mem_size = mem.size();
+        let grow_pages_num = new_mem_size - old_mem_size;
+        let mut gas_to_return_back = self
+            .context
+            .config
+            .mem_grow_cost
+            .saturating_mul((pages_num - grow_pages_num).0 as u64);
+
+        // Returns back greedily used gas for allocations
+        let first_page = page_number;
+        let last_page = first_page + pages_num - 1.into();
+        let mut new_allocated_pages_num = 0;
+        for page in first_page.0..=last_page.0 {
+            if !self.context.allocations_context.is_init_page(page.into()) {
+                new_allocated_pages_num += 1;
+            }
+        }
+        gas_to_return_back = gas_to_return_back.saturating_add(
+            self.context
+                .config
+                .alloc_cost
+                .saturating_mul((pages_num.0 - new_allocated_pages_num) as u64),
+        );
+
+        self.refund_gas(gas_to_return_back)?;
+
+        Ok(page_number)
+    }
+
+    /// Into ext info inner impl.
+    /// `pages_for_data` returns vector of pages which data will be stored in info.
+    pub fn into_ext_info_inner(
+        self,
+        memory: &impl Memory,
+        pages_for_data: impl FnOnce(WasmPageNumber, &BTreeSet<WasmPageNumber>) -> Vec<PageNumber>,
+    ) -> Result<ExtInfo, (MemoryError, GasAmount)> {
+        let ProcessorContext {
+            allocations_context,
+            message_context,
+            gas_counter,
+            program_candidates_data,
+            ..
+        } = self.context;
+
+        let (static_pages, initial_allocations, allocations) = allocations_context.into_parts();
+        let mut pages_data = BTreeMap::new();
+        for page in pages_for_data(static_pages, &allocations) {
+            let mut buf = PageBuf::new_zeroed();
+            if let Err(err) = memory.read(page.offset(), buf.as_mut_slice()) {
+                return Err((err, gas_counter.into()));
+            }
+            pages_data.insert(page, buf);
+        }
+
+        let (outcome, context_store) = message_context.drain();
+        let (generated_dispatches, awakening) = outcome.drain();
+
+        let info = ExtInfo {
+            gas_amount: gas_counter.into(),
+            allocations: allocations.ne(&initial_allocations).then_some(allocations),
+            pages_data,
+            generated_dispatches,
+            awakening,
+            context_store,
+            program_candidates_data,
+        };
+        Ok(info)
     }
 }

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -16,57 +16,19 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use alloc::collections::BTreeSet;
+use alloc::{collections::BTreeSet, vec::Vec};
 use core_processor::{Ext, ProcessorContext, ProcessorError, ProcessorExt};
-use gear_backend_common::{
-    error_processor::IntoExtError, AsTerminationReason, ExtInfo, GetGasAmount, IntoExtInfo,
-    TerminationReason, TrapExplanation,
-};
+use gear_backend_common::{ExtInfo, GetGasAmount, IntoExtInfo, TrapExplanation};
 use gear_core::{
     costs::RuntimeCosts,
     env::Ext as EnvExt,
     gas::GasAmount,
     ids::{MessageId, ProgramId},
-    memory::{Memory, PageBuf, WasmPageNumber},
+    memory::{GrowHandler, Memory, PageNumber, WasmPageNumber},
     message::{ExitCode, HandlePacket, InitPacket, ReplyPacket},
 };
-use gear_core_errors::{CoreError, ExtError, MemoryError};
+use gear_core_errors::{ExtError, MemoryError};
 use gear_lazy_pages_common as lazy_pages;
-use sp_std::collections::btree_map::BTreeMap;
-
-#[derive(Debug, Clone, PartialEq, Eq, derive_more::Display, derive_more::From)]
-pub enum Error {
-    #[from]
-    #[display(fmt = "{}", _0)]
-    Processor(ProcessorError),
-    #[from]
-    #[display(fmt = "{}", _0)]
-    LazyPages(lazy_pages::Error),
-}
-
-impl CoreError for Error {
-    fn forbidden_function() -> Self {
-        Self::Processor(ProcessorError::forbidden_function())
-    }
-}
-
-impl IntoExtError for Error {
-    fn into_ext_error(self) -> Result<ExtError, Self> {
-        match self {
-            Error::Processor(err) => Ok(err.into_ext_error()?),
-            err => Err(err),
-        }
-    }
-}
-
-impl AsTerminationReason for Error {
-    fn as_termination_reason(&self) -> Option<&TerminationReason> {
-        match self {
-            Error::Processor(err) => err.as_termination_reason(),
-            Error::LazyPages(_) => None,
-        }
-    }
-}
 
 /// Ext with lazy pages support.
 pub struct LazyPagesExt {
@@ -75,47 +37,19 @@ pub struct LazyPagesExt {
 
 impl IntoExtInfo for LazyPagesExt {
     fn into_ext_info(self, memory: &impl Memory) -> Result<ExtInfo, (MemoryError, GasAmount)> {
-        let ProcessorContext {
-            allocations_context,
-            message_context,
-            gas_counter,
-            program_candidates_data,
-            ..
-        } = self.inner.context;
-
-        // Accessed pages are all pages except current lazy pages
-        let static_pages = allocations_context.static_pages();
-        let (initial_allocations, allocations) = allocations_context.into_parts();
-        let mut accessed_pages = lazy_pages::get_released_pages();
-        accessed_pages.retain(|p| {
-            let wasm_page = p.to_wasm_page();
-            wasm_page < static_pages || allocations.contains(&wasm_page)
-        });
-
-        log::trace!("accessed pages numbers = {:?}", accessed_pages);
-
-        let mut accessed_pages_data = BTreeMap::new();
-        for page in accessed_pages {
-            let mut buf = PageBuf::new_zeroed();
-            if let Err(err) = memory.read(page.offset(), buf.as_mut_slice()) {
-                return Err((err, gas_counter.into()));
-            }
-            accessed_pages_data.insert(page, buf);
-        }
-
-        let (outcome, context_store) = message_context.drain();
-        let (generated_dispatches, awakening) = outcome.drain();
-
-        let info = ExtInfo {
-            gas_amount: gas_counter.into(),
-            allocations: allocations.ne(&initial_allocations).then_some(allocations),
-            pages_data: accessed_pages_data,
-            generated_dispatches,
-            awakening,
-            context_store,
-            program_candidates_data,
+        let pages_for_data = |static_pages: WasmPageNumber,
+                              allocations: &BTreeSet<WasmPageNumber>|
+         -> Vec<PageNumber> {
+            // Accessed pages are all pages, that had been released and are in allocations set or static.
+            let mut accessed_pages = lazy_pages::get_released_pages();
+            accessed_pages.retain(|p| {
+                let wasm_page = p.to_wasm_page();
+                wasm_page < static_pages || allocations.contains(&wasm_page)
+            });
+            log::trace!("accessed pages numbers = {:?}", accessed_pages);
+            accessed_pages
         };
-        Ok(info)
+        self.inner.into_ext_info_inner(memory, pages_for_data)
     }
 
     fn into_gas_amount(self) -> gear_core::gas::GasAmount {
@@ -140,7 +74,6 @@ impl GetGasAmount for LazyPagesExt {
 }
 
 impl ProcessorExt for LazyPagesExt {
-    type Error = Error;
     const LAZY_PAGES_ENABLED: bool = true;
 
     fn new(context: ProcessorContext) -> Self {
@@ -153,115 +86,81 @@ impl ProcessorExt for LazyPagesExt {
         mem: &mut impl Memory,
         prog_id: ProgramId,
         stack_end: Option<WasmPageNumber>,
-    ) -> Result<(), Self::Error> {
-        lazy_pages::init_for_program(mem, prog_id, stack_end).map_err(Into::into)
+    ) {
+        lazy_pages::init_for_program(mem, prog_id, stack_end);
     }
 
-    fn lazy_pages_post_execution_actions(mem: &mut impl Memory) -> Result<(), Self::Error> {
-        lazy_pages::remove_lazy_pages_prot(mem).map_err(Into::into)
+    fn lazy_pages_post_execution_actions(mem: &mut impl Memory) {
+        lazy_pages::remove_lazy_pages_prot(mem);
+    }
+}
+
+struct GrowHandlerLazy {
+    old_mem_addr: Option<u64>,
+    old_mem_size: WasmPageNumber,
+}
+
+impl GrowHandler for GrowHandlerLazy {
+    fn before_grow_action(mem: &mut impl Memory) -> Self {
+        // New pages allocation may change wasm memory buffer location.
+        // So we remove protections from lazy-pages
+        // and then in `after_grow_action` we set protection back for new wasm memory buffer.
+        let old_mem_addr = mem.get_buffer_host_addr();
+        lazy_pages::remove_lazy_pages_prot(mem);
+        Self {
+            old_mem_addr,
+            old_mem_size: mem.size(),
+        }
+    }
+    fn after_grow_action(self, mem: &mut impl Memory) -> Result<(), MemoryError> {
+        // Add new allocations to lazy pages.
+        // Protect all lazy pages including new allocations.
+        let new_mem_addr = mem
+            .get_buffer_host_addr()
+            .ok_or(MemoryError::MemSizeIsZeroAfterGrow)?;
+        lazy_pages::update_lazy_pages_and_protect_again(
+            mem,
+            self.old_mem_addr,
+            self.old_mem_size,
+            new_mem_addr,
+        );
+        Ok(())
     }
 }
 
 impl EnvExt for LazyPagesExt {
-    type Error = Error;
+    type Error = ProcessorError;
 
     fn alloc(
         &mut self,
         pages_num: WasmPageNumber,
         mem: &mut impl Memory,
     ) -> Result<WasmPageNumber, Self::Error> {
-        self.charge_gas_runtime(RuntimeCosts::Alloc)?;
-
-        // Greedily charge gas for allocations
-        self.charge_gas((pages_num.0 as u64).saturating_mul(self.inner.context.config.alloc_cost))?;
-        // Greedily charge gas for grow
-        self.charge_gas(
-            (pages_num.0 as u64).saturating_mul(self.inner.context.config.mem_grow_cost),
-        )?;
-
-        let old_mem_size = mem.size();
-
-        // New pages allocation may change wasm memory buffer location.
-        // So we remove protections from lazy-pages
-        // and set protection back for new wasm memory buffer pages.
-        // Also we correct lazy-pages info if need.
-        let old_mem_addr = mem.get_buffer_host_addr();
-        lazy_pages::remove_lazy_pages_prot(mem)?;
-
-        let result = self
-            .inner
-            .context
-            .allocations_context
-            .alloc(pages_num, mem)
-            .map_err(ExtError::Memory);
-
-        let page_number = self.inner.return_and_store_err(result)?;
-
-        // Add new allocations to lazy pages.
-        // Protect all lazy pages including new allocations.
-        lazy_pages::update_lazy_pages_and_protect_again(mem, old_mem_addr, old_mem_size)?;
-
-        // Returns back greedily used gas for grow
-        let new_mem_size = mem.size();
-        let grow_pages_num = new_mem_size - old_mem_size;
-        let mut gas_to_return_back = self
-            .inner
-            .context
-            .config
-            .mem_grow_cost
-            .saturating_mul((pages_num - grow_pages_num).0 as u64);
-
-        // Returns back greedily used gas for allocations
-        let first_page = page_number;
-        let last_page = first_page + pages_num - 1.into();
-        let mut new_allocated_pages_num = WasmPageNumber(0);
-        for page in first_page.0..=last_page.0 {
-            if !self
-                .inner
-                .context
-                .allocations_context
-                .is_init_page(page.into())
-            {
-                new_allocated_pages_num = new_allocated_pages_num + 1.into();
-            }
-        }
-        gas_to_return_back = gas_to_return_back.saturating_add(
-            self.inner
-                .context
-                .config
-                .alloc_cost
-                .saturating_mul((pages_num - new_allocated_pages_num).0 as u64),
-        );
-
-        self.refund_gas(gas_to_return_back)?;
-
-        Ok(page_number)
+        self.inner.alloc_inner::<GrowHandlerLazy>(pages_num, mem)
     }
 
     fn block_height(&mut self) -> Result<u32, Self::Error> {
-        self.inner.block_height().map_err(Error::Processor)
+        self.inner.block_height()
     }
 
     fn block_timestamp(&mut self) -> Result<u64, Self::Error> {
-        self.inner.block_timestamp().map_err(Error::Processor)
+        self.inner.block_timestamp()
     }
 
     fn origin(&mut self) -> Result<ProgramId, Self::Error> {
-        self.inner.origin().map_err(Error::Processor)
+        self.inner.origin()
     }
 
     fn send_init(&mut self) -> Result<usize, Self::Error> {
-        self.inner.send_init().map_err(Error::Processor)
+        self.inner.send_init()
     }
 
     fn send_push(&mut self, handle: usize, buffer: &[u8]) -> Result<(), Self::Error> {
-        self.inner
-            .send_push(handle, buffer)
-            .map_err(Error::Processor)
+        self.inner.send_push(handle, buffer)
     }
 
     fn reply_push(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
-        self.inner.reply_push(buffer).map_err(Error::Processor)
+        self.inner.reply_push(buffer)
     }
 
     fn send_commit(
@@ -270,111 +169,103 @@ impl EnvExt for LazyPagesExt {
         msg: HandlePacket,
         delay: u32,
     ) -> Result<MessageId, Self::Error> {
-        self.inner
-            .send_commit(handle, msg, delay)
-            .map_err(Error::Processor)
+        self.inner.send_commit(handle, msg, delay)
     }
 
     fn reply_commit(&mut self, msg: ReplyPacket, delay: u32) -> Result<MessageId, Self::Error> {
-        self.inner
-            .reply_commit(msg, delay)
-            .map_err(Error::Processor)
+        self.inner.reply_commit(msg, delay)
     }
 
     fn reply_to(&mut self) -> Result<Option<MessageId>, Self::Error> {
-        self.inner.reply_to().map_err(Error::Processor)
+        self.inner.reply_to()
     }
 
     fn source(&mut self) -> Result<ProgramId, Self::Error> {
-        self.inner.source().map_err(Error::Processor)
+        self.inner.source()
     }
 
     fn exit(&mut self) -> Result<(), Self::Error> {
-        self.inner.exit().map_err(Error::Processor)
+        self.inner.exit()
     }
 
     fn exit_code(&mut self) -> Result<Option<ExitCode>, Self::Error> {
-        self.inner.exit_code().map_err(Error::Processor)
+        self.inner.exit_code()
     }
 
     fn message_id(&mut self) -> Result<MessageId, Self::Error> {
-        self.inner.message_id().map_err(Error::Processor)
+        self.inner.message_id()
     }
 
     fn program_id(&mut self) -> Result<ProgramId, Self::Error> {
-        self.inner.program_id().map_err(Error::Processor)
+        self.inner.program_id()
     }
 
     fn free(&mut self, page: WasmPageNumber) -> Result<(), Self::Error> {
-        self.inner.free(page).map_err(Error::Processor)
+        self.inner.free(page)
     }
 
     fn debug(&mut self, data: &str) -> Result<(), Self::Error> {
-        self.inner.debug(data).map_err(Error::Processor)
+        self.inner.debug(data)
     }
 
     fn read(&mut self) -> Result<&[u8], Self::Error> {
-        self.inner.read().map_err(Error::Processor)
+        self.inner.read()
     }
 
     fn size(&mut self) -> Result<usize, Self::Error> {
-        self.inner.size().map_err(Error::Processor)
+        self.inner.size()
     }
 
     fn charge_gas(&mut self, val: u64) -> Result<(), Self::Error> {
-        self.inner.charge_gas(val).map_err(Error::Processor)
+        self.inner.charge_gas(val)
     }
 
     fn refund_gas(&mut self, val: u64) -> Result<(), Self::Error> {
-        self.inner.refund_gas(val).map_err(Error::Processor)
+        self.inner.refund_gas(val)
     }
 
     fn gas(&mut self, val: u32) -> Result<(), Self::Error> {
-        self.inner.gas(val).map_err(Error::Processor)
+        self.inner.gas(val)
     }
 
     fn gas_available(&mut self) -> Result<u64, Self::Error> {
-        self.inner.gas_available().map_err(Error::Processor)
+        self.inner.gas_available()
     }
 
     fn value(&mut self) -> Result<u128, Self::Error> {
-        self.inner.value().map_err(Error::Processor)
+        self.inner.value()
     }
 
     fn leave(&mut self) -> Result<(), Self::Error> {
-        self.inner.leave().map_err(Error::Processor)
+        self.inner.leave()
     }
 
     fn wait(&mut self) -> Result<(), Self::Error> {
-        self.inner.wait().map_err(Error::Processor)
+        self.inner.wait()
     }
 
     fn wait_for(&mut self, duration: u32) -> Result<(), Self::Error> {
-        self.inner.wait_for(duration).map_err(Error::Processor)
+        self.inner.wait_for(duration)
     }
 
     fn wait_up_to(&mut self, duration: u32) -> Result<(), Self::Error> {
-        self.inner.wait_up_to(duration).map_err(Error::Processor)
+        self.inner.wait_up_to(duration)
     }
 
     fn wake(&mut self, waker_id: MessageId, delay: u32) -> Result<(), Self::Error> {
-        self.inner.wake(waker_id, delay).map_err(Error::Processor)
+        self.inner.wake(waker_id, delay)
     }
 
     fn value_available(&mut self) -> Result<u128, Self::Error> {
-        self.inner.value_available().map_err(Error::Processor)
+        self.inner.value_available()
     }
 
     fn create_program(&mut self, packet: InitPacket, delay: u32) -> Result<ProgramId, Self::Error> {
-        self.inner
-            .create_program(packet, delay)
-            .map_err(Error::Processor)
+        self.inner.create_program(packet, delay)
     }
 
     fn charge_gas_runtime(&mut self, costs: RuntimeCosts) -> Result<(), Self::Error> {
-        self.inner
-            .charge_gas_runtime(costs)
-            .map_err(Error::Processor)
+        self.inner.charge_gas_runtime(costs)
     }
 
     fn forbidden_funcs(&self) -> &BTreeSet<&'static str> {

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -32,7 +32,7 @@ use common::{
     event::*, program_exists, scheduler::*, storage::*, CodeStorage, GasPrice as _, GasTree,
     Origin as _,
 };
-use core_processor::{common::ExecutionErrorReason, ProcessorExt};
+use core_processor::common::ExecutionErrorReason;
 use demo_compose::WASM_BINARY as COMPOSE_WASM_BINARY;
 use demo_distributor::{Request, WASM_BINARY};
 use demo_mul_by_const::WASM_BINARY as MUL_CONST_WASM_BINARY;
@@ -6334,7 +6334,7 @@ fn check_gr_read_error_works() {
         assert_failed(
             message_id,
             ExecutionErrorReason::Ext(TrapExplanation::Other(
-                FuncError::<<crate::Ext as ProcessorExt>::Error>::ReadWrongRange(0..10, 0)
+                FuncError::<u32>::ReadWrongRange(0..10, 0)
                     .to_string()
                     .into(),
             )),

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -6334,7 +6334,7 @@ fn check_gr_read_error_works() {
         assert_failed(
             message_id,
             ExecutionErrorReason::Ext(TrapExplanation::Other(
-                FuncError::<u32>::ReadWrongRange(0..10, 0)
+                FuncError::<&str>::ReadWrongRange(0..10, 0)
                     .to_string()
                     .into(),
             )),

--- a/program/src/api/generated/metadata.rs
+++ b/program/src/api/generated/metadata.rs
@@ -1544,9 +1544,10 @@ pub mod api {
                     let metadata = locked_metadata.read();
                     if metadata.constant_hash("System", "Version")?
                         == [
-                            21u8, 222u8, 31u8, 241u8, 229u8, 155u8, 160u8, 189u8, 47u8, 113u8,
-                            240u8, 52u8, 211u8, 142u8, 100u8, 214u8, 36u8, 116u8, 91u8, 199u8, 9u8,
-                            33u8, 163u8, 100u8, 167u8, 248u8, 5u8, 241u8, 115u8, 98u8, 142u8, 71u8,
+                            190u8, 150u8, 209u8, 218u8, 0u8, 199u8, 123u8, 192u8, 146u8, 70u8,
+                            213u8, 142u8, 150u8, 229u8, 176u8, 10u8, 24u8, 141u8, 119u8, 29u8,
+                            125u8, 218u8, 102u8, 137u8, 80u8, 187u8, 17u8, 169u8, 139u8, 247u8,
+                            138u8, 68u8,
                         ]
                     {
                         let pallet = metadata.pallet("System")?;
@@ -11426,9 +11427,9 @@ pub mod api {
             };
             if runtime_metadata_hash
                 != [
-                    43u8, 193u8, 63u8, 146u8, 26u8, 183u8, 253u8, 98u8, 93u8, 60u8, 119u8, 237u8,
-                    114u8, 235u8, 187u8, 35u8, 65u8, 109u8, 244u8, 78u8, 23u8, 39u8, 250u8, 200u8,
-                    54u8, 243u8, 74u8, 44u8, 177u8, 77u8, 235u8, 126u8,
+                    164u8, 46u8, 74u8, 79u8, 41u8, 242u8, 58u8, 48u8, 53u8, 136u8, 62u8, 1u8, 93u8,
+                    93u8, 186u8, 70u8, 235u8, 162u8, 137u8, 168u8, 73u8, 150u8, 104u8, 198u8,
+                    180u8, 35u8, 78u8, 194u8, 164u8, 174u8, 36u8, 180u8,
                 ]
             {
                 Err(::subxt::MetadataError::IncompatibleMetadata)

--- a/program/src/api/generated/metadata.rs
+++ b/program/src/api/generated/metadata.rs
@@ -1544,10 +1544,9 @@ pub mod api {
                     let metadata = locked_metadata.read();
                     if metadata.constant_hash("System", "Version")?
                         == [
-                            67u8, 215u8, 49u8, 154u8, 163u8, 163u8, 13u8, 232u8, 106u8, 96u8,
-                            128u8, 91u8, 254u8, 243u8, 143u8, 250u8, 203u8, 221u8, 175u8, 142u8,
-                            134u8, 125u8, 149u8, 1u8, 147u8, 195u8, 92u8, 206u8, 186u8, 237u8,
-                            111u8, 166u8,
+                            21u8, 222u8, 31u8, 241u8, 229u8, 155u8, 160u8, 189u8, 47u8, 113u8,
+                            240u8, 52u8, 211u8, 142u8, 100u8, 214u8, 36u8, 116u8, 91u8, 199u8, 9u8,
+                            33u8, 163u8, 100u8, 167u8, 248u8, 5u8, 241u8, 115u8, 98u8, 142u8, 71u8,
                         ]
                     {
                         let pallet = metadata.pallet("System")?;
@@ -11427,9 +11426,9 @@ pub mod api {
             };
             if runtime_metadata_hash
                 != [
-                    206u8, 28u8, 41u8, 82u8, 159u8, 93u8, 70u8, 175u8, 157u8, 13u8, 130u8, 122u8,
-                    43u8, 44u8, 14u8, 196u8, 140u8, 111u8, 140u8, 168u8, 110u8, 239u8, 233u8,
-                    147u8, 216u8, 246u8, 32u8, 138u8, 242u8, 95u8, 218u8, 64u8,
+                    43u8, 193u8, 63u8, 146u8, 26u8, 183u8, 253u8, 98u8, 93u8, 60u8, 119u8, 237u8,
+                    114u8, 235u8, 187u8, 35u8, 65u8, 109u8, 244u8, 78u8, 23u8, 39u8, 250u8, 200u8,
+                    54u8, 243u8, 74u8, 44u8, 177u8, 77u8, 235u8, 126u8,
                 ]
             {
                 Err(::subxt::MetadataError::IncompatibleMetadata)

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -99,7 +99,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 360,
+    spec_version: 370,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -100,7 +100,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 360,
+    spec_version: 370,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Resolves #1390  #1395 #1391.
remove lazy pages errors
improve lazy pages handling in allocation
reuse alloc and into_ext_info in both externalities struct

