### PR TITLE
Remove redundant feature

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -244,7 +244,7 @@ jobs:
 
       - name: "Test: runtime spec tests no lazy pages"
         run: |
-          cargo build -p gear-cli --release --no-default-features --features=cli,runtime-test,gear-native --out-dir target-no-lazy -Z unstable-options
+          cargo build -p gear-cli --release --no-default-features --features=runtime-test,gear-native --out-dir target-no-lazy -Z unstable-options
           ./target-no-lazy/gear runtime-spec-tests ./gear-test/spec/* --runtime gear
 
       - name: "Test: Runtime upgrade and queue processing"

--- a/Makefile
+++ b/Makefile
@@ -73,15 +73,15 @@ node-release:
 
 .PHONY: node-release-rtest
 node-release-rtest:
-	@ ./scripts/gear.sh build node --release --no-default-features --features=gear-native,lazy-pages,program-cli,runtime-test
+	@ ./scripts/gear.sh build node --release --no-default-features --features=gear-native,lazy-pages,runtime-test
 
 .PHONY: vara
 vara:
-	@ ./scripts/gear.sh build node --no-default-features --features=vara-native,lazy-pages
+	@ ./scripts/gear.sh build node --no-default-features --features=vara-native,lazy-pages,program
 
 .PHONY: vara-release
 vara-release:
-	@ ./scripts/gear.sh build node --release --no-default-features --features=vara-native,lazy-pages
+	@ ./scripts/gear.sh build node --release --no-default-features --features=vara-native,lazy-pages,program
 
 .PHONY: vara-release-rtest
 vara-release-rtest:

--- a/examples/gui-test/src/lib.rs
+++ b/examples/gui-test/src/lib.rs
@@ -56,7 +56,7 @@ unsafe extern "C" fn init() {
         }
     };
 
-    msg::reply(outgoing, 555).unwrap();
+    msg::reply(outgoing, 1_001_000).unwrap();
 }
 
 type HandleIncoming = (BTreeMap<String, u8>, Option<(Option<u8>, u128, [u8; 3])>);
@@ -80,5 +80,5 @@ unsafe extern "C" fn handle() {
         }
     };
 
-    msg::reply(outgoing, 555).unwrap();
+    msg::reply(outgoing, 1_001_000).unwrap();
 }

--- a/gear-test/spec/test_gui.yaml
+++ b/gear-test/spec/test_gui.yaml
@@ -10,7 +10,7 @@ programs:
           zerokey: 0
           lonelykey: 1
           couplekey: 2
-    init_value: 100000    
+    init_value: 10000000000
 
 fixtures:
   - title: gui

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -22,7 +22,7 @@ scale-info = { version = "2.1.1", default-features = false, features = ["derive"
 # Gear
 runtime-primitives = { package = "gear-runtime-primitives", version = "0.1.0", default-features = false, path = "../../runtime/primitives" }
 gear-runtime-test-cli = { path = "../../utils/gear-runtime-test-cli", optional = true }
-service = { package = "gear-service", path = "../service", default-features = false, optional = true }
+service = { package = "gear-service", path = "../service", default-features = false }
 pallet-gear-payment = { version = "0.1.0", path = "../../pallets/payment" }
 
 # Gear Runtimes
@@ -32,10 +32,10 @@ vara-runtime = { path = "../../runtime/vara", optional = true }
 # Substrate client
 sc-cli = { version = "0.10.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", features = [
 	"wasmtime",
-], optional = true }
+] }
 sc-service = { version = "0.10.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", features = [
 	"wasmtime",
-], optional = true }
+] }
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 
 # Substrate primitives
@@ -58,39 +58,34 @@ gear-program = { path = "../../program", features = [ "cli" ], optional = true }
 substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 
 [features]
-default = ["cli", "gear-native", "vara-native", "program"]
-cli = [
-	"service",
-	"sc-cli",
-	"sc-service",
-]
+default = ["gear-native", "vara-native", "program"]
 gear-native = [
-	"service?/gear-native",
+	"service/gear-native",
 	"gear-runtime-test-cli?/gear-native",
 	"gear-runtime",
 ]
 vara-native = [
-	"service?/vara-native",
+	"service/vara-native",
 	"gear-runtime-test-cli?/vara-native",
 	"vara-runtime",
 ]
 lazy-pages = [
-	"service?/lazy-pages",
+	"service/lazy-pages",
 	"gear-runtime-test-cli?/lazy-pages",
 	"vara-runtime?/lazy-pages",
 	"gear-runtime?/lazy-pages",
 ]
 runtime-benchmarks = [
-	"service?/runtime-benchmarks",
+	"service/runtime-benchmarks",
 	"frame-benchmarking-cli/runtime-benchmarks",
 ]
 debug-mode = [
-	"service?/debug-mode",
+	"service/debug-mode",
 	"gear-runtime?/debug-mode",
 	"vara-runtime?/debug-mode",
 ]
 try-runtime = [
-	"service?/try-runtime",
+	"service/try-runtime",
 	"try-runtime-cli",
 ]
 runtime-test = ["gear-runtime-test-cli"]

--- a/program/src/api/generated/metadata.rs
+++ b/program/src/api/generated/metadata.rs
@@ -1544,9 +1544,10 @@ pub mod api {
                     let metadata = locked_metadata.read();
                     if metadata.constant_hash("System", "Version")?
                         == [
-                            11u8, 117u8, 206u8, 47u8, 240u8, 216u8, 123u8, 154u8, 105u8, 65u8,
-                            67u8, 66u8, 143u8, 50u8, 36u8, 81u8, 20u8, 55u8, 23u8, 77u8, 143u8,
-                            77u8, 8u8, 150u8, 238u8, 166u8, 101u8, 183u8, 240u8, 85u8, 40u8, 178u8,
+                            164u8, 52u8, 124u8, 196u8, 109u8, 235u8, 65u8, 247u8, 215u8, 135u8,
+                            238u8, 131u8, 224u8, 206u8, 172u8, 67u8, 18u8, 233u8, 232u8, 26u8,
+                            92u8, 198u8, 169u8, 41u8, 115u8, 64u8, 111u8, 119u8, 148u8, 203u8,
+                            200u8, 14u8,
                         ]
                     {
                         let pallet = metadata.pallet("System")?;
@@ -6547,10 +6548,10 @@ pub mod api {
                         };
                         if runtime_storage_hash
                             == [
-                                13u8, 201u8, 57u8, 102u8, 238u8, 251u8, 200u8, 48u8, 0u8, 230u8,
-                                239u8, 55u8, 59u8, 1u8, 41u8, 201u8, 29u8, 252u8, 61u8, 174u8,
-                                130u8, 13u8, 33u8, 139u8, 218u8, 239u8, 211u8, 178u8, 89u8, 232u8,
-                                38u8, 2u8,
+                                85u8, 245u8, 180u8, 137u8, 173u8, 33u8, 39u8, 0u8, 93u8, 81u8,
+                                117u8, 68u8, 240u8, 149u8, 206u8, 147u8, 4u8, 228u8, 149u8, 171u8,
+                                170u8, 138u8, 72u8, 187u8, 74u8, 64u8, 148u8, 23u8, 194u8, 222u8,
+                                227u8, 239u8,
                             ]
                         {
                             let entry = PausedPrograms(_0);
@@ -6581,10 +6582,10 @@ pub mod api {
                         };
                         if runtime_storage_hash
                             == [
-                                13u8, 201u8, 57u8, 102u8, 238u8, 251u8, 200u8, 48u8, 0u8, 230u8,
-                                239u8, 55u8, 59u8, 1u8, 41u8, 201u8, 29u8, 252u8, 61u8, 174u8,
-                                130u8, 13u8, 33u8, 139u8, 218u8, 239u8, 211u8, 178u8, 89u8, 232u8,
-                                38u8, 2u8,
+                                85u8, 245u8, 180u8, 137u8, 173u8, 33u8, 39u8, 0u8, 93u8, 81u8,
+                                117u8, 68u8, 240u8, 149u8, 206u8, 147u8, 4u8, 228u8, 149u8, 171u8,
+                                170u8, 138u8, 72u8, 187u8, 74u8, 64u8, 148u8, 23u8, 194u8, 222u8,
+                                227u8, 239u8,
                             ]
                         {
                             client.storage().iter(block_hash).await
@@ -8321,9 +8322,10 @@ pub mod api {
                     let metadata = locked_metadata.read();
                     if metadata.constant_hash("Gear", "Schedule")?
                         == [
-                            190u8, 249u8, 239u8, 138u8, 76u8, 42u8, 7u8, 80u8, 198u8, 241u8, 123u8,
-                            55u8, 30u8, 245u8, 2u8, 11u8, 199u8, 93u8, 105u8, 198u8, 118u8, 254u8,
-                            198u8, 41u8, 202u8, 168u8, 165u8, 146u8, 28u8, 56u8, 198u8, 124u8,
+                            172u8, 140u8, 25u8, 127u8, 19u8, 228u8, 243u8, 34u8, 71u8, 170u8, 44u8,
+                            48u8, 165u8, 123u8, 232u8, 46u8, 41u8, 22u8, 246u8, 100u8, 173u8,
+                            160u8, 235u8, 5u8, 242u8, 184u8, 71u8, 254u8, 243u8, 226u8, 120u8,
+                            81u8,
                         ]
                     {
                         let pallet = metadata.pallet("Gear")?;
@@ -8379,6 +8381,29 @@ pub mod api {
                     {
                         let pallet = metadata.pallet("Gear")?;
                         let constant = pallet.constant("MailboxThreshold")?;
+                        let value = ::subxt::codec::Decode::decode(&mut &constant.value[..])?;
+                        Ok(value)
+                    } else {
+                        Err(::subxt::MetadataError::IncompatibleMetadata.into())
+                    }
+                }
+                #[doc = " The cost per loaded byte."]
+                pub fn read_per_byte_cost(
+                    &self,
+                ) -> ::core::result::Result<::core::primitive::u64, ::subxt::BasicError>
+                {
+                    let locked_metadata = self.client.metadata();
+                    let metadata = locked_metadata.read();
+                    if metadata.constant_hash("Gear", "ReadPerByteCost")?
+                        == [
+                            187u8, 170u8, 175u8, 60u8, 38u8, 70u8, 96u8, 130u8, 174u8, 35u8, 140u8,
+                            211u8, 34u8, 175u8, 75u8, 238u8, 57u8, 136u8, 142u8, 57u8, 115u8,
+                            130u8, 167u8, 234u8, 210u8, 176u8, 137u8, 130u8, 78u8, 18u8, 128u8,
+                            245u8,
+                        ]
+                    {
+                        let pallet = metadata.pallet("Gear")?;
+                        let constant = pallet.constant("ReadPerByteCost")?;
                         let value = ::subxt::codec::Decode::decode(&mut &constant.value[..])?;
                         Ok(value)
                     } else {
@@ -8904,6 +8929,9 @@ pub mod api {
                 pub allocations: ::std::vec::Vec<runtime_types::gear_core::memory::WasmPageNumber>,
                 pub pages_with_data: ::std::vec::Vec<runtime_types::gear_core::memory::PageNumber>,
                 pub code_hash: ::subxt::sp_core::H256,
+                pub code_length_bytes: ::core::primitive::u32,
+                pub code_exports: ::std::vec::Vec<runtime_types::gear_core::message::DispatchKind>,
+                pub static_pages: runtime_types::gear_core::memory::WasmPageNumber,
                 pub state: runtime_types::gear_common::ProgramState,
             }
             #[derive(:: subxt :: codec :: Decode, :: subxt :: codec :: Encode, Debug)]
@@ -9899,8 +9927,7 @@ pub mod api {
                 }
                 #[derive(:: subxt :: codec :: Decode, :: subxt :: codec :: Encode, Debug)]
                 pub struct Limits {
-                    pub event_topics: ::core::primitive::u32,
-                    pub stack_height: ::core::primitive::u32,
+                    pub stack_height: ::core::option::Option<::core::primitive::u32>,
                     pub globals: ::core::primitive::u32,
                     pub parameters: ::core::primitive::u32,
                     pub memory_pages: ::core::primitive::u32,
@@ -11585,9 +11612,9 @@ pub mod api {
             };
             if runtime_metadata_hash
                 != [
-                    104u8, 116u8, 103u8, 35u8, 166u8, 108u8, 99u8, 170u8, 227u8, 100u8, 234u8,
-                    149u8, 235u8, 170u8, 204u8, 49u8, 11u8, 220u8, 107u8, 177u8, 68u8, 75u8, 129u8,
-                    93u8, 119u8, 174u8, 245u8, 25u8, 4u8, 77u8, 76u8, 12u8,
+                    175u8, 130u8, 80u8, 50u8, 194u8, 174u8, 13u8, 78u8, 26u8, 88u8, 128u8, 209u8,
+                    249u8, 105u8, 124u8, 203u8, 249u8, 213u8, 62u8, 54u8, 181u8, 0u8, 200u8, 215u8,
+                    56u8, 62u8, 71u8, 110u8, 99u8, 18u8, 140u8, 0u8,
                 ]
             {
                 Err(::subxt::MetadataError::IncompatibleMetadata)

--- a/scripts/test-utils/package-lock.json
+++ b/scripts/test-utils/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@polkadot/api": "^8.14.1"
+        "@polkadot/api": "^9.5.1"
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.4.tgz",
+      "integrity": "sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
-      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
+      "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==",
       "funding": [
         {
           "type": "individual",
@@ -35,9 +35,9 @@
       ]
     },
     "node_modules/@noble/secp256k1": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
-      "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
+      "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==",
       "funding": [
         {
           "type": "individual",
@@ -46,160 +46,160 @@
       ]
     },
     "node_modules/@polkadot/api": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-8.14.1.tgz",
-      "integrity": "sha512-jg26eIKFYqVfDBTAopHL3aDaNw9j6TdUkXuvYJOnynpecU4xwbTVKcOtSOjJ2eRX4MgMQ4zlyMHJx3iKw0uUTA==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-9.5.1.tgz",
+      "integrity": "sha512-A2i/+mCl6cbFJ84ExMcWosUDfq0gVvzyKftkbRMs0oDzvHVVucTm0nCCzBgi/ltvSsFq8oJQ4pVqNTfT/IXgeQ==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api-augment": "8.14.1",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/api-derive": "8.14.1",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/rpc-provider": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/types-known": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/api-augment": "9.5.1",
+        "@polkadot/api-base": "9.5.1",
+        "@polkadot/api-derive": "9.5.1",
+        "@polkadot/keyring": "^10.1.10",
+        "@polkadot/rpc-augment": "9.5.1",
+        "@polkadot/rpc-core": "9.5.1",
+        "@polkadot/rpc-provider": "9.5.1",
+        "@polkadot/types": "9.5.1",
+        "@polkadot/types-augment": "9.5.1",
+        "@polkadot/types-codec": "9.5.1",
+        "@polkadot/types-create": "9.5.1",
+        "@polkadot/types-known": "9.5.1",
+        "@polkadot/util": "^10.1.10",
+        "@polkadot/util-crypto": "^10.1.10",
         "eventemitter3": "^4.0.7",
-        "rxjs": "^7.5.6"
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/api-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-8.14.1.tgz",
-      "integrity": "sha512-65GMlgVnZd08Ifh8uAj+p/+MlXxvsAfBcCHjQhOmbCE0dki+rzTPUR31LsWyDKtuw+nUBj0iZN4PelO+wU4r0g==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-9.5.1.tgz",
+      "integrity": "sha512-9NQ2miIKVJvyhR2Zhk0XcHA+pgnWhQ0815lqcq0kz9ny5JHUFeGlNtxECw7AEnxoiC81EqpfWkOHpJpfiIcOmw==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/api-base": "9.5.1",
+        "@polkadot/rpc-augment": "9.5.1",
+        "@polkadot/types": "9.5.1",
+        "@polkadot/types-augment": "9.5.1",
+        "@polkadot/types-codec": "9.5.1",
+        "@polkadot/util": "^10.1.10"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/api-base": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-8.14.1.tgz",
-      "integrity": "sha512-EXFhNXIfpirf18IsqcG2pGQW1/Xn+bfjqVYQMMJ4ZONtYH4baZZlXk7SoXCCHonN2x1ixs4DOcRx5oVxjabdIQ==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-9.5.1.tgz",
+      "integrity": "sha512-3qsMsIhYbU3zp+YnP5h6Hg98y3B+FrxgPW7r2Uk6Kp1uSPmIzhMCyGuxur/BAcDVbd3KME+zWLHJDYOdyhuUwQ==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/rpc-core": "9.5.1",
+        "@polkadot/types": "9.5.1",
+        "@polkadot/util": "^10.1.10",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/api-derive": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-8.14.1.tgz",
-      "integrity": "sha512-eWG1MrQhHMUjt9gDHN9/9/ZMATu1MolqcalPFhNoGtdON3+I0J3ntjQ4y5X7+p2OGwQplpYRKqbK4k7tKzu8tA==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-9.5.1.tgz",
+      "integrity": "sha512-fKlKQe8WZ3jrm44w/zptMofljW5qj+jZxnryK08CAH/MINlZArPfCtn+EJla2ND9aTnRMUWlEBtytyCPImI/Hg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api": "8.14.1",
-        "@polkadot/api-augment": "8.14.1",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/api": "9.5.1",
+        "@polkadot/api-augment": "9.5.1",
+        "@polkadot/api-base": "9.5.1",
+        "@polkadot/rpc-core": "9.5.1",
+        "@polkadot/types": "9.5.1",
+        "@polkadot/types-codec": "9.5.1",
+        "@polkadot/util": "^10.1.10",
+        "@polkadot/util-crypto": "^10.1.10",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/keyring": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.1.1.tgz",
-      "integrity": "sha512-lgYS9UIa611FBnYXb7DnVuLsiMnUR2S8x1jfNBJT32x7T66XSRnc7kpwgHW0MNGVTwjFVVfIr7XfpvXGDoBZgg==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.1.10.tgz",
+      "integrity": "sha512-crKYBbwmPcFoTP6mby2+o1QWsjAyi5QlKzU8tXuXOApP6SBuqmDujIuLOKNG2vZoftNdVldsVL0WmKVYtBeuQg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "10.1.1",
-        "@polkadot/util-crypto": "10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/util": "10.1.10",
+        "@polkadot/util-crypto": "10.1.10"
       },
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@polkadot/util": "10.1.1",
-        "@polkadot/util-crypto": "10.1.1"
+        "@polkadot/util": "10.1.10",
+        "@polkadot/util-crypto": "10.1.10"
       }
     },
     "node_modules/@polkadot/networks": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.1.1.tgz",
-      "integrity": "sha512-upM8r0mrsCVA+vPVbJUjtnkAfdleBMHB+Fbxvy3xtbK1IFpzQTUhSOQb6lBnBAPBFGyxMtQ3TytnInckAdYZeg==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.1.10.tgz",
+      "integrity": "sha512-Db78t2XnFIZbdSdu1aFuj3/1cNwcSzG/+wNrpCQ9dPhnGPy5S1GVbmU8pyxTftPKdTFc+8RdBr+5bc0d5ijGiA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "10.1.1",
-        "@substrate/ss58-registry": "^1.24.0"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/util": "10.1.10",
+        "@substrate/ss58-registry": "^1.31.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/rpc-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-8.14.1.tgz",
-      "integrity": "sha512-0dIsNVIMeCp0kV7+Obz0Odt6K32Ka2ygwhiV5jhhJthy8GJBPo94mKDed5gzln3Dgl2LEdJJt1h/pgCx4a2i4A==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-9.5.1.tgz",
+      "integrity": "sha512-7Qm6oIoVIqv6VOaIqDal45hUTb3TVZ58S3zkSr60p/dPMlGCaFMcojtfcQErHtCW0hgvzFNsDl9ShpXRcPWu7g==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/rpc-core": "9.5.1",
+        "@polkadot/types": "9.5.1",
+        "@polkadot/types-codec": "9.5.1",
+        "@polkadot/util": "^10.1.10"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/rpc-core": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-8.14.1.tgz",
-      "integrity": "sha512-deQ8Ob59ao/1fZQdaVtFjYR/HCBdxSYvQGt7/alBu1Uig9Sahx9oKcMkU5rWY36XqGZYos4zLay98W2hDlf+6Q==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-9.5.1.tgz",
+      "integrity": "sha512-8CXgBVTEUjeuN5VOwS6MjTeqpN+9qrNJAAwNEba36/72g6Wgg3flza11kx0luQ6OLPVgCM7OcAjZ17p16phXDA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/rpc-provider": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/rpc-augment": "9.5.1",
+        "@polkadot/rpc-provider": "9.5.1",
+        "@polkadot/types": "9.5.1",
+        "@polkadot/util": "^10.1.10",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/rpc-provider": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-8.14.1.tgz",
-      "integrity": "sha512-pAUSHZiSWLhBSYf4LmLc8iCaeqTu7Ajn8AzyqxvZDHGnIrzV5M7eTjpNDP84qno6jWRHKQ/IILr62hausEmS5w==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-9.5.1.tgz",
+      "integrity": "sha512-CxyEo1SzwbcByUsrW5RUm5GTLNK7yjmVlTMseex8zQLO4+4erqUoQzr6TTIPSt4LWyk+TjbZdtGtlt7p6i2nJg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-support": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "@polkadot/x-fetch": "^10.1.1",
-        "@polkadot/x-global": "^10.1.1",
-        "@polkadot/x-ws": "^10.1.1",
-        "@substrate/connect": "0.7.9",
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/keyring": "^10.1.10",
+        "@polkadot/types": "9.5.1",
+        "@polkadot/types-support": "9.5.1",
+        "@polkadot/util": "^10.1.10",
+        "@polkadot/util-crypto": "^10.1.10",
+        "@polkadot/x-fetch": "^10.1.10",
+        "@polkadot/x-global": "^10.1.10",
+        "@polkadot/x-ws": "^10.1.10",
+        "@substrate/connect": "0.7.14",
         "eventemitter3": "^4.0.7",
         "mock-socket": "^9.1.5",
         "nock": "^13.2.9"
@@ -209,102 +209,102 @@
       }
     },
     "node_modules/@polkadot/types": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.14.1.tgz",
-      "integrity": "sha512-Xza16ejKrSd4XhTOlbfISyxZ2sRmbMAZk5pX7VEMHVZHqV98o+bJ2f9Kk7F8YJijkHHGosCLDestP9R5nLoOoA==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.5.1.tgz",
+      "integrity": "sha512-xuhYq+O4JRl2iqLVEwKVHnfOA9AfwoNlHzrFx2DChDcIWdmgmUDASq9TkZhBP+jx81SieMH7iTf4zY6UwPKYQw==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/keyring": "^10.1.10",
+        "@polkadot/types-augment": "9.5.1",
+        "@polkadot/types-codec": "9.5.1",
+        "@polkadot/types-create": "9.5.1",
+        "@polkadot/util": "^10.1.10",
+        "@polkadot/util-crypto": "^10.1.10",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.14.1.tgz",
-      "integrity": "sha512-Xa4TUFqyZT+IJ6pBSwDjWcF42u/E34OyC+gbs5Z2vWQ4EzSDkq4xNoUKjJlEEgTemsD9lhPOIc4jvqTCefwxEw==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.5.1.tgz",
+      "integrity": "sha512-1AzQpGe5bGttYbbjR1UhV19htsFjgqJ651eyT3YdRqo1hotZ2GwTCkGXuTJtcmQQH9G09xUUwS3nx8WsSyQ70A==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/types": "9.5.1",
+        "@polkadot/types-codec": "9.5.1",
+        "@polkadot/util": "^10.1.10"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-codec": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.14.1.tgz",
-      "integrity": "sha512-y6YDN4HwvEgSWlgrEV04QBBxDxES1cTuUQFzZJzOTuZCWpA371Mdj3M9wYxGXMnj0wa+rCQGECHPZZaNxBMiKg==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.5.1.tgz",
+      "integrity": "sha512-7Dy8TeApu4lN8DqdMZLuh34ocdHQh9jzAob6cQl1fl1ypOiCO/SwPjFkj0Xnhh7QQz9X9w63jZzbaFR3PPT+0g==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/x-bigint": "^10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/util": "^10.1.10",
+        "@polkadot/x-bigint": "^10.1.10"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-create": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.14.1.tgz",
-      "integrity": "sha512-fb9yyblj5AYAPzeCIq0kYSfzDxRDi/0ud9gN2UzB3H7M/O4n2mPC1vD4UOLF+B7l9QzCrt4e+k+/riGp7GfvyA==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.5.1.tgz",
+      "integrity": "sha512-pUQ1U0mho5aKRdi4iR9DP9ldIoj9U+ApHIeYyxkBY8RexMQOpkt8PZfpFhg4z2H5vZj/sgNIBXq65HjXuyu+9w==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/types-codec": "9.5.1",
+        "@polkadot/util": "^10.1.10"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-known": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-8.14.1.tgz",
-      "integrity": "sha512-GP7gRo9nmitykkrRnoLF61Qm19UFdTwMsOnJkdm7AOeWDmZGxutacgO6k1tBsHr38hsiCCGsB/JiseUgywvGIw==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-9.5.1.tgz",
+      "integrity": "sha512-SedfPDxJREYPATa7X2Fv26z6UVPYv6v9Z9P4nulnC6Yl8C2+Q4A/VIqTtgsJc0DU1YT3gM8ofVxircfHqqRVNA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/networks": "^10.1.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/networks": "^10.1.10",
+        "@polkadot/types": "9.5.1",
+        "@polkadot/types-codec": "9.5.1",
+        "@polkadot/types-create": "9.5.1",
+        "@polkadot/util": "^10.1.10"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-support": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-8.14.1.tgz",
-      "integrity": "sha512-XqR4qq6pCZyNBuFVod8nFSNUmLssrjoU9bOIn4Ua2cqNlI9xsuKaI1X5ySEn/oWOtKQ2L5hbCm9vkXrEtXBl1w==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.5.1.tgz",
+      "integrity": "sha512-mjenEGNT/ReY1xFexb37NDgV7QHHBBfWt31ZQMZKDkQL+R2P0rXFpmitcE3eOCV3oY4mf+GaU2N/ZfnsFl3tPQ==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/util": "^10.1.10"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/util": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.1.1.tgz",
-      "integrity": "sha512-/g0sEqOOXfiNmQnWcFK3H1+wKBjbJEfGj6lTmbQ0xnL4TS5mFFQ7ZZEvxD60EkoXVMuCmSSh9E54goNLzh+Zyg==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.1.10.tgz",
+      "integrity": "sha512-BQoTfSxZ3BWAgWDjgKBVdyw1AJGaoOeAidCA+LZcHV6wlMu5643AZPUnoMrW413MbbpxsIhJXtNttqOwjo8MjA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/x-bigint": "10.1.1",
-        "@polkadot/x-global": "10.1.1",
-        "@polkadot/x-textdecoder": "10.1.1",
-        "@polkadot/x-textencoder": "10.1.1",
-        "@types/bn.js": "^5.1.0",
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/x-bigint": "10.1.10",
+        "@polkadot/x-global": "10.1.10",
+        "@polkadot/x-textdecoder": "10.1.10",
+        "@polkadot/x-textencoder": "10.1.10",
+        "@types/bn.js": "^5.1.1",
         "bn.js": "^5.2.1"
       },
       "engines": {
@@ -312,18 +312,18 @@
       }
     },
     "node_modules/@polkadot/util-crypto": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.1.1.tgz",
-      "integrity": "sha512-R0V++xXbL2pvnCFIuXnKc/TlNhBkyxcno1u8rmjYNuH9S5GOmi2jY/8cNhbrwk6wafBsi+xMPHrEbUnduk82Ag==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.1.10.tgz",
+      "integrity": "sha512-w9h/wf4wZXeUkRnihhnfqlaKuoQtrjkjK3C5liCQkr9vx5zOsmg/nMSDP8UUFJX0msPPYpFeNvzn7oDIs6qSZA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@noble/hashes": "1.1.2",
-        "@noble/secp256k1": "1.6.3",
-        "@polkadot/networks": "10.1.1",
-        "@polkadot/util": "10.1.1",
+        "@babel/runtime": "^7.19.0",
+        "@noble/hashes": "1.1.3",
+        "@noble/secp256k1": "1.7.0",
+        "@polkadot/networks": "10.1.10",
+        "@polkadot/util": "10.1.10",
         "@polkadot/wasm-crypto": "^6.3.1",
-        "@polkadot/x-bigint": "10.1.1",
-        "@polkadot/x-randomvalues": "10.1.1",
+        "@polkadot/x-bigint": "10.1.10",
+        "@polkadot/x-randomvalues": "10.1.10",
         "@scure/base": "1.1.1",
         "ed2curve": "^0.3.0",
         "tweetnacl": "^1.0.3"
@@ -332,7 +332,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@polkadot/util": "10.1.1"
+        "@polkadot/util": "10.1.10"
       }
     },
     "node_modules/@polkadot/wasm-bridge": {
@@ -432,85 +432,85 @@
       }
     },
     "node_modules/@polkadot/x-bigint": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.1.1.tgz",
-      "integrity": "sha512-YNYN64N4icKyqiDIw0tcGyWwz3g/282Kk0ozfcA5TM0wGRe2BwmoB4gYrZ7pJDxvsHnRPR6Dw0r9Xxh8DNIzHQ==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.1.10.tgz",
+      "integrity": "sha512-4Jt0BO0WTby6r9A2DgkDxf/LFaICQHvSl1VSFtBf0Z0GV2n4OxkBX5x/1bdEdGEvYT5rM7RbR3xI7EL+W1ixHA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/x-global": "10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/x-global": "10.1.10"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-fetch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.1.1.tgz",
-      "integrity": "sha512-xSKZClZBT3QSaJeEIZwzWPm/AdJ0pPCuUEhBv0e6XU2ANn1w+OAwwlNB94DEVzN+WouZqcNgE6mC2yVd5t7JZQ==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.1.10.tgz",
+      "integrity": "sha512-LvTxAN6GaJzfgZ74WFYPZrIkMEThpX5u7O4ILiExcJt87E19cSWlYSHDa5n+OLjUpq0lBV2ueF90iUblt6aHpg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/x-global": "10.1.1",
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/x-global": "10.1.10",
         "@types/node-fetch": "^2.6.2",
-        "node-fetch": "^3.2.9"
+        "node-fetch": "^3.2.10"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-global": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.1.1.tgz",
-      "integrity": "sha512-wB3rZTTNN14umLSfR2GLL0dJrlGM1YRUNw7XvbA+3B8jxGCIOmjSyAkdZBeiCxg2XIbJD3EkB0hBhga2mNuS6g==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.1.10.tgz",
+      "integrity": "sha512-WFfgaZSrzPlKLdnOus2mIFGzUbSDIQK6RMCfFfM9SmF3DkoxN40z5Nkni4PztfKr22stlkhmhnX/Lp/NxpuT6Q==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9"
+        "@babel/runtime": "^7.19.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-randomvalues": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.1.1.tgz",
-      "integrity": "sha512-opVFNEnzCir7cWsFfyDqNlrGazkpjnL+JpkxE/b9WmSco6y0IUzn/Q7rL3EaBzBEvxY0/J8KeSGGs3W+mf6tBQ==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.1.10.tgz",
+      "integrity": "sha512-KM4sCI/DNLIXlmnkeJIuYvh3pPuWvnkbR1a6TUB12J1izUJ+uGV+cAFRR4/EZk3oEsG/Tgivbs56meEOo3ws5A==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/x-global": "10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/x-global": "10.1.10"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-textdecoder": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.1.1.tgz",
-      "integrity": "sha512-a52ah/sUS+aGZcCCL7BhrytAeV/7kiqu1zbuCoZtIzxP6x34a2vcic3bLPoyynLcX2ruzvLKFhJDGOJ4Bq5lcA==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.1.10.tgz",
+      "integrity": "sha512-cAk37faYXx8IICeaq/tdl+aiIXwo3SLrx9XNoQqhX02g+SEs3ARM7zJcohj/p8ynWAI+ezNcsKn1wh174nquHw==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/x-global": "10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/x-global": "10.1.10"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-textencoder": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.1.1.tgz",
-      "integrity": "sha512-prTzUXXW9OxFyf17EwGSBxe2GvVFG60cmKV8goC50nghhNMl1y0GdGpvKNQTFG6hIk5fIon9/pBpWsas4iAf+Q==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.1.10.tgz",
+      "integrity": "sha512-Auaql6BL5UHtWakZUQyj4y/BrM0tm4bYG5vXCMQCA1Gg0ky+46DhgpRrAQ9F7NNgWg1A6dA2I9KuAA4BTbNx0w==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/x-global": "10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/x-global": "10.1.10"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-ws": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.1.1.tgz",
-      "integrity": "sha512-IdakU22dcAqmLRNyL8oWUXxnHwnoUteoU3Xyc6W4wxJ8K6GNxjbUtSjoT/FTEW1JmxVVtFHu8kKRnKhu5WbWdg==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.1.10.tgz",
+      "integrity": "sha512-JxDgfm0ox2XPAtdTeJXYl6qq7LY/KOPi69wRpFMczWaYUsZubO6EiRzgzjuFlHY4/oxfjS/D+YbzcjefTxHz6g==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/x-global": "10.1.1",
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/x-global": "10.1.10",
         "@types/websocket": "^1.0.5",
         "websocket": "^1.0.34"
       },
@@ -530,12 +530,12 @@
       ]
     },
     "node_modules/@substrate/connect": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.9.tgz",
-      "integrity": "sha512-E6bdBhzsfHNAKlmQSvbTW1jyb0WcIvgbrEBfJ4B6FZ3t1wpGjldL6GrYtegVtKr9/ySQ/pFNn0uVbugukpMDjQ==",
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.14.tgz",
+      "integrity": "sha512-uW5uBmihpivshmmmw+rsg7qOV0KqVSep4rWOXFMP8aFQinvmqw4JqxP21og4H/7JZxttYUBFQVsdtXHGKJ0aVQ==",
       "dependencies": {
         "@substrate/connect-extension-protocol": "^1.0.1",
-        "@substrate/smoldot-light": "0.6.25",
+        "@substrate/smoldot-light": "0.6.34",
         "eventemitter3": "^4.0.7"
       }
     },
@@ -545,30 +545,31 @@
       "integrity": "sha512-161JhCC1csjH3GE5mPLEd7HbWtwNSPJBg3p1Ksz9SFlTzj/bgEwudiRN2y5i0MoLGCIJRYKyKGMxVnd29PzNjg=="
     },
     "node_modules/@substrate/smoldot-light": {
-      "version": "0.6.25",
-      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.6.25.tgz",
-      "integrity": "sha512-OQ9/bnJJy90xSRg5Vp9MIvrgbrVt/r/FwXYSmyLeBBNbJt6o1gSeshVo8icD+2VWwd/TJ2oHl5CVQWe89MyByA==",
+      "version": "0.6.34",
+      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.6.34.tgz",
+      "integrity": "sha512-+HK9MaJ0HelJmpf4YYR+salJ7dhVBltmhGlyz5l8OXS9DW18fe0Z2wxEo8P5kX9CUxlCXEb8J9JBRQAYBPHbwQ==",
       "dependencies": {
-        "websocket": "^1.0.32"
+        "pako": "^2.0.4",
+        "ws": "^8.8.1"
       }
     },
     "node_modules/@substrate/ss58-registry": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.25.0.tgz",
-      "integrity": "sha512-LmCH4QJRdHaeLsLTPSgJaXguMoIW+Ig9fA9LRPpeya9HefVAJ7gZuUYinldv+QmX7evNm5CL0rspNUS8l1DvXg=="
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.33.0.tgz",
+      "integrity": "sha512-DztMuMcEfu+tJrtIQIIp5gO8/XJZ8N8UwPObDCSNgrp7trtSkPJAUFB9qXaReXtN9UvTcVBMTWk6VPfFi04Wkg=="
     },
     "node_modules/@types/bn.js": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-      "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
+      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
-      "version": "18.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
-      "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ=="
+      "version": "18.8.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.5.tgz",
+      "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -670,9 +671,9 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.61",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
       "hasInstallScript": true,
       "dependencies": {
         "es6-iterator": "^2.0.3",
@@ -708,17 +709,17 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "node_modules/ext": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
-      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
       "dependencies": {
-        "type": "^2.5.0"
+        "type": "^2.7.2"
       }
     },
     "node_modules/ext/node_modules/type": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
-      "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -877,6 +878,11 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
+    "node_modules/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
+    },
     "node_modules/propagate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
@@ -886,14 +892,14 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
+      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
     },
     "node_modules/rxjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
-      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -970,6 +976,26 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/ws": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
+      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/yaeti": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
@@ -981,250 +1007,250 @@
   },
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.4.tgz",
+      "integrity": "sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@noble/hashes": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
-      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
+      "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A=="
     },
     "@noble/secp256k1": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
-      "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
+      "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw=="
     },
     "@polkadot/api": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-8.14.1.tgz",
-      "integrity": "sha512-jg26eIKFYqVfDBTAopHL3aDaNw9j6TdUkXuvYJOnynpecU4xwbTVKcOtSOjJ2eRX4MgMQ4zlyMHJx3iKw0uUTA==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-9.5.1.tgz",
+      "integrity": "sha512-A2i/+mCl6cbFJ84ExMcWosUDfq0gVvzyKftkbRMs0oDzvHVVucTm0nCCzBgi/ltvSsFq8oJQ4pVqNTfT/IXgeQ==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api-augment": "8.14.1",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/api-derive": "8.14.1",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/rpc-provider": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/types-known": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/api-augment": "9.5.1",
+        "@polkadot/api-base": "9.5.1",
+        "@polkadot/api-derive": "9.5.1",
+        "@polkadot/keyring": "^10.1.10",
+        "@polkadot/rpc-augment": "9.5.1",
+        "@polkadot/rpc-core": "9.5.1",
+        "@polkadot/rpc-provider": "9.5.1",
+        "@polkadot/types": "9.5.1",
+        "@polkadot/types-augment": "9.5.1",
+        "@polkadot/types-codec": "9.5.1",
+        "@polkadot/types-create": "9.5.1",
+        "@polkadot/types-known": "9.5.1",
+        "@polkadot/util": "^10.1.10",
+        "@polkadot/util-crypto": "^10.1.10",
         "eventemitter3": "^4.0.7",
-        "rxjs": "^7.5.6"
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/api-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-8.14.1.tgz",
-      "integrity": "sha512-65GMlgVnZd08Ifh8uAj+p/+MlXxvsAfBcCHjQhOmbCE0dki+rzTPUR31LsWyDKtuw+nUBj0iZN4PelO+wU4r0g==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-9.5.1.tgz",
+      "integrity": "sha512-9NQ2miIKVJvyhR2Zhk0XcHA+pgnWhQ0815lqcq0kz9ny5JHUFeGlNtxECw7AEnxoiC81EqpfWkOHpJpfiIcOmw==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/api-base": "9.5.1",
+        "@polkadot/rpc-augment": "9.5.1",
+        "@polkadot/types": "9.5.1",
+        "@polkadot/types-augment": "9.5.1",
+        "@polkadot/types-codec": "9.5.1",
+        "@polkadot/util": "^10.1.10"
       }
     },
     "@polkadot/api-base": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-8.14.1.tgz",
-      "integrity": "sha512-EXFhNXIfpirf18IsqcG2pGQW1/Xn+bfjqVYQMMJ4ZONtYH4baZZlXk7SoXCCHonN2x1ixs4DOcRx5oVxjabdIQ==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-9.5.1.tgz",
+      "integrity": "sha512-3qsMsIhYbU3zp+YnP5h6Hg98y3B+FrxgPW7r2Uk6Kp1uSPmIzhMCyGuxur/BAcDVbd3KME+zWLHJDYOdyhuUwQ==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/rpc-core": "9.5.1",
+        "@polkadot/types": "9.5.1",
+        "@polkadot/util": "^10.1.10",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/api-derive": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-8.14.1.tgz",
-      "integrity": "sha512-eWG1MrQhHMUjt9gDHN9/9/ZMATu1MolqcalPFhNoGtdON3+I0J3ntjQ4y5X7+p2OGwQplpYRKqbK4k7tKzu8tA==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-9.5.1.tgz",
+      "integrity": "sha512-fKlKQe8WZ3jrm44w/zptMofljW5qj+jZxnryK08CAH/MINlZArPfCtn+EJla2ND9aTnRMUWlEBtytyCPImI/Hg==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api": "8.14.1",
-        "@polkadot/api-augment": "8.14.1",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/api": "9.5.1",
+        "@polkadot/api-augment": "9.5.1",
+        "@polkadot/api-base": "9.5.1",
+        "@polkadot/rpc-core": "9.5.1",
+        "@polkadot/types": "9.5.1",
+        "@polkadot/types-codec": "9.5.1",
+        "@polkadot/util": "^10.1.10",
+        "@polkadot/util-crypto": "^10.1.10",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/keyring": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.1.1.tgz",
-      "integrity": "sha512-lgYS9UIa611FBnYXb7DnVuLsiMnUR2S8x1jfNBJT32x7T66XSRnc7kpwgHW0MNGVTwjFVVfIr7XfpvXGDoBZgg==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.1.10.tgz",
+      "integrity": "sha512-crKYBbwmPcFoTP6mby2+o1QWsjAyi5QlKzU8tXuXOApP6SBuqmDujIuLOKNG2vZoftNdVldsVL0WmKVYtBeuQg==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "10.1.1",
-        "@polkadot/util-crypto": "10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/util": "10.1.10",
+        "@polkadot/util-crypto": "10.1.10"
       }
     },
     "@polkadot/networks": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.1.1.tgz",
-      "integrity": "sha512-upM8r0mrsCVA+vPVbJUjtnkAfdleBMHB+Fbxvy3xtbK1IFpzQTUhSOQb6lBnBAPBFGyxMtQ3TytnInckAdYZeg==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.1.10.tgz",
+      "integrity": "sha512-Db78t2XnFIZbdSdu1aFuj3/1cNwcSzG/+wNrpCQ9dPhnGPy5S1GVbmU8pyxTftPKdTFc+8RdBr+5bc0d5ijGiA==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "10.1.1",
-        "@substrate/ss58-registry": "^1.24.0"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/util": "10.1.10",
+        "@substrate/ss58-registry": "^1.31.0"
       }
     },
     "@polkadot/rpc-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-8.14.1.tgz",
-      "integrity": "sha512-0dIsNVIMeCp0kV7+Obz0Odt6K32Ka2ygwhiV5jhhJthy8GJBPo94mKDed5gzln3Dgl2LEdJJt1h/pgCx4a2i4A==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-9.5.1.tgz",
+      "integrity": "sha512-7Qm6oIoVIqv6VOaIqDal45hUTb3TVZ58S3zkSr60p/dPMlGCaFMcojtfcQErHtCW0hgvzFNsDl9ShpXRcPWu7g==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/rpc-core": "9.5.1",
+        "@polkadot/types": "9.5.1",
+        "@polkadot/types-codec": "9.5.1",
+        "@polkadot/util": "^10.1.10"
       }
     },
     "@polkadot/rpc-core": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-8.14.1.tgz",
-      "integrity": "sha512-deQ8Ob59ao/1fZQdaVtFjYR/HCBdxSYvQGt7/alBu1Uig9Sahx9oKcMkU5rWY36XqGZYos4zLay98W2hDlf+6Q==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-9.5.1.tgz",
+      "integrity": "sha512-8CXgBVTEUjeuN5VOwS6MjTeqpN+9qrNJAAwNEba36/72g6Wgg3flza11kx0luQ6OLPVgCM7OcAjZ17p16phXDA==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/rpc-provider": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/rpc-augment": "9.5.1",
+        "@polkadot/rpc-provider": "9.5.1",
+        "@polkadot/types": "9.5.1",
+        "@polkadot/util": "^10.1.10",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/rpc-provider": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-8.14.1.tgz",
-      "integrity": "sha512-pAUSHZiSWLhBSYf4LmLc8iCaeqTu7Ajn8AzyqxvZDHGnIrzV5M7eTjpNDP84qno6jWRHKQ/IILr62hausEmS5w==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-9.5.1.tgz",
+      "integrity": "sha512-CxyEo1SzwbcByUsrW5RUm5GTLNK7yjmVlTMseex8zQLO4+4erqUoQzr6TTIPSt4LWyk+TjbZdtGtlt7p6i2nJg==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-support": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "@polkadot/x-fetch": "^10.1.1",
-        "@polkadot/x-global": "^10.1.1",
-        "@polkadot/x-ws": "^10.1.1",
-        "@substrate/connect": "0.7.9",
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/keyring": "^10.1.10",
+        "@polkadot/types": "9.5.1",
+        "@polkadot/types-support": "9.5.1",
+        "@polkadot/util": "^10.1.10",
+        "@polkadot/util-crypto": "^10.1.10",
+        "@polkadot/x-fetch": "^10.1.10",
+        "@polkadot/x-global": "^10.1.10",
+        "@polkadot/x-ws": "^10.1.10",
+        "@substrate/connect": "0.7.14",
         "eventemitter3": "^4.0.7",
         "mock-socket": "^9.1.5",
         "nock": "^13.2.9"
       }
     },
     "@polkadot/types": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.14.1.tgz",
-      "integrity": "sha512-Xza16ejKrSd4XhTOlbfISyxZ2sRmbMAZk5pX7VEMHVZHqV98o+bJ2f9Kk7F8YJijkHHGosCLDestP9R5nLoOoA==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.5.1.tgz",
+      "integrity": "sha512-xuhYq+O4JRl2iqLVEwKVHnfOA9AfwoNlHzrFx2DChDcIWdmgmUDASq9TkZhBP+jx81SieMH7iTf4zY6UwPKYQw==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/keyring": "^10.1.10",
+        "@polkadot/types-augment": "9.5.1",
+        "@polkadot/types-codec": "9.5.1",
+        "@polkadot/types-create": "9.5.1",
+        "@polkadot/util": "^10.1.10",
+        "@polkadot/util-crypto": "^10.1.10",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/types-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.14.1.tgz",
-      "integrity": "sha512-Xa4TUFqyZT+IJ6pBSwDjWcF42u/E34OyC+gbs5Z2vWQ4EzSDkq4xNoUKjJlEEgTemsD9lhPOIc4jvqTCefwxEw==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.5.1.tgz",
+      "integrity": "sha512-1AzQpGe5bGttYbbjR1UhV19htsFjgqJ651eyT3YdRqo1hotZ2GwTCkGXuTJtcmQQH9G09xUUwS3nx8WsSyQ70A==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/types": "9.5.1",
+        "@polkadot/types-codec": "9.5.1",
+        "@polkadot/util": "^10.1.10"
       }
     },
     "@polkadot/types-codec": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.14.1.tgz",
-      "integrity": "sha512-y6YDN4HwvEgSWlgrEV04QBBxDxES1cTuUQFzZJzOTuZCWpA371Mdj3M9wYxGXMnj0wa+rCQGECHPZZaNxBMiKg==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.5.1.tgz",
+      "integrity": "sha512-7Dy8TeApu4lN8DqdMZLuh34ocdHQh9jzAob6cQl1fl1ypOiCO/SwPjFkj0Xnhh7QQz9X9w63jZzbaFR3PPT+0g==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/x-bigint": "^10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/util": "^10.1.10",
+        "@polkadot/x-bigint": "^10.1.10"
       }
     },
     "@polkadot/types-create": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.14.1.tgz",
-      "integrity": "sha512-fb9yyblj5AYAPzeCIq0kYSfzDxRDi/0ud9gN2UzB3H7M/O4n2mPC1vD4UOLF+B7l9QzCrt4e+k+/riGp7GfvyA==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.5.1.tgz",
+      "integrity": "sha512-pUQ1U0mho5aKRdi4iR9DP9ldIoj9U+ApHIeYyxkBY8RexMQOpkt8PZfpFhg4z2H5vZj/sgNIBXq65HjXuyu+9w==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/types-codec": "9.5.1",
+        "@polkadot/util": "^10.1.10"
       }
     },
     "@polkadot/types-known": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-8.14.1.tgz",
-      "integrity": "sha512-GP7gRo9nmitykkrRnoLF61Qm19UFdTwMsOnJkdm7AOeWDmZGxutacgO6k1tBsHr38hsiCCGsB/JiseUgywvGIw==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-9.5.1.tgz",
+      "integrity": "sha512-SedfPDxJREYPATa7X2Fv26z6UVPYv6v9Z9P4nulnC6Yl8C2+Q4A/VIqTtgsJc0DU1YT3gM8ofVxircfHqqRVNA==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/networks": "^10.1.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/networks": "^10.1.10",
+        "@polkadot/types": "9.5.1",
+        "@polkadot/types-codec": "9.5.1",
+        "@polkadot/types-create": "9.5.1",
+        "@polkadot/util": "^10.1.10"
       }
     },
     "@polkadot/types-support": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-8.14.1.tgz",
-      "integrity": "sha512-XqR4qq6pCZyNBuFVod8nFSNUmLssrjoU9bOIn4Ua2cqNlI9xsuKaI1X5ySEn/oWOtKQ2L5hbCm9vkXrEtXBl1w==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.5.1.tgz",
+      "integrity": "sha512-mjenEGNT/ReY1xFexb37NDgV7QHHBBfWt31ZQMZKDkQL+R2P0rXFpmitcE3eOCV3oY4mf+GaU2N/ZfnsFl3tPQ==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/util": "^10.1.10"
       }
     },
     "@polkadot/util": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.1.1.tgz",
-      "integrity": "sha512-/g0sEqOOXfiNmQnWcFK3H1+wKBjbJEfGj6lTmbQ0xnL4TS5mFFQ7ZZEvxD60EkoXVMuCmSSh9E54goNLzh+Zyg==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.1.10.tgz",
+      "integrity": "sha512-BQoTfSxZ3BWAgWDjgKBVdyw1AJGaoOeAidCA+LZcHV6wlMu5643AZPUnoMrW413MbbpxsIhJXtNttqOwjo8MjA==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/x-bigint": "10.1.1",
-        "@polkadot/x-global": "10.1.1",
-        "@polkadot/x-textdecoder": "10.1.1",
-        "@polkadot/x-textencoder": "10.1.1",
-        "@types/bn.js": "^5.1.0",
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/x-bigint": "10.1.10",
+        "@polkadot/x-global": "10.1.10",
+        "@polkadot/x-textdecoder": "10.1.10",
+        "@polkadot/x-textencoder": "10.1.10",
+        "@types/bn.js": "^5.1.1",
         "bn.js": "^5.2.1"
       }
     },
     "@polkadot/util-crypto": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.1.1.tgz",
-      "integrity": "sha512-R0V++xXbL2pvnCFIuXnKc/TlNhBkyxcno1u8rmjYNuH9S5GOmi2jY/8cNhbrwk6wafBsi+xMPHrEbUnduk82Ag==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.1.10.tgz",
+      "integrity": "sha512-w9h/wf4wZXeUkRnihhnfqlaKuoQtrjkjK3C5liCQkr9vx5zOsmg/nMSDP8UUFJX0msPPYpFeNvzn7oDIs6qSZA==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@noble/hashes": "1.1.2",
-        "@noble/secp256k1": "1.6.3",
-        "@polkadot/networks": "10.1.1",
-        "@polkadot/util": "10.1.1",
+        "@babel/runtime": "^7.19.0",
+        "@noble/hashes": "1.1.3",
+        "@noble/secp256k1": "1.7.0",
+        "@polkadot/networks": "10.1.10",
+        "@polkadot/util": "10.1.10",
         "@polkadot/wasm-crypto": "^6.3.1",
-        "@polkadot/x-bigint": "10.1.1",
-        "@polkadot/x-randomvalues": "10.1.1",
+        "@polkadot/x-bigint": "10.1.10",
+        "@polkadot/x-randomvalues": "10.1.10",
         "@scure/base": "1.1.1",
         "ed2curve": "^0.3.0",
         "tweetnacl": "^1.0.3"
@@ -1288,67 +1314,67 @@
       }
     },
     "@polkadot/x-bigint": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.1.1.tgz",
-      "integrity": "sha512-YNYN64N4icKyqiDIw0tcGyWwz3g/282Kk0ozfcA5TM0wGRe2BwmoB4gYrZ7pJDxvsHnRPR6Dw0r9Xxh8DNIzHQ==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.1.10.tgz",
+      "integrity": "sha512-4Jt0BO0WTby6r9A2DgkDxf/LFaICQHvSl1VSFtBf0Z0GV2n4OxkBX5x/1bdEdGEvYT5rM7RbR3xI7EL+W1ixHA==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/x-global": "10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/x-global": "10.1.10"
       }
     },
     "@polkadot/x-fetch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.1.1.tgz",
-      "integrity": "sha512-xSKZClZBT3QSaJeEIZwzWPm/AdJ0pPCuUEhBv0e6XU2ANn1w+OAwwlNB94DEVzN+WouZqcNgE6mC2yVd5t7JZQ==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.1.10.tgz",
+      "integrity": "sha512-LvTxAN6GaJzfgZ74WFYPZrIkMEThpX5u7O4ILiExcJt87E19cSWlYSHDa5n+OLjUpq0lBV2ueF90iUblt6aHpg==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/x-global": "10.1.1",
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/x-global": "10.1.10",
         "@types/node-fetch": "^2.6.2",
-        "node-fetch": "^3.2.9"
+        "node-fetch": "^3.2.10"
       }
     },
     "@polkadot/x-global": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.1.1.tgz",
-      "integrity": "sha512-wB3rZTTNN14umLSfR2GLL0dJrlGM1YRUNw7XvbA+3B8jxGCIOmjSyAkdZBeiCxg2XIbJD3EkB0hBhga2mNuS6g==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.1.10.tgz",
+      "integrity": "sha512-WFfgaZSrzPlKLdnOus2mIFGzUbSDIQK6RMCfFfM9SmF3DkoxN40z5Nkni4PztfKr22stlkhmhnX/Lp/NxpuT6Q==",
       "requires": {
-        "@babel/runtime": "^7.18.9"
+        "@babel/runtime": "^7.19.0"
       }
     },
     "@polkadot/x-randomvalues": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.1.1.tgz",
-      "integrity": "sha512-opVFNEnzCir7cWsFfyDqNlrGazkpjnL+JpkxE/b9WmSco6y0IUzn/Q7rL3EaBzBEvxY0/J8KeSGGs3W+mf6tBQ==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.1.10.tgz",
+      "integrity": "sha512-KM4sCI/DNLIXlmnkeJIuYvh3pPuWvnkbR1a6TUB12J1izUJ+uGV+cAFRR4/EZk3oEsG/Tgivbs56meEOo3ws5A==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/x-global": "10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/x-global": "10.1.10"
       }
     },
     "@polkadot/x-textdecoder": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.1.1.tgz",
-      "integrity": "sha512-a52ah/sUS+aGZcCCL7BhrytAeV/7kiqu1zbuCoZtIzxP6x34a2vcic3bLPoyynLcX2ruzvLKFhJDGOJ4Bq5lcA==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.1.10.tgz",
+      "integrity": "sha512-cAk37faYXx8IICeaq/tdl+aiIXwo3SLrx9XNoQqhX02g+SEs3ARM7zJcohj/p8ynWAI+ezNcsKn1wh174nquHw==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/x-global": "10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/x-global": "10.1.10"
       }
     },
     "@polkadot/x-textencoder": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.1.1.tgz",
-      "integrity": "sha512-prTzUXXW9OxFyf17EwGSBxe2GvVFG60cmKV8goC50nghhNMl1y0GdGpvKNQTFG6hIk5fIon9/pBpWsas4iAf+Q==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.1.10.tgz",
+      "integrity": "sha512-Auaql6BL5UHtWakZUQyj4y/BrM0tm4bYG5vXCMQCA1Gg0ky+46DhgpRrAQ9F7NNgWg1A6dA2I9KuAA4BTbNx0w==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/x-global": "10.1.1"
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/x-global": "10.1.10"
       }
     },
     "@polkadot/x-ws": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.1.1.tgz",
-      "integrity": "sha512-IdakU22dcAqmLRNyL8oWUXxnHwnoUteoU3Xyc6W4wxJ8K6GNxjbUtSjoT/FTEW1JmxVVtFHu8kKRnKhu5WbWdg==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.1.10.tgz",
+      "integrity": "sha512-JxDgfm0ox2XPAtdTeJXYl6qq7LY/KOPi69wRpFMczWaYUsZubO6EiRzgzjuFlHY4/oxfjS/D+YbzcjefTxHz6g==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/x-global": "10.1.1",
+        "@babel/runtime": "^7.19.0",
+        "@polkadot/x-global": "10.1.10",
         "@types/websocket": "^1.0.5",
         "websocket": "^1.0.34"
       }
@@ -1359,12 +1385,12 @@
       "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA=="
     },
     "@substrate/connect": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.9.tgz",
-      "integrity": "sha512-E6bdBhzsfHNAKlmQSvbTW1jyb0WcIvgbrEBfJ4B6FZ3t1wpGjldL6GrYtegVtKr9/ySQ/pFNn0uVbugukpMDjQ==",
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.14.tgz",
+      "integrity": "sha512-uW5uBmihpivshmmmw+rsg7qOV0KqVSep4rWOXFMP8aFQinvmqw4JqxP21og4H/7JZxttYUBFQVsdtXHGKJ0aVQ==",
       "requires": {
         "@substrate/connect-extension-protocol": "^1.0.1",
-        "@substrate/smoldot-light": "0.6.25",
+        "@substrate/smoldot-light": "0.6.34",
         "eventemitter3": "^4.0.7"
       }
     },
@@ -1374,30 +1400,31 @@
       "integrity": "sha512-161JhCC1csjH3GE5mPLEd7HbWtwNSPJBg3p1Ksz9SFlTzj/bgEwudiRN2y5i0MoLGCIJRYKyKGMxVnd29PzNjg=="
     },
     "@substrate/smoldot-light": {
-      "version": "0.6.25",
-      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.6.25.tgz",
-      "integrity": "sha512-OQ9/bnJJy90xSRg5Vp9MIvrgbrVt/r/FwXYSmyLeBBNbJt6o1gSeshVo8icD+2VWwd/TJ2oHl5CVQWe89MyByA==",
+      "version": "0.6.34",
+      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.6.34.tgz",
+      "integrity": "sha512-+HK9MaJ0HelJmpf4YYR+salJ7dhVBltmhGlyz5l8OXS9DW18fe0Z2wxEo8P5kX9CUxlCXEb8J9JBRQAYBPHbwQ==",
       "requires": {
-        "websocket": "^1.0.32"
+        "pako": "^2.0.4",
+        "ws": "^8.8.1"
       }
     },
     "@substrate/ss58-registry": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.25.0.tgz",
-      "integrity": "sha512-LmCH4QJRdHaeLsLTPSgJaXguMoIW+Ig9fA9LRPpeya9HefVAJ7gZuUYinldv+QmX7evNm5CL0rspNUS8l1DvXg=="
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.33.0.tgz",
+      "integrity": "sha512-DztMuMcEfu+tJrtIQIIp5gO8/XJZ8N8UwPObDCSNgrp7trtSkPJAUFB9qXaReXtN9UvTcVBMTWk6VPfFi04Wkg=="
     },
     "@types/bn.js": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-      "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
+      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "18.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
-      "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ=="
+      "version": "18.8.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.5.tgz",
+      "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q=="
     },
     "@types/node-fetch": {
       "version": "2.6.2",
@@ -1478,9 +1505,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.61",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
       "requires": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -1512,17 +1539,17 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "ext": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
-      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
       "requires": {
-        "type": "^2.5.0"
+        "type": "^2.7.2"
       },
       "dependencies": {
         "type": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
-          "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+          "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
         }
       }
     },
@@ -1627,20 +1654,25 @@
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
       "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
     },
+    "pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
+    },
     "propagate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag=="
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
+      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
     },
     "rxjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
-      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
       "requires": {
         "tslib": "^2.1.0"
       }
@@ -1708,6 +1740,12 @@
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         }
       }
+    },
+    "ws": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
+      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
+      "requires": {}
     },
     "yaeti": {
       "version": "0.0.6",


### PR DESCRIPTION
- Remove superfluous "cli" feature from `gear-cli` crate which is always on anyway - building the node without it doesn't make much sense.

- Fix failing rtest on vara by making sure the value passed to and from a program would surpass the existential deposit.