### PR TITLE
Add features to fix tests in a dependency

### DIFF
--- a/gclient/tests/upload.rs
+++ b/gclient/tests/upload.rs
@@ -97,7 +97,7 @@ async fn alloc_zero_pages() -> Result<()> {
     let api = GearApi::dev().await?.with("//Bob")?;
     let codes = vec![wat::parse_str(wat_code).unwrap()];
     async_std::future::timeout(
-        Duration::from_secs(5),
+        Duration::from_secs(6),
         upload_programs_and_check(&api, codes),
     )
     .await

--- a/utils/test-runtime/Cargo.toml
+++ b/utils/test-runtime/Cargo.toml
@@ -102,6 +102,8 @@ std = [
 	"sp-trie/std",
 	"sp-transaction-pool/std",
 	"trie-db/std",
+	"pallet-gear-rpc-runtime-api/std",
+	"pallet-gear/std",
 ]
 # Special feature to disable logging
 disable-logging = [ "sp-api/disable-logging" ]

--- a/utils/test-runtime/src/lib.rs
+++ b/utils/test-runtime/src/lib.rs
@@ -1152,12 +1152,14 @@ fn test_witness(proof: StorageProof, root: crate::Hash) {
 
 #[cfg(test)]
 mod tests {
+    use crate::Extrinsic;
     use codec::Encode;
+    use pallet_gear_rpc_runtime_api::GearApi;
     use sc_block_builder::BlockBuilderProvider;
     use sp_api::ProvideRuntimeApi;
     use sp_consensus::BlockOrigin;
     use sp_core::storage::well_known_keys::HEAP_PAGES;
-    use sp_runtime::generic::BlockId;
+    use sp_runtime::{generic::BlockId, traits::Extrinsic as ExtrinsicT};
     use sp_state_machine::ExecutionStrategy;
     use test_client::{
         prelude::*, runtime::TestRuntimeAPI, DefaultTestClientBuilderExt, TestClientBuilder,
@@ -1237,5 +1239,19 @@ mod tests {
         let block_id = BlockId::Number(client.chain_info().best_number);
 
         runtime_api.test_witness(&block_id, proof, root).unwrap();
+    }
+
+    #[test]
+    fn test_gear_runtime_api() {
+        let client = TestClientBuilder::new()
+            .set_execution_strategy(ExecutionStrategy::Both)
+            .build();
+        let runtime_api = client.runtime_api();
+        let block_id = BlockId::Number(client.chain_info().best_number);
+
+        assert_eq!(
+            runtime_api.gear_run_extrinsic(&block_id).unwrap().encode(),
+            Extrinsic::new(Extrinsic::Process, None).unwrap().encode()
+        );
     }
 }


### PR DESCRIPTION
- Fix tests in one of the dependencies (test-runtime);
- Add test of the newly added gear `runtime-api` call.