### PR TITLE
tune load and store weights

### DIFF
--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -58,7 +58,7 @@ gear-program = { path = "../../program", features = [ "cli" ], optional = true }
 substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 
 [features]
-default = ["gear-native", "vara-native", "lazy-pages", "program", "runtime-benchmarks"]
+default = ["gear-native", "vara-native", "lazy-pages", "program"]
 gear-native = [
 	"service/gear-native",
 	"gear-runtime-test-cli?/gear-native",

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -58,7 +58,7 @@ gear-program = { path = "../../program", features = [ "cli" ], optional = true }
 substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 
 [features]
-default = ["gear-native", "vara-native", "lazy-pages", "program"]
+default = ["gear-native", "vara-native", "lazy-pages", "program", "runtime-benchmarks"]
 gear-native = [
 	"service/gear-native",
 	"gear-runtime-test-cli?/gear-native",

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -70,7 +70,7 @@ use gear_core::{
     code::{Code, CodeAndId},
     gas::{GasAllowanceCounter, GasCounter, ValueCounter},
     ids::{MessageId, ProgramId},
-    memory::{AllocationsContext, PageBuf, PageNumber},
+    memory::{AllocationsContext, PageBuf, PageNumber, WasmPageNumber},
     message::{ContextSettings, MessageContext},
     reservation::GasReserver,
 };
@@ -970,34 +970,60 @@ benchmarks! {
         verify_process(res.unwrap());
     }
 
-    // TODO: fix it #1728
+    lazy_pages_read_access {
+        let p in 0 .. code::max_pages::<T>();
+        let mut res = None;
+        let exec = Benches::<T>::lazy_pages_read_access(p)?;
+    }: {
+        res.replace(run_process(exec));
+    }
+    verify {
+        verify_process(res.unwrap());
+    }
+
+    lazy_pages_write_access {
+        let p in 0 .. code::max_pages::<T>();
+        let mut res = None;
+        let exec = Benches::<T>::lazy_pages_write_access(p)?;
+    }: {
+        res.replace(run_process(exec));
+    }
+    verify {
+        verify_process(res.unwrap());
+    }
+
     // w_load = w_bench
     instr_i64load {
         let r in 0 .. INSTR_BENCHMARK_BATCHES;
+        let mem_pages = code::max_pages::<T>();
+        // Warm up memory.
+        let mut instrs = body::write_access_all_pages_instrs(mem_pages, vec![]);
+        instrs = body::repeated_dyn_instr(r * INSTR_BENCHMARK_BATCH_SIZE, vec![
+                        RandomUnaligned(0, mem_pages * WasmPageNumber::size() as u32 - 8),
+                        Regular(Instruction::I64Load(3, 0)),
+                        Regular(Instruction::Drop)], instrs);
         let mut sbox = Sandbox::from(&WasmModule::<T>::from(ModuleDefinition {
-            memory: Some(ImportedMemory::max::<T>()),
-            handle_body: Some(body::repeated_dyn(r * INSTR_BENCHMARK_BATCH_SIZE, vec![
-                RandomUnaligned(0, 2 * 64 * 1024 - 8),
-                Regular(Instruction::I64Load(3, 0)),
-                Regular(Instruction::Drop),
-            ])),
+            memory: Some(ImportedMemory{min_pages: mem_pages}),
+            handle_body: Some(body::from_instructions(instrs)),
             .. Default::default()
         }));
     }: {
         sbox.invoke();
     }
 
-    // TODO: Fix it #1728
     // w_store = w_bench - w_i64const
     instr_i64store {
         let r in 0 .. INSTR_BENCHMARK_BATCHES;
+        let mem_pages = code::max_pages::<T>();
+        // Warm up memory.
+        let mut instrs = body::write_access_all_pages_instrs(mem_pages, vec![]);
+        instrs = body::repeated_dyn_instr(r * INSTR_BENCHMARK_BATCH_SIZE, vec![
+                        RandomUnaligned(0, mem_pages * WasmPageNumber::size() as u32 - 8),
+                        RandomI64Repeated(1),
+                        Regular(Instruction::I64Store(3, 0))], instrs);
         let mut sbox = Sandbox::from(&WasmModule::<T>::from(ModuleDefinition {
-            memory: Some(ImportedMemory::max::<T>()),
-            handle_body: Some(body::repeated_dyn(r * INSTR_BENCHMARK_BATCH_SIZE, vec![
-                RandomUnaligned(0, 2 * 64 * 1024 - 8),
-                RandomI64Repeated(1),
-                Regular(Instruction::I64Store(3, 0)),
-            ])),
+            memory: Some(ImportedMemory{min_pages: mem_pages}),
+            handle_body: Some(body::from_instructions(instrs)),
             .. Default::default()
         }));
     }: {

--- a/pallets/gear/src/benchmarking/syscalls.rs
+++ b/pallets/gear/src/benchmarking/syscalls.rs
@@ -1163,4 +1163,25 @@ where
 
         Self::prepare_handle(code, 0)
     }
+
+    pub fn lazy_pages_read_access(wasm_pages: u32) -> Result<Exec<T>, &'static str> {
+        let instrs = body::read_access_all_pages_instrs(wasm_pages, vec![]);
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            handle_body: Some(body::from_instructions(instrs)),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 0)
+    }
+
+    pub fn lazy_pages_write_access(wasm_pages: u32) -> Result<Exec<T>, &'static str> {
+        let mut instrs = body::read_access_all_pages_instrs(max_pages::<T>(), vec![]);
+        instrs = body::write_access_all_pages_instrs(wasm_pages, instrs);
+        let code = WasmModule::<T>::from(ModuleDefinition {
+            memory: Some(ImportedMemory::max::<T>()),
+            handle_body: Some(body::from_instructions(instrs)),
+            ..Default::default()
+        });
+        Self::prepare_handle(code, 0)
+    }
 }

--- a/pallets/gear/src/weights.rs
+++ b/pallets/gear/src/weights.rs
@@ -92,6 +92,8 @@ pub trait WeightInfo {
     fn gr_wake(r: u32, ) -> Weight;
     fn gr_create_program_wgas(r: u32, ) -> Weight;
     fn gr_create_program_wgas_per_kb(p: u32, s: u32, ) -> Weight;
+    fn lazy_pages_read_access(p: u32, ) -> Weight;
+    fn lazy_pages_write_access(p: u32, ) -> Weight;
     fn instr_i64load(r: u32, ) -> Weight;
     fn instr_i64store(r: u32, ) -> Weight;
     fn instr_select(r: u32, ) -> Weight;
@@ -502,17 +504,31 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             .saturating_add(Weight::from_ref_time(183_740_947 as u64).saturating_mul(s as u64))
             .saturating_add(T::DbWeight::get().reads(257 as u64))
     }
+    /// The range of component `p` is `[0, 512]`.
+    fn lazy_pages_read_access(p: u32, ) -> Weight {
+        Weight::from_ref_time(82_129_000 as u64)
+            // Standard Error: 6_491
+            .saturating_add(Weight::from_ref_time(49_098_637 as u64).saturating_mul(p as u64))
+            .saturating_add(T::DbWeight::get().reads((16 as u64).saturating_mul(p as u64)))
+    }
+    /// The range of component `p` is `[0, 512]`.
+    fn lazy_pages_write_access(p: u32, ) -> Weight {
+        Weight::from_ref_time(25_317_785_000 as u64)
+            // Standard Error: 18_986
+            .saturating_add(Weight::from_ref_time(69_601_626 as u64).saturating_mul(p as u64))
+            .saturating_add(T::DbWeight::get().reads(8192 as u64))
+    }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64load(r: u32, ) -> Weight {
-        Weight::from_ref_time(4_466_000 as u64)
-            // Standard Error: 6_072
-            .saturating_add(Weight::from_ref_time(4_453_430 as u64).saturating_mul(r as u64))
+        Weight::from_ref_time(11_639_583_000 as u64)
+            // Standard Error: 121_168
+            .saturating_add(Weight::from_ref_time(30_753_009 as u64).saturating_mul(r as u64))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64store(r: u32, ) -> Weight {
-        Weight::from_ref_time(4_465_000 as u64)
-            // Standard Error: 11_423
-            .saturating_add(Weight::from_ref_time(6_404_772 as u64).saturating_mul(r as u64))
+        Weight::from_ref_time(11_670_404_000 as u64)
+            // Standard Error: 116_067
+            .saturating_add(Weight::from_ref_time(42_656_030 as u64).saturating_mul(r as u64))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_select(r: u32, ) -> Weight {
@@ -1160,17 +1176,31 @@ impl WeightInfo for () {
             .saturating_add(Weight::from_ref_time(183_740_947 as u64).saturating_mul(s as u64))
             .saturating_add(RocksDbWeight::get().reads(257 as u64))
     }
+    /// The range of component `p` is `[0, 512]`.
+    fn lazy_pages_read_access(p: u32, ) -> Weight {
+        Weight::from_ref_time(82_129_000 as u64)
+            // Standard Error: 6_491
+            .saturating_add(Weight::from_ref_time(49_098_637 as u64).saturating_mul(p as u64))
+            .saturating_add(RocksDbWeight::get().reads((16 as u64).saturating_mul(p as u64)))
+    }
+    /// The range of component `p` is `[0, 512]`.
+    fn lazy_pages_write_access(p: u32, ) -> Weight {
+        Weight::from_ref_time(25_317_785_000 as u64)
+            // Standard Error: 18_986
+            .saturating_add(Weight::from_ref_time(69_601_626 as u64).saturating_mul(p as u64))
+            .saturating_add(RocksDbWeight::get().reads(8192 as u64))
+    }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64load(r: u32, ) -> Weight {
-        Weight::from_ref_time(4_466_000 as u64)
-            // Standard Error: 6_072
-            .saturating_add(Weight::from_ref_time(4_453_430 as u64).saturating_mul(r as u64))
+        Weight::from_ref_time(11_639_583_000 as u64)
+            // Standard Error: 121_168
+            .saturating_add(Weight::from_ref_time(30_753_009 as u64).saturating_mul(r as u64))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64store(r: u32, ) -> Weight {
-        Weight::from_ref_time(4_465_000 as u64)
-            // Standard Error: 11_423
-            .saturating_add(Weight::from_ref_time(6_404_772 as u64).saturating_mul(r as u64))
+        Weight::from_ref_time(11_670_404_000 as u64)
+            // Standard Error: 116_067
+            .saturating_add(Weight::from_ref_time(42_656_030 as u64).saturating_mul(r as u64))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_select(r: u32, ) -> Weight {

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -97,7 +97,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 170,
+    spec_version: 180,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/gear/src/weights/pallet_gear.rs
+++ b/runtime/gear/src/weights/pallet_gear.rs
@@ -92,6 +92,8 @@ pub trait WeightInfo {
     fn gr_wake(r: u32, ) -> Weight;
     fn gr_create_program_wgas(r: u32, ) -> Weight;
     fn gr_create_program_wgas_per_kb(p: u32, s: u32, ) -> Weight;
+    fn lazy_pages_read_access(p: u32, ) -> Weight;
+    fn lazy_pages_write_access(p: u32, ) -> Weight;
     fn instr_i64load(r: u32, ) -> Weight;
     fn instr_i64store(r: u32, ) -> Weight;
     fn instr_select(r: u32, ) -> Weight;
@@ -502,17 +504,31 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
             .saturating_add(Weight::from_ref_time(183_740_947 as u64).saturating_mul(s as u64))
             .saturating_add(T::DbWeight::get().reads(257 as u64))
     }
+    /// The range of component `p` is `[0, 512]`.
+    fn lazy_pages_read_access(p: u32, ) -> Weight {
+        Weight::from_ref_time(82_129_000 as u64)
+            // Standard Error: 6_491
+            .saturating_add(Weight::from_ref_time(49_098_637 as u64).saturating_mul(p as u64))
+            .saturating_add(T::DbWeight::get().reads((16 as u64).saturating_mul(p as u64)))
+    }
+    /// The range of component `p` is `[0, 512]`.
+    fn lazy_pages_write_access(p: u32, ) -> Weight {
+        Weight::from_ref_time(25_317_785_000 as u64)
+            // Standard Error: 18_986
+            .saturating_add(Weight::from_ref_time(69_601_626 as u64).saturating_mul(p as u64))
+            .saturating_add(T::DbWeight::get().reads(8192 as u64))
+    }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64load(r: u32, ) -> Weight {
-        Weight::from_ref_time(4_466_000 as u64)
-            // Standard Error: 6_072
-            .saturating_add(Weight::from_ref_time(4_453_430 as u64).saturating_mul(r as u64))
+        Weight::from_ref_time(11_639_583_000 as u64)
+            // Standard Error: 121_168
+            .saturating_add(Weight::from_ref_time(30_753_009 as u64).saturating_mul(r as u64))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64store(r: u32, ) -> Weight {
-        Weight::from_ref_time(4_465_000 as u64)
-            // Standard Error: 11_423
-            .saturating_add(Weight::from_ref_time(6_404_772 as u64).saturating_mul(r as u64))
+        Weight::from_ref_time(11_670_404_000 as u64)
+            // Standard Error: 116_067
+            .saturating_add(Weight::from_ref_time(42_656_030 as u64).saturating_mul(r as u64))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_select(r: u32, ) -> Weight {
@@ -1161,17 +1177,31 @@ impl WeightInfo for () {
             .saturating_add(Weight::from_ref_time(183_740_947 as u64).saturating_mul(s as u64))
             .saturating_add(RocksDbWeight::get().reads(257 as u64))
     }
+    /// The range of component `p` is `[0, 512]`.
+    fn lazy_pages_read_access(p: u32, ) -> Weight {
+        Weight::from_ref_time(82_129_000 as u64)
+            // Standard Error: 6_491
+            .saturating_add(Weight::from_ref_time(49_098_637 as u64).saturating_mul(p as u64))
+            .saturating_add(RocksDbWeight::get().reads((16 as u64).saturating_mul(p as u64)))
+    }
+    /// The range of component `p` is `[0, 512]`.
+    fn lazy_pages_write_access(p: u32, ) -> Weight {
+        Weight::from_ref_time(25_317_785_000 as u64)
+            // Standard Error: 18_986
+            .saturating_add(Weight::from_ref_time(69_601_626 as u64).saturating_mul(p as u64))
+            .saturating_add(RocksDbWeight::get().reads(8192 as u64))
+    }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64load(r: u32, ) -> Weight {
-        Weight::from_ref_time(4_466_000 as u64)
-            // Standard Error: 6_072
-            .saturating_add(Weight::from_ref_time(4_453_430 as u64).saturating_mul(r as u64))
+        Weight::from_ref_time(11_639_583_000 as u64)
+            // Standard Error: 121_168
+            .saturating_add(Weight::from_ref_time(30_753_009 as u64).saturating_mul(r as u64))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64store(r: u32, ) -> Weight {
-        Weight::from_ref_time(4_465_000 as u64)
-            // Standard Error: 11_423
-            .saturating_add(Weight::from_ref_time(6_404_772 as u64).saturating_mul(r as u64))
+        Weight::from_ref_time(11_670_404_000 as u64)
+            // Standard Error: 116_067
+            .saturating_add(Weight::from_ref_time(42_656_030 as u64).saturating_mul(r as u64))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_select(r: u32, ) -> Weight {

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 170,
+    spec_version: 180,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/vara/src/weights/pallet_gear.rs
+++ b/runtime/vara/src/weights/pallet_gear.rs
@@ -92,6 +92,8 @@ pub trait WeightInfo {
     fn gr_wake(r: u32, ) -> Weight;
     fn gr_create_program_wgas(r: u32, ) -> Weight;
     fn gr_create_program_wgas_per_kb(p: u32, s: u32, ) -> Weight;
+    fn lazy_pages_read_access(p: u32, ) -> Weight;
+    fn lazy_pages_write_access(p: u32, ) -> Weight;
     fn instr_i64load(r: u32, ) -> Weight;
     fn instr_i64store(r: u32, ) -> Weight;
     fn instr_select(r: u32, ) -> Weight;
@@ -502,17 +504,31 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
             .saturating_add(Weight::from_ref_time(196_730_758 as u64).saturating_mul(s as u64))
             .saturating_add(T::DbWeight::get().reads(257 as u64))
     }
+    /// The range of component `p` is `[0, 512]`.
+    fn lazy_pages_read_access(p: u32, ) -> Weight {
+        Weight::from_ref_time(82_129_000 as u64)
+            // Standard Error: 6_491
+            .saturating_add(Weight::from_ref_time(49_098_637 as u64).saturating_mul(p as u64))
+            .saturating_add(T::DbWeight::get().reads((16 as u64).saturating_mul(p as u64)))
+    }
+    /// The range of component `p` is `[0, 512]`.
+    fn lazy_pages_write_access(p: u32, ) -> Weight {
+        Weight::from_ref_time(25_317_785_000 as u64)
+            // Standard Error: 18_986
+            .saturating_add(Weight::from_ref_time(69_601_626 as u64).saturating_mul(p as u64))
+            .saturating_add(T::DbWeight::get().reads(8192 as u64))
+    }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64load(r: u32, ) -> Weight {
-        Weight::from_ref_time(5_757_000 as u64)
-            // Standard Error: 6_513
-            .saturating_add(Weight::from_ref_time(4_921_048 as u64).saturating_mul(r as u64))
+        Weight::from_ref_time(11_639_583_000 as u64)
+            // Standard Error: 121_168
+            .saturating_add(Weight::from_ref_time(30_753_009 as u64).saturating_mul(r as u64))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64store(r: u32, ) -> Weight {
-        Weight::from_ref_time(5_676_000 as u64)
-            // Standard Error: 8_817
-            .saturating_add(Weight::from_ref_time(8_731_529 as u64).saturating_mul(r as u64))
+        Weight::from_ref_time(11_670_404_000 as u64)
+            // Standard Error: 116_067
+            .saturating_add(Weight::from_ref_time(42_656_030 as u64).saturating_mul(r as u64))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_select(r: u32, ) -> Weight {
@@ -1161,17 +1177,31 @@ impl WeightInfo for () {
             .saturating_add(Weight::from_ref_time(196_730_758 as u64).saturating_mul(s as u64))
             .saturating_add(RocksDbWeight::get().reads(257 as u64))
     }
+    /// The range of component `p` is `[0, 512]`.
+    fn lazy_pages_read_access(p: u32, ) -> Weight {
+        Weight::from_ref_time(82_129_000 as u64)
+            // Standard Error: 6_491
+            .saturating_add(Weight::from_ref_time(49_098_637 as u64).saturating_mul(p as u64))
+            .saturating_add(RocksDbWeight::get().reads((16 as u64).saturating_mul(p as u64)))
+    }
+    /// The range of component `p` is `[0, 512]`.
+    fn lazy_pages_write_access(p: u32, ) -> Weight {
+        Weight::from_ref_time(25_317_785_000 as u64)
+            // Standard Error: 18_986
+            .saturating_add(Weight::from_ref_time(69_601_626 as u64).saturating_mul(p as u64))
+            .saturating_add(RocksDbWeight::get().reads(8192 as u64))
+    }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64load(r: u32, ) -> Weight {
-        Weight::from_ref_time(5_757_000 as u64)
-            // Standard Error: 6_513
-            .saturating_add(Weight::from_ref_time(4_921_048 as u64).saturating_mul(r as u64))
+        Weight::from_ref_time(11_639_583_000 as u64)
+            // Standard Error: 121_168
+            .saturating_add(Weight::from_ref_time(30_753_009 as u64).saturating_mul(r as u64))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64store(r: u32, ) -> Weight {
-        Weight::from_ref_time(5_676_000 as u64)
-            // Standard Error: 8_817
-            .saturating_add(Weight::from_ref_time(8_731_529 as u64).saturating_mul(r as u64))
+        Weight::from_ref_time(11_670_404_000 as u64)
+            // Standard Error: 116_067
+            .saturating_add(Weight::from_ref_time(42_656_030 as u64).saturating_mul(r as u64))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_select(r: u32, ) -> Weight {


### PR DESCRIPTION
Resolves #1728.

Make random access overall 512 wasm pages memory. Which makes load and stores much more expensive, because of L1 and L2 caches misses (see also #1817 ). To reduce `lazy mmap` factor, make all memory pages access before.

Add also `lazy-pages` read/write access benchmarks and weights for future using.
