### PR TITLE
test(program): test program state with real types

### DIFF
--- a/examples/binaries/meta/src/lib.rs
+++ b/examples/binaries/meta/src/lib.rs
@@ -94,13 +94,13 @@ pub struct Id {
     pub hex: Vec<u8>,
 }
 
-#[derive(TypeInfo, Encode, Clone)]
+#[derive(TypeInfo, Encode, Decode, Clone, Debug)]
 pub struct Person {
     pub surname: String,
     pub name: String,
 }
 
-#[derive(TypeInfo, Encode, Clone)]
+#[derive(TypeInfo, Encode, Decode, Clone, Debug)]
 pub struct Wallet {
     pub id: Id,
     pub person: Person,

--- a/program/tests/cmd/program.rs
+++ b/program/tests/cmd/program.rs
@@ -1,8 +1,7 @@
 //! Integration tests for command `program`
 use crate::common::{self, env, logs, traits::Convert, Result};
+use demo_meta::{Id, Person, Wallet};
 use parity_scale_codec::Encode;
-
-const META_STATE_WITH_NONE_INPUT: &str = "0x08010000000000000004012c536f6d655375726e616d6520536f6d654e616d6502000000000000000402244f746865724e616d65304f746865725375726e616d65";
 
 #[derive(Encode)]
 struct MessageInitIn {
@@ -59,6 +58,32 @@ async fn test_command_state_works() -> Result<()> {
         "0x00", // None
     ])?;
 
-    assert!(state.stdout.convert().contains(META_STATE_WITH_NONE_INPUT));
+    let default_wallets = vec![
+        Wallet {
+            id: Id {
+                decimal: 1,
+                hex: vec![1u8],
+            },
+            person: Person {
+                surname: "SomeSurname".into(),
+                name: "SomeName".into(),
+            },
+        },
+        Wallet {
+            id: Id {
+                decimal: 2,
+                hex: vec![2u8],
+            },
+            person: Person {
+                surname: "OtherName".into(),
+                name: "OtherSurname".into(),
+            },
+        },
+    ];
+
+    assert!(state
+        .stdout
+        .convert()
+        .contains(&hex::encode(default_wallets.encode())));
     Ok(())
 }


### PR DESCRIPTION
Resolves # .

- [x] use `Vec<Wallet>` from demo_meta instead only testing the encoding.


@breathx 
