### PR TITLE
Add a new runtime-api call (vara-stage-2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3193,6 +3193,8 @@ dependencies = [
  "log",
  "memory-db",
  "pallet-babe",
+ "pallet-gear",
+ "pallet-gear-rpc-runtime-api",
  "pallet-timestamp",
  "parity-scale-codec",
  "parity-util-mem",
@@ -5925,6 +5927,7 @@ dependencies = [
  "pallet-gear",
  "sp-api",
  "sp-core",
+ "sp-runtime",
  "sp-std",
 ]
 

--- a/pallets/gear/rpc/runtime-api/Cargo.toml
+++ b/pallets/gear/rpc/runtime-api/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/gear-tech/gear"
 [dependencies]
 sp-api = { version = '4.0.0-dev', git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false }
 sp-core = { version = '6.0.0', git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false }
+sp-runtime = { version = '6.0.0', git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false }
 sp-std = { version = '4.0.0-dev', git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable", default-features = false }
 pallet-gear = { version = "2.0.0", default-features = false, path = "../../../gear" }
 

--- a/pallets/gear/rpc/runtime-api/src/lib.rs
+++ b/pallets/gear/rpc/runtime-api/src/lib.rs
@@ -20,11 +20,15 @@
 
 pub use pallet_gear::{manager::HandleKind, GasInfo};
 use sp_core::H256;
+use sp_runtime::traits::Block as BlockT;
 use sp_std::vec::Vec;
 
 sp_api::decl_runtime_apis! {
     pub trait GearApi {
         #[allow(clippy::too_many_arguments)]
         fn calculate_gas_info(source: H256, kind: HandleKind, payload: Vec<u8>, value: u128, allow_other_panics: bool, initial_gas: Option<u64>,) -> Result<GasInfo, Vec<u8>>;
+
+        /// Generate inherent-like extrinsic the runs message queue processing.
+        fn gear_run_extrinsic() -> <Block as BlockT>::Extrinsic;
     }
 }

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -1642,6 +1642,10 @@ pub mod pallet {
 
             Ok(())
         }
+
+        pub fn run_call() -> Call<T> {
+            Call::run {}
+        }
     }
 
     #[pallet::call]

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -154,6 +154,9 @@ macro_rules! impl_runtime_apis_plus_common {
 				) -> Result<pallet_gear::GasInfo, Vec<u8>> {
 					Gear::calculate_gas_info(account_id, kind, payload, value, allow_other_panics, initial_gas)
 				}
+				fn gear_run_extrinsic() -> <Block as BlockT>::Extrinsic {
+					UncheckedExtrinsic::new_unsigned(Gear::run_call().into()).into()
+				}
 			}
 
 			#[cfg(feature = "runtime-benchmarks")]

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 440,
+    spec_version: 450,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -128,7 +128,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 440,
+    spec_version: 450,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/utils/test-runtime/Cargo.toml
+++ b/utils/test-runtime/Cargo.toml
@@ -54,6 +54,8 @@ pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "htt
 
 # Gear
 common = { package = "gear-common", path = "../../common", default-features = false }
+pallet-gear-rpc-runtime-api = { version = "2.0.0", default-features = false, path = "../../pallets/gear/rpc/runtime-api" }
+pallet-gear = { version = "2.0.0", default-features = false, path = "../../pallets/gear" }
 
 [dev-dependencies]
 sc-block-builder = { version = "0.10.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
@@ -101,6 +103,8 @@ std = [
 	"sp-trie/std",
 	"sp-transaction-pool/std",
 	"trie-db/std",
+	"pallet-gear-rpc-runtime-api/std",
+	"pallet-gear/std",
 ]
 # Special feature to disable logging
 disable-logging = [ "sp-api/disable-logging" ]


### PR DESCRIPTION
Add a new runtime-api call that would return a properly encoded custom unsigned extrinsic that runs the message queue.

This is a necessary prerequisite for a transition to proper block production free of the previously observed RuntimeCall encoding issues before the node binaries can be updated.

**N.B.:** it seems a better idea to rebase this branch on top of the `vara-stage-1` that would already have this change.