### PR TITLE
Rename `gear-node` base dir to `gear` instead of changing base path

### DIFF
--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -126,6 +126,12 @@ macro_rules! unwrap_client {
 pub fn run() -> sc_cli::Result<()> {
     let mut cli = Cli::from_args();
 
+    let old_base = BasePath::from_project("", "", "gear-node");
+    let new_base = BasePath::from_project("", "", &Cli::executable_name());
+    if old_base.path().exists() && !new_base.path().exists() {
+        _ = std::fs::rename(old_base.path(), new_base.path());
+    }
+
     // Force setting `Wasm` as default execution strategy.
     cli.run
         .base
@@ -133,13 +139,6 @@ pub fn run() -> sc_cli::Result<()> {
         .execution_strategies
         .execution
         .get_or_insert(ExecutionStrategy::Wasm);
-
-    // Set default base directory to `gear-node`.
-    cli.run
-        .base
-        .shared_params
-        .base_path
-        .get_or_insert_with(|| BasePath::from_project("", "", "gear-node").path().into());
 
     match &cli.subcommand {
         Some(Subcommand::Key(cmd)) => cmd.run(&cli),

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -97,7 +97,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 210,
+    spec_version: 220,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 210,
+    spec_version: 220,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Resolves #1776

- Rename the `gear-node` base directory to `gear` if the first exists and the latter doesn't.
- Default base directory now depends on the executable name as it was before the executable binary renaming.

@gear-tech/dev 
