### PR TITLE
Set proper gas to value conversion

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -38,7 +38,7 @@ use core::{fmt, mem};
 use frame_support::{
     dispatch::DispatchError,
     traits::Get,
-    weights::{IdentityFee, Weight, WeightToFee},
+    weights::{ConstantMultiplier, Weight, WeightToFee},
 };
 use gear_core::{
     ids::{CodeId, MessageId, ProgramId},
@@ -143,10 +143,14 @@ impl Origin for CodeId {
 pub trait GasPrice {
     type Balance: BaseArithmetic + From<u32> + Copy + Unsigned;
 
+    type GasToBalanceMultiplier: Get<Self::Balance>;
+
     /// A price for the `gas` amount of gas.
     /// In general case, this doesn't necessarily has to be constant.
     fn gas_price(gas: u64) -> Self::Balance {
-        IdentityFee::<Self::Balance>::weight_to_fee(&Weight::from_ref_time(gas))
+        ConstantMultiplier::<Self::Balance, Self::GasToBalanceMultiplier>::weight_to_fee(
+            &Weight::from_ref_time(gas),
+        )
     }
 }
 

--- a/pallets/gear-debug/src/mock.rs
+++ b/pallets/gear-debug/src/mock.rs
@@ -189,7 +189,6 @@ construct_runtime!(
 );
 
 // Build genesis storage according to the mock runtime.
-#[allow(unused)]
 pub fn new_test_ext() -> sp_io::TestExternalities {
     let mut t = system::GenesisConfig::default()
         .build_storage::<Test>()
@@ -197,16 +196,20 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
     pallet_balances::GenesisConfig::<Test> {
         balances: vec![
-            (1, 100_000_000_000_u128),
-            (2, 2_u128),
-            (BLOCK_AUTHOR, 1_u128),
+            (1, 100_000_000_000_000_u128),
+            (2, 2_000_u128),
+            (BLOCK_AUTHOR, 1_000_u128),
         ],
     }
     .assimilate_storage(&mut t)
     .unwrap();
 
     let mut ext = sp_io::TestExternalities::new(t);
-    ext.execute_with(|| System::set_block_number(1));
+    ext.execute_with(|| {
+        Gear::force_always();
+        System::set_block_number(1);
+        Gear::on_initialize(System::block_number());
+    });
     ext
 }
 

--- a/pallets/gear-debug/src/mock.rs
+++ b/pallets/gear-debug/src/mock.rs
@@ -24,6 +24,7 @@ use frame_support::{
 };
 use frame_system as system;
 use primitive_types::H256;
+use sp_core::ConstU128;
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, ConstU64, IdentityLookup},
@@ -121,6 +122,7 @@ impl pallet_timestamp::Config for Test {
 pub struct GasConverter;
 impl common::GasPrice for GasConverter {
     type Balance = u128;
+    type GasToBalanceMultiplier = ConstU128<1_000>;
 }
 
 impl pallet_gear_program::Config for Test {

--- a/pallets/gear-scheduler/src/mock.rs
+++ b/pallets/gear-scheduler/src/mock.rs
@@ -27,7 +27,7 @@ use frame_support::{
 };
 use frame_system as system;
 use pallet_gear::BlockGasLimitOf;
-use sp_core::H256;
+use sp_core::{ConstU128, H256};
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
@@ -112,6 +112,7 @@ impl system::Config for Test {
 pub struct GasConverter;
 impl common::GasPrice for GasConverter {
     type Balance = u128;
+    type GasToBalanceMultiplier = ConstU128<1_000>;
 }
 
 impl pallet_gear_program::Config for Test {

--- a/pallets/gear-scheduler/src/mock.rs
+++ b/pallets/gear-scheduler/src/mock.rs
@@ -201,11 +201,11 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
     pallet_balances::GenesisConfig::<Test> {
         balances: vec![
-            (USER_1, 500_000_000_000_u128),
-            (USER_2, 200_000_000_000_u128),
-            (USER_3, 500_000_000_000_u128),
-            (LOW_BALANCE_USER, 1000_u128),
-            (BLOCK_AUTHOR, 500_u128),
+            (USER_1, 500_000_000_000_000_u128),
+            (USER_2, 200_000_000_000_000_u128),
+            (USER_3, 500_000_000_000_000_u128),
+            (LOW_BALANCE_USER, 1_000_000_u128),
+            (BLOCK_AUTHOR, 500_000_u128),
         ],
     }
     .assimilate_storage(&mut t)

--- a/pallets/gear/src/mock.rs
+++ b/pallets/gear/src/mock.rs
@@ -216,11 +216,11 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
     pallet_balances::GenesisConfig::<Test> {
         balances: vec![
-            (USER_1, 500_000_000_000_u128),
-            (USER_2, 200_000_000_000_u128),
-            (USER_3, 500_000_000_000_u128),
-            (LOW_BALANCE_USER, 1000_u128),
-            (BLOCK_AUTHOR, 500_u128),
+            (USER_1, 500_000_000_000_000_u128),
+            (USER_2, 200_000_000_000_000_u128),
+            (USER_3, 500_000_000_000_000_u128),
+            (LOW_BALANCE_USER, 1_000_000_u128),
+            (BLOCK_AUTHOR, 500_000_u128),
         ],
     }
     .assimilate_storage(&mut t)

--- a/pallets/gear/src/mock.rs
+++ b/pallets/gear/src/mock.rs
@@ -27,7 +27,7 @@ use frame_support::{
     weights::RuntimeDbWeight,
 };
 use frame_system as system;
-use sp_core::H256;
+use sp_core::{ConstU128, H256};
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
@@ -127,6 +127,7 @@ impl system::Config for Test {
 pub struct GasConverter;
 impl common::GasPrice for GasConverter {
     type Balance = u128;
+    type GasToBalanceMultiplier = ConstU128<1_000>;
 }
 
 impl pallet_gear_program::Config for Test {

--- a/pallets/payment/src/mock.rs
+++ b/pallets/payment/src/mock.rs
@@ -19,7 +19,9 @@
 use crate as pallet_gear_payment;
 use frame_support::{
     construct_runtime, parameter_types,
-    traits::{ConstU8, Contains, Currency, FindAuthor, OnFinalize, OnInitialize, OnUnbalanced},
+    traits::{
+        ConstU128, ConstU8, Contains, Currency, FindAuthor, OnFinalize, OnInitialize, OnUnbalanced,
+    },
     weights::{constants::WEIGHT_PER_SECOND, IdentityFee},
 };
 use frame_system as system;
@@ -155,6 +157,7 @@ impl pallet_transaction_payment::Config for Test {
 pub struct GasConverter;
 impl common::GasPrice for GasConverter {
     type Balance = u128;
+    type GasToBalanceMultiplier = ConstU128<1_000>;
 }
 
 parameter_types! {

--- a/pallets/payment/src/mock.rs
+++ b/pallets/payment/src/mock.rs
@@ -259,7 +259,11 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
     .unwrap();
 
     let mut ext = sp_io::TestExternalities::new(t);
-    ext.execute_with(|| System::set_block_number(1));
+    ext.execute_with(|| {
+        Gear::force_always();
+        System::set_block_number(1);
+        Gear::on_initialize(System::block_number());
+    });
     ext
 }
 

--- a/program/tests/cmd/claim.rs
+++ b/program/tests/cmd/claim.rs
@@ -2,7 +2,7 @@
 use crate::common::{self, Result, ALICE_SS58_ADDRESS as ADDRESS};
 use gear_program::api::Api;
 
-const REWARD_PER_BLOCK: u128 = 3000;
+const REWARD_PER_BLOCK: u128 = 3_000_000; // 3_000 gas * 1_000 value per gas
 
 #[tokio::test]
 async fn test_command_claim_works() -> Result<()> {

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -22,7 +22,7 @@ mod apis;
 
 use frame_support::{
     parameter_types,
-    traits::{Currency, OnUnbalanced},
+    traits::{ConstU128, Currency, OnUnbalanced},
 };
 use runtime_primitives::{AccountId, Balance, BlockNumber};
 use sp_runtime::Perbill;
@@ -44,6 +44,7 @@ parameter_types! {
 pub struct GasConverter;
 impl gear_common::GasPrice for GasConverter {
     type Balance = Balance;
+    type GasToBalanceMultiplier = ConstU128<1_000>;
 }
 
 pub type NegativeImbalance<T> = <pallet_balances::Pallet<T> as Currency<

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 570,
+    spec_version: 580,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 510,
+    spec_version: 520,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -99,7 +99,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 570,
+    spec_version: 580,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -99,7 +99,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 510,
+    spec_version: 520,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/utils/gear-runtime-test-cli/src/util.rs
+++ b/utils/gear-runtime-test-cli/src/util.rs
@@ -21,7 +21,7 @@
 use codec::Encode;
 use frame_support::traits::{Currency, GenesisBuild, OnFinalize, OnInitialize};
 use frame_system as system;
-use gear_common::{storage::*, Origin, QueueRunner};
+use gear_common::{storage::*, GasPrice, Origin, QueueRunner};
 use gear_core::message::{StoredDispatch, StoredMessage};
 use pallet_gear::{BlockGasLimitOf, Config, GasAllowanceOf};
 use pallet_gear_debug::DebugData;
@@ -152,11 +152,15 @@ macro_rules! utils {
             let balances = vec![
                 (
                     AccountId32::unchecked_from(1000001.into_origin()),
-                    (BlockGasLimitOf::<Runtime>::get() * 20) as u128,
+                    <Runtime as Config>::GasPrice::gas_price(
+                        BlockGasLimitOf::<Runtime>::get() * 20,
+                    ),
                 ),
                 (
                     AccountId32::unchecked_from(crate::HACK.into_origin()),
-                    (BlockGasLimitOf::<Runtime>::get() * 20) as u128,
+                    <Runtime as Config>::GasPrice::gas_price(
+                        BlockGasLimitOf::<Runtime>::get() * 20,
+                    ),
                 ),
             ];
 


### PR DESCRIPTION
Resolves #1511.

That's temporary solution, written in most efficient and easy way for the moment.
Should be replaced with more complicated one in order to support changing gas price multiplicator with runtime upgrade in future.