### PR TITLE
gstd: Enable `debug` feature only for debug profile or propagate it from contract features

### DIFF
--- a/gcore/src/lib.rs
+++ b/gcore/src/lib.rs
@@ -30,9 +30,9 @@ pub mod prog;
 mod general;
 pub use general::*;
 
-#[cfg(feature = "debug")]
+#[cfg(any(feature = "debug", debug_assertions))]
 mod utils;
-#[cfg(feature = "debug")]
+#[cfg(any(feature = "debug", debug_assertions))]
 pub use utils::ext;
 
 use core::mem::size_of;

--- a/gcore/src/utils.rs
+++ b/gcore/src/utils.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#[cfg(feature = "debug")]
+#[cfg(any(feature = "debug", debug_assertions))]
 pub mod ext {
     use crate::error::{ExtError, Result};
 

--- a/gstd/src/common/handlers.rs
+++ b/gstd/src/common/handlers.rs
@@ -29,13 +29,14 @@
 use core::{alloc::Layout, arch::wasm32, panic::PanicInfo};
 
 #[cfg(not(feature = "debug"))]
+#[cfg(not(debug_assertions))]
 #[cfg(target_arch = "wasm32")]
 #[alloc_error_handler]
 pub fn oom(_: Layout) -> ! {
     wasm32::unreachable()
 }
 
-#[cfg(feature = "debug")]
+#[cfg(any(feature = "debug", debug_assertions))]
 #[cfg(target_arch = "wasm32")]
 #[alloc_error_handler]
 pub fn oom(_: Layout) -> ! {
@@ -44,13 +45,14 @@ pub fn oom(_: Layout) -> ! {
 }
 
 #[cfg(not(feature = "debug"))]
+#[cfg(not(debug_assertions))]
 #[cfg(target_arch = "wasm32")]
 #[panic_handler]
 pub fn panic(_: &PanicInfo) -> ! {
     wasm32::unreachable();
 }
 
-#[cfg(feature = "debug")]
+#[cfg(any(feature = "debug", debug_assertions))]
 #[cfg(target_arch = "wasm32")]
 #[panic_handler]
 pub fn panic(panic_info: &PanicInfo) -> ! {

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -22,7 +22,7 @@
 #![no_std]
 #![cfg_attr(target_arch = "wasm32", feature(alloc_error_handler))]
 #![cfg_attr(
-    all(target_arch = "wasm32", feature = "debug"),
+    all(target_arch = "wasm32", any(feature = "debug", debug_assertions)),
     feature(panic_info_message)
 )]
 #![cfg_attr(feature = "strict", deny(warnings))]
@@ -47,7 +47,7 @@ pub use macros::util;
 
 pub use prelude::*;
 
-#[cfg(feature = "debug")]
+#[cfg(any(feature = "debug", debug_assertions))]
 pub use gcore::ext;
 
 use core::mem::size_of;

--- a/gstd/src/macros/bail.rs
+++ b/gstd/src/macros/bail.rs
@@ -42,7 +42,7 @@
 ///
 /// Panics with the same `static_release` in release mode and with
 /// `format!(formatter, args)` + error message in debug mode.
-#[cfg(feature = "debug")]
+#[cfg(any(feature = "debug", debug_assertions))]
 #[macro_export]
 macro_rules! bail {
     ($res:expr, $msg:literal) => {
@@ -59,6 +59,7 @@ macro_rules! bail {
 }
 
 #[cfg(not(feature = "debug"))]
+#[cfg(not(debug_assertions))]
 #[macro_export]
 macro_rules! bail {
     ($res:expr, $msg:literal) => {

--- a/gstd/src/macros/debug.rs
+++ b/gstd/src/macros/debug.rs
@@ -19,7 +19,7 @@
 //! Gear `debug!` macro.
 //! Enables output of the logs from Wasm if the `debug` feature is enabled.
 
-#[cfg(feature = "debug")]
+#[cfg(any(feature = "debug", debug_assertions))]
 #[macro_export]
 macro_rules! debug {
     ($arg:literal) => {
@@ -34,6 +34,7 @@ macro_rules! debug {
 }
 
 #[cfg(not(feature = "debug"))]
+#[cfg(not(debug_assertions))]
 #[macro_export]
 macro_rules! debug {
     ($arg:expr) => { let _ = $arg; };

--- a/utils/wasm-builder/src/crate_info.rs
+++ b/utils/wasm-builder/src/crate_info.rs
@@ -18,7 +18,7 @@
 
 use anyhow::{Context, Result};
 use cargo_metadata::{Metadata, MetadataCommand, Package};
-use std::path::Path;
+use std::{collections::HashMap, path::Path};
 
 use crate::builder_error::BuilderError;
 
@@ -31,6 +31,8 @@ pub struct CrateInfo {
     pub snake_case_name: String,
     /// Crate version.
     pub version: String,
+    /// Crate features.
+    pub features: HashMap<String, Vec<String>>,
 }
 
 impl CrateInfo {
@@ -53,11 +55,13 @@ impl CrateInfo {
         let name = root_package.name.clone();
         let snake_case_name = name.replace('-', "_");
         let version = root_package.version.to_string();
+        let features = root_package.features.clone();
 
         Ok(Self {
             name,
             snake_case_name,
             version,
+            features,
         })
     }
 

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -138,11 +138,28 @@ impl WasmProject {
         let mut dependencies = Table::new();
         dependencies.insert("orig-project".into(), crate_package.into());
 
+        let mut features = Table::new();
+        if crate_info.features.contains_key("default") {
+            features.insert(
+                "default".into(),
+                crate_info.features["default"].clone().into(),
+            );
+        }
+        for feature in crate_info.features.keys() {
+            if feature != "default" {
+                features.insert(
+                    feature.into(),
+                    vec![format!("orig-project/{feature}")].into(),
+                );
+            }
+        }
+
         let mut cargo_toml = Table::new();
         cargo_toml.insert("package".into(), package.into());
         cargo_toml.insert("lib".into(), lib.into());
         cargo_toml.insert("dependencies".into(), dependencies.into());
         cargo_toml.insert("profile".into(), profile.into());
+        cargo_toml.insert("features".into(), features.into());
         cargo_toml.insert("workspace".into(), Table::new().into());
 
         fs::write(self.manifest_path(), toml::to_string_pretty(&cargo_toml)?)?;

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -139,12 +139,6 @@ impl WasmProject {
         dependencies.insert("orig-project".into(), crate_package.into());
 
         let mut features = Table::new();
-        if crate_info.features.contains_key("default") {
-            features.insert(
-                "default".into(),
-                crate_info.features["default"].clone().into(),
-            );
-        }
         for feature in crate_info.features.keys() {
             if feature != "default" {
                 features.insert(


### PR DESCRIPTION
- Resolves #1739
- Enable `debug!/bail!` macros automatically for the debug profile and disable them for the release profile.
- Propagate features from smart contracts.

@gear-tech/dev

### Usage

1. If you use `gstd` in the program with no any feature.

    ```toml
    gstd = { git = "https://github.com/gear-tech/gear.git" }
    ```

    `debug!/bail!` macros will work in the debug build profile and will be replaced by blanks on the release build profile.

    ```shell
    cargo build # `debug!` will show the debug message
    cargo build --release # `debug!` will do nothing
    ```

2. If you add a debug feature to the program.

    ```toml
    gstd = { git = "https://github.com/gear-tech/gear.git" }

    [features]
    debug = ["gstd/debug"]
    ```

    `debug!/bail!` macros will work in release profiles if you add the `debug` feature during the build. 

    ```shell
    cargo build --release --features=debug # debug!` will show the debug message
    cargo build --release # `debug!` will do nothing
    ```

3. If you add a debug feature to the `gstd`.

    ```toml
    gstd = { git = "https://github.com/gear-tech/gear.git", features = ["debug"] }
    ```

    `debug!/bail!` macros will work in both profiles by default

    ```shell
    cargo build # `debug!` will show the debug message
    cargo build --release # debug!` will show the debug message
    ```
