### PR TITLE
Update README (add  Protocol Buffer Compiler)

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -10,7 +10,7 @@ Gear substrate-based node, ready for hacking :rocket:
 ```
 sudo apt update
 # May prompt for location information
-sudo apt install -y git clang curl libssl-dev llvm libudev-dev protobuf-compiler
+sudo apt install -y git clang curl libssl-dev llvm libudev-dev cmake protobuf-compiler
 ```
 
 #### MacOS

--- a/node/README.md
+++ b/node/README.md
@@ -10,7 +10,7 @@ Gear substrate-based node, ready for hacking :rocket:
 ```
 sudo apt update
 # May prompt for location information
-sudo apt install -y git clang curl libssl-dev llvm libudev-dev
+sudo apt install -y git clang curl libssl-dev llvm libudev-dev protobuf-compiler
 ```
 
 #### MacOS


### PR DESCRIPTION
## Add additional dependencies to Installing process - Protocol Buffer Compiler. 

## During the cargo building from source I got an ERROR: 
```
error: failed to run custom build command for sc-network-sync v0.10.0-dev (https://github.com/gear-tech/substrate.git?branch+gear-stable#988411fe)
```
<img width="1430" alt="Screen Shot 2022-11-01 at 18 50 44" src="https://user-images.githubusercontent.com/90826754/199244429-098b8160-f2b5-4e7f-9a5b-d8d932823abb.png">

## Resolves:
## The problem was solved by installation additional [protoc](https://grpc.io/docs/protoc-installation/)
## For Linux, using `apt`or `apt-get`:
```
$ apt install -y protobuf-compiler
$ protoc --version
```
>## Ensure compiler version is 3+

@reviewer-or-team
