### PR TITLE
Add pallets to docs and fix links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,15 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: "Install nightly toolchain"
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-
       - name: "Install: Nightly toolchain"
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
+          components: clippy, rustfmt
+          target: wasm32-unknown-unknown
 
       - name: "Install: Show specific nightly version"
         if: ${{ env.NIGHTLY_TOOLCHAIN_VERSION != '' }}

--- a/Makefile
+++ b/Makefile
@@ -257,9 +257,11 @@ test-client: node-release examples wat-examples
 .PHONY: doc
 doc:
 	@ RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo +nightly doc --no-deps \
-		-p galloc -p gcore -p gear-backend-common -p gear-backend-sandbox \
+		-p galloc -p gclient -p gcore -p gear-backend-common -p gear-backend-sandbox \
 		-p gear-core -p gear-core-processor -p gear-lazy-pages -p gear-core-errors \
-		-p gstd -p gtest -p gear-wasm-builder -p gear-common
+		-p gstd -p gtest -p gear-wasm-builder -p gear-common \
+		-p pallet-gear -p pallet-gear-gas -p pallet-gear-messenger -p pallet-gear-payment \
+		-p pallet-gear-program -p pallet-gear-rpc -p pallet-gear-scheduler
 	@ cp -f images/logo.svg target/doc/rust-logo.svg
 
 .PHONY: fuzz

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ Gear node can run in a single Dev Net mode or you can create a Multi-Node local 
 
 1. Compile and launch node as described in [Gear Node README](https://github.com/gear-tech/gear/tree/master/node/README.md). Alternatively, download nightly build of Gear node:
 
-    - **Windows x64**: [gear-nightly-windows-x86_64.zip](https://builds.gear.rs/gear-nightly-windows-x86_64.zip)
-    - **macOS M1**: [gear-nightly-macos-m1.tar.gz](https://builds.gear.rs/gear-nightly-macos-m1.tar.gz)
-    - **macOS Intel x64**: [gear-nightly-macos-x86_64.tar.gz](https://builds.gear.rs/gear-nightly-macos-x86_64.tar.gz)
-    - **Linux x64**: [gear-nightly-linux-x86_64.tar.xz](https://builds.gear.rs/gear-nightly-linux-x86_64.tar.xz)
+    - **Windows x64**: [gear-nightly-windows-x86_64.zip](https://get.gear.rs/gear-nightly-windows-x86_64.zip)
+    - **macOS M-series (ARM)**: [gear-nightly-macos-m.tar.gz](https://get.gear.rs/gear-nightly-macos-m.tar.gz)
+    - **macOS Intel x64**: [gear-nightly-macos-x86_64.tar.gz](https://get.gear.rs/gear-nightly-macos-x86_64.tar.gz)
+    - **Linux x64**: [gear-nightly-linux-x86_64.tar.xz](https://get.gear.rs/gear-nightly-linux-x86_64.tar.xz)
 
 2. Run Gear node without special arguments to get a node connected to the testnet:
 

--- a/core/src/message/common.rs
+++ b/core/src/message/common.rs
@@ -159,7 +159,7 @@ impl Message {
 
 /// Reply details data.
 ///
-/// Part of [`ReplyMessage`] logic, containing data about on which message id
+/// Part of [`ReplyMessage`](crate::message::ReplyMessage) logic, containing data about on which message id
 /// this replies and its exit code.
 #[derive(
     Clone, Copy, Default, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Decode, Encode, TypeInfo,

--- a/gstd/src/msg/encoded.rs
+++ b/gstd/src/msg/encoded.rs
@@ -88,7 +88,8 @@ pub fn reply_delayed<E: Encode>(payload: E, value: u128, delay: u32) -> Result<M
 ///
 /// # See also
 ///
-/// [`reply_push`] function allows to form a reply message in parts.
+/// [`reply_push`](crate::msg::reply_push) function allows to form a reply
+/// message in parts.
 #[wait_for_reply]
 pub fn reply_with_gas<E: Encode>(payload: E, gas_limit: u64, value: u128) -> Result<MessageId> {
     super::reply_bytes_with_gas(payload.encode(), gas_limit, value)

--- a/pallets/gear/rpc/src/lib.rs
+++ b/pallets/gear/rpc/src/lib.rs
@@ -93,7 +93,7 @@ pub trait GearApi<BlockHash, ResponseType> {
     ) -> RpcResult<GasInfo>;
 }
 
-/// A struct that implements the [`GearApi`].
+/// A struct that implements the [`GearApi`](/gclient/struct.GearApi.html).
 pub struct Gear<C, P> {
     // If you have more generics, no need to Gear<C, M, N, P, ...>
     // just use a tuple like Gear<C, (M, N, P, ...)>

--- a/pallets/gear/src/manager/mod.rs
+++ b/pallets/gear/src/manager/mod.rs
@@ -26,15 +26,17 @@
 //! in case of execution resulting in a trap. So, it gives us a guarantee that regardless of the result of message execution, there is **always some
 //! value** to perform asset management, i.e move tokens further to the recipient or give back to sender. The guarantee is implemented by using
 //! corresponding `pallet_balances` functions (`reserve`, `repatriate_reserved`, `unreserve` along with `transfer`) in `pallet_gear` extrinsics,
-//! [`JournalHandler::send_dispatch`] and [`JournalHandler::send_value`] procedures.
+//! [`JournalHandler::send_dispatch`](core_processor::common::JournalHandler::send_dispatch) and
+//! [`JournalHandler::send_value`](core_processor::common::JournalHandler::send_value) procedures.
 //!
 //! 2. **Balance sufficiency before adding message with value to the queue**.
 //! Before message is added to the queue, sender's balance is checked for having adequate amount of assets to send desired value. For actors, who
 //! can sign transactions, these checks are done in extrinsic calls. For programs these checks are done on core backend level during execution. In details,
 //! when a message is executed, it has some context, which is set from the pallet level, and a part of the context data is program's actual balance (current balance +
 //! value sent within the executing message). So if during execution of the original message some other messages were sent, message send call is followed
-//! by program's balance checks. The check gives guarantee that value reservation call in [`JournalHandler::send_dispatch`] for program's messages won't fail,
-//! because there is always a sufficient balance for the call.
+//! by program's balance checks. The check gives guarantee that value reservation call in
+//! [`JournalHandler::send_dispatch`](core_processor::common::JournalHandler::send_dispatch) for program's messages won't fail, because there is always a
+//! sufficient balance for the call.
 //!
 //! 3. **Messages's value management considers existential deposit rule**.
 //! It means that before message with value is added to the queue, value is checked to be in the valid range - `{0} ∪ [existential_deposit; +inf)`. This is


### PR DESCRIPTION
- Added to https://docs.gear.rs: `gclient`, `pallet-gear`, `pallet-gear-gas`, `pallet-gear-messenger`, `pallet-gear-payment`, `pallet-gear-program`, `pallet-gear-rpc`, `pallet-gear-scheduler`.
- Fixed links from `builds.gear.rs` to `get.gear.rs` in `README.md`.
- Fixed links in doc-comments.

Rendered: https://docs.gear.rs/pr-1636/

@gear-tech/dev 
