### PR TITLE
add syscalls table in gear-wasm-instruments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3486,14 +3486,11 @@ name = "gear-wasm-gen"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "gear-backend-common",
- "gear-backend-wasmi",
- "gear-core",
  "gear-wasm-instrument",
  "indicatif",
  "rand 0.8.5",
  "wasm-smith",
- "wasmparser 0.92.0",
+ "wasmparser 0.93.0",
  "wasmprinter",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3501,6 +3501,9 @@ dependencies = [
 name = "gear-wasm-instrument"
 version = "0.1.0"
 dependencies = [
+ "gear-backend-common",
+ "gear-backend-wasmi",
+ "gear-core",
  "wasm-instrument 0.2.1",
  "wasmparser 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wat",

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -58,7 +58,7 @@ gear-program = { path = "../../program", features = [ "cli" ], optional = true }
 substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 
 [features]
-default = ["gear-native", "vara-native", "lazy-pages", "program", "runtime-benchmarks"]
+default = ["gear-native", "vara-native", "lazy-pages", "program"]
 gear-native = [
 	"service/gear-native",
 	"gear-runtime-test-cli?/gear-native",

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -58,7 +58,7 @@ gear-program = { path = "../../program", features = [ "cli" ], optional = true }
 substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 
 [features]
-default = ["gear-native", "vara-native", "lazy-pages", "program"]
+default = ["gear-native", "vara-native", "lazy-pages", "program", "runtime-benchmarks"]
 gear-native = [
 	"service/gear-native",
 	"gear-runtime-test-cli?/gear-native",

--- a/pallets/gear/src/benchmarking/code.rs
+++ b/pallets/gear/src/benchmarking/code.rs
@@ -29,14 +29,16 @@ use crate::Config;
 use common::Origin;
 use frame_support::traits::Get;
 use gear_core::ids::CodeId;
-use gear_wasm_instrument::parity_wasm::{
-    builder,
-    elements::{
-        self, BlockType, CustomSection, FuncBody, Instruction, Instructions, Module, Section,
-        ValueType,
+use gear_wasm_instrument::{
+    parity_wasm::{
+        builder,
+        elements::{
+            self, BlockType, CustomSection, FuncBody, Instruction, Instructions, Module, Section,
+            ValueType,
+        },
     },
+    syscalls,
 };
-use gear_wasm_instrument::syscalls;
 use sp_sandbox::{
     default_executor::{EnvironmentDefinitionBuilder, Memory},
     SandboxEnvironmentBuilder, SandboxMemory,

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -841,7 +841,7 @@ benchmarks! {
     gr_leave {
         let r in 0 .. 1;
         let mut res = None;
-        let exec = Benches::<T>::no_return_bench("gr_leave", Some(0xff), r)?;
+        let exec = Benches::<T>::no_return_bench("gr_leave", None, r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -854,7 +854,7 @@ benchmarks! {
     gr_wait {
         let r in 0 .. 1;
         let mut res = None;
-        let exec = Benches::<T>::no_return_bench("gr_wait", Some(0xff), r)?;
+        let exec = Benches::<T>::no_return_bench("gr_wait", None, r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -867,7 +867,7 @@ benchmarks! {
     gr_wait_for {
         let r in 0 .. 1;
         let mut res = None;
-        let exec = Benches::<T>::no_return_bench("gr_wait_for", Some(0xff), r)?;
+        let exec = Benches::<T>::no_return_bench("gr_wait_for", Some(10), r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -880,7 +880,7 @@ benchmarks! {
     gr_wait_up_to {
         let r in 0 .. 1;
         let mut res = None;
-        let exec = Benches::<T>::no_return_bench("gr_wait_up_to", Some(0xff), r)?;
+        let exec = Benches::<T>::no_return_bench("gr_wait_up_to", Some(100), r)?;
     }: {
         res.replace(run_process(exec));
     }

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -615,7 +615,7 @@ benchmarks! {
     gr_gas_available {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = number_getter_bench::<T>("gr_gas_available", ValueType::I64, r)?;
+        let exec = number_getter_bench::<T>("gr_gas_available", r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -626,7 +626,7 @@ benchmarks! {
     gr_size {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = number_getter_bench::<T>("gr_size", ValueType::I32, r)?;
+        let exec = number_getter_bench::<T>("gr_size", r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -659,7 +659,7 @@ benchmarks! {
     gr_block_height {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = number_getter_bench::<T>("gr_block_height", ValueType::I32, r)?;
+        let exec = number_getter_bench::<T>("gr_block_height", r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -670,7 +670,7 @@ benchmarks! {
     gr_block_timestamp {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = number_getter_bench::<T>("gr_block_timestamp", ValueType::I64, r)?;
+        let exec = number_getter_bench::<T>("gr_block_timestamp", r)?;
     }: {
         res.replace(run_process(exec));
     }

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -24,7 +24,7 @@
 mod code;
 mod sandbox;
 mod syscalls;
-use syscalls::*;
+use syscalls::Benches;
 
 use self::{
     code::{
@@ -505,7 +505,7 @@ benchmarks! {
     alloc {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = alloc_bench::<T>(r)?;
+        let exec = Benches::<T>::alloc(r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -516,7 +516,7 @@ benchmarks! {
     free {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = free_bench::<T>(r)?;
+        let exec = Benches::<T>::free(r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -527,7 +527,7 @@ benchmarks! {
     gr_reserve_gas {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = gr_reserve_gas_bench::<T>(r)?;
+        let exec = Benches::<T>::gr_reserve_gas(r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -538,7 +538,7 @@ benchmarks! {
     gr_unreserve_gas {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = gr_unreserve_gas_bench::<T>(r)?;
+        let exec = Benches::<T>::gr_unreserve_gas(r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -549,7 +549,7 @@ benchmarks! {
     gr_message_id {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = getter_bench::<T>("gr_message_id", r)?;
+        let exec = Benches::<T>::getter("gr_message_id", r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -560,7 +560,7 @@ benchmarks! {
     gr_origin {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = getter_bench::<T>("gr_origin", r)?;
+        let exec = Benches::<T>::getter("gr_origin", r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -571,7 +571,7 @@ benchmarks! {
     gr_program_id {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = getter_bench::<T>("gr_program_id", r)?;
+        let exec = Benches::<T>::getter("gr_program_id", r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -582,7 +582,7 @@ benchmarks! {
     gr_source {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = getter_bench::<T>("gr_source", r)?;
+        let exec = Benches::<T>::getter("gr_source", r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -593,7 +593,7 @@ benchmarks! {
     gr_value {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = getter_bench::<T>("gr_value", r)?;
+        let exec = Benches::<T>::getter("gr_value", r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -604,7 +604,7 @@ benchmarks! {
     gr_value_available {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = getter_bench::<T>("gr_value_available", r)?;
+        let exec = Benches::<T>::getter("gr_value_available", r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -615,7 +615,7 @@ benchmarks! {
     gr_gas_available {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = number_getter_bench::<T>("gr_gas_available", r)?;
+        let exec = Benches::<T>::number_getter("gr_gas_available", r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -626,7 +626,7 @@ benchmarks! {
     gr_size {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = number_getter_bench::<T>("gr_size", r)?;
+        let exec = Benches::<T>::number_getter("gr_size", r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -637,7 +637,7 @@ benchmarks! {
     gr_read {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = gr_read_bench::<T>(r)?;
+        let exec = Benches::<T>::gr_read(r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -648,7 +648,7 @@ benchmarks! {
     gr_read_per_kb {
         let n in 0 .. T::Schedule::get().limits.payload_len / 1024;
         let mut res = None;
-        let exec = gr_read_per_kb_bench::<T>(n)?;
+        let exec = Benches::<T>::gr_read_per_kb(n)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -659,7 +659,7 @@ benchmarks! {
     gr_block_height {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = number_getter_bench::<T>("gr_block_height", r)?;
+        let exec = Benches::<T>::number_getter("gr_block_height", r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -670,7 +670,7 @@ benchmarks! {
     gr_block_timestamp {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = number_getter_bench::<T>("gr_block_timestamp", r)?;
+        let exec = Benches::<T>::number_getter("gr_block_timestamp", r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -692,7 +692,7 @@ benchmarks! {
     gr_send_init {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = gr_send_init_bench::<T>(r)?;
+        let exec = Benches::<T>::gr_send_init(r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -703,7 +703,7 @@ benchmarks! {
     gr_send_push {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = gr_send_push_bench::<T>(r)?;
+        let exec = Benches::<T>::gr_send_push(r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -714,7 +714,7 @@ benchmarks! {
     gr_send_push_per_kb {
         let n in 0 .. T::Schedule::get().limits.payload_len / 1024;
         let mut res = None;
-        let exec = gr_send_push_per_kb_bench::<T>(n)?;
+        let exec = Benches::<T>::gr_send_push_per_kb(n)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -725,7 +725,7 @@ benchmarks! {
     gr_send_commit {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = gr_send_commit_bench::<T>(r)?;
+        let exec = Benches::<T>::gr_send_commit(r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -736,7 +736,7 @@ benchmarks! {
     gr_send_commit_per_kb {
         let n in 0 .. T::Schedule::get().limits.payload_len / 1024;
         let mut res = None;
-        let exec = gr_send_commit_per_kb_bench::<T>(n)?;
+        let exec = Benches::<T>::gr_send_commit_per_kb(n)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -748,7 +748,7 @@ benchmarks! {
     gr_reply_commit {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = gr_reply_commit_bench::<T>(r)?;
+        let exec = Benches::<T>::gr_reply_commit(r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -760,7 +760,7 @@ benchmarks! {
     gr_reply_push {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = gr_reply_push_bench::<T>(r)?;
+        let exec = Benches::<T>::gr_reply_push(r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -771,7 +771,7 @@ benchmarks! {
     gr_reply_push_per_kb {
         let n in 0 .. T::Schedule::get().limits.payload_len / 1024;
         let mut res = None;
-        let exec = gr_reply_push_per_kb_bench::<T>(n)?;
+        let exec = Benches::<T>::gr_reply_push_per_kb(n)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -782,7 +782,7 @@ benchmarks! {
     gr_reply_to {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = gr_reply_to_bench::<T>(r)?;
+        let exec = Benches::<T>::gr_reply_to(r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -793,7 +793,7 @@ benchmarks! {
     gr_debug {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = gr_debug_bench::<T>(r)?;
+        let exec = Benches::<T>::gr_debug(r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -804,7 +804,7 @@ benchmarks! {
     gr_debug_per_kb {
         let n in 0 .. T::Schedule::get().limits.payload_len / 1024;
         let mut res = None;
-        let exec = gr_debug_per_kb_bench::<T>(n)?;
+        let exec = Benches::<T>::gr_debug_per_kb(n)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -815,7 +815,7 @@ benchmarks! {
     gr_exit_code {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = gr_exit_code_bench::<T>(r)?;
+        let exec = Benches::<T>::gr_exit_code(r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -828,7 +828,7 @@ benchmarks! {
     gr_exit {
         let r in 0 .. 1;
         let mut res = None;
-        let exec = no_return_bench::<T>("gr_exit", Some(0xff), r)?;
+        let exec = Benches::<T>::no_return_bench("gr_exit", Some(0xff), r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -841,7 +841,7 @@ benchmarks! {
     gr_leave {
         let r in 0 .. 1;
         let mut res = None;
-        let exec = no_return_bench::<T>("gr_leave", None, r)?;
+        let exec = Benches::<T>::no_return_bench("gr_leave", Some(0xff), r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -854,7 +854,7 @@ benchmarks! {
     gr_wait {
         let r in 0 .. 1;
         let mut res = None;
-        let exec = no_return_bench::<T>("gr_wait", None, r)?;
+        let exec = Benches::<T>::no_return_bench("gr_wait", Some(0xff), r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -867,7 +867,7 @@ benchmarks! {
     gr_wait_for {
         let r in 0 .. 1;
         let mut res = None;
-        let exec = no_return_bench::<T>("gr_wait_for", Some(10), r)?;
+        let exec = Benches::<T>::no_return_bench("gr_wait_for", Some(0xff), r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -880,7 +880,7 @@ benchmarks! {
     gr_wait_up_to {
         let r in 0 .. 1;
         let mut res = None;
-        let exec = no_return_bench::<T>("gr_wait_up_to", Some(100), r)?;
+        let exec = Benches::<T>::no_return_bench("gr_wait_up_to", Some(0xff), r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -891,7 +891,7 @@ benchmarks! {
     gr_wake {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = gr_wake_bench::<T>(r)?;
+        let exec = Benches::<T>::gr_wake(r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -902,7 +902,7 @@ benchmarks! {
     gr_create_program_wgas {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = gr_create_program_wgas_bench::<T>(r)?;
+        let exec = Benches::<T>::gr_create_program_wgas(r)?;
     }: {
         res.replace(run_process(exec));
     }
@@ -914,7 +914,7 @@ benchmarks! {
         let p in 0 .. T::Schedule::get().limits.payload_len / 1024;
         let s in 0 .. T::Schedule::get().limits.payload_len / 1024;
         let mut res = None;
-        let exec = gr_create_program_wgas_per_kb_bench::<T>(p, s)?;
+        let exec = Benches::<T>::gr_create_program_wgas_per_kb(p, s)?;
     }: {
         res.replace(run_process(exec));
     }

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -681,7 +681,7 @@ benchmarks! {
     gr_random {
         let r in 0 .. API_BENCHMARK_BATCHES;
         let mut res = None;
-        let exec = gr_random_bench::<T>(r)?;
+        let exec = Benches::<T>::gr_random(r)?;
     }: {
         res.replace(run_process(exec));
     }

--- a/pallets/gear/src/benchmarking/syscalls.rs
+++ b/pallets/gear/src/benchmarking/syscalls.rs
@@ -24,7 +24,7 @@ use gear_core::{
     ids::{CodeId, MessageId, ProgramId},
     message::{Dispatch, DispatchKind, Message, ReplyDetails},
 };
-use gear_wasm_instrument::parity_wasm::elements::Instruction;
+use gear_wasm_instrument::{parity_wasm::elements::Instruction, syscalls::syscall_signature};
 use sp_core::H256;
 use sp_runtime::traits::UniqueSaturatedInto;
 use sp_std::{convert::TryInto, prelude::*};
@@ -773,8 +773,10 @@ where
         assert!(r <= 1);
 
         let instructions = if let Some(c) = param {
+            assert!(syscall_signature(name).params.len() == 1);
             vec![Instruction::I32Const(c as i32), Instruction::Call(0)]
         } else {
+            assert!(syscall_signature(name).params.is_empty());
             vec![Instruction::Call(0)]
         };
 

--- a/pallets/gear/src/benchmarking/syscalls.rs
+++ b/pallets/gear/src/benchmarking/syscalls.rs
@@ -1,6 +1,6 @@
 use super::code::{
     body::{self, DynInstr::*},
-    max_pages, DataSegment, ImportedFunction, ImportedMemory, ModuleDefinition, WasmModule,
+    max_pages, DataSegment, ImportedMemory, ModuleDefinition, WasmModule,
 };
 use crate::{
     manager::{CodeInfo, ExtManager, HandleKind},
@@ -24,7 +24,7 @@ use gear_core::{
     ids::{CodeId, MessageId, ProgramId},
     message::{Dispatch, DispatchKind, Message, ReplyDetails},
 };
-use gear_wasm_instrument::parity_wasm::elements::{Instruction, ValueType};
+use gear_wasm_instrument::parity_wasm::elements::Instruction;
 use sp_core::H256;
 use sp_runtime::traits::UniqueSaturatedInto;
 use sp_std::{convert::TryInto, prelude::*};
@@ -237,12 +237,7 @@ where
 {
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory { min_pages: 0 }),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "alloc",
-            params: vec![ValueType::I32],
-            return_type: Some(ValueType::I32),
-        }],
+        imported_functions: vec!["alloc"],
         handle_body: Some(body::repeated(
             r * API_BENCHMARK_BATCH_SIZE,
             &[
@@ -285,20 +280,7 @@ where
 
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory { min_pages: 0 }),
-        imported_functions: vec![
-            ImportedFunction {
-                module: "env",
-                name: "alloc",
-                params: vec![ValueType::I32],
-                return_type: Some(ValueType::I32),
-            },
-            ImportedFunction {
-                module: "env",
-                name: "free",
-                params: vec![ValueType::I32],
-                return_type: None,
-            },
-        ],
+        imported_functions: vec!["alloc", "free"],
         init_body: None,
         handle_body: Some(body::plain(instructions)),
         ..Default::default()
@@ -322,12 +304,7 @@ where
 
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "gr_reserve_gas",
-            params: vec![ValueType::I64, ValueType::I32, ValueType::I32],
-            return_type: Some(ValueType::I32),
-        }],
+        imported_functions: vec!["gr_reserve_gas"],
         data_segments: vec![DataSegment {
             offset: id_offset,
             value: id_bytes,
@@ -368,12 +345,7 @@ where
 
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "gr_unreserve_gas",
-            params: vec![ValueType::I32, ValueType::I32],
-            return_type: Some(ValueType::I32),
-        }],
+        imported_functions: vec!["gr_unreserve_gas"],
         data_segments: vec![
             DataSegment {
                 offset: id_offset,
@@ -411,12 +383,7 @@ where
 {
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name,
-            params: vec![ValueType::I32],
-            return_type: None,
-        }],
+        imported_functions: vec![name],
         handle_body: Some(body::repeated(
             r * API_BENCHMARK_BATCH_SIZE,
             &[Instruction::I32Const(0), Instruction::Call(0)],
@@ -432,23 +399,14 @@ where
     )
 }
 
-pub fn number_getter_bench<T>(
-    name: &'static str,
-    return_type: ValueType,
-    r: u32,
-) -> Result<Exec<T>, &'static str>
+pub fn number_getter_bench<T>(name: &'static str, r: u32) -> Result<Exec<T>, &'static str>
 where
     T: Config,
     T::AccountId: Origin,
 {
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name,
-            params: vec![],
-            return_type: Some(return_type),
-        }],
+        imported_functions: vec![name],
         handle_body: Some(body::repeated(
             r * API_BENCHMARK_BATCH_SIZE,
             &[Instruction::Call(0), Instruction::Drop],
@@ -474,12 +432,7 @@ where
 
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "gr_read",
-            params: vec![ValueType::I32, ValueType::I32, ValueType::I32],
-            return_type: Some(ValueType::I32),
-        }],
+        imported_functions: vec!["gr_read"],
         handle_body: Some(body::repeated(
             r * API_BENCHMARK_BATCH_SIZE,
             &[
@@ -511,12 +464,7 @@ where
 
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "gr_read",
-            params: vec![ValueType::I32, ValueType::I32, ValueType::I32],
-            return_type: Some(ValueType::I32),
-        }],
+        imported_functions: vec!["gr_read"],
         handle_body: Some(body::repeated(
             API_BENCHMARK_BATCH_SIZE,
             &[
@@ -584,12 +532,7 @@ where
 {
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "gr_send_init",
-            params: vec![ValueType::I32],
-            return_type: Some(ValueType::I32),
-        }],
+        imported_functions: vec!["gr_send_init"],
         handle_body: Some(body::repeated(
             r * API_BENCHMARK_BATCH_SIZE,
             &[
@@ -619,20 +562,7 @@ where
 
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![
-            ImportedFunction {
-                module: "env",
-                name: "gr_send_init",
-                params: vec![ValueType::I32],
-                return_type: Some(ValueType::I32),
-            },
-            ImportedFunction {
-                module: "env",
-                name: "gr_send_push",
-                params: vec![ValueType::I32, ValueType::I32, ValueType::I32],
-                return_type: Some(ValueType::I32),
-            },
-        ],
+        imported_functions: vec!["gr_send_init", "gr_send_push"],
         handle_body: Some(body::repeated(
             r * API_BENCHMARK_BATCH_SIZE,
             &[
@@ -668,20 +598,7 @@ where
 
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![
-            ImportedFunction {
-                module: "env",
-                name: "gr_send_init",
-                params: vec![ValueType::I32],
-                return_type: Some(ValueType::I32),
-            },
-            ImportedFunction {
-                module: "env",
-                name: "gr_send_push",
-                params: vec![ValueType::I32, ValueType::I32, ValueType::I32],
-                return_type: Some(ValueType::I32),
-            },
-        ],
+        imported_functions: vec!["gr_send_init", "gr_send_push"],
         handle_body: Some(body::repeated(
             API_BENCHMARK_BATCH_SIZE,
             &[
@@ -718,19 +635,7 @@ where
 
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "gr_send",
-            params: vec![
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-            ],
-            return_type: Some(ValueType::I32),
-        }],
+        imported_functions: vec!["gr_send"],
         handle_body: Some(body::repeated(
             r * API_BENCHMARK_BATCH_SIZE,
             &[
@@ -767,19 +672,7 @@ where
 
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "gr_send",
-            params: vec![
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-            ],
-            return_type: Some(ValueType::I32),
-        }],
+        imported_functions: vec!["gr_send"],
         handle_body: Some(body::repeated(
             API_BENCHMARK_BATCH_SIZE,
             &[
@@ -813,12 +706,7 @@ where
 
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "gr_reply_commit",
-            params: vec![ValueType::I32, ValueType::I32, ValueType::I32],
-            return_type: Some(ValueType::I32),
-        }],
+        imported_functions: vec!["gr_reply_commit"],
         handle_body: Some(body::repeated(
             r * API_BENCHMARK_BATCH_SIZE,
             &[
@@ -850,12 +738,7 @@ where
 
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "gr_reply_push",
-            params: vec![ValueType::I32, ValueType::I32],
-            return_type: Some(ValueType::I32),
-        }],
+        imported_functions: vec!["gr_reply_push"],
         handle_body: Some(body::repeated(
             r * API_BENCHMARK_BATCH_SIZE,
             &[
@@ -886,12 +769,7 @@ where
 
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "gr_reply_push",
-            params: vec![ValueType::I32, ValueType::I32],
-            return_type: Some(ValueType::I32),
-        }],
+        imported_functions: vec!["gr_reply_push"],
         handle_body: Some(body::repeated(
             API_BENCHMARK_BATCH_SIZE,
             &[
@@ -921,12 +799,7 @@ where
 
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "gr_reply_to",
-            params: vec![ValueType::I32],
-            return_type: Some(ValueType::I32),
-        }],
+        imported_functions: vec!["gr_reply_to"],
         reply_body: Some(body::repeated(
             r * API_BENCHMARK_BATCH_SIZE,
             &[
@@ -968,12 +841,7 @@ where
 
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "gr_exit_code",
-            params: vec![ValueType::I32],
-            return_type: Some(ValueType::I32),
-        }],
+        imported_functions: vec!["gr_exit_code"],
         reply_body: Some(body::repeated(
             r * API_BENCHMARK_BATCH_SIZE,
             &[
@@ -1016,12 +884,7 @@ where
 
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "gr_debug",
-            params: vec![ValueType::I32, ValueType::I32],
-            return_type: None,
-        }],
+        imported_functions: vec!["gr_debug"],
         handle_body: Some(body::repeated(
             r * API_BENCHMARK_BATCH_SIZE,
             &[
@@ -1051,12 +914,7 @@ where
 
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "gr_debug",
-            params: vec![ValueType::I32, ValueType::I32],
-            return_type: None,
-        }],
+        imported_functions: vec!["gr_debug"],
         handle_body: Some(body::repeated(
             API_BENCHMARK_BATCH_SIZE,
             &[
@@ -1087,23 +945,15 @@ where
 {
     assert!(r <= 1);
 
-    let (instructions, params) = if let Some(c) = param {
-        (
-            vec![Instruction::I32Const(c as i32), Instruction::Call(0)],
-            vec![ValueType::I32],
-        )
+    let instructions = if let Some(c) = param {
+        vec![Instruction::I32Const(c as i32), Instruction::Call(0)]
     } else {
-        (vec![Instruction::Call(0)], vec![])
+        vec![Instruction::Call(0)]
     };
 
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name,
-            params,
-            return_type: None,
-        }],
+        imported_functions: vec![name],
         handle_body: Some(body::repeated(r, &instructions)),
         ..Default::default()
     });
@@ -1129,12 +979,7 @@ where
 
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "gr_wake",
-            params: vec![ValueType::I32, ValueType::I32],
-            return_type: Some(ValueType::I32),
-        }],
+        imported_functions: vec!["gr_wake"],
         data_segments: vec![DataSegment {
             offset,
             value: message_id_bytes,
@@ -1207,23 +1052,7 @@ where
     );
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "gr_create_program_wgas",
-            params: vec![
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I64,
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-            ],
-            return_type: Some(ValueType::I32),
-        }],
+        imported_functions: vec!["gr_create_program_wgas"],
         data_segments: vec![
             DataSegment {
                 offset: code_hash_offset,
@@ -1296,23 +1125,7 @@ where
     );
     let code = WasmModule::<T>::from(ModuleDefinition {
         memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "gr_create_program_wgas",
-            params: vec![
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I64,
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-            ],
-            return_type: Some(ValueType::I32),
-        }],
+        imported_functions: vec!["gr_create_program_wgas"],
         data_segments: vec![
             DataSegment {
                 offset: code_hash_offset,

--- a/pallets/gear/src/benchmarking/syscalls.rs
+++ b/pallets/gear/src/benchmarking/syscalls.rs
@@ -429,20 +429,10 @@ where
         Self::prepare_handle(code, 0)
     }
 
-    pub fn gr_random_bench(r: u32) -> Result<Exec<T>, &'static str> {
+    pub fn gr_random(r: u32) -> Result<Exec<T>, &'static str> {
         let code = WasmModule::<T>::from(ModuleDefinition {
             memory: Some(ImportedMemory::max::<T>()),
-            imported_functions: vec![ImportedFunction {
-                module: "env",
-                name: "gr_random",
-                params: vec![
-                    ValueType::I32,
-                    ValueType::I32,
-                    ValueType::I32,
-                    ValueType::I32,
-                ],
-                return_type: None,
-            }],
+            imported_functions: vec!["gr_random"],
             handle_body: Some(body::repeated(
                 r * API_BENCHMARK_BATCH_SIZE,
                 &[

--- a/pallets/gear/src/benchmarking/syscalls.rs
+++ b/pallets/gear/src/benchmarking/syscalls.rs
@@ -12,7 +12,7 @@ use codec::Encode;
 use common::{
     benchmarking, scheduler::SchedulingCostsPerBlock, storage::*, CodeStorage, GasTree, Origin,
 };
-use core::mem::size_of;
+use core::{marker::PhantomData, mem::size_of};
 use core_processor::{
     configs::{AllocationsConfig, BlockConfig, BlockInfo, MessageExecutionContext},
     PrechargeResult, PrepareResult,
@@ -230,937 +230,737 @@ where
     }
 }
 
-pub fn alloc_bench<T>(r: u32) -> Result<Exec<T>, &'static str>
+pub(crate) struct Benches<T>
 where
     T: Config,
     T::AccountId: Origin,
 {
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory { min_pages: 0 }),
-        imported_functions: vec!["alloc"],
-        handle_body: Some(body::repeated(
-            r * API_BENCHMARK_BATCH_SIZE,
-            &[
-                // Alloc 0 pages take almost the same amount of resources as another amount.
-                Instruction::I32Const(0),
-                Instruction::Call(0),
-                Instruction::Drop,
-            ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        0u32.into(),
-    )
+    _phantom: PhantomData<T>,
 }
 
-pub fn free_bench<T>(r: u32) -> Result<Exec<T>, &'static str>
+impl<T> Benches<T>
 where
     T: Config,
     T::AccountId: Origin,
 {
-    assert!(r <= max_pages::<T>());
-
-    use Instruction::*;
-    let mut instructions = vec![];
-    for _ in 0..API_BENCHMARK_BATCH_SIZE {
-        instructions.push(I32Const(r as i32));
-        instructions.push(Call(0));
-        instructions.push(Drop);
-        for page in 0..r {
-            instructions.push(I32Const(page as i32));
-            instructions.push(Call(1));
-        }
+    fn prepare_handle(code: WasmModule<T>, value: u32) -> Result<Exec<T>, &'static str> {
+        let instance = Program::<T>::new(code, vec![])?;
+        prepare::<T>(
+            instance.caller.into_origin(),
+            HandleKind::Handle(ProgramId::from_origin(instance.addr)),
+            vec![],
+            value.into(),
+        )
     }
-    instructions.push(End);
 
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory { min_pages: 0 }),
-        imported_functions: vec!["alloc", "free"],
-        init_body: None,
-        handle_body: Some(body::plain(instructions)),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        0u32.into(),
-    )
-}
+    pub fn alloc(r: u32) -> Result<Exec<T>, &'static str> {
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory { min_pages: 0 }),
+            imported_functions: vec!["alloc"],
+            handle_body: Some(body::repeated(
+                r * API_BENCHMARK_BATCH_SIZE,
+                &[
+                    // Alloc 0 pages take almost the same amount of resources as another amount.
+                    Instruction::I32Const(0),
+                    Instruction::Call(0),
+                    Instruction::Drop,
+                ],
+            )),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 0)
+    }
 
-pub fn gr_reserve_gas_bench<T>(r: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let id_offset = 1;
-    let id_bytes = u128::MAX.encode();
+    pub fn free(r: u32) -> Result<Exec<T>, &'static str> {
+        assert!(r <= max_pages::<T>());
 
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_reserve_gas"],
-        data_segments: vec![DataSegment {
-            offset: id_offset,
-            value: id_bytes,
-        }],
-        handle_body: Some(body::repeated(
-            r * API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I64Const(50_000_000),       // gas amount
-                Instruction::I32Const(10),               // duration
-                Instruction::I32Const(id_offset as i32), // id ptr
-                Instruction::Call(0),
-                Instruction::Drop,
-            ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        0u32.into(),
-    )
-}
+        use Instruction::*;
+        let mut instructions = vec![];
+        for _ in 0..API_BENCHMARK_BATCH_SIZE {
+            instructions.push(I32Const(r as i32));
+            instructions.push(Call(0));
+            instructions.push(Drop);
+            for page in 0..r {
+                instructions.push(I32Const(page as i32));
+                instructions.push(Call(1));
+            }
+        }
+        instructions.push(End);
 
-// TODO: currently each syscall execution returns error: ExecutionError::InvalidReservationId.
-// We need to fill reservations set with data first. (issue #1724)
-pub fn gr_unreserve_gas_bench<T>(r: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let id_bytes = u128::MAX.encode();
-    let id_len = id_bytes.len() as u32;
-    let id_offset = 1;
-    let amount_bytes = 1000u64.encode();
-    let amount_offset = id_offset + id_len;
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory { min_pages: 0 }),
+            imported_functions: vec!["alloc", "free"],
+            init_body: None,
+            handle_body: Some(body::plain(instructions)),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 0)
+    }
 
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_unreserve_gas"],
-        data_segments: vec![
-            DataSegment {
+    pub fn gr_reserve_gas(r: u32) -> Result<Exec<T>, &'static str> {
+        let id_offset = 1;
+        let id_bytes = u128::MAX.encode();
+
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_reserve_gas"],
+            data_segments: vec![DataSegment {
                 offset: id_offset,
                 value: id_bytes,
-            },
-            DataSegment {
-                offset: amount_offset,
-                value: amount_bytes,
-            },
-        ],
-        handle_body: Some(body::repeated(
-            r * API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I32Const(id_offset as i32),     // id ptr
-                Instruction::I32Const(amount_offset as i32), // unreserved amount ptr
-                Instruction::Call(0),
-                Instruction::Drop,
+            }],
+            handle_body: Some(body::repeated(
+                r * API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I64Const(50_000_000),       // gas amount
+                    Instruction::I32Const(10),               // duration
+                    Instruction::I32Const(id_offset as i32), // id ptr
+                    Instruction::Call(0),
+                    Instruction::Drop,
+                ],
+            )),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 0)
+    }
+
+    // TODO: currently each syscall execution returns error: ExecutionError::InvalidReservationId.
+    // We need to fill reservations set with data first. (issue #1724)
+    pub fn gr_unreserve_gas(r: u32) -> Result<Exec<T>, &'static str> {
+        let id_bytes = u128::MAX.encode();
+        let id_len = id_bytes.len() as u32;
+        let id_offset = 1;
+        let amount_bytes = 1000u64.encode();
+        let amount_offset = id_offset + id_len;
+
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_unreserve_gas"],
+            data_segments: vec![
+                DataSegment {
+                    offset: id_offset,
+                    value: id_bytes,
+                },
+                DataSegment {
+                    offset: amount_offset,
+                    value: amount_bytes,
+                },
             ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        0u32.into(),
-    )
-}
+            handle_body: Some(body::repeated(
+                r * API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I32Const(id_offset as i32),     // id ptr
+                    Instruction::I32Const(amount_offset as i32), // unreserved amount ptr
+                    Instruction::Call(0),
+                    Instruction::Drop,
+                ],
+            )),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 0)
+    }
 
-pub fn getter_bench<T>(name: &'static str, r: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![name],
-        handle_body: Some(body::repeated(
-            r * API_BENCHMARK_BATCH_SIZE,
-            &[Instruction::I32Const(0), Instruction::Call(0)],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        0u32.into(),
-    )
-}
+    pub fn getter(name: &'static str, r: u32) -> Result<Exec<T>, &'static str> {
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec![name],
+            handle_body: Some(body::repeated(
+                r * API_BENCHMARK_BATCH_SIZE,
+                &[Instruction::I32Const(0), Instruction::Call(0)],
+            )),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 0)
+    }
 
-pub fn number_getter_bench<T>(name: &'static str, r: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![name],
-        handle_body: Some(body::repeated(
-            r * API_BENCHMARK_BATCH_SIZE,
-            &[Instruction::Call(0), Instruction::Drop],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        0u32.into(),
-    )
-}
+    pub fn number_getter(name: &'static str, r: u32) -> Result<Exec<T>, &'static str> {
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec![name],
+            handle_body: Some(body::repeated(
+                r * API_BENCHMARK_BATCH_SIZE,
+                &[Instruction::Call(0), Instruction::Drop],
+            )),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 0)
+    }
 
-pub fn gr_read_bench<T>(r: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let buffer_offset = 1;
-    let payload = vec![1u8; 100];
+    pub fn gr_read(r: u32) -> Result<Exec<T>, &'static str> {
+        let buffer_offset = 1;
+        let payload = vec![1u8; 100];
 
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_read"],
-        handle_body: Some(body::repeated(
-            r * API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I32Const(0),
-                Instruction::I32Const(payload.len() as i32),
-                Instruction::I32Const(buffer_offset),
-                Instruction::Call(0),
-                Instruction::Drop,
-            ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        payload,
-        0u32.into(),
-    )
-}
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_read"],
+            handle_body: Some(body::repeated(
+                r * API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I32Const(0),
+                    Instruction::I32Const(payload.len() as i32),
+                    Instruction::I32Const(buffer_offset),
+                    Instruction::Call(0),
+                    Instruction::Drop,
+                ],
+            )),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 0)
+    }
 
-pub fn gr_read_per_kb_bench<T>(n: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let buffer_offset = 1;
-    let payload = vec![0xff; (n * 1024) as usize];
+    pub fn gr_read_per_kb(n: u32) -> Result<Exec<T>, &'static str> {
+        let buffer_offset = 1;
+        let payload = vec![0xff; (n * 1024) as usize];
 
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_read"],
-        handle_body: Some(body::repeated(
-            API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I32Const(0),
-                Instruction::I32Const(payload.len() as i32),
-                Instruction::I32Const(buffer_offset),
-                Instruction::Call(0),
-                Instruction::Drop,
-            ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        payload,
-        0u32.into(),
-    )
-}
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_read"],
+            handle_body: Some(body::repeated(
+                API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I32Const(0),
+                    Instruction::I32Const(payload.len() as i32),
+                    Instruction::I32Const(buffer_offset),
+                    Instruction::Call(0),
+                    Instruction::Drop,
+                ],
+            )),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 0)
+    }
 
-pub fn gr_random_bench<T>(r: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![ImportedFunction {
-            module: "env",
-            name: "gr_random",
-            params: vec![
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-                ValueType::I32,
-            ],
-            return_type: None,
-        }],
-        handle_body: Some(body::repeated(
-            r * API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I32Const(0),  // subject ptr
-                Instruction::I32Const(32), // subject len
-                Instruction::I32Const(33), // random ptr
-                Instruction::I32Const(0),  // bn ptr
-                Instruction::Call(0),
-            ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        0u32.into(),
-    )
-}
+    pub fn gr_random_bench(r: u32) -> Result<Exec<T>, &'static str> {
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec![ImportedFunction {
+                module: "env",
+                name: "gr_random",
+                params: vec![
+                    ValueType::I32,
+                    ValueType::I32,
+                    ValueType::I32,
+                    ValueType::I32,
+                ],
+                return_type: None,
+            }],
+            handle_body: Some(body::repeated(
+                r * API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I32Const(0),  // subject ptr
+                    Instruction::I32Const(32), // subject len
+                    Instruction::I32Const(33), // random ptr
+                    Instruction::I32Const(0),  // bn ptr
+                    Instruction::Call(0),
+                ],
+            )),
+            ..Default::default()
+        });
+        let instance = Program::<T>::new(code, vec![])?;
+        prepare::<T>(
+            instance.caller.into_origin(),
+            HandleKind::Handle(ProgramId::from_origin(instance.addr)),
+            vec![],
+            0u32.into(),
+        )
+    }
 
-pub fn gr_send_init_bench<T>(r: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_send_init"],
-        handle_body: Some(body::repeated(
-            r * API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I32Const(0), // handle
-                Instruction::Call(0),
-                Instruction::Drop,
-            ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        0u32.into(),
-    )
-}
+    pub fn gr_send_init(r: u32) -> Result<Exec<T>, &'static str> {
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_send_init"],
+            handle_body: Some(body::repeated(
+                r * API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I32Const(0), // handle
+                    Instruction::Call(0),
+                    Instruction::Drop,
+                ],
+            )),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 0)
+    }
 
-pub fn gr_send_push_bench<T>(r: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let payload_offset = 1;
-    let payload_len = 100;
+    pub fn gr_send_push(r: u32) -> Result<Exec<T>, &'static str> {
+        let payload_offset = 1;
+        let payload_len = 100;
 
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_send_init", "gr_send_push"],
-        handle_body: Some(body::repeated(
-            r * API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I32Const(0), // handle
-                Instruction::Call(0),
-                Instruction::Drop,
-                Instruction::I32Const(0), // handle
-                Instruction::I32Const(payload_offset),
-                Instruction::I32Const(payload_len),
-                Instruction::Call(1),
-                Instruction::Drop,
-            ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        0u32.into(),
-    )
-}
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_send_init", "gr_send_push"],
+            handle_body: Some(body::repeated(
+                r * API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I32Const(0), // handle
+                    Instruction::Call(0),
+                    Instruction::Drop,
+                    Instruction::I32Const(0), // handle
+                    Instruction::I32Const(payload_offset),
+                    Instruction::I32Const(payload_len),
+                    Instruction::Call(1),
+                    Instruction::Drop,
+                ],
+            )),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 0)
+    }
 
-// TODO: investigate how handle changes can affect on syscall perf (issue #1722).
-pub fn gr_send_push_per_kb_bench<T>(n: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let payload_offset = 1;
-    let payload_len = n * 1024;
+    // TODO: investigate how handle changes can affect on syscall perf (issue #1722).
+    pub fn gr_send_push_per_kb(n: u32) -> Result<Exec<T>, &'static str> {
+        let payload_offset = 1;
+        let payload_len = n * 1024;
 
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_send_init", "gr_send_push"],
-        handle_body: Some(body::repeated(
-            API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I32Const(0), // handle
-                Instruction::Call(0),
-                Instruction::Drop,
-                Instruction::I32Const(0), // handle
-                Instruction::I32Const(payload_offset),
-                Instruction::I32Const(payload_len as i32),
-                Instruction::Call(1),
-                Instruction::Drop,
-            ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        0u32.into(),
-    )
-}
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_send_init", "gr_send_push"],
+            handle_body: Some(body::repeated(
+                API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I32Const(0), // handle
+                    Instruction::Call(0),
+                    Instruction::Drop,
+                    Instruction::I32Const(0), // handle
+                    Instruction::I32Const(payload_offset),
+                    Instruction::I32Const(payload_len as i32),
+                    Instruction::Call(1),
+                    Instruction::Drop,
+                ],
+            )),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 0)
+    }
 
-// Benchmark the `gr_send_commit` call.
-// `gr_send` call is shortcut for `gr_send_init` + `gr_send_commit`
-pub fn gr_send_commit_bench<T>(r: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let offset = 1;
-    let payload_len = 100;
+    // Benchmark the `gr_send_commit` call.
+    // `gr_send` call is shortcut for `gr_send_init` + `gr_send_commit`
+    pub fn gr_send_commit(r: u32) -> Result<Exec<T>, &'static str> {
+        let offset = 1;
+        let payload_len = 100;
 
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_send"],
-        handle_body: Some(body::repeated(
-            r * API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I32Const(offset), // dest ptr
-                Instruction::I32Const(offset), // payload ptr
-                Instruction::I32Const(payload_len),
-                Instruction::I32Const(offset), // value ptr
-                Instruction::I32Const(10),     // delay
-                Instruction::I32Const(offset), // message_id ptr
-                Instruction::Call(0),
-                Instruction::Drop,
-            ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        10000000u32.into(),
-    )
-}
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_send"],
+            handle_body: Some(body::repeated(
+                r * API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I32Const(offset), // dest ptr
+                    Instruction::I32Const(offset), // payload ptr
+                    Instruction::I32Const(payload_len),
+                    Instruction::I32Const(offset), // value ptr
+                    Instruction::I32Const(10),     // delay
+                    Instruction::I32Const(offset), // message_id ptr
+                    Instruction::Call(0),
+                    Instruction::Drop,
+                ],
+            )),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 10000000)
+    }
 
-// Benchmark the `gr_send_commit` call.
-// `gr_send` call is shortcut for `gr_send_init` + `gr_send_commit`
-pub fn gr_send_commit_per_kb_bench<T>(n: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let offset = 1;
-    let payload_len = n as i32 * 1024;
+    // Benchmark the `gr_send_commit` call.
+    // `gr_send` call is shortcut for `gr_send_init` + `gr_send_commit`
+    pub fn gr_send_commit_per_kb(n: u32) -> Result<Exec<T>, &'static str> {
+        let offset = 1;
+        let payload_len = n as i32 * 1024;
 
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_send"],
-        handle_body: Some(body::repeated(
-            API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I32Const(offset), // dest ptr
-                Instruction::I32Const(offset), // payload ptr
-                Instruction::I32Const(payload_len),
-                Instruction::I32Const(offset), // value ptr
-                Instruction::I32Const(10),     // delay
-                Instruction::I32Const(offset), // message_id ptr
-                Instruction::Call(0),
-                Instruction::Drop,
-            ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        10000000u32.into(),
-    )
-}
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_send"],
+            handle_body: Some(body::repeated(
+                API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I32Const(offset), // dest ptr
+                    Instruction::I32Const(offset), // payload ptr
+                    Instruction::I32Const(payload_len),
+                    Instruction::I32Const(offset), // value ptr
+                    Instruction::I32Const(10),     // delay
+                    Instruction::I32Const(offset), // message_id ptr
+                    Instruction::Call(0),
+                    Instruction::Drop,
+                ],
+            )),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 10000000)
+    }
 
-pub fn gr_reply_commit_bench<T>(r: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let offset = 1;
+    pub fn gr_reply_commit(r: u32) -> Result<Exec<T>, &'static str> {
+        let offset = 1;
 
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_reply_commit"],
-        handle_body: Some(body::repeated(
-            r * API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I32Const(offset), // value ptr
-                Instruction::I32Const(10),     // delay
-                Instruction::I32Const(offset), // result: message_id ptr
-                Instruction::Call(0),
-                Instruction::Drop,
-            ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        10000000u32.into(),
-    )
-}
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_reply_commit"],
+            handle_body: Some(body::repeated(
+                r * API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I32Const(offset), // value ptr
+                    Instruction::I32Const(10),     // delay
+                    Instruction::I32Const(offset), // result: message_id ptr
+                    Instruction::Call(0),
+                    Instruction::Drop,
+                ],
+            )),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 10000000)
+    }
 
-pub fn gr_reply_push_bench<T>(r: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let payload_offset = 1;
-    let payload_len = 100;
+    pub fn gr_reply_push(r: u32) -> Result<Exec<T>, &'static str> {
+        let payload_offset = 1;
+        let payload_len = 100;
 
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_reply_push"],
-        handle_body: Some(body::repeated(
-            r * API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I32Const(payload_offset),
-                Instruction::I32Const(payload_len),
-                Instruction::Call(0),
-                Instruction::Drop,
-            ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        10000000u32.into(),
-    )
-}
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_reply_push"],
+            handle_body: Some(body::repeated(
+                r * API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I32Const(payload_offset),
+                    Instruction::I32Const(payload_len),
+                    Instruction::Call(0),
+                    Instruction::Drop,
+                ],
+            )),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 10000000)
+    }
 
-pub fn gr_reply_push_per_kb_bench<T>(n: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let payload_offset = 1;
-    let payload_len = n as i32 * 1024;
+    pub fn gr_reply_push_per_kb(n: u32) -> Result<Exec<T>, &'static str> {
+        let payload_offset = 1;
+        let payload_len = n as i32 * 1024;
 
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_reply_push"],
-        handle_body: Some(body::repeated(
-            API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I32Const(payload_offset),
-                Instruction::I32Const(payload_len),
-                Instruction::Call(0),
-                Instruction::Drop,
-            ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        10000000u32.into(),
-    )
-}
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_reply_push"],
+            handle_body: Some(body::repeated(
+                API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I32Const(payload_offset),
+                    Instruction::I32Const(payload_len),
+                    Instruction::Call(0),
+                    Instruction::Drop,
+                ],
+            )),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 10000000)
+    }
 
-pub fn gr_reply_to_bench<T>(r: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let message_id_offset = 1;
+    pub fn gr_reply_to(r: u32) -> Result<Exec<T>, &'static str> {
+        let message_id_offset = 1;
 
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_reply_to"],
-        reply_body: Some(body::repeated(
-            r * API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I32Const(message_id_offset),
-                Instruction::Call(0),
-                Instruction::Drop,
-            ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    let msg_id = MessageId::from(10);
-    let msg = gear_core::message::Message::new(
-        msg_id,
-        instance.addr.as_bytes().into(),
-        ProgramId::from(instance.caller.clone().into_origin().as_bytes()),
-        Default::default(),
-        Some(1_000_000),
-        0,
-        None,
-    )
-    .into_stored();
-    MailboxOf::<T>::insert(msg, u32::MAX.unique_saturated_into())
-        .expect("Error during mailbox insertion");
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Reply(msg_id, 0),
-        vec![],
-        0u32.into(),
-    )
-}
-
-pub fn gr_exit_code_bench<T>(r: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let exit_code_offset = 1;
-
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_exit_code"],
-        reply_body: Some(body::repeated(
-            r * API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I32Const(exit_code_offset),
-                Instruction::Call(0),
-                Instruction::Drop,
-            ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    let msg_id = MessageId::from(10);
-    let msg = gear_core::message::Message::new(
-        msg_id,
-        instance.addr.as_bytes().into(),
-        ProgramId::from(instance.caller.clone().into_origin().as_bytes()),
-        Default::default(),
-        Some(1_000_000),
-        0,
-        None,
-    )
-    .into_stored();
-    MailboxOf::<T>::insert(msg, u32::MAX.unique_saturated_into())
-        .expect("Error during mailbox insertion");
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Reply(msg_id, 0),
-        vec![],
-        0u32.into(),
-    )
-}
-
-pub fn gr_debug_bench<T>(r: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let string_offset = 1;
-    let string_len = 100;
-
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_debug"],
-        handle_body: Some(body::repeated(
-            r * API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I32Const(string_offset),
-                Instruction::I32Const(string_len),
-                Instruction::Call(0),
-            ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        0u32.into(),
-    )
-}
-
-pub fn gr_debug_per_kb_bench<T>(n: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let string_offset = 1;
-    let string_len = n as i32 * 1024;
-
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_debug"],
-        handle_body: Some(body::repeated(
-            API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I32Const(string_offset),
-                Instruction::I32Const(string_len),
-                Instruction::Call(0),
-            ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        0u32.into(),
-    )
-}
-
-pub fn no_return_bench<T>(
-    name: &'static str,
-    param: Option<u32>,
-    r: u32,
-) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    assert!(r <= 1);
-
-    let instructions = if let Some(c) = param {
-        vec![Instruction::I32Const(c as i32), Instruction::Call(0)]
-    } else {
-        vec![Instruction::Call(0)]
-    };
-
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec![name],
-        handle_body: Some(body::repeated(r, &instructions)),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        0u32.into(),
-    )
-}
-
-pub fn gr_wake_bench<T>(r: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let offset = 1;
-    let message_ids = (0..r)
-        .map(|i| MessageId::from(i as u64))
-        .collect::<Vec<_>>();
-    let message_id_bytes = message_ids.iter().flat_map(|x| x.encode()).collect();
-
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_wake"],
-        data_segments: vec![DataSegment {
-            offset,
-            value: message_id_bytes,
-        }],
-        handle_body: Some(body::repeated_dyn(
-            r * API_BENCHMARK_BATCH_SIZE,
-            vec![
-                Counter(offset, size_of::<MessageId>() as u32), // message_id ptr
-                Regular(Instruction::I32Const(10)),             // delay
-                Regular(Instruction::Call(0)),
-                Regular(Instruction::Drop),
-            ],
-        )),
-        ..Default::default()
-    });
-
-    let instance = Program::<T>::new(code, vec![])?;
-    for message_id in message_ids {
-        let message = gear_core::message::Message::new(
-            message_id,
-            1.into(),
-            ProgramId::from(instance.addr.as_bytes()),
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_reply_to"],
+            reply_body: Some(body::repeated(
+                r * API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I32Const(message_id_offset),
+                    Instruction::Call(0),
+                    Instruction::Drop,
+                ],
+            )),
+            ..Default::default()
+        });
+        let instance = Program::<T>::new(code, vec![])?;
+        let msg_id = MessageId::from(10);
+        let msg = gear_core::message::Message::new(
+            msg_id,
+            instance.addr.as_bytes().into(),
+            ProgramId::from(instance.caller.clone().into_origin().as_bytes()),
             Default::default(),
             Some(1_000_000),
             0,
             None,
-        );
-        let dispatch =
-            gear_core::message::Dispatch::new(gear_core::message::DispatchKind::Handle, message)
-                .into_stored();
-        WaitlistOf::<T>::insert(dispatch.clone(), u32::MAX.unique_saturated_into())
-            .expect("Duplicate wl message");
+        )
+        .into_stored();
+        MailboxOf::<T>::insert(msg, u32::MAX.unique_saturated_into())
+            .expect("Error during mailbox insertion");
+        prepare::<T>(
+            instance.caller.into_origin(),
+            HandleKind::Reply(msg_id, 0),
+            vec![],
+            0u32.into(),
+        )
     }
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        0u32.into(),
-    )
-}
 
-pub fn gr_create_program_wgas_bench<T>(r: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let module = WasmModule::<T>::dummy();
-    let code_hash_bytes = module.hash.encode();
-    let code_hash_len = code_hash_bytes.len();
-    let code_hash_offset = 1;
+    pub fn gr_exit_code(r: u32) -> Result<Exec<T>, &'static str> {
+        let exit_code_offset = 1;
 
-    let salt_bytes = u8::MAX.encode();
-    let salt_bytes_len = salt_bytes.len();
-    let salt_offset = code_hash_offset + code_hash_len as u32;
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_exit_code"],
+            reply_body: Some(body::repeated(
+                r * API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I32Const(exit_code_offset),
+                    Instruction::Call(0),
+                    Instruction::Drop,
+                ],
+            )),
+            ..Default::default()
+        });
+        let instance = Program::<T>::new(code, vec![])?;
+        let msg_id = MessageId::from(10);
+        let msg = gear_core::message::Message::new(
+            msg_id,
+            instance.addr.as_bytes().into(),
+            ProgramId::from(instance.caller.clone().into_origin().as_bytes()),
+            Default::default(),
+            Some(1_000_000),
+            0,
+            None,
+        )
+        .into_stored();
+        MailboxOf::<T>::insert(msg, u32::MAX.unique_saturated_into())
+            .expect("Error during mailbox insertion");
+        prepare::<T>(
+            instance.caller.into_origin(),
+            HandleKind::Reply(msg_id, 0),
+            vec![],
+            0u32.into(),
+        )
+    }
 
-    let value_bytes = u128::MAX.encode();
-    let value_bytes_len = value_bytes.len();
-    let value_offset = salt_offset + salt_bytes_len as u32;
+    pub fn gr_debug(r: u32) -> Result<Exec<T>, &'static str> {
+        let string_offset = 1;
+        let string_len = 100;
 
-    let payload = vec![1, 2, 3];
-    let payload_len = payload.len();
-    let payload_offset = value_offset + value_bytes_len as u32;
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_debug"],
+            handle_body: Some(body::repeated(
+                r * API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I32Const(string_offset),
+                    Instruction::I32Const(string_len),
+                    Instruction::Call(0),
+                ],
+            )),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 0)
+    }
 
-    let message_id_offset = 1;
-    let program_id_offset = 1;
+    pub fn gr_debug_per_kb(n: u32) -> Result<Exec<T>, &'static str> {
+        let string_offset = 1;
+        let string_len = n as i32 * 1024;
 
-    let _ = Gear::<T>::upload_code_raw(
-        RawOrigin::Signed(benchmarking::account("instantiator", 0, 0)).into(),
-        module.code,
-    );
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_create_program_wgas"],
-        data_segments: vec![
-            DataSegment {
-                offset: code_hash_offset,
-                value: code_hash_bytes,
-            },
-            DataSegment {
-                offset: salt_offset,
-                value: salt_bytes,
-            },
-            DataSegment {
-                offset: value_offset,
-                value: value_bytes,
-            },
-            DataSegment {
-                offset: payload_offset,
-                value: payload,
-            },
-        ],
-        handle_body: Some(body::repeated(
-            r * API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I32Const(code_hash_offset as i32), // code_id ptr
-                Instruction::I32Const(salt_offset as i32),      // salt ptr
-                Instruction::I32Const(salt_bytes_len as i32),   // salt len
-                Instruction::I32Const(payload_offset as i32),   // payload ptr
-                Instruction::I32Const(payload_len as i32),      // payload len
-                Instruction::I64Const(100000000),               // gas limit
-                Instruction::I32Const(value_offset as i32),     // value ptr
-                Instruction::I32Const(10),                      // delay
-                Instruction::I32Const(message_id_offset),       // message_id ptr
-                Instruction::I32Const(program_id_offset),       // program_id ptr
-                Instruction::Call(0),
-                Instruction::Drop,
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_debug"],
+            handle_body: Some(body::repeated(
+                API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I32Const(string_offset),
+                    Instruction::I32Const(string_len),
+                    Instruction::Call(0),
+                ],
+            )),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 0)
+    }
+
+    pub fn no_return_bench(
+        name: &'static str,
+        param: Option<u32>,
+        r: u32,
+    ) -> Result<Exec<T>, &'static str> {
+        assert!(r <= 1);
+
+        let instructions = if let Some(c) = param {
+            vec![Instruction::I32Const(c as i32), Instruction::Call(0)]
+        } else {
+            vec![Instruction::Call(0)]
+        };
+
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec![name],
+            handle_body: Some(body::repeated(r, &instructions)),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 0)
+    }
+
+    pub fn gr_wake(r: u32) -> Result<Exec<T>, &'static str> {
+        let offset = 1;
+        let message_ids = (0..r)
+            .map(|i| MessageId::from(i as u64))
+            .collect::<Vec<_>>();
+        let message_id_bytes = message_ids.iter().flat_map(|x| x.encode()).collect();
+
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_wake"],
+            data_segments: vec![DataSegment {
+                offset,
+                value: message_id_bytes,
+            }],
+            handle_body: Some(body::repeated_dyn(
+                r * API_BENCHMARK_BATCH_SIZE,
+                vec![
+                    Counter(offset, size_of::<MessageId>() as u32), // message_id ptr
+                    Regular(Instruction::I32Const(10)),             // delay
+                    Regular(Instruction::Call(0)),
+                    Regular(Instruction::Drop),
+                ],
+            )),
+            ..Default::default()
+        });
+
+        let instance = Program::<T>::new(code, vec![])?;
+        for message_id in message_ids {
+            let message = gear_core::message::Message::new(
+                message_id,
+                1.into(),
+                ProgramId::from(instance.addr.as_bytes()),
+                Default::default(),
+                Some(1_000_000),
+                0,
+                None,
+            );
+            let dispatch = gear_core::message::Dispatch::new(
+                gear_core::message::DispatchKind::Handle,
+                message,
+            )
+            .into_stored();
+            WaitlistOf::<T>::insert(dispatch.clone(), u32::MAX.unique_saturated_into())
+                .expect("Duplicate wl message");
+        }
+        prepare::<T>(
+            instance.caller.into_origin(),
+            HandleKind::Handle(ProgramId::from_origin(instance.addr)),
+            vec![],
+            0u32.into(),
+        )
+    }
+
+    pub fn gr_create_program_wgas(r: u32) -> Result<Exec<T>, &'static str> {
+        let module = WasmModule::<T>::dummy();
+        let code_hash_bytes = module.hash.encode();
+        let code_hash_len = code_hash_bytes.len();
+        let code_hash_offset = 1;
+
+        let salt_bytes = u8::MAX.encode();
+        let salt_bytes_len = salt_bytes.len();
+        let salt_offset = code_hash_offset + code_hash_len as u32;
+
+        let value_bytes = u128::MAX.encode();
+        let value_bytes_len = value_bytes.len();
+        let value_offset = salt_offset + salt_bytes_len as u32;
+
+        let payload = vec![1, 2, 3];
+        let payload_len = payload.len();
+        let payload_offset = value_offset + value_bytes_len as u32;
+
+        let message_id_offset = 1;
+        let program_id_offset = 1;
+
+        let _ = Gear::<T>::upload_code_raw(
+            RawOrigin::Signed(benchmarking::account("instantiator", 0, 0)).into(),
+            module.code,
+        );
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_create_program_wgas"],
+            data_segments: vec![
+                DataSegment {
+                    offset: code_hash_offset,
+                    value: code_hash_bytes,
+                },
+                DataSegment {
+                    offset: salt_offset,
+                    value: salt_bytes,
+                },
+                DataSegment {
+                    offset: value_offset,
+                    value: value_bytes,
+                },
+                DataSegment {
+                    offset: payload_offset,
+                    value: payload,
+                },
             ],
-        )),
-        ..Default::default()
-    });
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        0u32.into(),
-    )
-}
+            handle_body: Some(body::repeated(
+                r * API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I32Const(code_hash_offset as i32), // code_id ptr
+                    Instruction::I32Const(salt_offset as i32),      // salt ptr
+                    Instruction::I32Const(salt_bytes_len as i32),   // salt len
+                    Instruction::I32Const(payload_offset as i32),   // payload ptr
+                    Instruction::I32Const(payload_len as i32),      // payload len
+                    Instruction::I64Const(100000000),               // gas limit
+                    Instruction::I32Const(value_offset as i32),     // value ptr
+                    Instruction::I32Const(10),                      // delay
+                    Instruction::I32Const(message_id_offset),       // message_id ptr
+                    Instruction::I32Const(program_id_offset),       // program_id ptr
+                    Instruction::Call(0),
+                    Instruction::Drop,
+                ],
+            )),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 0)
+    }
 
-pub fn gr_create_program_wgas_per_kb_bench<T>(pkb: u32, skb: u32) -> Result<Exec<T>, &'static str>
-where
-    T: Config,
-    T::AccountId: Origin,
-{
-    let module = WasmModule::<T>::dummy();
-    let code_hash_bytes = module.hash.encode();
-    let code_hash_len = code_hash_bytes.len();
-    let code_hash_offset = 1;
+    pub fn gr_create_program_wgas_per_kb(pkb: u32, skb: u32) -> Result<Exec<T>, &'static str> {
+        let module = WasmModule::<T>::dummy();
+        let code_hash_bytes = module.hash.encode();
+        let code_hash_len = code_hash_bytes.len();
+        let code_hash_offset = 1;
 
-    let value_bytes = u128::MAX.encode();
-    let value_offset = code_hash_offset + code_hash_len as u32;
+        let value_bytes = u128::MAX.encode();
+        let value_offset = code_hash_offset + code_hash_len as u32;
 
-    let salt_bytes_len = skb * 1024;
-    let payload_len = pkb * 1024;
-    let payload_offset = 1;
-    let salt_offset = 1;
-    let message_id_offset = 1;
-    let program_id_offset = 1;
+        let salt_bytes_len = skb * 1024;
+        let payload_len = pkb * 1024;
+        let payload_offset = 1;
+        let salt_offset = 1;
+        let message_id_offset = 1;
+        let program_id_offset = 1;
 
-    let _ = Gear::<T>::upload_code_raw(
-        RawOrigin::Signed(benchmarking::account("instantiator", 0, 0)).into(),
-        module.code,
-    );
-    let code = WasmModule::<T>::from(ModuleDefinition {
-        memory: Some(ImportedMemory::max::<T>()),
-        imported_functions: vec!["gr_create_program_wgas"],
-        data_segments: vec![
-            DataSegment {
-                offset: code_hash_offset,
-                value: code_hash_bytes,
-            },
-            DataSegment {
-                offset: value_offset,
-                value: value_bytes,
-            },
-        ],
-        handle_body: Some(body::repeated(
-            API_BENCHMARK_BATCH_SIZE,
-            &[
-                Instruction::I32Const(code_hash_offset as i32), // code_hash ptr
-                Instruction::I32Const(salt_offset),             // salt ptr
-                Instruction::I32Const(salt_bytes_len as i32),   // salt len
-                Instruction::I32Const(payload_offset),          // payload ptr
-                Instruction::I32Const(payload_len as i32),      // payload len
-                Instruction::I64Const(100000000),               // gas limit
-                Instruction::I32Const(value_offset as i32),     // value ptr
-                Instruction::I32Const(10),                      // delay
-                Instruction::I32Const(message_id_offset),       // message_id ptr
-                Instruction::I32Const(program_id_offset),       // program_id ptr
-                Instruction::Call(0),
-                Instruction::Drop,
+        let _ = Gear::<T>::upload_code_raw(
+            RawOrigin::Signed(benchmarking::account("instantiator", 0, 0)).into(),
+            module.code,
+        );
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            imported_functions: vec!["gr_create_program_wgas"],
+            data_segments: vec![
+                DataSegment {
+                    offset: code_hash_offset,
+                    value: code_hash_bytes,
+                },
+                DataSegment {
+                    offset: value_offset,
+                    value: value_bytes,
+                },
             ],
-        )),
-        ..Default::default()
-    });
+            handle_body: Some(body::repeated(
+                API_BENCHMARK_BATCH_SIZE,
+                &[
+                    Instruction::I32Const(code_hash_offset as i32), // code_hash ptr
+                    Instruction::I32Const(salt_offset),             // salt ptr
+                    Instruction::I32Const(salt_bytes_len as i32),   // salt len
+                    Instruction::I32Const(payload_offset),          // payload ptr
+                    Instruction::I32Const(payload_len as i32),      // payload len
+                    Instruction::I64Const(100000000),               // gas limit
+                    Instruction::I32Const(value_offset as i32),     // value ptr
+                    Instruction::I32Const(10),                      // delay
+                    Instruction::I32Const(message_id_offset),       // message_id ptr
+                    Instruction::I32Const(program_id_offset),       // program_id ptr
+                    Instruction::Call(0),
+                    Instruction::Drop,
+                ],
+            )),
+            ..Default::default()
+        });
 
-    let instance = Program::<T>::new(code, vec![])?;
-    prepare::<T>(
-        instance.caller.into_origin(),
-        HandleKind::Handle(ProgramId::from_origin(instance.addr)),
-        vec![],
-        0u32.into(),
-    )
+        Self::prepare_handle(code, 0)
+    }
 }

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 620,
+    spec_version: 630,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -99,7 +99,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 620,
+    spec_version: 630,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/utils/wasm-gen/Cargo.toml
+++ b/utils/wasm-gen/Cargo.toml
@@ -13,8 +13,5 @@ wasmprinter = "0.2"
 
 [dev-dependencies]
 rand = { version = "0.8.0", features = ["small_rng"] }
-wasmparser = { version = "0.92.0" }
+wasmparser = { version = "0.93.0" }
 indicatif = "*"
-gear-backend-wasmi = { path = "../../core-backend/wasmi" }
-gear-backend-common = { path = "../../core-backend/common", features = ["mock"] }
-gear-core = { path = "../../core" }

--- a/utils/wasm-instrument/Cargo.toml
+++ b/utils/wasm-instrument/Cargo.toml
@@ -11,6 +11,9 @@ wasm-instrument = { version = "0.2.1", git = "https://github.com/gear-tech/wasm-
 [dev-dependencies]
 wasmparser = "0.90"
 wat = "1.0.50"
+gear-backend-wasmi = { path = "../../core-backend/wasmi" }
+gear-backend-common = { path = "../../core-backend/common", features = ["mock"] }
+gear-core = { path = "../../core" }
 
 [features]
 default = ["std"]

--- a/utils/wasm-instrument/src/lib.rs
+++ b/utils/wasm-instrument/src/lib.rs
@@ -35,6 +35,8 @@ pub use wasm_instrument::{self, parity_wasm};
 #[cfg(test)]
 mod tests;
 
+pub mod syscalls;
+
 pub const GLOBAL_NAME_GAS: &str = "gear_gas";
 pub const GLOBAL_NAME_ALLOWANCE: &str = "gear_allowance";
 

--- a/utils/wasm-instrument/src/syscalls.rs
+++ b/utils/wasm-instrument/src/syscalls.rs
@@ -19,7 +19,9 @@
 //! Gear syscalls for smart contracts execution signatures.
 
 use crate::parity_wasm::elements::{FunctionType, ValueType};
+use alloc::{vec, vec::Vec};
 
+/// Syscall param type.
 #[derive(Debug, Clone, Copy)]
 pub enum ParamType {
     Size,            // i32 buffers size in memory
@@ -42,6 +44,7 @@ impl From<ParamType> for ValueType {
     }
 }
 
+/// Syscall signature.
 #[derive(Debug, Clone)]
 pub struct SysCallSignature {
     pub params: Vec<ParamType>,
@@ -67,6 +70,7 @@ impl SysCallSignature {
     }
 }
 
+/// Returns list of all syscall names (actually supported by this module syscalls).
 pub fn syscalls_name_list() -> Vec<&'static str> {
     vec![
         "alloc",
@@ -108,6 +112,7 @@ pub fn syscalls_name_list() -> Vec<&'static str> {
     ]
 }
 
+/// Returns signature for syscall by name.
 pub fn syscall_signature(name: &str) -> SysCallSignature {
     use ParamType::*;
     use ValueType::{I32, I64};

--- a/utils/wasm-instrument/src/syscalls.rs
+++ b/utils/wasm-instrument/src/syscalls.rs
@@ -1,0 +1,158 @@
+// This file is part of Gear.
+
+// Copyright (C) 2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Gear syscalls for smart contracts execution signatures.
+
+use crate::parity_wasm::elements::{FunctionType, ValueType};
+
+#[derive(Debug, Clone, Copy)]
+pub enum ParamType {
+    Size,            // i32 buffers size in memory
+    Ptr,             // i32 pointer
+    Gas,             // i64 gas amount
+    MessagePosition, // i32 message position
+    Duration,        // i32 duration in blocks
+    Delay,           // i32 delay in blocks
+    Handler,         // i32 handler number
+    Alloc,           // i32 alloc pages
+    Free,            // i32 free page
+}
+
+impl From<ParamType> for ValueType {
+    fn from(value: ParamType) -> Self {
+        match value {
+            ParamType::Gas => ValueType::I64,
+            _ => ValueType::I32,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SysCallSignature {
+    pub params: Vec<ParamType>,
+    pub results: Vec<ValueType>,
+}
+
+impl SysCallSignature {
+    fn new<const N: usize, const M: usize>(
+        params: [ParamType; N],
+        results: [ValueType; M],
+    ) -> Self {
+        Self {
+            params: params.to_vec(),
+            results: results.to_vec(),
+        }
+    }
+
+    pub fn func_type(&self) -> FunctionType {
+        FunctionType::new(
+            self.params.iter().copied().map(Into::into).collect(),
+            self.results.clone(),
+        )
+    }
+}
+
+pub fn syscalls_name_list() -> Vec<&'static str> {
+    vec![
+        "alloc",
+        "free",
+        "gr_debug",
+        "gr_error",
+        "gr_block_height",
+        "gr_block_timestamp",
+        "gr_exit",
+        "gr_gas_available",
+        "gr_program_id",
+        "gr_origin",
+        "gr_leave",
+        "gr_value_available",
+        "gr_wait",
+        "gr_wait_up_to",
+        "gr_wait_for",
+        "gr_wake",
+        "gr_exit_code",
+        "gr_message_id",
+        "gr_read",
+        "gr_reply",
+        "gr_reply_wgas",
+        "gr_reply_commit",
+        "gr_reply_commit_wgas",
+        "gr_reply_push",
+        "gr_reply_to",
+        "gr_send",
+        "gr_send_wgas",
+        "gr_send_commit",
+        "gr_send_commit_wgas",
+        "gr_send_init",
+        "gr_send_push",
+        "gr_size",
+        "gr_source",
+        "gr_value",
+        "gr_create_program",
+        "gr_create_program_wgas",
+    ]
+}
+
+pub fn syscall_signature(name: &str) -> SysCallSignature {
+    use ParamType::*;
+    use ValueType::{I32, I64};
+    match name {
+        "alloc" => SysCallSignature::new([Alloc], [I32]),
+        "free" => SysCallSignature::new([Free], []),
+        "gr_debug" => SysCallSignature::new([Ptr, Size], []),
+        "gr_error" => SysCallSignature::new([Ptr], [I32]),
+        "gr_block_height" => SysCallSignature::new([], [I32]),
+        "gr_block_timestamp" => SysCallSignature::new([], [I64]),
+        "gr_exit" => SysCallSignature::new([Ptr], []),
+        "gr_gas_available" => SysCallSignature::new([], [I64]),
+        "gr_program_id" => SysCallSignature::new([Ptr], []),
+        "gr_origin" => SysCallSignature::new([Ptr], []),
+        "gr_leave" => SysCallSignature::new([], []),
+        "gr_value_available" => SysCallSignature::new([Ptr], []),
+        "gr_wait" => SysCallSignature::new([], []),
+        "gr_wait_up_to" => SysCallSignature::new([Duration], []),
+        "gr_wait_for" => SysCallSignature::new([Duration], []),
+        "gr_wake" => SysCallSignature::new([Ptr, Delay], [I32]),
+        "gr_exit_code" => SysCallSignature::new([Ptr], [I32]),
+        "gr_message_id" => SysCallSignature::new([Ptr], []),
+        "gr_read" => SysCallSignature::new([MessagePosition, Size, Ptr], [I32]),
+        "gr_reply" => SysCallSignature::new([Ptr, Size, Ptr, Ptr, Delay], [I32]),
+        "gr_reply_wgas" => SysCallSignature::new([Ptr, Size, Gas, Ptr, Delay, Ptr], [I32]),
+        "gr_reply_commit" => SysCallSignature::new([Ptr, Delay, Ptr], [I32]),
+        "gr_reply_commit_wgas" => SysCallSignature::new([Gas, Ptr, Delay, Ptr], [I32]),
+        "gr_reply_push" => SysCallSignature::new([Ptr, Size], [I32]),
+        "gr_reply_to" => SysCallSignature::new([Ptr], [I32]),
+        "gr_send" => SysCallSignature::new([Ptr, Ptr, Size, Ptr, Delay, Ptr], [I32]),
+        "gr_send_wgas" => SysCallSignature::new([Ptr, Ptr, Size, Gas, Ptr, Delay, Ptr], [I32]),
+        "gr_send_commit" => SysCallSignature::new([Handler, Ptr, Ptr, Delay, Ptr], [I32]),
+        "gr_send_commit_wgas" => SysCallSignature::new([Handler, Ptr, Gas, Ptr, Delay, Ptr], [I32]),
+        "gr_send_init" => SysCallSignature::new([Handler], [I32]),
+        "gr_send_push" => SysCallSignature::new([Handler, Ptr, Size], [I32]),
+        "gr_size" => SysCallSignature::new([], [I32]),
+        "gr_source" => SysCallSignature::new([Ptr], []),
+        "gr_value" => SysCallSignature::new([Ptr], []),
+        "gr_create_program" => {
+            SysCallSignature::new([Ptr, Ptr, Size, Ptr, Size, Ptr, Delay, Ptr, Ptr], [I32])
+        }
+        "gr_create_program_wgas" => SysCallSignature::new(
+            [Ptr, Ptr, Size, Ptr, Size, Gas, Ptr, Delay, Ptr, Ptr],
+            [I32],
+        ),
+        other => panic!("Unknown syscall name: '{}'", other),
+    }
+}

--- a/utils/wasm-instrument/src/syscalls.rs
+++ b/utils/wasm-instrument/src/syscalls.rs
@@ -111,6 +111,7 @@ pub fn syscalls_name_list() -> Vec<&'static str> {
         "gr_create_program_wgas",
         "gr_reserve_gas",
         "gr_unreserve_gas",
+        "gr_random",
     ]
 }
 
@@ -162,6 +163,7 @@ pub fn syscall_signature(name: &str) -> SysCallSignature {
         ),
         "gr_reserve_gas" => SysCallSignature::new([Gas, Duration, Ptr], [I32]),
         "gr_unreserve_gas" => SysCallSignature::new([Ptr, Ptr], [I32]),
+        "gr_random" => SysCallSignature::new([Ptr, Size, Ptr, Ptr], []),
         other => panic!("Unknown syscall name: '{}'", other),
     }
 }

--- a/utils/wasm-instrument/src/syscalls.rs
+++ b/utils/wasm-instrument/src/syscalls.rs
@@ -109,6 +109,8 @@ pub fn syscalls_name_list() -> Vec<&'static str> {
         "gr_value",
         "gr_create_program",
         "gr_create_program_wgas",
+        "gr_reserve_gas",
+        "gr_unreserve_gas",
     ]
 }
 
@@ -158,6 +160,8 @@ pub fn syscall_signature(name: &str) -> SysCallSignature {
             [Ptr, Ptr, Size, Ptr, Size, Gas, Ptr, Delay, Ptr, Ptr],
             [I32],
         ),
+        "gr_reserve_gas" => SysCallSignature::new([Gas, Duration, Ptr], [I32]),
+        "gr_unreserve_gas" => SysCallSignature::new([Ptr, Ptr], [I32]),
         other => panic!("Unknown syscall name: '{}'", other),
     }
 }

--- a/utils/wasm-instrument/src/tests.rs
+++ b/utils/wasm-instrument/src/tests.rs
@@ -599,12 +599,12 @@ test_gas_counter_injection! {
 /// Check that all sys calls are supported by backend.
 #[test]
 fn test_sys_calls_table() {
-    use parity_wasm::builder;
     use gas_metering::ConstantCostRules;
-    use syscalls::{syscalls_name_list, syscall_signature};
     use gear_backend_common::{mock::MockExt, Environment, TerminationReason};
     use gear_backend_wasmi::WasmiEnvironment;
     use gear_core::message::DispatchKind;
+    use parity_wasm::builder;
+    use syscalls::{syscall_signature, syscalls_name_list};
 
     // Make module with one empty function.
     let mut module = builder::module()


### PR DESCRIPTION
Resolves #1726 .
1) Move syscalls table to `gear-wasm-instruments` in order to use it both in `gear-wasm-gen` and in `runtime-benchmarks`.
2) Make very simple refactoring in syscalls benches and wasm-gen syscalls, in order to simplify code.