### PR TITLE
Implement gas counting without system call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2865,9 +2865,9 @@ dependencies = [
  "gear-backend-common",
  "gear-core",
  "gear-core-errors",
+ "gear-wasm-instrument",
  "log",
  "parity-scale-codec",
- "parity-wasm 0.45.0",
  "wasmi 0.14.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2851,9 +2851,9 @@ dependencies = [
  "gear-backend-common",
  "gear-core",
  "gear-core-errors",
+ "gear-wasm-instrument",
  "log",
  "parity-scale-codec",
- "parity-wasm 0.45.0",
  "sp-sandbox",
 ]
 

--- a/core-backend/common/src/mock.rs
+++ b/core-backend/common/src/mock.rs
@@ -135,9 +135,6 @@ impl Ext for MockExt {
     fn size(&mut self) -> Result<usize, Self::Error> {
         Ok(0)
     }
-    fn gas(&mut self, _amount: u32) -> Result<(), Self::Error> {
-        Ok(())
-    }
     fn charge_gas(&mut self, _amount: u64) -> Result<(), Self::Error> {
         Ok(())
     }

--- a/core-backend/common/src/mock.rs
+++ b/core-backend/common/src/mock.rs
@@ -187,6 +187,21 @@ impl Ext for MockExt {
     fn unreserve_gas(&mut self, _id: ReservationId) -> Result<u64, Self::Error> {
         Ok(0)
     }
+
+    fn counters(&self) -> (u64, u64) {
+        (0, 0)
+    }
+
+    fn update_counters(&mut self, _gas: u64, _allowance: u64) {
+    }
+
+    fn out_of_allowance(&mut self) -> Self::Error {
+        Error
+    }
+
+    fn out_of_gas(&mut self) -> Self::Error {
+        Error
+    }
 }
 
 impl IntoExtInfo<<MockExt as Ext>::Error> for MockExt {

--- a/core-backend/common/src/mock.rs
+++ b/core-backend/common/src/mock.rs
@@ -189,8 +189,7 @@ impl Ext for MockExt {
         (0, 0)
     }
 
-    fn update_counters(&mut self, _gas: u64, _allowance: u64) {
-    }
+    fn update_counters(&mut self, _gas: u64, _allowance: u64) {}
 
     fn out_of_allowance(&mut self) -> Self::Error {
         Error

--- a/core-backend/sandbox/Cargo.toml
+++ b/core-backend/sandbox/Cargo.toml
@@ -10,7 +10,7 @@ gear-core = { path = "../../core" }
 gear-core-errors = { path = "../../core-errors", features = ["codec"] }
 gear-backend-common = { path = "../common" }
 
-parity-wasm = { version = "0.45.0", default-features = false }
+gear-wasm-instrument = { path = "../../utils/wasm-instrument", default-features = false }
 sp-sandbox = { version = "0.10.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false, features = ["host-sandbox"] }
 # Use max_level_debug feature to remove tracing in sys-calls by default.
 log = { version = "0.4.17", default-features = false }
@@ -19,5 +19,5 @@ codec = { package = "parity-scale-codec", version = "3.1.3", default-features = 
 
 [features]
 default = ["std"]
-std = ["sp-sandbox/std", "parity-wasm/std", "log/std"]
+std = ["sp-sandbox/std", "gear-wasm-instrument/std", "log/std"]
 sys-trace = []

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -34,12 +34,14 @@ use gear_backend_common::{
     STACK_END_EXPORT_NAME,
 };
 use gear_core::{env::Ext, gas::GasAmount, memory::WasmPageNumber, message::DispatchKind};
+use gear_wasm_instrument::{
+    GLOBAL_NAME_ALLOWANCE, GLOBAL_NAME_GAS, IMPORT_NAME_OUT_OF_ALLOWANCE, IMPORT_NAME_OUT_OF_GAS,
+};
 use sp_sandbox::{
     default_executor::{EnvironmentDefinitionBuilder, Instance, Memory as DefaultExecutorMemory},
-    HostFuncType, ReturnValue, SandboxEnvironmentBuilder, SandboxInstance, SandboxMemory, InstanceGlobals,
-    Value,
+    HostFuncType, InstanceGlobals, ReturnValue, SandboxEnvironmentBuilder, SandboxInstance,
+    SandboxMemory, Value,
 };
-use gear_wasm_instrument::{GLOBAL_NAME_ALLOWANCE, GLOBAL_NAME_GAS, IMPORT_NAME_OUT_OF_ALLOWANCE, IMPORT_NAME_OUT_OF_GAS};
 
 #[derive(Debug, derive_more::Display, derive_more::From)]
 pub enum SandboxEnvironmentError {
@@ -226,7 +228,8 @@ where
             Err(e) => return Err((runtime.ext.gas_amount(), StackEnd(e)).into()),
         };
 
-        runtime.globals = instance.instance_globals()
+        runtime.globals = instance
+            .instance_globals()
             .ok_or((runtime.ext.gas_amount(), MutableGlobalsNotSupported))?;
 
         let (gas, allowance) = runtime.ext.counters();
@@ -254,11 +257,15 @@ where
             Ok(ReturnValue::Unit)
         };
 
-        let gas = runtime.globals.get_global_val(GLOBAL_NAME_GAS)
+        let gas = runtime
+            .globals
+            .get_global_val(GLOBAL_NAME_GAS)
             .and_then(runtime::as_i64)
             .ok_or((runtime.ext.gas_amount(), WrongInjectedGas))?;
 
-        let allowance = runtime.globals.get_global_val(GLOBAL_NAME_ALLOWANCE)
+        let allowance = runtime
+            .globals
+            .get_global_val(GLOBAL_NAME_ALLOWANCE)
             .and_then(runtime::as_i64)
             .ok_or((runtime.ext.gas_amount(), WrongInjectedAllowance))?;
 

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -77,6 +77,8 @@ pub enum FuncError<E: Display> {
     ReadWrongRange(Range<u32>, u32),
     #[display(fmt = "Overflow at {} + len {} in `gr_read`", _0, _1)]
     ReadLenOverflow(u32, u32),
+    #[display(fmt = "Binary code has wrong instrumentation")]
+    WrongInstrumentation,
 }
 
 impl<E: fmt::Display> FuncError<E> {
@@ -322,25 +324,6 @@ where
                 .error_len_on_success(|exit_code| {
                     ctx.write_output(exit_code_ptr, exit_code.to_le_bytes().as_ref())
                 })
-        })
-    }
-
-    pub fn gas(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
-        sys_trace!(target: "gas::gear", "gas, args = {}", args_to_str(args));
-
-        let gas = args.iter().read()?;
-
-        ctx.run(|ctx| {
-            ctx.ext.gas(gas).map_err(|e| {
-                if matches!(
-                    e.as_termination_reason(),
-                    Some(&TerminationReason::GasAllowanceExceeded)
-                ) {
-                    FuncError::Terminated(TerminationReason::GasAllowanceExceeded)
-                } else {
-                    FuncError::Core(e)
-                }
-            })
         })
     }
 
@@ -773,7 +756,7 @@ where
         })
     }
 
-    pub fn error(ctx: &mut Runtime<E>, args: &[Value]) -> Result<ReturnValue, HostError> {
+    pub fn error(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
         sys_trace!(target: "syscall::gear", "error, args = {}", args_to_str(args));
 
         let buffer_ptr = args.iter().read()?;
@@ -791,6 +774,23 @@ where
         sys_trace!(target: "syscall::gear", "forbidden");
 
         ctx.run(|_ctx| -> Result<(), _> { Err(FuncError::Core(E::Error::forbidden_function())) })
+    }
+
+    pub fn out_of_gas(ctx: &mut Runtime<E>, _args: &[Value]) -> SyscallOutput {
+        sys_trace!(target: "syscall::gear", "out_of_gas");
+
+        ctx.err = FuncError::Core(ctx.ext.out_of_gas());
+
+        Err(HostError)
+    }
+
+    pub fn out_of_allowance(ctx: &mut Runtime<E>, _args: &[Value]) -> SyscallOutput {
+        sys_trace!(target: "syscall::gear", "out_of_allowance");
+
+        ctx.ext.out_of_allowance();
+        ctx.err = FuncError::Terminated(TerminationReason::GasAllowanceExceeded);
+
+        Err(HostError)
     }
 }
 

--- a/core-backend/sandbox/src/runtime.rs
+++ b/core-backend/sandbox/src/runtime.rs
@@ -4,8 +4,11 @@ use gear_backend_common::{RuntimeCtx, RuntimeCtxError};
 use gear_core::{buffer::RuntimeBuffer, env::Ext, memory::WasmPageNumber};
 
 use gear_core_errors::MemoryError;
-use sp_sandbox::{default_executor::Memory as DefaultExecutorMemory, HostError, SandboxMemory, InstanceGlobals, Value};
 use gear_wasm_instrument::{GLOBAL_NAME_ALLOWANCE, GLOBAL_NAME_GAS};
+use sp_sandbox::{
+    default_executor::Memory as DefaultExecutorMemory, HostError, InstanceGlobals, SandboxMemory,
+    Value,
+};
 
 use crate::{
     funcs::{FuncError, SyscallOutput, WasmCompatible},
@@ -33,14 +36,18 @@ impl<E: Ext> Runtime<E> {
         T: WasmCompatible,
         F: FnOnce(&mut Self) -> Result<T, FuncError<E::Error>>,
     {
-        let gas = self.globals.get_global_val(GLOBAL_NAME_GAS)
+        let gas = self
+            .globals
+            .get_global_val(GLOBAL_NAME_GAS)
             .and_then(as_i64)
             .ok_or({
                 self.err = FuncError::WrongInstrumentation;
                 HostError
             })?;
 
-        let allowance = self.globals.get_global_val(GLOBAL_NAME_ALLOWANCE)
+        let allowance = self
+            .globals
+            .get_global_val(GLOBAL_NAME_ALLOWANCE)
             .and_then(as_i64)
             .ok_or({
                 self.err = FuncError::WrongInstrumentation;

--- a/core-backend/wasmi/Cargo.toml
+++ b/core-backend/wasmi/Cargo.toml
@@ -10,7 +10,7 @@ gear-core = { path = "../../core" }
 gear-core-errors = { path = "../../core-errors", features = ["codec"] }
 gear-backend-common = { path = "../common" }
 
-parity-wasm = { version = "0.45.0", default-features = false }
+gear-wasm-instrument = { path = "../../utils/wasm-instrument", default-features = false }
 wasmi = { version = "0.14.0", default-features = false }
 log = { version = "0.4.17", default-features = false }
 derive_more = "0.99.17"
@@ -21,4 +21,4 @@ gear-backend-common = { path = "../common", features = ["mock"] }
 
 [features]
 default = ["std"]
-std = ["wasmi/virtual_memory", "parity-wasm/std", "log/std"]
+std = ["wasmi/virtual_memory", "gear-wasm-instrument/std", "log/std"]

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -36,10 +36,8 @@ use gear_backend_common::{
     STACK_END_EXPORT_NAME,
 };
 use gear_core::{env::Ext, gas::GasAmount, memory::WasmPageNumber, message::DispatchKind};
-use wasmi::{
-    Engine, Extern, Instance, Linker, Memory, MemoryType, Module, Store, core::Value,
-};
 use gear_wasm_instrument::{GLOBAL_NAME_ALLOWANCE, GLOBAL_NAME_GAS};
+use wasmi::{core::Value, Engine, Extern, Instance, Linker, Memory, MemoryType, Module, Store};
 
 #[derive(Debug, derive_more::Display, derive_more::From)]
 pub enum WasmiEnvironmentError {
@@ -240,13 +238,12 @@ where
             Ok(())
         };
 
-        let gas = gear_gas.get(&memory_wrap.store)
-            .try_into::<i64>()
-            .ok_or({
-                let store = &memory_wrap.store;
-                (gas_amount!(store), WrongInjectedGas)
-            })?;
-        let allowance = gear_allowance.get(&memory_wrap.store)
+        let gas = gear_gas.get(&memory_wrap.store).try_into::<i64>().ok_or({
+            let store = &memory_wrap.store;
+            (gas_amount!(store), WrongInjectedGas)
+        })?;
+        let allowance = gear_allowance
+            .get(&memory_wrap.store)
             .try_into::<i64>()
             .ok_or({
                 let store = &memory_wrap.store;
@@ -259,7 +256,9 @@ where
             .take()
             .expect("set before the block; qed");
 
-        let State { mut ext, err: trap, .. } = runtime;
+        let State {
+            mut ext, err: trap, ..
+        } = runtime;
 
         ext.update_counters(gas as u64, allowance as u64);
 

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -37,8 +37,9 @@ use gear_backend_common::{
 };
 use gear_core::{env::Ext, gas::GasAmount, memory::WasmPageNumber, message::DispatchKind};
 use wasmi::{
-    Engine, Extern, Instance, Linker, Memory as WasmiMemory, Memory, MemoryType, Module, Store,
+    Engine, Extern, Instance, Linker, Memory, MemoryType, Module, Store, core::Value,
 };
+use gear_wasm_instrument::{GLOBAL_NAME_ALLOWANCE, GLOBAL_NAME_GAS};
 
 #[derive(Debug, derive_more::Display, derive_more::From)]
 pub enum WasmiEnvironmentError {
@@ -56,6 +57,10 @@ pub enum WasmiEnvironmentError {
     PreExecutionHandler(String),
     #[from]
     StackEnd(StackEndError),
+    #[display(fmt = "Gas counter not found or has wrong type")]
+    WrongInjectedGas,
+    #[display(fmt = "Allowance counter not found or has wrong type")]
+    WrongInjectedAllowance,
 }
 
 #[derive(Debug, derive_more::Display, derive_more::From)]
@@ -112,7 +117,7 @@ where
         let mut linker: Linker<HostState<E>> = Linker::new();
 
         let memory_type = MemoryType::new(mem_size.0, None);
-        let memory = WasmiMemory::new(&mut store, memory_type)
+        let memory = Memory::new(&mut store, memory_type)
             .map_err(|e| (ext.gas_amount(), CreateEnvMemory(e)))?;
 
         linker
@@ -167,7 +172,7 @@ where
 
         let Self {
             instance,
-            store,
+            mut store,
             memory,
             entries,
         } = self;
@@ -178,6 +183,29 @@ where
             .and_then(|g| g.get(&store).try_into::<i32>());
         let stack_end_page =
             calc_stack_end(stack_end).map_err(|e| (gas_amount!(store), StackEnd(e)))?;
+
+        let (gas, allowance) = store
+            .state()
+            .as_ref()
+            .expect("should be set")
+            .ext
+            .counters();
+
+        let gear_gas = instance
+            .get_export(&store, GLOBAL_NAME_GAS)
+            .and_then(Extern::into_global)
+            .and_then(|g| g.set(&mut store, Value::I64(gas as i64)).map(|_| g).ok())
+            .ok_or((gas_amount!(store), WrongInjectedGas))?;
+
+        let gear_allowance = instance
+            .get_export(&store, GLOBAL_NAME_ALLOWANCE)
+            .and_then(Extern::into_global)
+            .and_then(|g| {
+                g.set(&mut store, Value::I64(allowance as i64))
+                    .map(|_| g)
+                    .ok()
+            })
+            .ok_or((gas_amount!(store), WrongInjectedAllowance))?;
 
         let mut memory_wrap = MemoryWrap::new(memory, store);
         pre_execution_handler(&mut memory_wrap, stack_end_page).map_err(|e| {
@@ -212,13 +240,28 @@ where
             Ok(())
         };
 
+        let gas = gear_gas.get(&memory_wrap.store)
+            .try_into::<i64>()
+            .ok_or({
+                let store = &memory_wrap.store;
+                (gas_amount!(store), WrongInjectedGas)
+            })?;
+        let allowance = gear_allowance.get(&memory_wrap.store)
+            .try_into::<i64>()
+            .ok_or({
+                let store = &memory_wrap.store;
+                (gas_amount!(store), WrongInjectedAllowance)
+            })?;
+
         let runtime = memory_wrap
             .store
             .state_mut()
             .take()
             .expect("set before the block; qed");
 
-        let State { ext, err: trap, .. } = runtime;
+        let State { mut ext, err: trap, .. } = runtime;
+
+        ext.update_counters(gas as u64, allowance as u64);
 
         log::debug!("WasmiEnvironment::execute result = {res:?}");
 

--- a/core-backend/wasmi/src/funcs/internal.rs
+++ b/core-backend/wasmi/src/funcs/internal.rs
@@ -36,7 +36,8 @@ macro_rules! update_globals {
     ($caller:ident) => {{
         let (gas, allowance) = host_state_mut!($caller).ext.counters();
 
-        match $caller.get_export(GLOBAL_NAME_GAS)
+        match $caller
+            .get_export(GLOBAL_NAME_GAS)
             .and_then(Extern::into_global)
             .and_then(|g| g.set(&mut $caller, Value::I64(gas as i64)).ok())
             .and_then(|_| $caller.get_export(GLOBAL_NAME_ALLOWANCE))
@@ -119,9 +120,7 @@ where
             }
         }
         Err(e) => match e.into_ext_error() {
-            Ok(ext_error) => {
-                Ok((ext_error.encoded_size() as u32,))
-            }
+            Ok(ext_error) => Ok((ext_error.encoded_size() as u32,)),
             Err(e) => {
                 host_state.err = FuncError::Core(e);
                 Err(Error::Trap(TrapCode::Unreachable.into()))
@@ -186,7 +185,7 @@ where
         Err(e) => {
             host_state.err = FuncError::Core(e);
             Err(Error::Trap(TrapCode::Unreachable.into()))
-        },
+        }
     };
 
     update_globals!(caller).map_err(Error::Trap).and(result)

--- a/core-backend/wasmi/src/funcs/mod.rs
+++ b/core-backend/wasmi/src/funcs/mod.rs
@@ -512,9 +512,14 @@ where
                 read_memory_as(&memory_wrap, inheritor_id_ptr)
             };
 
-            host_state_mut!(caller).err = match read_result {
-                Ok(id) => FuncError::Terminated(TerminationReason::Exit(id)),
-                Err(e) => e.into(),
+            let call_result = host_state_mut!(caller).ext.exit();
+
+            host_state_mut!(caller).err = match call_result {
+                Err(e) => FuncError::Core(e),
+                Ok(_) => match read_result {
+                    Ok(id) => FuncError::Terminated(TerminationReason::Exit(id)),
+                    Err(e) => e.into(),
+                }
             };
 
             Err(TrapCode::Unreachable.into())

--- a/core-backend/wasmi/src/funcs_tree.rs
+++ b/core-backend/wasmi/src/funcs_tree.rs
@@ -22,6 +22,7 @@ use codec::Encode;
 use gear_backend_common::{error_processor::IntoExtError, AsTerminationReason, IntoExtInfo};
 use gear_core::env::Ext;
 use wasmi::{Func, Memory, Store};
+use gear_wasm_instrument::{IMPORT_NAME_OUT_OF_ALLOWANCE, IMPORT_NAME_OUT_OF_GAS};
 
 struct FunctionBuilder<'a>(Option<&'a BTreeSet<&'a str>>);
 
@@ -71,7 +72,6 @@ where
         f.build("gr_exit_code", |forbidden| {
             F::exit_code(store, forbidden, memory)
         }),
-        f.build("gas", |_| F::gas(store)),
         f.build("alloc", |forbidden| F::alloc(store, forbidden, memory)),
         f.build("free", |forbidden| F::free(store, forbidden)),
         f.build("gr_block_height", |forbidden| {
@@ -130,6 +130,8 @@ where
         f.build("gr_unreserve_gas", |forbidden| {
             F::unreserve_gas(store, forbidden, memory)
         }),
+        f.build(IMPORT_NAME_OUT_OF_GAS, |_| F::out_of_gas(store)),
+        f.build(IMPORT_NAME_OUT_OF_ALLOWANCE, |_| F::out_of_allowance(store)),
     ]
     .into();
 

--- a/core-backend/wasmi/src/funcs_tree.rs
+++ b/core-backend/wasmi/src/funcs_tree.rs
@@ -21,8 +21,8 @@ use alloc::collections::{BTreeMap, BTreeSet};
 use codec::Encode;
 use gear_backend_common::{error_processor::IntoExtError, AsTerminationReason, IntoExtInfo};
 use gear_core::env::Ext;
-use wasmi::{Func, Memory, Store};
 use gear_wasm_instrument::{IMPORT_NAME_OUT_OF_ALLOWANCE, IMPORT_NAME_OUT_OF_GAS};
+use wasmi::{Func, Memory, Store};
 
 struct FunctionBuilder<'a>(Option<&'a BTreeSet<&'a str>>);
 

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -689,6 +689,39 @@ impl EnvExt for Ext {
     fn forbidden_funcs(&self) -> &BTreeSet<&'static str> {
         &self.context.forbidden_funcs
     }
+
+    fn counters(&self) -> (u64, u64) {
+        (
+            self.context.gas_counter.left(),
+            self.context.gas_allowance_counter.left(),
+        )
+    }
+
+    fn update_counters(&mut self, gas: u64, allowance: u64) {
+        let gas_left = self.context.gas_counter.left();
+        if gas_left > gas {
+            self.context.gas_counter.charge(gas_left - gas);
+        } else {
+            self.context.gas_counter.refund(gas - gas_left);
+        }
+
+        let allowance_left = self.context.gas_allowance_counter.left();
+        if allowance_left > allowance {
+            self.context.gas_allowance_counter.charge(allowance_left - allowance);
+        } else {
+            self.context.gas_allowance_counter.refund(allowance - allowance_left);
+        }
+    }
+
+    fn out_of_gas(&mut self) -> Self::Error {
+        self.error_explanation = Some(ExecutionError::GasLimitExceeded.into());
+        ExecutionError::GasLimitExceeded.into()
+    }
+
+    fn out_of_allowance(&mut self) -> Self::Error {
+        self.error_explanation = Some(TerminationReason::GasAllowanceExceeded.into());
+        TerminationReason::GasAllowanceExceeded.into()
+    }
 }
 
 impl Ext {

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -703,9 +703,13 @@ impl EnvExt for Ext {
 
         let allowance_left = self.context.gas_allowance_counter.left();
         if allowance_left > allowance {
-            self.context.gas_allowance_counter.charge(allowance_left - allowance);
+            self.context
+                .gas_allowance_counter
+                .charge(allowance_left - allowance);
         } else {
-            self.context.gas_allowance_counter.refund(allowance - allowance_left);
+            self.context
+                .gas_allowance_counter
+                .refund(allowance - allowance_left);
         }
     }
 

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -519,10 +519,6 @@ impl EnvExt for Ext {
         Ok(self.context.message_context.current().payload().len())
     }
 
-    fn gas(&mut self, val: u32) -> Result<(), Self::Error> {
-        self.charge_gas_runtime(RuntimeCosts::MeteringBlock(val))
-    }
-
     fn charge_gas(&mut self, val: u64) -> Result<(), Self::Error> {
         let common_charge = self.context.gas_counter.charge(val);
         let allowance_charge = self.context.gas_allowance_counter.charge(val);

--- a/core/src/code.rs
+++ b/core/src/code.rs
@@ -161,9 +161,8 @@ impl Code {
 
         if exports.contains(&DispatchKind::Init) || exports.contains(&DispatchKind::Handle) {
             let gas_rules = get_gas_rules(&module);
-            let instrumented_module =
-                gear_wasm_instrument::inject(module, &gas_rules, "env")
-                    .map_err(|_| CodeError::GasInjection)?;
+            let instrumented_module = gear_wasm_instrument::inject(module, &gas_rules, "env")
+                .map_err(|_| CodeError::GasInjection)?;
 
             let instrumented = if let Some(limit) = stack_height {
                 let instrumented_module =
@@ -222,12 +221,9 @@ impl Code {
 
         if exports.contains(&DispatchKind::Init) || exports.contains(&DispatchKind::Handle) {
             if instrument_with_const_rules {
-                let instrumented_module = gear_wasm_instrument::inject(
-                    module,
-                    &ConstantCostRules::default(),
-                    "env",
-                )
-                .map_err(|_| CodeError::GasInjection)?;
+                let instrumented_module =
+                    gear_wasm_instrument::inject(module, &ConstantCostRules::default(), "env")
+                        .map_err(|_| CodeError::GasInjection)?;
 
                 let instrumented = parity_wasm::elements::serialize(instrumented_module)
                     .map_err(|_| CodeError::Encode)?;

--- a/core/src/code.rs
+++ b/core/src/code.rs
@@ -162,7 +162,7 @@ impl Code {
         if exports.contains(&DispatchKind::Init) || exports.contains(&DispatchKind::Handle) {
             let gas_rules = get_gas_rules(&module);
             let instrumented_module =
-                wasm_instrument::gas_metering::inject(module, &gas_rules, "env")
+                gear_wasm_instrument::inject(module, &gas_rules, "env")
                     .map_err(|_| CodeError::GasInjection)?;
 
             let instrumented = if let Some(limit) = stack_height {
@@ -222,7 +222,7 @@ impl Code {
 
         if exports.contains(&DispatchKind::Init) || exports.contains(&DispatchKind::Handle) {
             if instrument_with_const_rules {
-                let instrumented_module = wasm_instrument::gas_metering::inject(
+                let instrumented_module = gear_wasm_instrument::inject(
                     module,
                     &ConstantCostRules::default(),
                     "env",

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -181,4 +181,16 @@ pub trait Ext {
 
     /// Return the set of functions that are forbidden to be called.
     fn forbidden_funcs(&self) -> &BTreeSet<&'static str>;
+
+    /// Return gas and gas allowance left in the counters.
+    fn counters(&self) -> (u64, u64);
+
+    /// Update counters with the provided values.
+    fn update_counters(&mut self, gas: u64, allowance: u64);
+
+    /// Handler for the case when gas is out.
+    fn out_of_gas(&mut self) -> Self::Error;
+
+    /// Handler for the case when gas allowance is out.
+    fn out_of_allowance(&mut self) -> Self::Error;
 }

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -132,9 +132,6 @@ pub trait Ext {
     /// Size of currently handled message payload.
     fn size(&mut self) -> Result<usize, Self::Error>;
 
-    /// Default gas host call.
-    fn gas(&mut self, amount: u32) -> Result<(), Self::Error>;
-
     /// Charge some extra gas.
     fn charge_gas(&mut self, amount: u64) -> Result<(), Self::Error>;
 

--- a/core/src/gas.rs
+++ b/core/src/gas.rs
@@ -233,6 +233,11 @@ impl GasAllowanceCounter {
         Self(initial_amount as u128)
     }
 
+    /// Report how much gas allowance is left.
+    pub fn left(&self) -> u64 {
+        self.0 as u64
+    }
+
     /// Charge `amount` of gas.
     #[inline]
     pub fn charge(&mut self, amount: u64) -> ChargeResult {

--- a/gtest/src/error.rs
+++ b/gtest/src/error.rs
@@ -79,4 +79,8 @@ pub enum TestError {
     /// Wrapper for [`parity_scale_codec::Error`](https://docs.rs/parity-scale-codec/latest/parity_scale_codec/struct.Error.html).
     #[display(fmt = "{}", _0)]
     ScaleCodecError(CodecError),
+
+    /// Instrumentation of binary code failed.
+    #[display(fmt = "Instrumentation of binary code failed.")]
+    Instrumentation,
 }

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -705,37 +705,6 @@ benchmarks! {
     //     Gear::<T>::process_message(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 0u32.into())?;
     // }
 
-    gas {
-        let r in 0 .. API_BENCHMARK_BATCHES;
-        let code = WasmModule::<T>::from(ModuleDefinition {
-            memory: Some(ImportedMemory::max::<T>()),
-            imported_functions: vec![ImportedFunction {
-                module: "env",
-                name: "gas",
-                params: vec![ValueType::I32],
-                return_type: None,
-            }],
-            handle_body: Some(body::repeated(r * API_BENCHMARK_BATCH_SIZE, &[
-                Instruction::I32Const(42),
-                Instruction::Call(0),
-            ])),
-            .. Default::default()
-        });
-        let instance = Program::<T>::new(code, vec![])?;
-        let Exec {
-            ext_manager,
-            block_config,
-            context,
-            memory_pages,
-        } = prepare::<T>(instance.caller.into_origin(), HandleKind::Handle(ProgramId::from_origin(instance.addr)), vec![], 0u32.into())?;
-    }: {
-
-        core_processor::process::<
-            Externalities,
-            ExecutionEnvironment,
-        >(&block_config, context, memory_pages);
-    }
-
     gr_gas_available {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let code = WasmModule::<T>::from(ModuleDefinition {

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -283,4 +283,20 @@ impl EnvExt for LazyPagesExt {
     fn forbidden_funcs(&self) -> &BTreeSet<&'static str> {
         &self.inner.context.forbidden_funcs
     }
+
+    fn counters(&self) -> (u64, u64) {
+        self.inner.counters()
+    }
+
+    fn update_counters(&mut self, gas: u64, allowance: u64) {
+        self.inner.update_counters(gas, allowance)
+    }
+
+    fn out_of_gas(&mut self) -> Self::Error {
+        self.inner.out_of_gas()
+    }
+
+    fn out_of_allowance(&mut self) -> Self::Error {
+        self.inner.out_of_allowance()
+    }
 }

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -224,10 +224,6 @@ impl EnvExt for LazyPagesExt {
         self.inner.refund_gas(val)
     }
 
-    fn gas(&mut self, val: u32) -> Result<(), Self::Error> {
-        self.inner.gas(val)
-    }
-
     fn reserve_gas(&mut self, amount: u64, blocks: u32) -> Result<ReservationId, Self::Error> {
         self.inner.reserve_gas(amount, blocks)
     }

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -605,7 +605,7 @@ pub mod pallet {
             <BlockNumber<T>>::put(bn.saturated_into::<T::BlockNumber>());
         }
 
-        /// Submit program for benchmarks which does not check nor instrument the code.
+        /// Submit program for benchmarks which does not check the code.
         #[cfg(feature = "runtime-benchmarks")]
         pub fn upload_program_raw(
             origin: OriginFor<T>,
@@ -629,7 +629,7 @@ pub mod pallet {
                 code,
                 schedule.instruction_weights.version,
                 Some(module),
-                false,
+                true,
             )
             .map_err(|e| {
                 log::debug!("Code failed to load: {:?}", e);

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -4467,8 +4467,9 @@ fn gas_spent_precalculated() {
 
         let init_gas_id = upload_program_default(USER_3, ProgramCodeKind::Custom(wat_init))
             .expect("submit result was asserted");
-        let init_no_counter_id = upload_program_default(USER_3, ProgramCodeKind::Custom(wat_no_counter))
-            .expect("submit result was asserted");
+        let init_no_counter_id =
+            upload_program_default(USER_3, ProgramCodeKind::Custom(wat_no_counter))
+                .expect("submit result was asserted");
 
         run_to_block(2, None);
 
@@ -4479,11 +4480,13 @@ fn gas_spent_precalculated() {
         let init_code_len: u64 = common::get_program(init_gas_id.into_origin())
             .and_then(|p| common::ActiveProgram::try_from(p).ok())
             .expect("program must exist")
-            .code_length_bytes.into();
+            .code_length_bytes
+            .into();
         let init_no_gas_code_len: u64 = common::get_program(init_no_counter_id.into_origin())
             .and_then(|p| common::ActiveProgram::try_from(p).ok())
             .expect("program must exist")
-            .code_length_bytes.into();
+            .code_length_bytes
+            .into();
         // binaries have the same memory amount but different lengths
         // so take this into account in gas calculations
         let length_margin = init_code_len - init_no_gas_code_len;
@@ -4520,7 +4523,8 @@ fn gas_spent_precalculated() {
         let module_instantiation_per_byte = schedule.module_instantiation_per_byte;
 
         // gas_charge call in handle and "add" func
-        let gas_cost = gas_spent_init - gas_spent_no_counter
+        let gas_cost = gas_spent_init
+            - gas_spent_no_counter
             - const_i64_cost as u64
             - set_local_cost as u64
             - core_processor::calculate_gas_for_code(0, per_byte_cost, length_margin)
@@ -4541,8 +4545,7 @@ fn gas_spent_precalculated() {
         let call_cost = schedule.instruction_weights.call;
         let get_local_cost = schedule.instruction_weights.local_get;
         let add_cost = schedule.instruction_weights.i64add;
-        let module_instantiation =
-            module_instantiation_per_byte * code.len() as u64;
+        let module_instantiation = module_instantiation_per_byte * code.len() as u64;
         let load_page_cost = schedule.memory_weights.load_cost;
 
         let total_cost = {

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -4442,16 +4442,89 @@ fn gas_spent_precalculated() {
         )
     )"#;
 
+    let wat_no_counter = r#"
+    (module
+        (import "env" "memory" (memory 1))
+        (export "init" (func $init))
+        (func $init)
+    )"#;
+
+    let wat_init = r#"
+    (module
+        (import "env" "memory" (memory 1))
+        (export "init" (func $init))
+        (func $init
+            (local $1 i32)
+            i32.const 1
+            set_local $1
+        )
+    )"#;
+
     init_logger();
     new_test_ext().execute_with(|| {
         let prog = ProgramCodeKind::Custom(wat);
         let prog_id = upload_program_default(USER_1, prog).expect("submit result was asserted");
+
+        let init_gas_id = upload_program_default(USER_3, ProgramCodeKind::Custom(wat_init))
+            .expect("submit result was asserted");
+        let init_no_counter_id = upload_program_default(USER_3, ProgramCodeKind::Custom(wat_no_counter))
+            .expect("submit result was asserted");
 
         run_to_block(2, None);
 
         let code_id = CodeId::generate(&prog.to_bytes());
         let code = <Test as Config>::CodeStorage::get_code(code_id).unwrap();
         let code = code.code();
+
+        let init_code_len: u64 = common::get_program(init_gas_id.into_origin())
+            .and_then(|p| common::ActiveProgram::try_from(p).ok())
+            .expect("program must exist")
+            .code_length_bytes.into();
+        let init_no_gas_code_len: u64 = common::get_program(init_no_counter_id.into_origin())
+            .and_then(|p| common::ActiveProgram::try_from(p).ok())
+            .expect("program must exist")
+            .code_length_bytes.into();
+        // binaries have the same memory amount but different lengths
+        // so take this into account in gas calculations
+        let length_margin = init_code_len - init_no_gas_code_len;
+
+        let GasInfo {
+            min_limit: gas_spent_init,
+            ..
+        } = Gear::calculate_gas_info(
+            USER_1.into_origin(),
+            HandleKind::Init(ProgramCodeKind::Custom(wat_init).to_bytes()),
+            EMPTY_PAYLOAD.to_vec(),
+            0,
+            true,
+        )
+        .unwrap();
+
+        let GasInfo {
+            min_limit: gas_spent_no_counter,
+            ..
+        } = Gear::calculate_gas_info(
+            USER_1.into_origin(),
+            HandleKind::Init(ProgramCodeKind::Custom(wat_no_counter).to_bytes()),
+            EMPTY_PAYLOAD.to_vec(),
+            0,
+            true,
+        )
+        .unwrap();
+
+        let per_byte_cost = ReadPerByteCostOf::<Test>::get();
+
+        let schedule = <Test as Config>::Schedule::get();
+        let const_i64_cost = schedule.instruction_weights.i64const;
+        let set_local_cost = schedule.instruction_weights.local_set;
+        let module_instantiation_per_byte = schedule.module_instantiation_per_byte;
+
+        // gas_charge call in handle and "add" func
+        let gas_cost = gas_spent_init - gas_spent_no_counter
+            - const_i64_cost as u64
+            - set_local_cost as u64
+            - core_processor::calculate_gas_for_code(0, per_byte_cost, length_margin)
+            - module_instantiation_per_byte * length_margin;
 
         let GasInfo {
             min_limit: gas_spent_1,
@@ -4465,17 +4538,11 @@ fn gas_spent_precalculated() {
         )
         .unwrap();
 
-        let schedule = <Test as Config>::Schedule::get();
-
-        let const_i64_cost = schedule.instruction_weights.i64const;
         let call_cost = schedule.instruction_weights.call;
-        let set_local_cost = schedule.instruction_weights.local_set;
         let get_local_cost = schedule.instruction_weights.local_get;
         let add_cost = schedule.instruction_weights.i64add;
-        // gas call in handle and "add" func
-        let gas_cost = schedule.host_fn_weights.gas as u32;
         let module_instantiation =
-            schedule.module_instantiation_per_byte * code.len() as u64;
+            module_instantiation_per_byte * code.len() as u64;
         let load_page_cost = schedule.memory_weights.load_cost;
 
         let total_cost = {
@@ -4484,7 +4551,7 @@ fn gas_spent_precalculated() {
                 + set_local_cost
                 + get_local_cost * 2
                 + add_cost
-                + gas_cost * 2;
+                + gas_cost as u32 * 2;
 
             let code_len = common::get_program(prog_id.into_origin())
                 .and_then(|p| common::ActiveProgram::try_from(p).ok())
@@ -4497,7 +4564,7 @@ fn gas_spent_precalculated() {
                 // cost for loading program
                 + core_processor::calculate_gas_for_program(read_cost, 0)
                 // cost for loading code
-                + core_processor::calculate_gas_for_code(read_cost, ReadPerByteCostOf::<Test>::get(), code_len.into())
+                + core_processor::calculate_gas_for_code(read_cost, per_byte_cost, code_len.into())
                 + load_page_cost
                 + module_instantiation
         };

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -5346,7 +5346,7 @@ fn execution_over_blocks() {
         assert_ok!(Gear::send_message(
             RuntimeOrigin::signed(USER_1),
             in_one_block,
-            Package::new(1024, src).encode(),
+            Package::new(8_192, src).encode(),
             block_gas_limit,
             0,
         ));
@@ -5383,7 +5383,7 @@ fn execution_over_blocks() {
 
         assert!(program_exists(over_blocks.into_origin()));
 
-        let (src, id, expected) = ([0; 32], sha2_512_256(b"42"), 1024);
+        let (src, id, expected) = ([0; 32], sha2_512_256(b"42"), 8_192);
 
         // trigger calculation
         assert_ok!(Gear::send_message(

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 550,
+    spec_version: 560,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 560,
+    spec_version: 570,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 530,
+    spec_version: 540,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -99,7 +99,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 550,
+    spec_version: 560,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -99,7 +99,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 530,
+    spec_version: 540,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -99,7 +99,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 560,
+    spec_version: 570,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/utils/wasm-gen/src/syscalls.rs
+++ b/utils/wasm-gen/src/syscalls.rs
@@ -312,7 +312,10 @@ fn test_sys_calls_table() {
     use gear_backend_common::{mock::MockExt, Environment, TerminationReason};
     use gear_backend_wasmi::WasmiEnvironment;
     use gear_core::message::DispatchKind;
-    use gear_wasm_instrument::parity_wasm::{self, builder};
+    use gear_wasm_instrument::{
+        parity_wasm::{self, builder},
+        wasm_instrument::gas_metering::ConstantCostRules,
+    };
 
     let config = GearConfig::new_normal();
     let table = sys_calls_table(&config);
@@ -341,6 +344,8 @@ fn test_sys_calls_table() {
             .build();
     }
 
+    let module =
+        gear_wasm_instrument::inject(module, &ConstantCostRules::default(), "env").unwrap();
     let code = module.into_bytes().unwrap();
 
     // Execute wasm and check success.

--- a/utils/wasm-proc/src/main.rs
+++ b/utils/wasm-proc/src/main.rs
@@ -21,7 +21,7 @@ use gear_wasm_builder::optimize::{OptType, Optimizer};
 use parity_wasm::elements::External;
 use std::{collections::HashSet, fs, path::PathBuf};
 
-const RT_ALLOWED_IMPORTS: [&str; 49] = [
+const RT_ALLOWED_IMPORTS: [&str; 50] = [
     // From `Allocator` (substrate/primitives/io/src/lib.rs)
     "ext_allocator_free_version_1",
     "ext_allocator_malloc_version_1",
@@ -56,6 +56,7 @@ const RT_ALLOWED_IMPORTS: [&str; 49] = [
     // From `Sandbox` (substrate/primitives/io/src/lib.rs)
     "ext_sandbox_get_buff_version_1",
     "ext_sandbox_get_global_val_version_1",
+    "ext_sandbox_set_global_val_version_1",
     "ext_sandbox_instance_teardown_version_1",
     "ext_sandbox_instantiate_version_1",
     "ext_sandbox_invoke_version_1",


### PR DESCRIPTION
Resolves #1468 

Blocked by #1689 , https://github.com/gear-tech/substrate/pull/23

- refactor syscalls `create_program*` in wasmi backend
- fix regression in `exit` syscall for wasmi backend
- extend `Ext` trait: getters/setters for counters, `out_of_...` methods
- remove old `gas` handler
- use new injection method
- add `ext_sandbox_set_global_val_version_1` to the list of allowed imports in `wasm-proc`
- adjust other source code base to the changes

**Release notes**: Previous implementation of gas metering calls into the supervisor for every basic block in order to report some consumption from the gas meter. This is slow because calling imported functions is a heavy operation.
This PR contains implementation of gas metering in programs' userspace for both wasmer and wasmi execution backends. Userspace gas metering reduces gas consumption by programs significantly. Several tiny bugs were also fixed with these changes.

@gear-tech/dev 
