### PR TITLE
Fix tx-status waiting

### DIFF
--- a/utils/node-loader/src/batch_pool.rs
+++ b/utils/node-loader/src/batch_pool.rs
@@ -205,7 +205,7 @@ async fn process_events(
 
         if (utils::now() - now) as usize > wait_for_events_millisec {
             tracing::debug!("Timeout is reached while waiting for events");
-            return Err(anyhow!(utils::TIMEOUT_ERR_STR));
+            return Err(anyhow!(utils::EVENTS_TIMEOUT_ERR_STR));
         }
 
         if matches!(r, Err(GClientError::EventNotFoundInIterator)) {

--- a/utils/node-loader/src/batch_pool/api/mod.rs
+++ b/utils/node-loader/src/batch_pool/api/mod.rs
@@ -87,6 +87,7 @@ impl GearApiFacade {
     ) -> Result<T> {
         let (api, nonce) = self.prepare_api_for_call();
 
+        // TODO #1800
         let r = utils::with_timeout(batch_call(api)).await?;
         nonce::catch_missed_nonce(&r, nonce).expect("missed nonces storage is initialized");
 

--- a/utils/node-loader/src/batch_pool/report.rs
+++ b/utils/node-loader/src/batch_pool/report.rs
@@ -19,7 +19,7 @@ impl TryFrom<Error> for CrashAlert {
 
     fn try_from(err: Error) -> Result<Self, Self::Error> {
         let err_string = err.to_string();
-        if err_string.contains(utils::TIMEOUT_ERR_STR) {
+        if err_string.contains(utils::EVENTS_TIMEOUT_ERR_STR) {
             Ok(CrashAlert::Timeout)
         } else if err_string.contains(utils::SUBXT_RPC_REQUEST_ERR_STR) {
             Ok(CrashAlert::NodeIsDead)

--- a/utils/node-loader/src/utils.rs
+++ b/utils/node-loader/src/utils.rs
@@ -20,7 +20,7 @@ use std::{
 pub const SUBXT_RPC_REQUEST_ERR_STR: &str = "Rpc error: The background task been terminated because: Networking or low-level protocol error";
 /// subxt's GenericError::Rpc::RequestError::Call (CallError::Failed)
 pub const SUBXT_RPC_CALL_ERR_STR: &str = "Transaction would exhaust the block limits";
-pub const TIMEOUT_ERR_STR: &str = "Timeout";
+pub const EVENTS_TIMEOUT_ERR_STR: &str = "Block events timeout";
 
 pub fn now() -> u64 {
     let time_since_epoch = SystemTime::now()
@@ -123,8 +123,7 @@ pub async fn with_timeout<T>(fut: impl Future<Output = T>) -> Result<T> {
     tokio::select! {
         output = fut => Ok(output),
         _ = wait_task => {
-            tracing::debug!("Timeout occurred while running the action");
-            Err(anyhow!(TIMEOUT_ERR_STR))
+            Err(anyhow!("Timeout occurred while running the action"))
         }
     }
 }


### PR DESCRIPTION
On blocks reorg loader can stop if extrinsics were newly submitted to the discarded block. In this case we will wait for 512 blocks (see: https://github.com/paritytech/subxt/blob/33a9ec91afd16c459871e24ae18576f7afbb87c1/subxt/src/tx/tx_progress.rs#L266-L268) until task with processing tx status yields  `FinalityTimeout`.
This PR fixes `gear-node-loader`'s crashes in such situations.
