### PR TITLE
Fix events handling

### DIFF
--- a/gclient/src/api/listener/iterator.rs
+++ b/gclient/src/api/listener/iterator.rs
@@ -33,6 +33,10 @@ impl<'a> EventProcessor for EventListener<'a> {
 
     async fn proc<T>(&mut self, predicate: impl Fn(Event) -> Option<T>) -> Result<T> {
         while let Some(events) = self.0.next().await {
+            if let Err(events) = &events {
+                // TODO [SAB] Remove
+                println!("EVENTS ERR {events:?}");
+            }
             if let Some(res) = events?
                 .iter()
                 .filter_map(|event| predicate(event.ok()?.event))

--- a/gclient/src/api/listener/iterator.rs
+++ b/gclient/src/api/listener/iterator.rs
@@ -33,10 +33,6 @@ impl<'a> EventProcessor for EventListener<'a> {
 
     async fn proc<T>(&mut self, predicate: impl Fn(Event) -> Option<T>) -> Result<T> {
         while let Some(events) = self.0.next().await {
-            if let Err(events) = &events {
-                // TODO [SAB] Remove
-                println!("EVENTS ERR {events:?}");
-            }
             if let Some(res) = events?
                 .iter()
                 .filter_map(|event| predicate(event.ok()?.event))

--- a/gclient/src/api/listener/iterator.rs
+++ b/gclient/src/api/listener/iterator.rs
@@ -20,10 +20,10 @@ use super::EventProcessor;
 use crate::{Error, Result};
 use async_trait::async_trait;
 use futures::stream::StreamExt;
-use gp::api::{events::Events, generated::api::Event};
+use gp::api::{events::FinalizedEvents, generated::api::Event};
 use subxt::sp_core::H256;
 
-pub struct EventListener<'a>(pub(crate) Events<'a>);
+pub struct EventListener<'a>(pub(crate) FinalizedEvents<'a>);
 
 #[async_trait(?Send)]
 impl<'a> EventProcessor for EventListener<'a> {

--- a/program/src/api/events.rs
+++ b/program/src/api/events.rs
@@ -12,7 +12,7 @@ use crate::{
 use futures_util::StreamExt;
 use subxt::{
     codec::Decode,
-    events::EventSubscription,
+    events::{EventSubscription, FinalizedEventSub},
     rpc::Subscription,
     sp_runtime::{generic::Header, traits::BlakeTwo256},
     HasModuleError, ModuleError, RuntimeError, TransactionEvents, TransactionInBlock,
@@ -21,6 +21,10 @@ use subxt::{
 /// Generic events
 pub type Events<'a> =
     EventSubscription<'a, Subscription<Header<u32, BlakeTwo256>>, GearConfig, Event>;
+
+/// Generic finalized events
+pub type FinalizedEvents<'a> =
+    EventSubscription<'a, FinalizedEventSub<'a, Header<u32, BlakeTwo256>>, GearConfig, Event>;
 
 /// Transaction events
 #[allow(unused)]

--- a/program/src/api/mod.rs
+++ b/program/src/api/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     result::Result,
 };
 use core::ops::{Deref, DerefMut};
-use events::Events;
+use events::FinalizedEvents;
 use std::{str::FromStr, time::Duration};
 use subxt::{
     rpc::{RpcClientBuilder, Uri, WsTransportClientBuilder},
@@ -67,8 +67,8 @@ impl Api {
     }
 
     /// Subscribe all events
-    pub async fn events(&self) -> Result<Events<'_>> {
-        Ok(self.0.events().subscribe().await?)
+    pub async fn events(&self) -> Result<FinalizedEvents<'_>> {
+        Ok(self.0.events().subscribe_finalized().await?)
     }
 }
 

--- a/program/src/api/signer/calls.rs
+++ b/program/src/api/signer/calls.rs
@@ -181,6 +181,7 @@ impl Signer {
         while let Some(status) = process.next_item().await {
             let status = status?;
             self.log_status(&status);
+            // TODO [SAB] Remove
             println!("[SAB] Received status {status:?}");
             match status {
                 Future | Ready | Broadcast(_) | InBlock(_) => (),

--- a/program/src/api/signer/calls.rs
+++ b/program/src/api/signer/calls.rs
@@ -181,6 +181,7 @@ impl Signer {
         while let Some(status) = process.next_item().await {
             let status = status?;
             self.log_status(&status);
+            println!("[SAB] Received status {status:?}");
             match status {
                 Future | Ready | Broadcast(_) | InBlock(_) => (),
                 Dropped | Invalid | Usurped(_) | FinalityTimeout(_) | Retracted(_) => {

--- a/program/src/api/signer/calls.rs
+++ b/program/src/api/signer/calls.rs
@@ -181,8 +181,6 @@ impl Signer {
         while let Some(status) = process.next_item().await {
             let status = status?;
             self.log_status(&status);
-            // TODO [SAB] Remove
-            println!("[SAB] Received status {status:?}");
             match status {
                 Future | Ready | Broadcast(_) | InBlock(_) => (),
                 Dropped | Invalid | Usurped(_) | FinalityTimeout(_) | Retracted(_) => {

--- a/utils/node-loader/Cargo.toml
+++ b/utils/node-loader/Cargo.toml
@@ -2,7 +2,6 @@
 name = "gear-node-loader"
 version = "0.1.0"
 authors = ["Gear Technologies"]
-publish = false
 edition = "2021"
 
 [[bin]]

--- a/utils/node-loader/src/batch_pool.rs
+++ b/utils/node-loader/src/batch_pool.rs
@@ -234,6 +234,7 @@ async fn process_events(
     })
 }
 
+// TODO [SAB] Remove map_errs
 async fn inspect_crash_events(api: GearApi, node_stopper: String) -> Result<()> {
     let mut event_listener = api.subscribe().await.map_err(|e| {
         tracing::warn!("ERROR {e:?}");
@@ -243,10 +244,13 @@ async fn inspect_crash_events(api: GearApi, node_stopper: String) -> Result<()> 
     // Error means either event is not found an can't be found
     // in the listener, or some other error during event
     // parsing occurred.
-    event_listener.queue_processing_reverted().await.map_err(|e| {
-        tracing::warn!("ERROR {e:?}");
-        e
-    })?;
+    event_listener
+        .queue_processing_reverted()
+        .await
+        .map_err(|e| {
+            tracing::warn!("ERROR {e:?}");
+            e
+        })?;
 
     let crash_err = CrashAlert::MsgProcessingStopped;
     tracing::info!("{crash_err}");

--- a/utils/node-loader/src/batch_pool.rs
+++ b/utils/node-loader/src/batch_pool.rs
@@ -234,23 +234,13 @@ async fn process_events(
     })
 }
 
-// TODO [SAB] Remove map_errs
 async fn inspect_crash_events(api: GearApi, node_stopper: String) -> Result<()> {
-    let mut event_listener = api.subscribe().await.map_err(|e| {
-        tracing::warn!("ERROR {e:?}");
-        e
-    })?;
+    let mut event_listener = api.subscribe().await?;
     // Waits until the queue processing reverted event is found.
     // Error means either event is not found an can't be found
     // in the listener, or some other error during event
     // parsing occurred.
-    event_listener
-        .queue_processing_reverted()
-        .await
-        .map_err(|e| {
-            tracing::warn!("ERROR {e:?}");
-            e
-        })?;
+    event_listener.queue_processing_reverted().await?;
 
     let crash_err = CrashAlert::MsgProcessingStopped;
     tracing::info!("{crash_err}");

--- a/utils/node-loader/src/utils.rs
+++ b/utils/node-loader/src/utils.rs
@@ -7,6 +7,7 @@ use gclient::WSAddress;
 use rand::{Rng, RngCore, SeedableRng};
 use reqwest::Client;
 use std::{
+    collections::HashMap,
     fs::File,
     io::Write,
     iter,
@@ -130,12 +131,10 @@ pub async fn with_timeout<T>(fut: impl Future<Output = T>) -> Result<T> {
 
 pub async fn stop_node(monitor_url: String) -> Result<()> {
     let client = Client::new();
-    let form = ("__script_name", "stop-gear");
-    client
-        .post(monitor_url)
-        .form(&form)
-        .send()
-        .await?;
+    let mut params = HashMap::new();
+    params.insert("__script_name", "stop");
+
+    client.post(monitor_url).form(&params).send().await?;
 
     Ok(())
 }

--- a/utils/node-loader/src/utils.rs
+++ b/utils/node-loader/src/utils.rs
@@ -130,9 +130,10 @@ pub async fn with_timeout<T>(fut: impl Future<Output = T>) -> Result<T> {
 
 pub async fn stop_node(monitor_url: String) -> Result<()> {
     let client = Client::new();
+    let form = ("__script_name", "stop-gear");
     client
         .post(monitor_url)
-        .body("gear-node-loader=stop-gear")
+        .form(&form)
         .send()
         .await?;
 


### PR DESCRIPTION
Off-chain applications are unaware of forks, so they need a better block headers handling. That's because getting events of some block by, say, block header (as a key) can be a fallible action due to state of the block with that block hash being discarded. Solution here can be getting only finalized blocks and reading data from them.

That's the purpose of that fix - subscribe on finalized blocks only,

@gear-tech/dev
