### PR TITLE
Test `core-backend/common` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2843,6 +2843,7 @@ dependencies = [
  "gear-core-errors",
  "log",
  "parity-scale-codec",
+ "rand 0.8.5",
  "scale-info",
 ]
 

--- a/core-backend/common/Cargo.toml
+++ b/core-backend/common/Cargo.toml
@@ -13,5 +13,8 @@ derive_more = "0.99.17"
 codec = { package = "parity-scale-codec", version = "3.1.2", features = ["derive", "full"], default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 
+[dev-dependencies]
+rand = "0.8"
+
 [features]
 mock = []

--- a/core-backend/common/src/utils.rs
+++ b/core-backend/common/src/utils.rs
@@ -19,6 +19,7 @@
 use crate::StackEndError;
 use alloc::string::String;
 use gear_core::memory::WasmPageNumber;
+use rand::RngCore;
 
 #[macro_export]
 macro_rules! assert_ok {
@@ -67,8 +68,11 @@ pub fn calc_stack_end(stack_end: Option<i32>) -> Result<Option<WasmPageNumber>, 
     }
 }
 
-#[test]
-fn truncate_test() {
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{distributions::Standard, thread_rng, Rng};
+
     fn assert_result(string: &'static str, max_bytes: usize, expectation: &'static str) {
         let mut string = string.into();
         smart_truncate(&mut string, max_bytes);
@@ -89,84 +93,107 @@ fn truncate_test() {
         }
     }
 
-    // String for demonstration with UTF_8 encoding.
-    let utf_8 = "hello";
-    // Length in bytes.
-    assert_eq!(utf_8.len(), 5);
-    // Length in chars.
-    assert_eq!(utf_8.chars().count(), 5);
+    #[test]
+    fn truncate_test() {
+        // String for demonstration with UTF_8 encoding.
+        let utf_8 = "hello";
+        // Length in bytes.
+        assert_eq!(utf_8.len(), 5);
+        // Length in chars.
+        assert_eq!(utf_8.chars().count(), 5);
 
-    // Check that `smart_truncate` never panics.
-    //
-    // It calls the `smart_truncate` with `max_bytes` arg in 0..= len * 2.
-    check_panicking(utf_8, utf_8.len().saturating_mul(2));
+        // Check that `smart_truncate` never panics.
+        //
+        // It calls the `smart_truncate` with `max_bytes` arg in 0..= len * 2.
+        check_panicking(utf_8, utf_8.len().saturating_mul(2));
 
-    // Asserting results.
-    assert_result(utf_8, 0, "");
-    assert_result(utf_8, 1, "h");
-    assert_result(utf_8, 2, "he");
-    assert_result(utf_8, 3, "hel");
-    assert_result(utf_8, 4, "hell");
-    assert_result(utf_8, 5, "hello");
-    assert_result(utf_8, 6, "hello");
+        // Asserting results.
+        assert_result(utf_8, 0, "");
+        assert_result(utf_8, 1, "h");
+        assert_result(utf_8, 2, "he");
+        assert_result(utf_8, 3, "hel");
+        assert_result(utf_8, 4, "hell");
+        assert_result(utf_8, 5, "hello");
+        assert_result(utf_8, 6, "hello");
 
-    // String for demonstration with CJK encoding.
-    let cjk = "你好吗";
-    // Length in bytes.
-    assert_eq!(cjk.len(), 9);
-    // Length in chars.
-    assert_eq!(cjk.chars().count(), 3);
+        // String for demonstration with CJK encoding.
+        let cjk = "你好吗";
+        // Length in bytes.
+        assert_eq!(cjk.len(), 9);
+        // Length in chars.
+        assert_eq!(cjk.chars().count(), 3);
 
-    // Check that `smart_truncate` never panics.
-    //
-    // It calls the `smart_truncate` with `max_bytes` arg in 0..= len * 2.
-    check_panicking(cjk, cjk.len().saturating_mul(2));
+        // Check that `smart_truncate` never panics.
+        //
+        // It calls the `smart_truncate` with `max_bytes` arg in 0..= len * 2.
+        check_panicking(cjk, cjk.len().saturating_mul(2));
 
-    // Asserting results.
-    assert_result(cjk, 0, "");
-    assert_result(cjk, 1, "");
-    assert_result(cjk, 2, "");
-    assert_result(cjk, 3, "你");
-    assert_result(cjk, 4, "你");
-    assert_result(cjk, 5, "你");
-    assert_result(cjk, 6, "你好");
-    assert_result(cjk, 7, "你好");
-    assert_result(cjk, 8, "你好");
-    assert_result(cjk, 9, "你好吗");
-    assert_result(cjk, 10, "你好吗");
+        // Asserting results.
+        assert_result(cjk, 0, "");
+        assert_result(cjk, 1, "");
+        assert_result(cjk, 2, "");
+        assert_result(cjk, 3, "你");
+        assert_result(cjk, 4, "你");
+        assert_result(cjk, 5, "你");
+        assert_result(cjk, 6, "你好");
+        assert_result(cjk, 7, "你好");
+        assert_result(cjk, 8, "你好");
+        assert_result(cjk, 9, "你好吗");
+        assert_result(cjk, 10, "你好吗");
 
-    // String for demonstration with mixed CJK and UTF-8 encoding.
-    let mix = "你he好l吗lo"; // Chaotic sum of "hello" and "你好吗".
-                             // Length in bytes.
-    assert_eq!(mix.len(), utf_8.len() + cjk.len());
-    assert_eq!(mix.len(), 14);
-    // Length in chars.
-    assert_eq!(
-        mix.chars().count(),
-        utf_8.chars().count() + cjk.chars().count()
-    );
-    assert_eq!(mix.chars().count(), 8);
+        // String for demonstration with mixed CJK and UTF-8 encoding.
+        let mix = "你he好l吗lo"; // Chaotic sum of "hello" and "你好吗".
+                                 // Length in bytes.
+        assert_eq!(mix.len(), utf_8.len() + cjk.len());
+        assert_eq!(mix.len(), 14);
+        // Length in chars.
+        assert_eq!(
+            mix.chars().count(),
+            utf_8.chars().count() + cjk.chars().count()
+        );
+        assert_eq!(mix.chars().count(), 8);
 
-    // Check that `smart_truncate` never panics.
-    //
-    // It calls the `smart_truncate` with `max_bytes` arg in 0..= len * 2.
-    check_panicking(mix, mix.len().saturating_mul(2));
+        // Check that `smart_truncate` never panics.
+        //
+        // It calls the `smart_truncate` with `max_bytes` arg in 0..= len * 2.
+        check_panicking(mix, mix.len().saturating_mul(2));
 
-    // Asserting results.
-    assert_result(mix, 0, "");
-    assert_result(mix, 1, "");
-    assert_result(mix, 2, "");
-    assert_result(mix, 3, "你");
-    assert_result(mix, 4, "你h");
-    assert_result(mix, 5, "你he");
-    assert_result(mix, 6, "你he");
-    assert_result(mix, 7, "你he");
-    assert_result(mix, 8, "你he好");
-    assert_result(mix, 9, "你he好l");
-    assert_result(mix, 10, "你he好l");
-    assert_result(mix, 11, "你he好l");
-    assert_result(mix, 12, "你he好l吗");
-    assert_result(mix, 13, "你he好l吗l");
-    assert_result(mix, 14, "你he好l吗lo");
-    assert_result(mix, 15, "你he好l吗lo");
+        // Asserting results.
+        assert_result(mix, 0, "");
+        assert_result(mix, 1, "");
+        assert_result(mix, 2, "");
+        assert_result(mix, 3, "你");
+        assert_result(mix, 4, "你h");
+        assert_result(mix, 5, "你he");
+        assert_result(mix, 6, "你he");
+        assert_result(mix, 7, "你he");
+        assert_result(mix, 8, "你he好");
+        assert_result(mix, 9, "你he好l");
+        assert_result(mix, 10, "你he好l");
+        assert_result(mix, 11, "你he好l");
+        assert_result(mix, 12, "你he好l吗");
+        assert_result(mix, 13, "你he好l吗l");
+        assert_result(mix, 14, "你he好l吗lo");
+        assert_result(mix, 15, "你he好l吗lo");
+    }
+
+    #[test]
+    fn truncate_test_fuzz() {
+        for _ in 0..50 {
+            let mut thread_rng = rand::thread_rng();
+
+            let rand_len = thread_rng.gen_range(0..=100_000);
+            let max_bytes = thread_rng.gen_range(0..=rand_len);
+            let mut string = thread_rng
+                .sample_iter::<char, _>(Standard)
+                .take(rand_len)
+                .collect();
+
+            smart_truncate(&mut string, max_bytes);
+
+            if string.len() > max_bytes {
+                panic!("String '{}' input invalidated algorithms property", string);
+            }
+        }
+    }
 }

--- a/core-backend/common/src/utils.rs
+++ b/core-backend/common/src/utils.rs
@@ -19,7 +19,6 @@
 use crate::StackEndError;
 use alloc::string::String;
 use gear_core::memory::WasmPageNumber;
-use rand::RngCore;
 
 #[macro_export]
 macro_rules! assert_ok {
@@ -71,7 +70,7 @@ pub fn calc_stack_end(stack_end: Option<i32>) -> Result<Option<WasmPageNumber>, 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::{distributions::Standard, thread_rng, Rng};
+    use rand::{distributions::Standard, Rng};
 
     fn assert_result(string: &'static str, max_bytes: usize, expectation: &'static str) {
         let mut string = string.into();

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 540,
+    spec_version: 550,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 510,
+    spec_version: 520,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -99,7 +99,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 540,
+    spec_version: 550,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -99,7 +99,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 510,
+    spec_version: 520,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Partially #1496 .

Crate mostly consists of traits and type definitions without clear view on their usage.

@gear-tech/dev 
