### PR TITLE
chore(pallet-gear): test instructions have proper weights

### DIFF
--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -987,18 +987,20 @@ mod test {
 
         all_measured_instructions()
             .iter()
-            .filter(|i| match i {
-                I32WrapI64
-                | CallIndirect(_, _)
-                | End
-                | Unreachable
-                | Return
-                | Else
-                | Block(_)
-                | Loop(_)
-                | Nop
-                | Drop => false,
-                _ => true,
+            .filter(|i| {
+                !matches!(
+                    i,
+                    I32WrapI64
+                        | CallIndirect(_, _)
+                        | End
+                        | Unreachable
+                        | Return
+                        | Else
+                        | Block(_)
+                        | Loop(_)
+                        | Nop
+                        | Drop
+                )
             })
             .map(|i| rules.instruction_cost(i).expect("checked before"))
             .for_each(|w| assert!(w > i32_wrap_i64))


### PR DESCRIPTION
Resolves #1818 

https://github.com/gear-tech/gear/blob/0ebf95b28ec236c83d6520cd2010752abb00e967/pallets/gear/src/schedule.rs#L743

these instructions do have zero weights, including `CallIndirect(0, 0)`.

several instructions have weights under `1000` in the current implementation

| instr | weights |
|-|-|
| I32WrapI64 | 261 |
| I32Const | 301 |
| I64Const | 301 |
| I64ExtendUI32 | 337 |  
| I64ExtendSI32 | 757 |

checked all weights greater than `I32WrapI64` in the provided test

@gear-tech/dev 
