### PR TITLE
charge for accessed pages in lazy-pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -2026,7 +2026,7 @@ dependencies = [
  "demo-contract-template",
  "demo-mul-by-const",
  "demo-ncompose",
- "env_logger",
+ "env_logger 0.9.1",
  "frame-support",
  "frame-system",
  "gear-common",
@@ -2246,6 +2246,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "environmental"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2343,7 +2356,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e16290574b39ee41c71aeb90ae960c504ebaf1e2a1c87bd52aa56ed6e1a02f"
 dependencies = [
- "env_logger",
+ "env_logger 0.9.1",
  "log",
 ]
 
@@ -2859,7 +2872,7 @@ dependencies = [
  "anyhow",
  "async-std",
  "async-trait",
- "env_logger",
+ "env_logger 0.9.1",
  "futures",
  "futures-timer",
  "gear-core",
@@ -3038,7 +3051,7 @@ version = "0.1.0"
 dependencies = [
  "blake2-rfc",
  "derive_more",
- "env_logger",
+ "env_logger 0.9.1",
  "gear-core-errors",
  "gear-wasm-instrument",
  "hex",
@@ -3078,9 +3091,10 @@ version = "0.1.0"
 dependencies = [
  "cfg-if",
  "derive_more",
- "env_logger",
+ "env_logger 0.10.0",
  "errno",
  "gear-core",
+ "increment",
  "libc",
  "log",
  "mach",
@@ -3146,7 +3160,7 @@ dependencies = [
  "demo-meta",
  "demo-waiter",
  "dirs",
- "env_logger",
+ "env_logger 0.9.1",
  "frame-metadata",
  "futures-util",
  "gear-core",
@@ -3387,7 +3401,7 @@ dependencies = [
  "clap 3.2.23",
  "colored",
  "derive_more",
- "env_logger",
+ "env_logger 0.9.1",
  "gear-backend-common",
  "gear-backend-wasmi",
  "gear-common",
@@ -3670,7 +3684,7 @@ dependencies = [
  "anyhow",
  "colored",
  "derive_more",
- "env_logger",
+ "env_logger 0.9.1",
  "gear-backend-common",
  "gear-backend-wasmi",
  "gear-core",
@@ -3771,6 +3785,15 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -4034,6 +4057,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "increment"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0e22a10d95652add19cd2f9a35c2cb143f164181ccac7576784870bf17387d"
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4102,6 +4131,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e394faa0efb47f9f227f1cd89978f854542b318a6f64fa695489c9c993056656"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "ip_network"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4124,6 +4163,18 @@ name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae5bc6e2eb41c9def29a3e0f1306382807764b9b53112030eff57435667352d"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes 1.0.2",
+ "rustix 0.36.3",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "itertools"
@@ -5236,6 +5287,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5383,7 +5440,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "480b5a5de855d11ff13195950bdc8b98b5e942ef47afc447f6615cdcc4e15d80"
 dependencies = [
- "rustix",
+ "rustix 0.35.13",
 ]
 
 [[package]]
@@ -5880,7 +5937,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -6092,7 +6149,7 @@ dependencies = [
  "demo-waiter",
  "demo-waiting-proxy",
  "derive_more",
- "env_logger",
+ "env_logger 0.9.1",
  "frame-benchmarking",
  "frame-support",
  "frame-support-test",
@@ -6137,7 +6194,7 @@ dependencies = [
 name = "pallet-gear-debug"
 version = "2.0.0"
 dependencies = [
- "env_logger",
+ "env_logger 0.9.1",
  "frame-benchmarking",
  "frame-support",
  "frame-support-test",
@@ -6170,7 +6227,7 @@ dependencies = [
 name = "pallet-gear-gas"
 version = "2.0.0"
 dependencies = [
- "env_logger",
+ "env_logger 0.9.1",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -6194,7 +6251,7 @@ dependencies = [
 name = "pallet-gear-messenger"
 version = "1.0.0"
 dependencies = [
- "env_logger",
+ "env_logger 0.9.1",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -6217,7 +6274,7 @@ dependencies = [
 name = "pallet-gear-payment"
 version = "0.1.0"
 dependencies = [
- "env_logger",
+ "env_logger 0.9.1",
  "frame-benchmarking",
  "frame-support",
  "frame-support-test",
@@ -6258,7 +6315,7 @@ dependencies = [
 name = "pallet-gear-program"
 version = "2.0.0"
 dependencies = [
- "env_logger",
+ "env_logger 0.9.1",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -6309,7 +6366,7 @@ dependencies = [
 name = "pallet-gear-scheduler"
 version = "1.0.0"
 dependencies = [
- "env_logger",
+ "env_logger 0.9.1",
  "frame-benchmarking",
  "frame-support",
  "frame-support-test",
@@ -7474,7 +7531,7 @@ name = "remote-externalities"
 version = "0.10.0-dev"
 source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
- "env_logger",
+ "env_logger 0.9.1",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
@@ -7669,9 +7726,23 @@ checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes",
+ "io-lifetimes 0.7.5",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.0.46",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1fbb4dfc4eb1d390c02df47760bb19a84bb80b301ecc947ab5406394d8223e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes 1.0.2",
+ "libc",
+ "linux-raw-sys 0.1.3",
  "windows-sys 0.42.0",
 ]
 
@@ -8134,7 +8205,7 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "parity-wasm 0.45.0",
- "rustix",
+ "rustix 0.35.13",
  "sc-allocator",
  "sc-executor-common",
  "sp-runtime-interface",
@@ -11364,7 +11435,7 @@ name = "wasm-proc"
 version = "0.1.0"
 dependencies = [
  "clap 3.2.23",
- "env_logger",
+ "env_logger 0.9.1",
  "gear-wasm-builder",
  "log",
  "parity-wasm 0.45.0",
@@ -11822,7 +11893,7 @@ dependencies = [
  "directories-next",
  "file-per-thread-logger",
  "log",
- "rustix",
+ "rustix 0.35.13",
  "serde",
  "sha2 0.9.9",
  "toml",
@@ -11878,7 +11949,7 @@ checksum = "18fc45a6497f557382fc19b8782ad5d47ce3fced469bdaf303ec6b5b2e83c1a6"
 dependencies = [
  "cc",
  "cfg-if",
- "rustix",
+ "rustix 0.35.13",
  "wasmtime-asm-macros",
  "windows-sys 0.36.1",
 ]
@@ -11899,7 +11970,7 @@ dependencies = [
  "log",
  "object 0.29.0",
  "rustc-demangle",
- "rustix",
+ "rustix 0.35.13",
  "serde",
  "target-lexicon",
  "thiserror",
@@ -11917,7 +11988,7 @@ checksum = "25e82d4ef93296785de7efca92f7679dc67fe68a13b625a5ecc8d7503b377a37"
 dependencies = [
  "object 0.29.0",
  "once_cell",
- "rustix",
+ "rustix 0.35.13",
 ]
 
 [[package]]
@@ -11937,7 +12008,7 @@ dependencies = [
  "memoffset",
  "paste",
  "rand 0.8.5",
- "rustix",
+ "rustix 0.35.13",
  "thiserror",
  "wasmtime-asm-macros",
  "wasmtime-environ",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3142,6 +3142,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
+ "static_assertions",
 ]
 
 [[package]]
@@ -3150,16 +3151,19 @@ version = "0.1.0"
 dependencies = [
  "cfg-if",
  "derive_more",
+ "env_logger 0.10.0",
  "errno",
  "gear-core",
  "libc",
  "log",
  "mach",
- "nix 0.25.0",
+ "nix 0.26.1",
  "once_cell",
  "region",
+ "sc-executor-common",
  "sp-io",
  "sp-std",
+ "sp-wasm-interface",
  "static_assertions",
  "winapi",
 ]
@@ -3316,12 +3320,10 @@ name = "gear-runtime-interface"
 version = "0.1.0"
 dependencies = [
  "derive_more",
- "env_logger 0.9.3",
  "gear-core",
  "gear-lazy-pages",
  "libc",
  "log",
- "nix 0.24.2",
  "parity-scale-codec",
  "region",
  "sp-runtime-interface",
@@ -5863,21 +5865,20 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset 0.6.5",
 ]
 
 [[package]]
 name = "nix"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
+checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
 dependencies = [
- "autocfg",
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset 0.6.5",
+ "memoffset 0.7.1",
  "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "array-bytes"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a913633b0c922e6b745072795f50d90ebea78ba31a57e2ac8c2fc7b50950949"
+checksum = "f52f63c5c1316a16a4b35eaac8b76a98248961a533f061684cb2a7cb0eafb6c6"
 
 [[package]]
 name = "arrayref"
@@ -165,9 +165,9 @@ checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
 
 [[package]]
 name = "async-channel"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -176,15 +176,15 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
 dependencies = [
+ "async-lock",
  "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
- "once_cell",
  "slab",
 ]
 
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
+checksum = "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
 dependencies = [
  "async-lock",
  "autocfg",
@@ -220,7 +220,7 @@ dependencies = [
  "slab",
  "socket2",
  "waker-fn",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -235,20 +235,20 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02111fd8655a613c25069ea89fc8d9bb89331fa77486eb3bc059ee757cfa481c"
+checksum = "6381ead98388605d0d9ff86371043b5aa922a3905824244de40dc263a14fcba4"
 dependencies = [
  "async-io",
+ "async-lock",
  "autocfg",
  "blocking",
  "cfg-if",
  "event-listener",
  "futures-lite",
  "libc",
- "once_cell",
  "signal-hook",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "asynchronous-codec"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0de5164e5edbf51c45fb8c2d9664ae1c095cce1b265ecf7569093c0d66ef690"
+checksum = "06a0daa378f5fd10634e44b0a29b2a87b890657658e072a30d6f26e57ddee182"
 dependencies = [
  "bytes",
  "futures-sink",
@@ -356,7 +356,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.5.4",
  "object 0.29.0",
  "rustc-demangle",
 ]
@@ -469,11 +469,11 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9cf849ee05b2ee5fba5e36f97ff8ec2533916700fc0758d40d92136a42f3388"
+checksum = "b12e5fd123190ce1c2e559308a94c9bacad77907d4c6005d9e58fe1a0689e55e"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -483,7 +483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 dependencies = [
  "arrayvec 0.4.12",
- "constant_time_eq",
+ "constant_time_eq 0.1.5",
 ]
 
 [[package]]
@@ -494,7 +494,7 @@ checksum = "72936ee4afc7f8f736d1c38383b56480b5497b4617b4a77bdbf1d2ababc76127"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq",
+ "constant_time_eq 0.1.5",
 ]
 
 [[package]]
@@ -505,21 +505,21 @@ checksum = "db539cc2b5f6003621f1cd9ef92d7ded8ea5232c7de0f9faa2de251cd98730d4"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq",
+ "constant_time_eq 0.1.5",
 ]
 
 [[package]]
 name = "blake3"
-version = "1.3.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
+checksum = "42ae2468a89544a466886840aa467a25b766499f4f04bf7d9fcd10ecee9fccef"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
  "cc",
  "cfg-if",
- "constant_time_eq",
- "digest 0.10.5",
+ "constant_time_eq 0.2.4",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -579,16 +579,16 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blocking"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
+checksum = "3c67b173a56acffd6d2326fb7ab938ba0b00a71480e14902b2591c87bc5741e8"
 dependencies = [
  "async-channel",
+ "async-lock",
  "async-task",
  "atomic-waker",
  "fastrand",
  "futures-lite",
- "once_cell",
 ]
 
 [[package]]
@@ -668,9 +668,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "bzip2-sys"
@@ -682,12 +682,6 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
-
-[[package]]
-name = "cache-padded"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "camino"
@@ -736,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.74"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
 dependencies = [
  "jobserver",
 ]
@@ -800,15 +794,15 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-integer",
  "num-traits",
- "time 0.1.44",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -969,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "6.1.2"
+version = "6.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1090f39f45786ec6dc6286f8ea9c75d0a7ef0a0d3cda674cef0c3af7b307fbc2"
+checksum = "e621e7e86c46fd8a14c32c6ae3cb95656621b4743a27d0cffedb831d46e7ad21"
 dependencies = [
  "strum",
  "strum_macros",
@@ -980,11 +974,11 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "1.2.4"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
+checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
 dependencies = [
- "cache-padded",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1018,6 +1012,12 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
 
 [[package]]
 name = "convert_case"
@@ -1083,18 +1083,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.88.1"
+version = "0.88.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44409ccf2d0f663920cab563d2b79fcd6b2e9a2bcc6e929fef76c8f82ad6c17a"
+checksum = "52056f6d0584484b57fa6c1a65c1fcb15f3780d8b6a758426d9e3084169b2ddd"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.88.1"
+version = "0.88.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de2018ad96eb97f621f7d6b900a0cc661aec8d02ea4a50e56ecb48e5a2fcaf"
+checksum = "18fed94c8770dc25d01154c3ffa64ed0b3ba9d583736f305fed7beebe5d9cf74"
 dependencies = [
  "arrayvec 0.7.2",
  "bumpalo",
@@ -1112,33 +1112,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.88.1"
+version = "0.88.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5287ce36e6c4758fbaf298bd1a8697ad97a4f2375a3d1b61142ea538db4877e5"
+checksum = "1c451b81faf237d11c7e4f3165eeb6bac61112762c5cfe7b4c0fb7241474358f"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.88.1"
+version = "0.88.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2855c24219e2f08827f3f4ffb2da92e134ae8d8ecc185b11ec8f9878cf5f588e"
+checksum = "e7c940133198426d26128f08be2b40b0bd117b84771fd36798969c4d712d81fc"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.88.1"
+version = "0.88.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b65673279d75d34bf11af9660ae2dbd1c22e6d28f163f5c72f4e1dc56d56103"
+checksum = "87a0f1b2fdc18776956370cf8d9b009ded3f855350c480c1c52142510961f352"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.88.1"
+version = "0.88.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed2b3d7a4751163f6c4a349205ab1b7d9c00eecf19dcea48592ef1f7688eefc"
+checksum = "34897538b36b216cc8dd324e73263596d51b8cf610da6498322838b2546baf8a"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1148,15 +1148,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.88.1"
+version = "0.88.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be64cecea9d90105fc6a2ba2d003e98c867c1d6c4c86cc878f97ad9fb916293"
+checksum = "1b2629a569fae540f16a76b70afcc87ad7decb38dc28fa6c648ac73b51e78470"
 
 [[package]]
 name = "cranelift-native"
-version = "0.88.1"
+version = "0.88.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a03a6ac1b063e416ca4b93f6247978c991475e8271465340caa6f92f3c16a4"
+checksum = "20937dab4e14d3e225c5adfc9c7106bafd4ac669bdb43027b911ff794c6fb318"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.88.1"
+version = "0.88.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c699873f7b30bc5f20dd03a796b4183e073a46616c91704792ec35e45d13f913"
+checksum = "80fc2288957a94fd342a015811479de1837850924166d1f1856d8406e6f3609b"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1211,22 +1211,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.11"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.6.5",
+ "memoffset 0.7.1",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
 ]
@@ -1350,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.80"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
+checksum = "d4a41a86530d0fe7f5d9ea779916b7cadd2d4f9add748b99c2c029cbbdfaf453"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1362,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.80"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
+checksum = "06416d667ff3e3ad2df1cd8cd8afae5da26cf9cec4d0825040f88b5ca659a2f0"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1377,15 +1377,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.80"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
+checksum = "820a9a2af1669deeef27cb271f476ffd196a2c4b6731336011e0ba63e2c7cf71"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.80"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
+checksum = "a08a6e2fcc370a089ad3b4aaf54db3b1b4cee38ddabce5896b33eb693275f470"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1889,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
@@ -2290,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
@@ -2316,9 +2316,9 @@ dependencies = [
 
 [[package]]
 name = "environmental"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
+checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
 name = "errno"
@@ -2412,7 +2412,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e16290574b39ee41c71aeb90ae960c504ebaf1e2a1c87bd52aa56ed6e1a02f"
 dependencies = [
- "env_logger 0.9.1",
+ "env_logger 0.9.3",
  "log",
 ]
 
@@ -2470,13 +2470,13 @@ checksum = "cda653ca797810c02f7ca4b804b40b8b95ae046eb989d356bce17919a8c25499"
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
  "libz-sys",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
 ]
 
 [[package]]
@@ -2488,7 +2488,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2505,7 +2505,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2528,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -2579,7 +2579,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2608,7 +2608,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.2.1",
@@ -2666,7 +2666,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "frame-support-test"
 version = "3.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "frame-support",
  "frame-support-test-pallet",
@@ -2699,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "frame-support-test-pallet"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2710,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "frame-support",
  "log",
@@ -2728,7 +2728,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2743,7 +2743,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2752,7 +2752,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3142,7 +3142,6 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "static_assertions",
 ]
 
 [[package]]
@@ -3151,19 +3150,16 @@ version = "0.1.0"
 dependencies = [
  "cfg-if",
  "derive_more",
- "env_logger 0.10.0",
  "errno",
  "gear-core",
  "libc",
  "log",
  "mach",
- "nix 0.26.1",
+ "nix 0.25.0",
  "once_cell",
  "region",
- "sc-executor-common",
  "sp-io",
  "sp-std",
- "sp-wasm-interface",
  "static_assertions",
  "winapi",
 ]
@@ -3320,10 +3316,12 @@ name = "gear-runtime-interface"
 version = "0.1.0"
 dependencies = [
  "derive_more",
+ "env_logger 0.9.3",
  "gear-core",
  "gear-lazy-pages",
  "libc",
  "log",
+ "nix 0.24.2",
  "parity-scale-codec",
  "region",
  "sp-runtime-interface",
@@ -3685,9 +3683,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb7d06c1c8cc2a29bee7ec961009a0b2caa0793ee4900c2ffb348734ba1c8f9"
+checksum = "98c4a8d6391675c6b2ee1a6c8d06e8e2d03605c44cec1270675985a4c2a5500b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3971,9 +3969,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.22"
+version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
+checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3995,9 +3993,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+checksum = "59df7c4e19c950e6e0e868dcc0a300b09a9b88e9ec55bd879ca819087a77355d"
 dependencies = [
  "http",
  "hyper",
@@ -4125,9 +4123,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -4187,9 +4185,9 @@ checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e394faa0efb47f9f227f1cd89978f854542b318a6f64fa695489c9c993056656"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
 dependencies = [
  "libc",
  "windows-sys 0.42.0",
@@ -4203,31 +4201,31 @@ checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
 
 [[package]]
 name = "ipconfig"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723519edce41262b05d4143ceb95050e4c614f483e78e9fd9e39a8275a84ad98"
+checksum = "bd302af1b90f2463a98fa5ad469fc212c8e3175a41c3068601bfa2727591c5be"
 dependencies = [
  "socket2",
  "widestring",
  "winapi",
- "winreg 0.7.0",
+ "winreg",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae5bc6e2eb41c9def29a3e0f1306382807764b9b53112030eff57435667352d"
+checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
 dependencies = [
  "hermit-abi 0.2.6",
- "io-lifetimes 1.0.2",
- "rustix 0.36.3",
+ "io-lifetimes 1.0.3",
+ "rustix 0.36.4",
  "windows-sys 0.42.0",
 ]
 
@@ -4248,9 +4246,9 @@ checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "ittapi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "663fe0550070071ff59e981864a9cd3ee1c869ed0a088140d9ac4dc05ea6b1a1"
+checksum = "e8c4f6ff06169ce7048dac5150b1501c7e3716a929721aeb06b87e51a43e42f4"
 dependencies = [
  "anyhow",
  "ittapi-sys",
@@ -4259,9 +4257,9 @@ dependencies = [
 
 [[package]]
 name = "ittapi-sys"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21911b7183f38c71d75ab478a527f314e28db51027037ece2e5511ed9410703"
+checksum = "87e078cce01485f418bae3beb34dd604aaedf2065502853c7da17fbce8e64eda"
 dependencies = [
  "cc",
 ]
@@ -4471,9 +4469,12 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "keyring"
@@ -4578,9 +4579,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
@@ -4588,9 +4589,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "libp2p"
@@ -4732,8 +4733,8 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "pin-project",
- "prost 0.11.0",
- "prost-build 0.11.1",
+ "prost 0.11.3",
+ "prost-build 0.11.3",
  "rand 0.8.5",
  "rw-stream-sink",
  "sec1 0.3.0",
@@ -4851,8 +4852,8 @@ dependencies = [
  "libp2p-swarm 0.41.1",
  "log",
  "lru 0.8.1",
- "prost 0.11.0",
- "prost-build 0.11.1",
+ "prost 0.11.3",
+ "prost-build 0.11.3",
  "prost-codec 0.3.0",
  "smallvec",
  "thiserror",
@@ -5011,9 +5012,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-pnet"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5a702574223aa55d8878bdc8bf55c84a6086f87ddaddc28ce730b4caa81538"
+checksum = "de160c5631696cea22be326c19bd9d306e254c4964945263aea10f25f6e0864e"
 dependencies = [
  "futures",
  "log",
@@ -5479,18 +5480,18 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memfd"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "480b5a5de855d11ff13195950bdc8b98b5e942ef47afc447f6615cdcc4e15d80"
+checksum = "b20a59d985586e4a5aef64564ac77299f8586d8be6cf9106a5a40207e8908efb"
 dependencies = [
- "rustix 0.35.13",
+ "rustix 0.36.4",
 ]
 
 [[package]]
 name = "memmap2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
+checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
 dependencies = [
  "libc",
 ]
@@ -5582,6 +5583,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5656,7 +5666,7 @@ dependencies = [
  "blake2s_simd",
  "blake3",
  "core2",
- "digest 0.10.5",
+ "digest 0.10.6",
  "multihash-derive",
  "sha2 0.10.6",
  "sha3",
@@ -5853,20 +5863,21 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
 name = "nix"
-version = "0.26.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
+checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
 dependencies = [
+ "autocfg",
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset 0.7.1",
+ "memoffset 0.6.5",
  "pin-utils",
- "static_assertions",
 ]
 
 [[package]]
@@ -6013,20 +6024,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi 0.1.19",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
  "libc",
 ]
 
@@ -6086,9 +6088,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.1"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "output_vt100"
@@ -6143,7 +6145,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6158,7 +6160,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6182,7 +6184,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6231,7 +6233,7 @@ dependencies = [
  "demo-waiter",
  "demo-waiting-proxy",
  "derive_more",
- "env_logger 0.9.1",
+ "env_logger 0.9.3",
  "frame-benchmarking",
  "frame-support",
  "frame-support-test",
@@ -6477,7 +6479,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6500,7 +6502,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6521,7 +6523,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6535,7 +6537,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6553,7 +6555,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6569,7 +6571,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6584,7 +6586,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6595,7 +6597,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6743,7 +6745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.4",
+ "parking_lot_core 0.9.5",
 ]
 
 [[package]]
@@ -6762,9 +6764,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
@@ -6823,9 +6825,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc7bc69c062e492337d74d59b120c274fd3d261b6bf6d3207d499b4b379c41a"
+checksum = "5f400b0f7905bf702f9f3dc3df5a121b16c54e9e8012c082905fdf09a931861a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -6833,9 +6835,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b75706b9642ebcb34dab3bc7750f811609a0eb1dd8b88c2d15bf628c1c65b2"
+checksum = "423c2ba011d6e27b02b482a3707c773d19aec65cc024637aec44e19652e66f63"
 dependencies = [
  "pest",
  "pest_generator",
@@ -6843,9 +6845,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f9272122f5979a6511a749af9db9bfc810393f63119970d7085fed1c4ea0db"
+checksum = "3e64e6c2c85031c02fdbd9e5c72845445ca0a724d419aa0bc068ac620c9935c1"
 dependencies = [
  "pest",
  "pest_meta",
@@ -6856,9 +6858,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8717927f9b79515e565a64fe46c38b8cd0427e64c40680b14a7365ab09ac8d"
+checksum = "57959b91f0a133f89a68be874a5c88ed689c19cd729ecdb5d762ebf16c64d662"
 dependencies = [
  "once_cell",
  "pest",
@@ -6948,16 +6950,16 @@ checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
 
 [[package]]
 name = "polling"
-version = "2.4.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4609a838d88b73d8238967b60dd115cc08d38e2bbaf51ee1e4b695f89122e2"
+checksum = "166ca89eb77fd403230b9c156612965a81e094ec6ec3aa13663d4c8b113fa748"
 dependencies = [
  "autocfg",
  "cfg-if",
  "libc",
  "log",
  "wepoll-ffi",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -6991,9 +6993,9 @@ checksum = "15eb2c6e362923af47e13c23ca5afb859e83d54452c55b0b9ac763b8f7c1ac16"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "pretty_assertions"
@@ -7005,6 +7007,16 @@ dependencies = [
  "diff",
  "output_vt100",
  "yansi",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -7165,12 +7177,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
+checksum = "c0b18e655c21ff5ac2084a5ad0611e827b3f92badf79f4910b5a5c58f4d87ff0"
 dependencies = [
  "bytes",
- "prost-derive 0.11.0",
+ "prost-derive 0.11.2",
 ]
 
 [[package]]
@@ -7197,9 +7209,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
+checksum = "e330bf1316db56b12c2bcfa399e8edddd4821965ea25ddb2c134b610b1c1c604"
 dependencies = [
  "bytes",
  "heck 0.4.0",
@@ -7208,9 +7220,11 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost 0.11.0",
- "prost-types 0.11.1",
+ "prettyplease",
+ "prost 0.11.3",
+ "prost-types 0.11.2",
  "regex",
+ "syn",
  "tempfile",
  "which",
 ]
@@ -7236,7 +7250,7 @@ checksum = "0dc34979ff898b6e141106178981ce2596c387ea6e62533facfc61a37fc879c0"
 dependencies = [
  "asynchronous-codec",
  "bytes",
- "prost 0.11.0",
+ "prost 0.11.3",
  "thiserror",
  "unsigned-varint",
 ]
@@ -7256,9 +7270,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
+checksum = "164ae68b6587001ca506d3bf7f1000bfa248d0e1217b618108fba4ec1d0cc306"
 dependencies = [
  "anyhow",
  "itertools",
@@ -7279,12 +7293,12 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
+checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
 dependencies = [
  "bytes",
- "prost 0.11.0",
+ "prost 0.11.3",
 ]
 
 [[package]]
@@ -7587,9 +7601,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "region"
@@ -7622,9 +7636,9 @@ dependencies = [
 [[package]]
 name = "remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
- "env_logger 0.9.1",
+ "env_logger 0.9.3",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
@@ -7685,7 +7699,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg 0.10.1",
+ "winreg",
 ]
 
 [[package]]
@@ -7761,11 +7775,12 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.1.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c9f5d2a0c3e2ea729ab3706d22217177770654c3ef5056b68b69d07332d3f5"
+checksum = "6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322"
 dependencies = [
  "libc",
+ "rtoolbox",
  "winapi",
 ]
 
@@ -7782,6 +7797,16 @@ dependencies = [
  "netlink-proto",
  "nix 0.24.2",
  "thiserror",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -7827,13 +7852,13 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.3"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1fbb4dfc4eb1d390c02df47760bb19a84bb80b301ecc947ab5406394d8223e"
+checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes 1.0.2",
+ "io-lifetimes 1.0.3",
  "libc",
  "linux-raw-sys 0.1.3",
  "windows-sys 0.42.0",
@@ -7928,7 +7953,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "log",
  "sp-core",
@@ -7939,7 +7964,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "async-trait",
  "futures",
@@ -7948,8 +7973,8 @@ dependencies = [
  "libp2p 0.46.1",
  "log",
  "parity-scale-codec",
- "prost 0.11.0",
- "prost-build 0.11.1",
+ "prost 0.11.3",
+ "prost-build 0.11.3",
  "rand 0.7.3",
  "sc-client-api",
  "sc-network-common",
@@ -7966,7 +7991,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -7982,7 +8007,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "impl-trait-for-tuples",
  "memmap2",
@@ -7999,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "proc-macro-crate 1.2.1",
  "proc-macro2",
@@ -8010,7 +8035,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -8050,7 +8075,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "fnv",
  "futures",
@@ -8078,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -8103,7 +8128,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "async-trait",
  "futures",
@@ -8127,7 +8152,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -8169,7 +8194,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -8191,7 +8216,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -8204,7 +8229,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "async-trait",
  "futures",
@@ -8228,7 +8253,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "lazy_static",
  "lru 0.7.8",
@@ -8255,7 +8280,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "environmental",
  "log",
@@ -8275,7 +8300,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8290,7 +8315,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "cfg-if",
  "libc",
@@ -8310,7 +8335,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -8351,7 +8376,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -8372,7 +8397,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "ansi_term",
  "futures",
@@ -8389,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -8404,7 +8429,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -8426,7 +8451,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "pin-project",
- "prost 0.11.0",
+ "prost 0.11.3",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-client-api",
@@ -8451,14 +8476,14 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "cid",
  "futures",
  "libp2p 0.46.1",
  "log",
- "prost 0.11.0",
- "prost-build 0.11.1",
+ "prost 0.11.3",
+ "prost-build 0.11.3",
  "sc-client-api",
  "sc-network-common",
  "sp-blockchain",
@@ -8471,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -8481,7 +8506,7 @@ dependencies = [
  "libp2p 0.46.1",
  "linked_hash_set",
  "parity-scale-codec",
- "prost-build 0.11.1",
+ "prost-build 0.11.3",
  "sc-consensus",
  "sc-peerset",
  "serde",
@@ -8497,7 +8522,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "ahash",
  "futures",
@@ -8515,15 +8540,15 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "array-bytes",
  "futures",
  "libp2p 0.46.1",
  "log",
  "parity-scale-codec",
- "prost 0.11.0",
- "prost-build 0.11.1",
+ "prost 0.11.3",
+ "prost-build 0.11.3",
  "sc-client-api",
  "sc-network-common",
  "sc-peerset",
@@ -8536,7 +8561,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "array-bytes",
  "fork-tree",
@@ -8545,8 +8570,8 @@ dependencies = [
  "log",
  "lru 0.7.8",
  "parity-scale-codec",
- "prost 0.11.0",
- "prost-build 0.11.1",
+ "prost 0.11.3",
+ "prost-build 0.11.3",
  "sc-client-api",
  "sc-consensus",
  "sc-network-common",
@@ -8564,7 +8589,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "array-bytes",
  "futures",
@@ -8583,7 +8608,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -8613,7 +8638,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "futures",
  "libp2p 0.46.1",
@@ -8626,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -8635,7 +8660,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "futures",
  "hash-db",
@@ -8665,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -8688,7 +8713,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -8701,7 +8726,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "futures",
  "hex",
@@ -8720,7 +8745,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "async-trait",
  "directories",
@@ -8791,7 +8816,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8805,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -8824,7 +8849,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "futures",
  "libc",
@@ -8843,7 +8868,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "chrono",
  "futures",
@@ -8861,7 +8886,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "ansi_term",
  "atty",
@@ -8892,7 +8917,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "proc-macro-crate 1.2.1",
  "proc-macro2",
@@ -8903,7 +8928,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "async-trait",
  "futures",
@@ -8930,7 +8955,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "async-trait",
  "futures",
@@ -8944,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -9204,9 +9229,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
 dependencies = [
  "serde_derive",
 ]
@@ -9222,9 +9247,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9307,7 +9332,7 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -9343,7 +9368,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -9352,7 +9377,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
  "keccak",
 ]
 
@@ -9435,9 +9460,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "snap"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
+checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
 name = "snow"
@@ -9485,7 +9510,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "hash-db",
  "log",
@@ -9503,7 +9528,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "blake2",
  "proc-macro-crate 1.2.1",
@@ -9543,7 +9568,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9556,7 +9581,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9568,7 +9593,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9580,7 +9605,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "futures",
  "log",
@@ -9598,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "async-trait",
  "futures",
@@ -9617,7 +9642,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "async-trait",
  "merlin",
@@ -9640,7 +9665,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9654,7 +9679,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9717,7 +9742,7 @@ source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92ca
 dependencies = [
  "blake2",
  "byteorder",
- "digest 0.10.5",
+ "digest 0.10.6",
  "sha2 0.10.6",
  "sha3",
  "sp-std",
@@ -9727,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9738,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -9768,7 +9793,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -9786,7 +9811,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -9826,7 +9851,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -9854,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "thiserror",
  "zstd",
@@ -9863,7 +9888,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -9883,7 +9908,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -9946,7 +9971,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9960,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9974,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10025,7 +10050,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "log",
  "sp-core",
@@ -10038,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -10066,7 +10091,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -10075,7 +10100,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "async-trait",
  "log",
@@ -10114,7 +10139,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10131,7 +10156,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -10202,9 +10227,9 @@ dependencies = [
 
 [[package]]
 name = "ss58-registry"
-version = "1.33.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab7554f8a8b6f8d71cd5a8e6536ef116e2ce0504cf97ebf16311d58065dc8a6"
+checksum = "fa0813c10b9dbdc842c2305f949f724c64866e4ef4d09c9151e96f6a2106773c"
 dependencies = [
  "Inflector",
  "num-format",
@@ -10348,7 +10373,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "platforms",
 ]
@@ -10356,7 +10381,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -10377,7 +10402,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "futures-util",
  "hyper",
@@ -10390,7 +10415,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "jsonrpsee",
  "log",
@@ -10411,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -10437,7 +10462,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -10608,9 +10633,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
+checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
 
 [[package]]
 name = "tempfile"
@@ -10726,9 +10751,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
@@ -10737,13 +10762,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
  "itoa",
- "libc",
- "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -10757,9 +10780,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
 dependencies = [
  "time-core",
 ]
@@ -10820,9 +10843,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10901,7 +10924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.16",
+ "time 0.3.17",
  "tracing-subscriber 0.3.16",
 ]
 
@@ -11085,7 +11108,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "clap 3.2.23",
  "frame-try-runtime",
@@ -11110,9 +11133,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea496675d71016e9bc76aa42d87f16aefd95447cc5818e671e12b2d7e269075d"
+checksum = "db29f438342820400f2d9acfec0d363e987a38b2950bdb50a7069ed17b2148ee"
 dependencies = [
  "dissimilar",
  "glob 0.3.0",
@@ -11137,7 +11160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "digest 0.10.5",
+ "digest 0.10.6",
  "rand 0.8.5",
  "static_assertions",
 ]
@@ -11156,9 +11179,9 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "uint"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45526d29728d135c2900b0d30573fe3ee79fceb12ef534c7bb30e810a91b601"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -11968,9 +11991,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f511c4917c83d04da68333921107db75747c4e11a2f654a8e909cc5e0520dc"
+checksum = "4ad5af6ba38311282f2a21670d96e78266e8c8e2f38cbcd52c254df6ccbc7731"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11999,18 +12022,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bf3debfe744bf19dd3732990ce6f8c0ced7439e2370ba4e1d8f5a3660a3178"
+checksum = "45de63ddfc8b9223d1adc8f7b2ee5f35d1f6d112833934ad7ea66e4f4339e597"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece42fa4676a263f7558cdaaf5a71c2592bebcbac22a0580e33cf3406c103da2"
+checksum = "bcd849399d17d2270141cfe47fa0d91ee52d5f8ea9b98cf7ddde0d53e5f79882"
 dependencies = [
  "anyhow",
  "base64",
@@ -12028,9 +12051,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058217e28644b012bdcdf0e445f58d496d78c2e0b6a6dd93558e701591dad705"
+checksum = "4bd91339b742ff20bfed4532a27b73c86b5bcbfedd6bea2dcdf2d64471e1b5c6"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -12049,9 +12072,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7af06848df28b7661471d9a80d30a973e0f401f2e3ed5396ad7e225ed217047"
+checksum = "ebb881c61f4f627b5d45c54e629724974f8a8890d455bcbe634330cc27309644"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -12068,9 +12091,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fc45a6497f557382fc19b8782ad5d47ce3fced469bdaf303ec6b5b2e83c1a6"
+checksum = "7e867cf58e31bfa0ab137bd47e207d2e1e38c581d7838b2f258d47c8145db412"
 dependencies = [
  "cc",
  "cfg-if",
@@ -12081,9 +12104,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9028fb63a54185b3c192b7500ef8039c7bb8d7f62bfc9e7c258483a33a3d13bb"
+checksum = "1985c628011fe26adf5e23a5301bdc79b245e0e338f14bb58b39e4e25e4d8681"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -12107,9 +12130,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e82d4ef93296785de7efca92f7679dc67fe68a13b625a5ecc8d7503b377a37"
+checksum = "f671b588486f5ccec8c5a3dba6b4c07eac2e66ab8c60e6f4e53717c77f709731"
 dependencies = [
  "object 0.29.0",
  "once_cell",
@@ -12118,9 +12141,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0e9bea7d517d114fe66b930b2124ee086516ee93eeebfd97f75f366c5b0553"
+checksum = "ee8f92ad4b61736339c29361da85769ebc200f184361959d1792832e592a1afd"
 dependencies = [
  "anyhow",
  "cc",
@@ -12144,9 +12167,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b83e93ed41b8fdc936244cfd5e455480cf1eca1fd60c78a0040038b4ce5075"
+checksum = "d23d61cb4c46e837b431196dd06abb11731541021916d03476a178b54dc07aeb"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -12460,15 +12483,6 @@ checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winreg"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
@@ -12478,9 +12492,9 @@ dependencies = [
 
 [[package]]
 name = "wyz"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
@@ -12608,9 +12622,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.1+zstd.1.5.2"
+version = "2.0.4+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+checksum = "4fa202f2ef00074143e219d15b62ffc317d17cc33909feac471c044087cad7b0"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,9 +301,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1008,6 +1008,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
+name = "const-oid"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,6 +1454,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "demo-async-custom-entry"
+version = "0.1.0"
+dependencies = [
+ "gear-wasm-builder",
+ "gstd",
+ "gtest",
+ "parity-scale-codec",
+]
+
+[[package]]
 name = "demo-async-signal-entry"
 version = "0.1.0"
 dependencies = [
@@ -1680,6 +1696,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "demo-proxy-relay"
+version = "0.1.0"
+dependencies = [
+ "gear-wasm-builder",
+ "gstd",
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
 name = "demo-proxy-with-gas"
 version = "0.1.0"
 dependencies = [
@@ -1789,7 +1815,17 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
- "const-oid",
+ "const-oid 0.7.1",
+]
+
+[[package]]
+name = "der"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+dependencies = [
+ "const-oid 0.9.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -2011,7 +2047,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
 dependencies = [
- "der",
+ "der 0.5.1",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -2026,7 +2062,7 @@ dependencies = [
  "demo-contract-template",
  "demo-mul-by-const",
  "demo-ncompose",
- "env_logger 0.9.1",
+ "env_logger 0.10.0",
  "frame-support",
  "frame-system",
  "gear-common",
@@ -2133,12 +2169,12 @@ checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "der",
+ "der 0.5.1",
  "ff",
  "generic-array 0.14.6",
  "group",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.2.1",
  "subtle",
  "zeroize",
 ]
@@ -2176,7 +2212,16 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
 dependencies = [
- "enum-iterator-derive",
+ "enum-iterator-derive 0.7.0",
+]
+
+[[package]]
+name = "enum-iterator"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91a4ec26efacf4aeff80887a175a419493cb6f8b5480d26387eb0bd038976187"
+dependencies = [
+ "enum-iterator-derive 1.1.0",
 ]
 
 [[package]]
@@ -2184,6 +2229,17 @@ name = "enum-iterator-derive"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2490,7 +2546,7 @@ dependencies = [
  "lazy_static",
  "linked-hash-map",
  "log",
- "memory-db",
+ "memory-db 0.30.0",
  "parity-scale-codec",
  "rand 0.8.5",
  "rand_pcg 0.3.1",
@@ -2872,7 +2928,7 @@ dependencies = [
  "anyhow",
  "async-std",
  "async-trait",
- "env_logger 0.9.1",
+ "env_logger 0.10.0",
  "futures",
  "futures-timer",
  "gear-core",
@@ -2945,8 +3001,10 @@ name = "gear-backend-common"
 version = "0.1.0"
 dependencies = [
  "derive_more",
+ "enum-iterator 1.2.0",
  "gear-core",
  "gear-core-errors",
+ "gear-wasm-instrument",
  "log",
  "parity-scale-codec",
  "rand 0.8.5",
@@ -2998,6 +3056,7 @@ dependencies = [
  "gear-runtime-primitives",
  "gear-runtime-test-cli",
  "gear-service",
+ "log",
  "pallet-gear-payment",
  "sc-cli",
  "sc-client-api",
@@ -3051,7 +3110,7 @@ version = "0.1.0"
 dependencies = [
  "blake2-rfc",
  "derive_more",
- "env_logger 0.9.1",
+ "env_logger 0.10.0",
  "gear-core-errors",
  "gear-wasm-instrument",
  "hex",
@@ -3083,6 +3142,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
+ "static_assertions",
 ]
 
 [[package]]
@@ -3160,7 +3220,7 @@ dependencies = [
  "demo-meta",
  "demo-waiter",
  "dirs",
- "env_logger 0.9.1",
+ "env_logger 0.10.0",
  "frame-metadata",
  "futures-util",
  "gear-core",
@@ -3169,7 +3229,7 @@ dependencies = [
  "jsonrpsee",
  "keyring",
  "lazy_static",
- "libp2p 0.49.0",
+ "libp2p 0.50.0",
  "log",
  "messager",
  "nacl",
@@ -3401,7 +3461,7 @@ dependencies = [
  "clap 3.2.23",
  "colored",
  "derive_more",
- "env_logger 0.9.1",
+ "env_logger 0.10.0",
  "gear-backend-common",
  "gear-backend-wasmi",
  "gear-common",
@@ -3450,7 +3510,7 @@ dependencies = [
  "futures",
  "gear-test-client",
  "log",
- "memory-db",
+ "memory-db 0.31.0",
  "pallet-babe",
  "pallet-gear",
  "pallet-gear-rpc-runtime-api",
@@ -3668,9 +3728,11 @@ dependencies = [
 name = "gstd-codegen"
 version = "0.1.0"
 dependencies = [
+ "gstd",
  "proc-macro2",
  "quote",
  "syn",
+ "trybuild",
 ]
 
 [[package]]
@@ -3684,7 +3746,7 @@ dependencies = [
  "anyhow",
  "colored",
  "derive_more",
- "env_logger 0.9.1",
+ "env_logger 0.10.0",
  "gear-backend-common",
  "gear-backend-wasmi",
  "gear-core",
@@ -4411,7 +4473,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sec1",
+ "sec1 0.2.1",
 ]
 
 [[package]]
@@ -4568,13 +4630,13 @@ dependencies = [
  "libp2p-rendezvous",
  "libp2p-request-response",
  "libp2p-swarm 0.37.0",
- "libp2p-swarm-derive 0.28.0",
+ "libp2p-swarm-derive",
  "libp2p-tcp",
  "libp2p-uds",
  "libp2p-wasm-ext",
  "libp2p-websocket",
  "libp2p-yamux",
- "multiaddr",
+ "multiaddr 0.14.0",
  "parking_lot 0.12.1",
  "pin-project",
  "rand 0.7.3",
@@ -4583,22 +4645,20 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.49.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec878fda12ebec479186b3914ebc48ff180fa4c51847e11a1a68bf65249e02c1"
+checksum = "2e0a0d2f693675f49ded13c5d510c48b78069e23cbd9108d7ccd59f6dc568819"
 dependencies = [
  "bytes",
  "futures",
  "futures-timer",
  "getrandom 0.2.8",
  "instant",
- "lazy_static",
- "libp2p-core 0.37.0",
- "libp2p-identify 0.40.0",
- "libp2p-metrics 0.10.0",
- "libp2p-swarm 0.40.1",
- "libp2p-swarm-derive 0.30.1",
- "multiaddr",
+ "libp2p-core 0.38.0",
+ "libp2p-identify 0.41.0",
+ "libp2p-metrics 0.11.0",
+ "libp2p-swarm 0.41.1",
+ "multiaddr 0.16.0",
  "parking_lot 0.12.1",
  "pin-project",
  "smallvec",
@@ -4640,7 +4700,7 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log",
- "multiaddr",
+ "multiaddr 0.14.0",
  "multihash",
  "multistream-select 0.11.0",
  "parking_lot 0.12.1",
@@ -4660,9 +4720,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799676bb0807c788065e57551c6527d461ad572162b0519d1958946ff9e0539d"
+checksum = "b6a8fcd392ff67af6cc3f03b1426c41f7f26b6b9aff2dc632c1c56dd649e571f"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -4672,17 +4732,18 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "lazy_static",
  "log",
- "multiaddr",
+ "multiaddr 0.16.0",
  "multihash",
- "multistream-select 0.12.0",
+ "multistream-select 0.12.1",
+ "once_cell",
  "parking_lot 0.12.1",
  "pin-project",
  "prost 0.11.0",
  "prost-build 0.11.1",
  "rand 0.8.5",
  "rw-stream-sink",
+ "sec1 0.3.0",
  "sha2 0.10.6",
  "smallvec",
  "thiserror",
@@ -4786,20 +4847,20 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf9a121f699e8719bda2e6e9e9b6ddafc6cff4602471d6481c1067930ccb29b"
+checksum = "647d6a99f8d5b7366ee6bcc608ec186e2fb58b497cf914c8409b803bd0f594a2"
 dependencies = [
  "asynchronous-codec",
  "futures",
  "futures-timer",
- "libp2p-core 0.37.0",
- "libp2p-swarm 0.40.1",
+ "libp2p-core 0.38.0",
+ "libp2p-swarm 0.41.1",
  "log",
  "lru 0.8.1",
  "prost 0.11.0",
  "prost-build 0.11.1",
- "prost-codec 0.2.0",
+ "prost-codec 0.3.0",
  "smallvec",
  "thiserror",
  "void",
@@ -4872,13 +4933,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee31b08e78b7b8bfd1c4204a9dd8a87b4fcdf6dafc57eb51701c1c264a81cb9"
+checksum = "5ad8a64f29da86005c86a4d2728b8a0719e9b192f4092b609fd8790acb9dec55"
 dependencies = [
- "libp2p-core 0.37.0",
- "libp2p-identify 0.40.0",
- "libp2p-swarm 0.40.1",
+ "libp2p-core 0.38.0",
+ "libp2p-identify 0.41.0",
+ "libp2p-swarm 0.41.1",
  "prometheus-client 0.18.1",
 ]
 
@@ -5058,16 +5119,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.40.1"
+version = "0.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d13df7c37807965d82930c0e4b04a659efcb6cca237373b206043db5398ecf"
+checksum = "b2a35472fe3276b3855c00f1c032ea8413615e030256429ad5349cdf67c6e1a0"
 dependencies = [
  "either",
  "fnv",
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.37.0",
+ "libp2p-core 0.38.0",
  "log",
  "pin-project",
  "rand 0.8.5",
@@ -5082,17 +5143,6 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f54a64b6957249e0ce782f8abf41d97f69330d02bf229f0672d864f0650cc76"
 dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "libp2p-swarm-derive"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0eddc4497a8b5a506013c40e8189864f9c3a00db2b25671f428ae9007f3ba32"
-dependencies = [
- "heck 0.4.0",
  "quote",
  "syn",
 ]
@@ -5473,6 +5523,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "memory-db"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0c7cba9ce19ac7ffd2053ac9f49843bbd3f4318feedfd74e85c19d5fb0ba66"
+dependencies = [
+ "hash-db",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
 name = "memory_units"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5556,6 +5616,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiaddr"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aebdb21e90f81d13ed01dc84123320838e53963c2ca94b60b305d3fa64f31e"
+dependencies = [
+ "arrayref",
+ "byteorder",
+ "data-encoding",
+ "multibase",
+ "multihash",
+ "percent-encoding",
+ "serde",
+ "static_assertions",
+ "unsigned-varint",
+ "url",
+]
+
+[[package]]
 name = "multibase"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5619,9 +5697,9 @@ dependencies = [
 
 [[package]]
 name = "multistream-select"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc41247ec209813e2fd414d6e16b9d94297dacf3cd613fa6ef09cd4d9755c10"
+checksum = "c8552ab875c1313b97b8d20cb857b9fd63e2d1d6a0a1b53ce9821e575405f27a"
 dependencies = [
  "bytes",
  "futures",
@@ -6119,6 +6197,7 @@ name = "pallet-gear"
 version = "2.0.0"
 dependencies = [
  "blake2-rfc",
+ "demo-async-custom-entry",
  "demo-async-signal-entry",
  "demo-async-tester",
  "demo-btree",
@@ -6140,6 +6219,7 @@ dependencies = [
  "demo-mul-by-const",
  "demo-program-factory",
  "demo-proxy",
+ "demo-proxy-relay",
  "demo-proxy-with-gas",
  "demo-reserve-gas",
  "demo-send-from-reservation",
@@ -6187,6 +6267,7 @@ dependencies = [
  "sp-runtime",
  "sp-sandbox",
  "sp-std",
+ "test-syscalls",
  "wabt",
 ]
 
@@ -6194,7 +6275,7 @@ dependencies = [
 name = "pallet-gear-debug"
 version = "2.0.0"
 dependencies = [
- "env_logger 0.9.1",
+ "env_logger 0.10.0",
  "frame-benchmarking",
  "frame-support",
  "frame-support-test",
@@ -6227,7 +6308,7 @@ dependencies = [
 name = "pallet-gear-gas"
 version = "2.0.0"
 dependencies = [
- "env_logger 0.9.1",
+ "env_logger 0.10.0",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -6251,7 +6332,7 @@ dependencies = [
 name = "pallet-gear-messenger"
 version = "1.0.0"
 dependencies = [
- "env_logger 0.9.1",
+ "env_logger 0.10.0",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -6274,7 +6355,7 @@ dependencies = [
 name = "pallet-gear-payment"
 version = "0.1.0"
 dependencies = [
- "env_logger 0.9.1",
+ "env_logger 0.10.0",
  "frame-benchmarking",
  "frame-support",
  "frame-support-test",
@@ -6315,7 +6396,7 @@ dependencies = [
 name = "pallet-gear-program"
 version = "2.0.0"
 dependencies = [
- "env_logger 0.9.1",
+ "env_logger 0.10.0",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -6366,7 +6447,7 @@ dependencies = [
 name = "pallet-gear-scheduler"
 version = "1.0.0"
 dependencies = [
- "env_logger 0.9.1",
+ "env_logger 0.10.0",
  "frame-benchmarking",
  "frame-support",
  "frame-support-test",
@@ -6836,9 +6917,19 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
 dependencies = [
- "der",
- "spki",
+ "der 0.5.1",
+ "spki 0.5.4",
  "zeroize",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.0",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -7137,9 +7228,9 @@ dependencies = [
 
 [[package]]
 name = "prost-codec"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011ae9ff8359df7915f97302d591cdd9e0e27fbd5a4ddc5bd13b71079bb20987"
+checksum = "0dc34979ff898b6e141106178981ce2596c387ea6e62533facfc61a37fc879c0"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -8995,10 +9086,23 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
 dependencies = [
- "der",
+ "der 0.5.1",
  "generic-array 0.14.6",
- "pkcs8",
+ "pkcs8 0.8.0",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct",
+ "der 0.6.0",
+ "generic-array 0.14.6",
+ "pkcs8 0.9.0",
  "zeroize",
 ]
 
@@ -9409,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9422,7 +9526,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "5.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -9561,7 +9665,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "array-bytes",
  "base58",
@@ -9607,7 +9711,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "blake2",
  "byteorder",
@@ -9641,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "4.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9651,7 +9755,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.12.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9694,7 +9798,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "bytes",
  "futures",
@@ -9731,7 +9835,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.12.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "async-trait",
  "futures",
@@ -9767,7 +9871,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "4.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -9787,7 +9891,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -9810,7 +9914,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -9828,7 +9932,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.2.1",
@@ -9879,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.12.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "hash-db",
  "log",
@@ -9901,12 +10005,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 
 [[package]]
 name = "sp-storage"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9948,7 +10052,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "5.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -9985,14 +10089,14 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "ahash",
  "hash-db",
  "hashbrown 0.12.3",
  "lazy_static",
  "lru 0.7.8",
- "memory-db",
+ "memory-db 0.30.0",
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -10036,7 +10140,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -10049,7 +10153,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -10081,7 +10185,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.5.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.0",
 ]
 
 [[package]]
@@ -10418,9 +10532,9 @@ checksum = "7c68d531d83ec6c531150584c42a4290911964d5f0d79132b193b67252a23b71"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10527,6 +10641,15 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "test-syscalls"
+version = "0.1.0"
+dependencies = [
+ "gear-wasm-builder",
+ "gstd",
+ "parity-scale-codec",
 ]
 
 [[package]]
@@ -11435,7 +11558,7 @@ name = "wasm-proc"
 version = "0.1.0"
 dependencies = [
  "clap 3.2.23",
- "env_logger 0.9.1",
+ "env_logger 0.10.0",
  "gear-wasm-builder",
  "log",
  "parity-wasm 0.45.0",
@@ -11600,7 +11723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
 dependencies = [
  "cfg-if",
- "enum-iterator",
+ "enum-iterator 0.7.0",
  "enumset",
  "leb128",
  "libloading",
@@ -11645,7 +11768,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
 dependencies = [
- "enum-iterator",
+ "enum-iterator 0.7.0",
  "enumset",
  "loupe",
  "rkyv",
@@ -11674,7 +11797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
 dependencies = [
  "backtrace",
- "enum-iterator",
+ "enum-iterator 0.7.0",
  "indexmap",
  "loupe",
  "more-asserts",
@@ -11693,7 +11816,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "corosensei",
- "enum-iterator",
+ "enum-iterator 0.7.0",
  "indexmap",
  "lazy_static",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "array-bytes"
-version = "4.2.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52f63c5c1316a16a4b35eaac8b76a98248961a533f061684cb2a7cb0eafb6c6"
+checksum = "6a913633b0c922e6b745072795f50d90ebea78ba31a57e2ac8c2fc7b50950949"
 
 [[package]]
 name = "arrayref"
@@ -165,9 +165,9 @@ checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
 
 [[package]]
 name = "async-channel"
-version = "1.8.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -176,15 +176,15 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.5.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
+checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
 dependencies = [
- "async-lock",
  "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
+ "once_cell",
  "slab",
 ]
 
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.12.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
+checksum = "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
 dependencies = [
  "async-lock",
  "autocfg",
@@ -220,7 +220,7 @@ dependencies = [
  "slab",
  "socket2",
  "waker-fn",
- "windows-sys 0.42.0",
+ "winapi",
 ]
 
 [[package]]
@@ -235,20 +235,20 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.6.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6381ead98388605d0d9ff86371043b5aa922a3905824244de40dc263a14fcba4"
+checksum = "02111fd8655a613c25069ea89fc8d9bb89331fa77486eb3bc059ee757cfa481c"
 dependencies = [
  "async-io",
- "async-lock",
  "autocfg",
  "blocking",
  "cfg-if",
  "event-listener",
  "futures-lite",
  "libc",
+ "once_cell",
  "signal-hook",
- "windows-sys 0.42.0",
+ "winapi",
 ]
 
 [[package]]
@@ -301,9 +301,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.59"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
+checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "asynchronous-codec"
-version = "0.6.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a0daa378f5fd10634e44b0a29b2a87b890657658e072a30d6f26e57ddee182"
+checksum = "f0de5164e5edbf51c45fb8c2d9664ae1c095cce1b265ecf7569093c0d66ef690"
 dependencies = [
  "bytes",
  "futures-sink",
@@ -335,7 +335,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
  "winapi",
 ]
@@ -356,7 +356,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.5.4",
+ "miniz_oxide",
  "object 0.29.0",
  "rustc-demangle",
 ]
@@ -469,11 +469,11 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.10.5"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e5fd123190ce1c2e559308a94c9bacad77907d4c6005d9e58fe1a0689e55e"
+checksum = "b9cf849ee05b2ee5fba5e36f97ff8ec2533916700fc0758d40d92136a42f3388"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -483,7 +483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 dependencies = [
  "arrayvec 0.4.12",
- "constant_time_eq 0.1.5",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -494,7 +494,7 @@ checksum = "72936ee4afc7f8f736d1c38383b56480b5497b4617b4a77bdbf1d2ababc76127"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq 0.1.5",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -505,21 +505,21 @@ checksum = "db539cc2b5f6003621f1cd9ef92d7ded8ea5232c7de0f9faa2de251cd98730d4"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq 0.1.5",
+ "constant_time_eq",
 ]
 
 [[package]]
 name = "blake3"
-version = "1.3.3"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ae2468a89544a466886840aa467a25b766499f4f04bf7d9fcd10ecee9fccef"
+checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
  "cc",
  "cfg-if",
- "constant_time_eq 0.2.4",
- "digest 0.10.6",
+ "constant_time_eq",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -579,16 +579,16 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blocking"
-version = "1.3.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c67b173a56acffd6d2326fb7ab938ba0b00a71480e14902b2591c87bc5741e8"
+checksum = "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
 dependencies = [
  "async-channel",
- "async-lock",
  "async-task",
  "atomic-waker",
  "fastrand",
  "futures-lite",
+ "once_cell",
 ]
 
 [[package]]
@@ -668,9 +668,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "bzip2-sys"
@@ -682,6 +682,12 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "cache-padded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "camino"
@@ -730,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
 dependencies = [
  "jobserver",
 ]
@@ -794,15 +800,15 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-integer",
  "num-traits",
- "time 0.1.45",
+ "time 0.1.44",
  "wasm-bindgen",
  "winapi",
 ]
@@ -963,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "6.1.3"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e621e7e86c46fd8a14c32c6ae3cb95656621b4743a27d0cffedb831d46e7ad21"
+checksum = "1090f39f45786ec6dc6286f8ea9c75d0a7ef0a0d3cda674cef0c3af7b307fbc2"
 dependencies = [
  "strum",
  "strum_macros",
@@ -974,11 +980,11 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.0.0"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
+checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
 dependencies = [
- "crossbeam-utils",
+ "cache-padded",
 ]
 
 [[package]]
@@ -1002,22 +1008,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
-name = "const-oid"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
 
 [[package]]
 name = "convert_case"
@@ -1083,18 +1077,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.88.2"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52056f6d0584484b57fa6c1a65c1fcb15f3780d8b6a758426d9e3084169b2ddd"
+checksum = "44409ccf2d0f663920cab563d2b79fcd6b2e9a2bcc6e929fef76c8f82ad6c17a"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.88.2"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fed94c8770dc25d01154c3ffa64ed0b3ba9d583736f305fed7beebe5d9cf74"
+checksum = "98de2018ad96eb97f621f7d6b900a0cc661aec8d02ea4a50e56ecb48e5a2fcaf"
 dependencies = [
  "arrayvec 0.7.2",
  "bumpalo",
@@ -1112,33 +1106,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.88.2"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c451b81faf237d11c7e4f3165eeb6bac61112762c5cfe7b4c0fb7241474358f"
+checksum = "5287ce36e6c4758fbaf298bd1a8697ad97a4f2375a3d1b61142ea538db4877e5"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.88.2"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c940133198426d26128f08be2b40b0bd117b84771fd36798969c4d712d81fc"
+checksum = "2855c24219e2f08827f3f4ffb2da92e134ae8d8ecc185b11ec8f9878cf5f588e"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.88.2"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a0f1b2fdc18776956370cf8d9b009ded3f855350c480c1c52142510961f352"
+checksum = "0b65673279d75d34bf11af9660ae2dbd1c22e6d28f163f5c72f4e1dc56d56103"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.88.2"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34897538b36b216cc8dd324e73263596d51b8cf610da6498322838b2546baf8a"
+checksum = "3ed2b3d7a4751163f6c4a349205ab1b7d9c00eecf19dcea48592ef1f7688eefc"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1148,15 +1142,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.88.2"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2629a569fae540f16a76b70afcc87ad7decb38dc28fa6c648ac73b51e78470"
+checksum = "3be64cecea9d90105fc6a2ba2d003e98c867c1d6c4c86cc878f97ad9fb916293"
 
 [[package]]
 name = "cranelift-native"
-version = "0.88.2"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20937dab4e14d3e225c5adfc9c7106bafd4ac669bdb43027b911ff794c6fb318"
+checksum = "c4a03a6ac1b063e416ca4b93f6247978c991475e8271465340caa6f92f3c16a4"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1165,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.88.2"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fc2288957a94fd342a015811479de1837850924166d1f1856d8406e6f3609b"
+checksum = "c699873f7b30bc5f20dd03a796b4183e073a46616c91704792ec35e45d13f913"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1211,22 +1205,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.7.1",
+ "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
 ]
@@ -1350,9 +1344,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.82"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a41a86530d0fe7f5d9ea779916b7cadd2d4f9add748b99c2c029cbbdfaf453"
+checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1362,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.82"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06416d667ff3e3ad2df1cd8cd8afae5da26cf9cec4d0825040f88b5ca659a2f0"
+checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1377,15 +1371,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.82"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820a9a2af1669deeef27cb271f476ffd196a2c4b6731336011e0ba63e2c7cf71"
+checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.82"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08a6e2fcc370a089ad3b4aaf54db3b1b4cee38ddabce5896b33eb693275f470"
+checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1451,16 +1445,6 @@ checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
 dependencies = [
  "data-encoding",
  "syn",
-]
-
-[[package]]
-name = "demo-async-custom-entry"
-version = "0.1.0"
-dependencies = [
- "gear-wasm-builder",
- "gstd",
- "gtest",
- "parity-scale-codec",
 ]
 
 [[package]]
@@ -1696,16 +1680,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "demo-proxy-relay"
-version = "0.1.0"
-dependencies = [
- "gear-wasm-builder",
- "gstd",
- "parity-scale-codec",
- "scale-info",
-]
-
-[[package]]
 name = "demo-proxy-with-gas"
 version = "0.1.0"
 dependencies = [
@@ -1815,17 +1789,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
- "const-oid 0.7.1",
-]
-
-[[package]]
-name = "der"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
-dependencies = [
- "const-oid 0.9.1",
- "zeroize",
+ "const-oid",
 ]
 
 [[package]]
@@ -1889,9 +1853,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
@@ -2047,7 +2011,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
 dependencies = [
- "der 0.5.1",
+ "der",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -2062,7 +2026,7 @@ dependencies = [
  "demo-contract-template",
  "demo-mul-by-const",
  "demo-ncompose",
- "env_logger 0.10.0",
+ "env_logger",
  "frame-support",
  "frame-system",
  "gear-common",
@@ -2169,12 +2133,12 @@ checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "der 0.5.1",
+ "der",
  "ff",
  "generic-array 0.14.6",
  "group",
  "rand_core 0.6.4",
- "sec1 0.2.1",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -2212,16 +2176,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
 dependencies = [
- "enum-iterator-derive 0.7.0",
-]
-
-[[package]]
-name = "enum-iterator"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91a4ec26efacf4aeff80887a175a419493cb6f8b5480d26387eb0bd038976187"
-dependencies = [
- "enum-iterator-derive 1.1.0",
+ "enum-iterator-derive",
 ]
 
 [[package]]
@@ -2229,17 +2184,6 @@ name = "enum-iterator-derive"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2290,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
 dependencies = [
  "atty",
  "humantime",
@@ -2302,23 +2246,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "environmental"
-version = "1.1.4"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
+checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 
 [[package]]
 name = "errno"
@@ -2412,7 +2343,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e16290574b39ee41c71aeb90ae960c504ebaf1e2a1c87bd52aa56ed6e1a02f"
 dependencies = [
- "env_logger 0.9.3",
+ "env_logger",
  "log",
 ]
 
@@ -2470,13 +2401,13 @@ checksum = "cda653ca797810c02f7ca4b804b40b8b95ae046eb989d356bce17919a8c25499"
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
  "libz-sys",
- "miniz_oxide 0.6.2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -2488,7 +2419,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2505,7 +2436,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2528,7 +2459,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -2546,7 +2477,7 @@ dependencies = [
  "lazy_static",
  "linked-hash-map",
  "log",
- "memory-db 0.30.0",
+ "memory-db",
  "parity-scale-codec",
  "rand 0.8.5",
  "rand_pcg 0.3.1",
@@ -2579,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2608,7 +2539,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -2640,7 +2571,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2654,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.2.1",
@@ -2666,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2676,7 +2607,7 @@ dependencies = [
 [[package]]
 name = "frame-support-test"
 version = "3.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "frame-support",
  "frame-support-test-pallet",
@@ -2699,7 +2630,7 @@ dependencies = [
 [[package]]
 name = "frame-support-test-pallet"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2710,7 +2641,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "frame-support",
  "log",
@@ -2728,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2743,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2752,7 +2683,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -2928,7 +2859,7 @@ dependencies = [
  "anyhow",
  "async-std",
  "async-trait",
- "env_logger 0.10.0",
+ "env_logger",
  "futures",
  "futures-timer",
  "gear-core",
@@ -3001,10 +2932,8 @@ name = "gear-backend-common"
 version = "0.1.0"
 dependencies = [
  "derive_more",
- "enum-iterator 1.2.0",
  "gear-core",
  "gear-core-errors",
- "gear-wasm-instrument",
  "log",
  "parity-scale-codec",
  "rand 0.8.5",
@@ -3056,7 +2985,6 @@ dependencies = [
  "gear-runtime-primitives",
  "gear-runtime-test-cli",
  "gear-service",
- "log",
  "pallet-gear-payment",
  "sc-cli",
  "sc-client-api",
@@ -3110,7 +3038,7 @@ version = "0.1.0"
 dependencies = [
  "blake2-rfc",
  "derive_more",
- "env_logger 0.10.0",
+ "env_logger",
  "gear-core-errors",
  "gear-wasm-instrument",
  "hex",
@@ -3150,7 +3078,7 @@ version = "0.1.0"
 dependencies = [
  "cfg-if",
  "derive_more",
- "env_logger 0.9.3",
+ "env_logger",
  "errno",
  "gear-core",
  "libc",
@@ -3218,7 +3146,7 @@ dependencies = [
  "demo-meta",
  "demo-waiter",
  "dirs",
- "env_logger 0.10.0",
+ "env_logger",
  "frame-metadata",
  "futures-util",
  "gear-core",
@@ -3227,7 +3155,7 @@ dependencies = [
  "jsonrpsee",
  "keyring",
  "lazy_static",
- "libp2p 0.50.0",
+ "libp2p 0.49.0",
  "log",
  "messager",
  "nacl",
@@ -3459,7 +3387,7 @@ dependencies = [
  "clap 3.2.23",
  "colored",
  "derive_more",
- "env_logger 0.10.0",
+ "env_logger",
  "gear-backend-common",
  "gear-backend-wasmi",
  "gear-common",
@@ -3508,7 +3436,7 @@ dependencies = [
  "futures",
  "gear-test-client",
  "log",
- "memory-db 0.31.0",
+ "memory-db",
  "pallet-babe",
  "pallet-gear",
  "pallet-gear-rpc-runtime-api",
@@ -3684,9 +3612,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.5"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c4a8d6391675c6b2ee1a6c8d06e8e2d03605c44cec1270675985a4c2a5500b"
+checksum = "5fb7d06c1c8cc2a29bee7ec961009a0b2caa0793ee4900c2ffb348734ba1c8f9"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3726,11 +3654,9 @@ dependencies = [
 name = "gstd-codegen"
 version = "0.1.0"
 dependencies = [
- "gstd",
  "proc-macro2",
  "quote",
  "syn",
- "trybuild",
 ]
 
 [[package]]
@@ -3744,7 +3670,7 @@ dependencies = [
  "anyhow",
  "colored",
  "derive_more",
- "env_logger 0.10.0",
+ "env_logger",
  "gear-backend-common",
  "gear-backend-wasmi",
  "gear-core",
@@ -3845,15 +3771,6 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -3970,9 +3887,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3994,9 +3911,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59df7c4e19c950e6e0e868dcc0a300b09a9b88e9ec55bd879ca819087a77355d"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
  "http",
  "hyper",
@@ -4124,9 +4041,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -4185,16 +4102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
-dependencies = [
- "libc",
- "windows-sys 0.42.0",
-]
-
-[[package]]
 name = "ip_network"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4202,33 +4109,21 @@ checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
 
 [[package]]
 name = "ipconfig"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd302af1b90f2463a98fa5ad469fc212c8e3175a41c3068601bfa2727591c5be"
+checksum = "723519edce41262b05d4143ceb95050e4c614f483e78e9fd9e39a8275a84ad98"
 dependencies = [
  "socket2",
  "widestring",
  "winapi",
- "winreg",
+ "winreg 0.7.0",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.5.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
-dependencies = [
- "hermit-abi 0.2.6",
- "io-lifetimes 1.0.3",
- "rustix 0.36.4",
- "windows-sys 0.42.0",
-]
+checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
@@ -4247,9 +4142,9 @@ checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "ittapi"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c4f6ff06169ce7048dac5150b1501c7e3716a929721aeb06b87e51a43e42f4"
+checksum = "663fe0550070071ff59e981864a9cd3ee1c869ed0a088140d9ac4dc05ea6b1a1"
 dependencies = [
  "anyhow",
  "ittapi-sys",
@@ -4258,9 +4153,9 @@ dependencies = [
 
 [[package]]
 name = "ittapi-sys"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e078cce01485f418bae3beb34dd604aaedf2065502853c7da17fbce8e64eda"
+checksum = "e21911b7183f38c71d75ab478a527f314e28db51027037ece2e5511ed9410703"
 dependencies = [
  "cc",
 ]
@@ -4465,17 +4360,14 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sec1 0.2.1",
+ "sec1",
 ]
 
 [[package]]
 name = "keccak"
-version = "0.1.3"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
-dependencies = [
- "cpufeatures",
-]
+checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
 name = "keyring"
@@ -4580,9 +4472,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if",
  "winapi",
@@ -4590,9 +4482,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
 
 [[package]]
 name = "libp2p"
@@ -4625,13 +4517,13 @@ dependencies = [
  "libp2p-rendezvous",
  "libp2p-request-response",
  "libp2p-swarm 0.37.0",
- "libp2p-swarm-derive",
+ "libp2p-swarm-derive 0.28.0",
  "libp2p-tcp",
  "libp2p-uds",
  "libp2p-wasm-ext",
  "libp2p-websocket",
  "libp2p-yamux",
- "multiaddr 0.14.0",
+ "multiaddr",
  "parking_lot 0.12.1",
  "pin-project",
  "rand 0.7.3",
@@ -4640,20 +4532,22 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.50.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0a0d2f693675f49ded13c5d510c48b78069e23cbd9108d7ccd59f6dc568819"
+checksum = "ec878fda12ebec479186b3914ebc48ff180fa4c51847e11a1a68bf65249e02c1"
 dependencies = [
  "bytes",
  "futures",
  "futures-timer",
  "getrandom 0.2.8",
  "instant",
- "libp2p-core 0.38.0",
- "libp2p-identify 0.41.0",
- "libp2p-metrics 0.11.0",
- "libp2p-swarm 0.41.1",
- "multiaddr 0.16.0",
+ "lazy_static",
+ "libp2p-core 0.37.0",
+ "libp2p-identify 0.40.0",
+ "libp2p-metrics 0.10.0",
+ "libp2p-swarm 0.40.1",
+ "libp2p-swarm-derive 0.30.1",
+ "multiaddr",
  "parking_lot 0.12.1",
  "pin-project",
  "smallvec",
@@ -4695,7 +4589,7 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log",
- "multiaddr 0.14.0",
+ "multiaddr",
  "multihash",
  "multistream-select 0.11.0",
  "parking_lot 0.12.1",
@@ -4715,9 +4609,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.38.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a8fcd392ff67af6cc3f03b1426c41f7f26b6b9aff2dc632c1c56dd649e571f"
+checksum = "799676bb0807c788065e57551c6527d461ad572162b0519d1958946ff9e0539d"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -4727,18 +4621,17 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
+ "lazy_static",
  "log",
- "multiaddr 0.16.0",
+ "multiaddr",
  "multihash",
- "multistream-select 0.12.1",
- "once_cell",
+ "multistream-select 0.12.0",
  "parking_lot 0.12.1",
  "pin-project",
- "prost 0.11.3",
- "prost-build 0.11.3",
+ "prost 0.11.0",
+ "prost-build 0.11.1",
  "rand 0.8.5",
  "rw-stream-sink",
- "sec1 0.3.0",
  "sha2 0.10.6",
  "smallvec",
  "thiserror",
@@ -4842,20 +4735,20 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.41.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647d6a99f8d5b7366ee6bcc608ec186e2fb58b497cf914c8409b803bd0f594a2"
+checksum = "dcf9a121f699e8719bda2e6e9e9b6ddafc6cff4602471d6481c1067930ccb29b"
 dependencies = [
  "asynchronous-codec",
  "futures",
  "futures-timer",
- "libp2p-core 0.38.0",
- "libp2p-swarm 0.41.1",
+ "libp2p-core 0.37.0",
+ "libp2p-swarm 0.40.1",
  "log",
  "lru 0.8.1",
- "prost 0.11.3",
- "prost-build 0.11.3",
- "prost-codec 0.3.0",
+ "prost 0.11.0",
+ "prost-build 0.11.1",
+ "prost-codec 0.2.0",
  "smallvec",
  "thiserror",
  "void",
@@ -4928,13 +4821,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad8a64f29da86005c86a4d2728b8a0719e9b192f4092b609fd8790acb9dec55"
+checksum = "9ee31b08e78b7b8bfd1c4204a9dd8a87b4fcdf6dafc57eb51701c1c264a81cb9"
 dependencies = [
- "libp2p-core 0.38.0",
- "libp2p-identify 0.41.0",
- "libp2p-swarm 0.41.1",
+ "libp2p-core 0.37.0",
+ "libp2p-identify 0.40.0",
+ "libp2p-swarm 0.40.1",
  "prometheus-client 0.18.1",
 ]
 
@@ -5013,9 +4906,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-pnet"
-version = "0.22.2"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de160c5631696cea22be326c19bd9d306e254c4964945263aea10f25f6e0864e"
+checksum = "1a5a702574223aa55d8878bdc8bf55c84a6086f87ddaddc28ce730b4caa81538"
 dependencies = [
  "futures",
  "log",
@@ -5114,16 +5007,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.41.1"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a35472fe3276b3855c00f1c032ea8413615e030256429ad5349cdf67c6e1a0"
+checksum = "46d13df7c37807965d82930c0e4b04a659efcb6cca237373b206043db5398ecf"
 dependencies = [
  "either",
  "fnv",
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.38.0",
+ "libp2p-core 0.37.0",
  "log",
  "pin-project",
  "rand 0.8.5",
@@ -5138,6 +5031,17 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f54a64b6957249e0ce782f8abf41d97f69330d02bf229f0672d864f0650cc76"
 dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "libp2p-swarm-derive"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eddc4497a8b5a506013c40e8189864f9c3a00db2b25671f428ae9007f3ba32"
+dependencies = [
+ "heck 0.4.0",
  "quote",
  "syn",
 ]
@@ -5332,12 +5236,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
-
-[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5481,18 +5379,18 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memfd"
-version = "0.6.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b20a59d985586e4a5aef64564ac77299f8586d8be6cf9106a5a40207e8908efb"
+checksum = "480b5a5de855d11ff13195950bdc8b98b5e942ef47afc447f6615cdcc4e15d80"
 dependencies = [
- "rustix 0.36.4",
+ "rustix",
 ]
 
 [[package]]
 name = "memmap2"
-version = "0.5.8"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
+checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
 dependencies = [
  "libc",
 ]
@@ -5507,15 +5405,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "memory-db"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5524,16 +5413,6 @@ dependencies = [
  "hash-db",
  "hashbrown 0.12.3",
  "parity-util-mem",
-]
-
-[[package]]
-name = "memory-db"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0c7cba9ce19ac7ffd2053ac9f49843bbd3f4318feedfd74e85c19d5fb0ba66"
-dependencies = [
- "hash-db",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -5584,15 +5463,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
-
-[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5629,24 +5499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multiaddr"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aebdb21e90f81d13ed01dc84123320838e53963c2ca94b60b305d3fa64f31e"
-dependencies = [
- "arrayref",
- "byteorder",
- "data-encoding",
- "multibase",
- "multihash",
- "percent-encoding",
- "serde",
- "static_assertions",
- "unsigned-varint",
- "url",
-]
-
-[[package]]
 name = "multibase"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5667,7 +5519,7 @@ dependencies = [
  "blake2s_simd",
  "blake3",
  "core2",
- "digest 0.10.6",
+ "digest 0.10.5",
  "multihash-derive",
  "sha2 0.10.6",
  "sha3",
@@ -5710,9 +5562,9 @@ dependencies = [
 
 [[package]]
 name = "multistream-select"
-version = "0.12.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8552ab875c1313b97b8d20cb857b9fd63e2d1d6a0a1b53ce9821e575405f27a"
+checksum = "9bc41247ec209813e2fd414d6e16b9d94297dacf3cd613fa6ef09cd4d9755c10"
 dependencies = [
  "bytes",
  "futures",
@@ -5852,7 +5704,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "memoffset 0.6.5",
+ "memoffset",
 ]
 
 [[package]]
@@ -5876,7 +5728,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset 0.6.5",
+ "memoffset",
  "pin-utils",
 ]
 
@@ -6024,11 +5876,20 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -6088,9 +5949,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
 
 [[package]]
 name = "output_vt100"
@@ -6145,7 +6006,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6160,7 +6021,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6184,7 +6045,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6201,7 +6062,6 @@ name = "pallet-gear"
 version = "2.0.0"
 dependencies = [
  "blake2-rfc",
- "demo-async-custom-entry",
  "demo-async-signal-entry",
  "demo-async-tester",
  "demo-btree",
@@ -6223,7 +6083,6 @@ dependencies = [
  "demo-mul-by-const",
  "demo-program-factory",
  "demo-proxy",
- "demo-proxy-relay",
  "demo-proxy-with-gas",
  "demo-reserve-gas",
  "demo-send-from-reservation",
@@ -6233,7 +6092,7 @@ dependencies = [
  "demo-waiter",
  "demo-waiting-proxy",
  "derive_more",
- "env_logger 0.9.3",
+ "env_logger",
  "frame-benchmarking",
  "frame-support",
  "frame-support-test",
@@ -6271,7 +6130,6 @@ dependencies = [
  "sp-runtime",
  "sp-sandbox",
  "sp-std",
- "test-syscalls",
  "wabt",
 ]
 
@@ -6279,7 +6137,7 @@ dependencies = [
 name = "pallet-gear-debug"
 version = "2.0.0"
 dependencies = [
- "env_logger 0.10.0",
+ "env_logger",
  "frame-benchmarking",
  "frame-support",
  "frame-support-test",
@@ -6312,7 +6170,7 @@ dependencies = [
 name = "pallet-gear-gas"
 version = "2.0.0"
 dependencies = [
- "env_logger 0.10.0",
+ "env_logger",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -6336,7 +6194,7 @@ dependencies = [
 name = "pallet-gear-messenger"
 version = "1.0.0"
 dependencies = [
- "env_logger 0.10.0",
+ "env_logger",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -6359,7 +6217,7 @@ dependencies = [
 name = "pallet-gear-payment"
 version = "0.1.0"
 dependencies = [
- "env_logger 0.10.0",
+ "env_logger",
  "frame-benchmarking",
  "frame-support",
  "frame-support-test",
@@ -6400,7 +6258,7 @@ dependencies = [
 name = "pallet-gear-program"
 version = "2.0.0"
 dependencies = [
- "env_logger 0.10.0",
+ "env_logger",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -6451,7 +6309,7 @@ dependencies = [
 name = "pallet-gear-scheduler"
 version = "1.0.0"
 dependencies = [
- "env_logger 0.10.0",
+ "env_logger",
  "frame-benchmarking",
  "frame-support",
  "frame-support-test",
@@ -6479,7 +6337,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6502,7 +6360,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6523,7 +6381,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6537,7 +6395,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6555,7 +6413,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6571,7 +6429,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6586,7 +6444,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6597,7 +6455,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6745,7 +6603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.5",
+ "parking_lot_core 0.9.4",
 ]
 
 [[package]]
@@ -6764,9 +6622,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -6825,9 +6683,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f400b0f7905bf702f9f3dc3df5a121b16c54e9e8012c082905fdf09a931861a"
+checksum = "dbc7bc69c062e492337d74d59b120c274fd3d261b6bf6d3207d499b4b379c41a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -6835,9 +6693,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "423c2ba011d6e27b02b482a3707c773d19aec65cc024637aec44e19652e66f63"
+checksum = "60b75706b9642ebcb34dab3bc7750f811609a0eb1dd8b88c2d15bf628c1c65b2"
 dependencies = [
  "pest",
  "pest_generator",
@@ -6845,9 +6703,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e64e6c2c85031c02fdbd9e5c72845445ca0a724d419aa0bc068ac620c9935c1"
+checksum = "f4f9272122f5979a6511a749af9db9bfc810393f63119970d7085fed1c4ea0db"
 dependencies = [
  "pest",
  "pest_meta",
@@ -6858,9 +6716,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57959b91f0a133f89a68be874a5c88ed689c19cd729ecdb5d762ebf16c64d662"
+checksum = "4c8717927f9b79515e565a64fe46c38b8cd0427e64c40680b14a7365ab09ac8d"
 dependencies = [
  "once_cell",
  "pest",
@@ -6921,19 +6779,9 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
 dependencies = [
- "der 0.5.1",
- "spki 0.5.4",
+ "der",
+ "spki",
  "zeroize",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.0",
- "spki 0.6.0",
 ]
 
 [[package]]
@@ -6950,16 +6798,16 @@ checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
 
 [[package]]
 name = "polling"
-version = "2.5.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "166ca89eb77fd403230b9c156612965a81e094ec6ec3aa13663d4c8b113fa748"
+checksum = "ab4609a838d88b73d8238967b60dd115cc08d38e2bbaf51ee1e4b695f89122e2"
 dependencies = [
  "autocfg",
  "cfg-if",
  "libc",
  "log",
  "wepoll-ffi",
- "windows-sys 0.42.0",
+ "winapi",
 ]
 
 [[package]]
@@ -6993,9 +6841,9 @@ checksum = "15eb2c6e362923af47e13c23ca5afb859e83d54452c55b0b9ac763b8f7c1ac16"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "pretty_assertions"
@@ -7007,16 +6855,6 @@ dependencies = [
  "diff",
  "output_vt100",
  "yansi",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]
@@ -7177,12 +7015,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b18e655c21ff5ac2084a5ad0611e827b3f92badf79f4910b5a5c58f4d87ff0"
+checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
 dependencies = [
  "bytes",
- "prost-derive 0.11.2",
+ "prost-derive 0.11.0",
 ]
 
 [[package]]
@@ -7209,9 +7047,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e330bf1316db56b12c2bcfa399e8edddd4821965ea25ddb2c134b610b1c1c604"
+checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
 dependencies = [
  "bytes",
  "heck 0.4.0",
@@ -7220,11 +7058,9 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease",
- "prost 0.11.3",
- "prost-types 0.11.2",
+ "prost 0.11.0",
+ "prost-types 0.11.1",
  "regex",
- "syn",
  "tempfile",
  "which",
 ]
@@ -7244,13 +7080,13 @@ dependencies = [
 
 [[package]]
 name = "prost-codec"
-version = "0.3.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc34979ff898b6e141106178981ce2596c387ea6e62533facfc61a37fc879c0"
+checksum = "011ae9ff8359df7915f97302d591cdd9e0e27fbd5a4ddc5bd13b71079bb20987"
 dependencies = [
  "asynchronous-codec",
  "bytes",
- "prost 0.11.3",
+ "prost 0.11.0",
  "thiserror",
  "unsigned-varint",
 ]
@@ -7270,9 +7106,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164ae68b6587001ca506d3bf7f1000bfa248d0e1217b618108fba4ec1d0cc306"
+checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
 dependencies = [
  "anyhow",
  "itertools",
@@ -7293,12 +7129,12 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.2"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
+checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
 dependencies = [
  "bytes",
- "prost 0.11.3",
+ "prost 0.11.0",
 ]
 
 [[package]]
@@ -7601,9 +7437,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "region"
@@ -7636,9 +7472,9 @@ dependencies = [
 [[package]]
 name = "remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
- "env_logger 0.9.3",
+ "env_logger",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
@@ -7699,7 +7535,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -7775,12 +7611,11 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.2.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322"
+checksum = "20c9f5d2a0c3e2ea729ab3706d22217177770654c3ef5056b68b69d07332d3f5"
 dependencies = [
  "libc",
- "rtoolbox",
  "winapi",
 ]
 
@@ -7797,16 +7632,6 @@ dependencies = [
  "netlink-proto",
  "nix 0.24.2",
  "thiserror",
-]
-
-[[package]]
-name = "rtoolbox"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -7844,23 +7669,9 @@ checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes 0.7.5",
+ "io-lifetimes",
  "libc",
- "linux-raw-sys 0.0.46",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "rustix"
-version = "0.36.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes 1.0.3",
- "libc",
- "linux-raw-sys 0.1.3",
+ "linux-raw-sys",
  "windows-sys 0.42.0",
 ]
 
@@ -7953,7 +7764,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "log",
  "sp-core",
@@ -7964,7 +7775,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "async-trait",
  "futures",
@@ -7973,8 +7784,8 @@ dependencies = [
  "libp2p 0.46.1",
  "log",
  "parity-scale-codec",
- "prost 0.11.3",
- "prost-build 0.11.3",
+ "prost 0.11.0",
+ "prost-build 0.11.1",
  "rand 0.7.3",
  "sc-client-api",
  "sc-network-common",
@@ -7991,7 +7802,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -8007,7 +7818,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "impl-trait-for-tuples",
  "memmap2",
@@ -8024,7 +7835,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "proc-macro-crate 1.2.1",
  "proc-macro2",
@@ -8035,7 +7846,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -8075,7 +7886,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "fnv",
  "futures",
@@ -8103,7 +7914,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -8128,7 +7939,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "async-trait",
  "futures",
@@ -8152,7 +7963,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -8194,7 +8005,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -8216,7 +8027,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -8229,7 +8040,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "async-trait",
  "futures",
@@ -8253,7 +8064,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "lazy_static",
  "lru 0.7.8",
@@ -8280,7 +8091,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "environmental",
  "log",
@@ -8300,7 +8111,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8315,7 +8126,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "cfg-if",
  "libc",
@@ -8323,7 +8134,7 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "parity-wasm 0.45.0",
- "rustix 0.35.13",
+ "rustix",
  "sc-allocator",
  "sc-executor-common",
  "sp-runtime-interface",
@@ -8335,7 +8146,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -8376,7 +8187,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -8397,7 +8208,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "ansi_term",
  "futures",
@@ -8414,7 +8225,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -8429,7 +8240,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -8451,7 +8262,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "pin-project",
- "prost 0.11.3",
+ "prost 0.11.0",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-client-api",
@@ -8476,14 +8287,14 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "cid",
  "futures",
  "libp2p 0.46.1",
  "log",
- "prost 0.11.3",
- "prost-build 0.11.3",
+ "prost 0.11.0",
+ "prost-build 0.11.1",
  "sc-client-api",
  "sc-network-common",
  "sp-blockchain",
@@ -8496,7 +8307,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -8506,7 +8317,7 @@ dependencies = [
  "libp2p 0.46.1",
  "linked_hash_set",
  "parity-scale-codec",
- "prost-build 0.11.3",
+ "prost-build 0.11.1",
  "sc-consensus",
  "sc-peerset",
  "serde",
@@ -8522,7 +8333,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "ahash",
  "futures",
@@ -8540,15 +8351,15 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "array-bytes",
  "futures",
  "libp2p 0.46.1",
  "log",
  "parity-scale-codec",
- "prost 0.11.3",
- "prost-build 0.11.3",
+ "prost 0.11.0",
+ "prost-build 0.11.1",
  "sc-client-api",
  "sc-network-common",
  "sc-peerset",
@@ -8561,7 +8372,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "array-bytes",
  "fork-tree",
@@ -8570,8 +8381,8 @@ dependencies = [
  "log",
  "lru 0.7.8",
  "parity-scale-codec",
- "prost 0.11.3",
- "prost-build 0.11.3",
+ "prost 0.11.0",
+ "prost-build 0.11.1",
  "sc-client-api",
  "sc-consensus",
  "sc-network-common",
@@ -8589,7 +8400,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "array-bytes",
  "futures",
@@ -8608,7 +8419,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -8638,7 +8449,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "futures",
  "libp2p 0.46.1",
@@ -8651,7 +8462,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -8660,7 +8471,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "futures",
  "hash-db",
@@ -8690,7 +8501,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -8713,7 +8524,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -8726,7 +8537,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "futures",
  "hex",
@@ -8745,7 +8556,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "async-trait",
  "directories",
@@ -8816,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8830,7 +8641,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -8849,7 +8660,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "futures",
  "libc",
@@ -8868,7 +8679,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "chrono",
  "futures",
@@ -8886,7 +8697,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "ansi_term",
  "atty",
@@ -8917,7 +8728,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "proc-macro-crate 1.2.1",
  "proc-macro2",
@@ -8928,7 +8739,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "async-trait",
  "futures",
@@ -8955,7 +8766,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "async-trait",
  "futures",
@@ -8969,7 +8780,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -9113,23 +8924,10 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
 dependencies = [
- "der 0.5.1",
+ "der",
  "generic-array 0.14.6",
- "pkcs8 0.8.0",
+ "pkcs8",
  "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sec1"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
-dependencies = [
- "base16ct",
- "der 0.6.0",
- "generic-array 0.14.6",
- "pkcs8 0.9.0",
  "zeroize",
 ]
 
@@ -9229,9 +9027,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.148"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
@@ -9247,9 +9045,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.148"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9332,7 +9130,7 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -9368,7 +9166,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -9377,7 +9175,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.5",
  "keccak",
 ]
 
@@ -9460,9 +9258,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "snap"
-version = "1.1.0"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
+checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "snow"
@@ -9510,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "hash-db",
  "log",
@@ -9528,7 +9326,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "blake2",
  "proc-macro-crate 1.2.1",
@@ -9540,7 +9338,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9553,7 +9351,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "5.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -9568,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9581,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9593,7 +9391,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9605,7 +9403,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "futures",
  "log",
@@ -9623,7 +9421,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "async-trait",
  "futures",
@@ -9642,7 +9440,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "async-trait",
  "merlin",
@@ -9665,7 +9463,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9679,7 +9477,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9692,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "array-bytes",
  "base58",
@@ -9738,11 +9536,11 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "blake2",
  "byteorder",
- "digest 0.10.6",
+ "digest 0.10.5",
  "sha2 0.10.6",
  "sha3",
  "sp-std",
@@ -9752,7 +9550,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9763,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -9772,7 +9570,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "4.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9782,7 +9580,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.12.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9793,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -9811,7 +9609,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -9825,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "bytes",
  "futures",
@@ -9851,7 +9649,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -9862,7 +9660,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.12.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "async-trait",
  "futures",
@@ -9879,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "thiserror",
  "zstd",
@@ -9888,7 +9686,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -9898,7 +9696,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "4.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -9908,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -9918,7 +9716,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -9941,7 +9739,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -9959,7 +9757,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.2.1",
@@ -9971,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9985,7 +9783,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9999,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10010,7 +9808,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.12.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "hash-db",
  "log",
@@ -10032,12 +9830,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 
 [[package]]
 name = "sp-storage"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10050,7 +9848,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "log",
  "sp-core",
@@ -10063,7 +9861,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -10079,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "5.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -10091,7 +9889,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -10100,7 +9898,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "async-trait",
  "log",
@@ -10116,14 +9914,14 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "ahash",
  "hash-db",
  "hashbrown 0.12.3",
  "lazy_static",
  "lru 0.7.8",
- "memory-db 0.30.0",
+ "memory-db",
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -10139,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10156,7 +9954,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -10167,7 +9965,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "6.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -10180,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -10212,24 +10010,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
 dependencies = [
  "base64ct",
- "der 0.5.1",
-]
-
-[[package]]
-name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.0",
+ "der",
 ]
 
 [[package]]
 name = "ss58-registry"
-version = "1.35.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0813c10b9dbdc842c2305f949f724c64866e4ef4d09c9151e96f6a2106773c"
+checksum = "3ab7554f8a8b6f8d71cd5a8e6536ef116e2ce0504cf97ebf16311d58065dc8a6"
 dependencies = [
  "Inflector",
  "num-format",
@@ -10373,7 +10161,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "platforms",
 ]
@@ -10381,7 +10169,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -10402,7 +10190,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "futures-util",
  "hyper",
@@ -10415,7 +10203,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "jsonrpsee",
  "log",
@@ -10436,7 +10224,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -10462,7 +10250,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -10559,9 +10347,9 @@ checksum = "7c68d531d83ec6c531150584c42a4290911964d5f0d79132b193b67252a23b71"
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10633,9 +10421,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.5"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
 
 [[package]]
 name = "tempfile"
@@ -10668,15 +10456,6 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "test-syscalls"
-version = "0.1.0"
-dependencies = [
- "gear-wasm-builder",
- "gstd",
- "parity-scale-codec",
 ]
 
 [[package]]
@@ -10751,9 +10530,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
@@ -10762,11 +10541,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
 dependencies = [
  "itoa",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -10780,9 +10561,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
 dependencies = [
  "time-core",
 ]
@@ -10843,9 +10624,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10924,7 +10705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.17",
+ "time 0.3.16",
  "tracing-subscriber 0.3.16",
 ]
 
@@ -11108,7 +10889,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#92cac9c73ba31ee470640260316b625655110b3e"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-stable#3941d3027cd94417688ec34109ed01bb10c81af3"
 dependencies = [
  "clap 3.2.23",
  "frame-try-runtime",
@@ -11133,9 +10914,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.72"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db29f438342820400f2d9acfec0d363e987a38b2950bdb50a7069ed17b2148ee"
+checksum = "ea496675d71016e9bc76aa42d87f16aefd95447cc5818e671e12b2d7e269075d"
 dependencies = [
  "dissimilar",
  "glob 0.3.0",
@@ -11160,7 +10941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "digest 0.10.6",
+ "digest 0.10.5",
  "rand 0.8.5",
  "static_assertions",
 ]
@@ -11179,9 +10960,9 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "uint"
-version = "0.9.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+checksum = "a45526d29728d135c2900b0d30573fe3ee79fceb12ef534c7bb30e810a91b601"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -11583,7 +11364,7 @@ name = "wasm-proc"
 version = "0.1.0"
 dependencies = [
  "clap 3.2.23",
- "env_logger 0.10.0",
+ "env_logger",
  "gear-wasm-builder",
  "log",
  "parity-wasm 0.45.0",
@@ -11748,7 +11529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
 dependencies = [
  "cfg-if",
- "enum-iterator 0.7.0",
+ "enum-iterator",
  "enumset",
  "leb128",
  "libloading",
@@ -11793,7 +11574,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
 dependencies = [
- "enum-iterator 0.7.0",
+ "enum-iterator",
  "enumset",
  "loupe",
  "rkyv",
@@ -11822,7 +11603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
 dependencies = [
  "backtrace",
- "enum-iterator 0.7.0",
+ "enum-iterator",
  "indexmap",
  "loupe",
  "more-asserts",
@@ -11841,13 +11622,13 @@ dependencies = [
  "cc",
  "cfg-if",
  "corosensei",
- "enum-iterator 0.7.0",
+ "enum-iterator",
  "indexmap",
  "lazy_static",
  "libc",
  "loupe",
  "mach",
- "memoffset 0.6.5",
+ "memoffset",
  "more-asserts",
  "region",
  "rkyv",
@@ -11991,9 +11772,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad5af6ba38311282f2a21670d96e78266e8c8e2f38cbcd52c254df6ccbc7731"
+checksum = "f1f511c4917c83d04da68333921107db75747c4e11a2f654a8e909cc5e0520dc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12022,18 +11803,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45de63ddfc8b9223d1adc8f7b2ee5f35d1f6d112833934ad7ea66e4f4339e597"
+checksum = "39bf3debfe744bf19dd3732990ce6f8c0ced7439e2370ba4e1d8f5a3660a3178"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd849399d17d2270141cfe47fa0d91ee52d5f8ea9b98cf7ddde0d53e5f79882"
+checksum = "ece42fa4676a263f7558cdaaf5a71c2592bebcbac22a0580e33cf3406c103da2"
 dependencies = [
  "anyhow",
  "base64",
@@ -12041,7 +11822,7 @@ dependencies = [
  "directories-next",
  "file-per-thread-logger",
  "log",
- "rustix 0.35.13",
+ "rustix",
  "serde",
  "sha2 0.9.9",
  "toml",
@@ -12051,9 +11832,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd91339b742ff20bfed4532a27b73c86b5bcbfedd6bea2dcdf2d64471e1b5c6"
+checksum = "058217e28644b012bdcdf0e445f58d496d78c2e0b6a6dd93558e701591dad705"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -12072,9 +11853,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb881c61f4f627b5d45c54e629724974f8a8890d455bcbe634330cc27309644"
+checksum = "c7af06848df28b7661471d9a80d30a973e0f401f2e3ed5396ad7e225ed217047"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -12091,22 +11872,22 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e867cf58e31bfa0ab137bd47e207d2e1e38c581d7838b2f258d47c8145db412"
+checksum = "18fc45a6497f557382fc19b8782ad5d47ce3fced469bdaf303ec6b5b2e83c1a6"
 dependencies = [
  "cc",
  "cfg-if",
- "rustix 0.35.13",
+ "rustix",
  "wasmtime-asm-macros",
  "windows-sys 0.36.1",
 ]
 
 [[package]]
 name = "wasmtime-jit"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1985c628011fe26adf5e23a5301bdc79b245e0e338f14bb58b39e4e25e4d8681"
+checksum = "9028fb63a54185b3c192b7500ef8039c7bb8d7f62bfc9e7c258483a33a3d13bb"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -12118,7 +11899,7 @@ dependencies = [
  "log",
  "object 0.29.0",
  "rustc-demangle",
- "rustix 0.35.13",
+ "rustix",
  "serde",
  "target-lexicon",
  "thiserror",
@@ -12130,20 +11911,20 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f671b588486f5ccec8c5a3dba6b4c07eac2e66ab8c60e6f4e53717c77f709731"
+checksum = "25e82d4ef93296785de7efca92f7679dc67fe68a13b625a5ecc8d7503b377a37"
 dependencies = [
  "object 0.29.0",
  "once_cell",
- "rustix 0.35.13",
+ "rustix",
 ]
 
 [[package]]
 name = "wasmtime-runtime"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8f92ad4b61736339c29361da85769ebc200f184361959d1792832e592a1afd"
+checksum = "9f0e9bea7d517d114fe66b930b2124ee086516ee93eeebfd97f75f366c5b0553"
 dependencies = [
  "anyhow",
  "cc",
@@ -12153,10 +11934,10 @@ dependencies = [
  "log",
  "mach",
  "memfd",
- "memoffset 0.6.5",
+ "memoffset",
  "paste",
  "rand 0.8.5",
- "rustix 0.35.13",
+ "rustix",
  "thiserror",
  "wasmtime-asm-macros",
  "wasmtime-environ",
@@ -12167,9 +11948,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23d61cb4c46e837b431196dd06abb11731541021916d03476a178b54dc07aeb"
+checksum = "69b83e93ed41b8fdc936244cfd5e455480cf1eca1fd60c78a0040038b4ce5075"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -12483,6 +12264,15 @@ checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
@@ -12492,9 +12282,9 @@ dependencies = [
 
 [[package]]
 name = "wyz"
-version = "0.5.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
 dependencies = [
  "tap",
 ]
@@ -12622,9 +12412,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.4+zstd.1.5.2"
+version = "2.0.1+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa202f2ef00074143e219d15b62ffc317d17cc33909feac471c044087cad7b0"
+checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,6 +3150,7 @@ version = "0.1.0"
 dependencies = [
  "cfg-if",
  "derive_more",
+ "env_logger 0.9.3",
  "errno",
  "gear-core",
  "libc",
@@ -3318,12 +3319,10 @@ name = "gear-runtime-interface"
 version = "0.1.0"
 dependencies = [
  "derive_more",
- "env_logger 0.9.3",
  "gear-core",
  "gear-lazy-pages",
  "libc",
  "log",
- "nix 0.24.2",
  "parity-scale-codec",
  "region",
  "sp-runtime-interface",
@@ -5865,7 +5864,6 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset 0.6.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3158,8 +3158,10 @@ dependencies = [
  "nix 0.25.0",
  "once_cell",
  "region",
+ "sc-executor-common",
  "sp-io",
  "sp-std",
+ "sp-wasm-interface",
  "static_assertions",
  "winapi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,7 +1218,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.6.5",
  "scopeguard",
 ]
 
@@ -3154,11 +3154,10 @@ dependencies = [
  "env_logger 0.10.0",
  "errno",
  "gear-core",
- "increment",
  "libc",
  "log",
  "mach",
- "nix 0.25.0",
+ "nix 0.26.1",
  "once_cell",
  "region",
  "sc-executor-common",
@@ -4117,12 +4116,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "increment"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0e22a10d95652add19cd2f9a35c2cb143f164181ccac7576784870bf17387d"
 
 [[package]]
 name = "indenter"
@@ -5512,6 +5505,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "memory-db"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5839,7 +5841,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -5855,16 +5857,16 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
+checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
 dependencies = [
- "autocfg",
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
  "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
@@ -11822,7 +11824,7 @@ dependencies = [
  "libc",
  "loupe",
  "mach",
- "memoffset",
+ "memoffset 0.6.5",
  "more-asserts",
  "region",
  "rkyv",
@@ -12128,7 +12130,7 @@ dependencies = [
  "log",
  "mach",
  "memfd",
- "memoffset",
+ "memoffset 0.6.5",
  "paste",
  "rand 0.8.5",
  "rustix 0.35.13",

--- a/common/lazy-pages/src/lib.rs
+++ b/common/lazy-pages/src/lib.rs
@@ -24,7 +24,7 @@ use core::fmt;
 use gear_common::{pages_prefix, Origin};
 use gear_core::{
     ids::ProgramId,
-    memory::{HostPointer, Memory, PageNumber, WasmPageNumber}, lazy_pages::GlobalsCtx,
+    memory::{HostPointer, Memory, PageNumber, WasmPageNumber}, lazy_pages::{GlobalsCtx, Status},
 };
 use gear_runtime_interface::gear_ri;
 use sp_std::vec::Vec;
@@ -116,4 +116,9 @@ pub fn get_released_pages() -> Vec<PageNumber> {
         .into_iter()
         .map(PageNumber)
         .collect()
+}
+
+/// Returns lazy pages actual status.
+pub fn get_status() -> Option<Status> {
+    gear_ri::get_lazy_pages_status()
 }

--- a/common/lazy-pages/src/lib.rs
+++ b/common/lazy-pages/src/lib.rs
@@ -24,7 +24,8 @@ use core::fmt;
 use gear_common::{pages_prefix, Origin};
 use gear_core::{
     ids::ProgramId,
-    memory::{HostPointer, Memory, PageNumber, WasmPageNumber}, lazy_pages::{GlobalsCtx, Status},
+    lazy_pages::{GlobalsCtx, Status},
+    memory::{HostPointer, Memory, PageNumber, WasmPageNumber},
 };
 use gear_runtime_interface::gear_ri;
 use sp_std::vec::Vec;

--- a/common/lazy-pages/src/lib.rs
+++ b/common/lazy-pages/src/lib.rs
@@ -25,7 +25,7 @@ use gear_common::{pages_prefix, Origin};
 use gear_core::{
     ids::ProgramId,
     lazy_pages::{GlobalsCtx, Status},
-    memory::{HostPointer, Memory, PageNumber, WasmPageNumber},
+    memory::{HostPointer, Memory, PageNumber, PageU32Size, WasmPageNumber},
 };
 use gear_runtime_interface::gear_ri;
 use sp_std::vec::Vec;
@@ -54,13 +54,13 @@ pub fn init_for_program(
     let program_prefix = crate::pages_prefix(prog_id.into_origin());
     let wasm_mem_addr = mem.get_buffer_host_addr();
     let wasm_mem_size = mem.size();
-    let stack_end_page = stack_end.map(|p| p.0);
+    let stack_end_page = stack_end.map(|page| page.raw());
 
     // Cannot panic unless OS allocates buffer in not aligned by native page addr, or
     // something goes wrong with pages protection.
     gear_ri::init_lazy_pages_for_program(
         wasm_mem_addr,
-        wasm_mem_size.0,
+        wasm_mem_size.raw(),
         stack_end_page,
         program_prefix,
         globals_ctx,
@@ -105,7 +105,7 @@ pub fn update_lazy_pages_and_protect_again(
 
     let new_mem_size = mem.size();
     if new_mem_size > old_mem_size {
-        gear_ri::set_wasm_mem_size(new_mem_size.0);
+        gear_ri::set_wasm_mem_size(new_mem_size.raw());
     }
 
     mprotect_lazy_pages(mem, true);
@@ -115,7 +115,7 @@ pub fn update_lazy_pages_and_protect_again(
 pub fn get_released_pages() -> Vec<PageNumber> {
     gear_ri::get_released_pages()
         .into_iter()
-        .map(PageNumber)
+        .map(|p| PageNumber::new(p).expect("Unexpected lazy pages behavior"))
         .collect()
 }
 

--- a/common/lazy-pages/src/lib.rs
+++ b/common/lazy-pages/src/lib.rs
@@ -24,7 +24,7 @@ use core::fmt;
 use gear_common::{pages_prefix, Origin};
 use gear_core::{
     ids::ProgramId,
-    memory::{HostPointer, Memory, PageNumber, WasmPageNumber},
+    memory::{HostPointer, Memory, PageNumber, WasmPageNumber}, lazy_pages::GlobalsCtx,
 };
 use gear_runtime_interface::gear_ri;
 use sp_std::vec::Vec;
@@ -48,6 +48,7 @@ pub fn init_for_program(
     mem: &mut impl Memory,
     prog_id: ProgramId,
     stack_end: Option<WasmPageNumber>,
+    globals_ctx: Option<GlobalsCtx>,
 ) {
     let program_prefix = crate::pages_prefix(prog_id.into_origin());
     let wasm_mem_addr = mem.get_buffer_host_addr();
@@ -61,6 +62,7 @@ pub fn init_for_program(
         wasm_mem_size.0,
         stack_end_page,
         program_prefix,
+        globals_ctx,
     );
 }
 

--- a/common/src/benchmarking.rs
+++ b/common/src/benchmarking.rs
@@ -18,7 +18,7 @@
 
 use super::*;
 
-use gear_core::memory::{PageNumber, WasmPageNumber};
+use gear_core::memory::{PageNumber, WasmPageNumber, to_page_iter};
 use gear_wasm_instrument::parity_wasm::{self, elements::*};
 use sp_io::hashing::blake2_256;
 use sp_std::borrow::ToOwned;
@@ -43,7 +43,7 @@ pub fn create_module(num_pages: WasmPageNumber) -> parity_wasm::elements::Module
         Section::Import(ImportSection::with_entries(vec![ImportEntry::new(
             "env".into(),
             "memory".into(),
-            External::Memory(MemoryType::new(num_pages.0, None)),
+            External::Memory(MemoryType::new(num_pages.raw(), None)),
         )])),
         Section::Function(FunctionSection::with_entries(vec![Func::new(0)])),
         Section::Export(ExportSection::with_entries(vec![ExportEntry::new(
@@ -106,7 +106,7 @@ pub fn generate_wasm2(num_pages: WasmPageNumber) -> Result<Vec<u8>, &'static str
             FuncBody::new(
                 vec![Local::new(1, ValueType::I32)],
                 Instructions::new(vec![
-                    Instruction::I32Const(num_pages.0 as i32),
+                    Instruction::I32Const(num_pages.raw() as i32),
                     Instruction::Call(0),
                     Instruction::SetLocal(0),
                     Instruction::End,
@@ -120,7 +120,7 @@ pub fn generate_wasm2(num_pages: WasmPageNumber) -> Result<Vec<u8>, &'static str
 }
 
 pub fn generate_wasm3(payload: Vec<u8>) -> Result<Vec<u8>, &'static str> {
-    let mut module = create_module(WasmPageNumber(1));
+    let mut module = create_module(1.into());
     module
         .insert_section(Section::Custom(CustomSection::new(
             "zeroed_section".to_owned(),
@@ -134,10 +134,10 @@ pub fn generate_wasm3(payload: Vec<u8>) -> Result<Vec<u8>, &'static str> {
 
 pub fn set_program(program_id: H256, code: Vec<u8>, static_pages: WasmPageNumber) {
     let code_id = CodeId::generate(&code).into_origin();
-    let allocations = (0..static_pages.0).map(WasmPageNumber);
+    let allocations = 0.into()..static_pages;
     let persistent_pages_data: BTreeMap<PageNumber, PageBuf> = allocations
         .clone()
-        .flat_map(|p| p.to_gear_pages_iter())
+        .flat_map(|p| to_page_iter(p))
         .map(|p| (p, PageBuf::new_zeroed()))
         .collect();
     super::set_program_and_pages_data(

--- a/common/src/benchmarking.rs
+++ b/common/src/benchmarking.rs
@@ -18,7 +18,7 @@
 
 use super::*;
 
-use gear_core::memory::{PageNumber, WasmPageNumber, to_page_iter};
+use gear_core::memory::{to_page_iter, PageNumber, WasmPageNumber};
 use gear_wasm_instrument::parity_wasm::{self, elements::*};
 use sp_io::hashing::blake2_256;
 use sp_std::borrow::ToOwned;
@@ -137,7 +137,7 @@ pub fn set_program(program_id: H256, code: Vec<u8>, static_pages: WasmPageNumber
     let allocations = 0.into()..static_pages;
     let persistent_pages_data: BTreeMap<PageNumber, PageBuf> = allocations
         .clone()
-        .flat_map(|p| to_page_iter(p))
+        .flat_map(to_page_iter)
         .map(|p| (p, PageBuf::new_zeroed()))
         .collect();
     super::set_program_and_pages_data(

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -42,7 +42,7 @@ use frame_support::{
 };
 use gear_core::{
     ids::{CodeId, MessageId, ProgramId},
-    memory::{Error as MemoryError, PageBuf, PageNumber, WasmPageNumber},
+    memory::{Error as MemoryError, PageBuf, PageNumber, PageU32Size, WasmPageNumber},
     message::DispatchKind,
     reservation::GasReservationMap,
 };
@@ -319,7 +319,7 @@ fn page_key(id: H256, page: PageNumber) -> Vec<u8> {
     key.extend(STORAGE_PROGRAM_PAGES_PREFIX);
     key.extend(id.as_fixed_bytes());
     key.extend(b"::");
-    key.extend(page.0.to_le_bytes());
+    key.extend(page.raw().to_le_bytes());
 
     key
 }
@@ -435,11 +435,7 @@ pub struct PageIsNotAllocatedErr(pub PageNumber);
 
 impl fmt::Display for PageIsNotAllocatedErr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "Page #{:?} is not allocated for current program",
-            self.0 .0
-        )
+        write!(f, "{:?} is not allocated for current program", self.0)
     }
 }
 

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -52,7 +52,7 @@ use gear_core::{
     ids::{CodeId, MessageId, ProgramId, ReservationId},
     memory::{Memory, PageBuf, PageNumber, WasmPageNumber},
     message::{ContextStore, Dispatch, DispatchKind, IncomingDispatch, MessageWaitedType},
-    reservation::GasReserver,
+    reservation::GasReserver, lazy_pages::GlobalsCtx,
 };
 use gear_core_errors::{ExtError, MemoryError};
 use scale_info::TypeInfo;
@@ -294,7 +294,7 @@ pub trait Environment<E: Ext + IntoExtInfo<E::Error> + 'static>: Sized {
         pre_execution_handler: F,
     ) -> Result<BackendReport<Self::Memory, E>, Self::Error>
     where
-        F: FnOnce(&mut Self::Memory, Option<WasmPageNumber>) -> Result<(), T>,
+        F: FnOnce(&mut Self::Memory, Option<WasmPageNumber>, Option<GlobalsCtx>) -> Result<(), T>,
         T: fmt::Display;
 }
 

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -179,7 +179,8 @@ pub enum RuntimeCtxError<E: Display> {
 
 pub trait RuntimeCtx<E: Ext> {
     /// Allocate new pages in instance memory.
-    fn alloc(&mut self, pages: WasmPageNumber) -> Result<WasmPageNumber, RuntimeCtxError<E::Error>>;
+    fn alloc(&mut self, pages: WasmPageNumber)
+        -> Result<WasmPageNumber, RuntimeCtxError<E::Error>>;
 
     /// Read designated chunk from the memory.
     fn read_memory(&self, ptr: u32, len: u32) -> Result<Vec<u8>, RuntimeCtxError<E::Error>>;

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -50,9 +50,10 @@ use gear_core::{
     env::Ext,
     gas::GasAmount,
     ids::{CodeId, MessageId, ProgramId, ReservationId},
+    lazy_pages::GlobalsCtx,
     memory::{Memory, PageBuf, PageNumber, WasmPageNumber},
     message::{ContextStore, Dispatch, DispatchKind, IncomingDispatch, MessageWaitedType},
-    reservation::GasReserver, lazy_pages::GlobalsCtx,
+    reservation::GasReserver,
 };
 use gear_core_errors::{ExtError, MemoryError};
 use scale_info::TypeInfo;

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -179,7 +179,7 @@ pub enum RuntimeCtxError<E: Display> {
 
 pub trait RuntimeCtx<E: Ext> {
     /// Allocate new pages in instance memory.
-    fn alloc(&mut self, pages: u32) -> Result<WasmPageNumber, RuntimeCtxError<E::Error>>;
+    fn alloc(&mut self, pages: WasmPageNumber) -> Result<WasmPageNumber, RuntimeCtxError<E::Error>>;
 
     /// Read designated chunk from the memory.
     fn read_memory(&self, ptr: u32, len: u32) -> Result<Vec<u8>, RuntimeCtxError<E::Error>>;
@@ -221,7 +221,7 @@ pub fn write_memory_as<T: Sized>(
     let slice =
         unsafe { slice::from_raw_parts(&obj as *const T as *const u8, mem::size_of::<T>()) };
 
-    memory.write(ptr as usize, slice)
+    memory.write(ptr, slice)
 }
 
 /// Reads bytes from given pointer to construct type T from them.
@@ -242,7 +242,7 @@ pub fn read_memory_as<T: Sized>(memory: &impl Memory, ptr: u32) -> Result<T, Mem
     let mut_slice =
         unsafe { slice::from_raw_parts_mut(buf.as_mut_ptr() as *mut u8, mem::size_of::<T>()) };
 
-    memory.read(ptr as usize, mut_slice)?;
+    memory.read(ptr, mut_slice)?;
 
     // # Safety:
     //
@@ -261,10 +261,8 @@ pub struct BackendReport<T, E> {
 
 #[derive(Debug, derive_more::Display)]
 pub enum StackEndError {
-    #[display(fmt = "Stack end addr {_0:#x} cannot be negative")]
-    IsNegative(i32),
     #[display(fmt = "Stack end addr {_0:#x} must be aligned to WASM page size")]
-    IsNotAligned(i32),
+    IsNotAligned(u32),
 }
 
 // '__gear_stack_end' export is inserted in wasm-proc or wasm-builder

--- a/core-backend/common/src/mock.rs
+++ b/core-backend/common/src/mock.rs
@@ -238,6 +238,10 @@ impl Ext for MockExt {
     ) -> Result<MessageId, Self::Error> {
         Ok(MessageId::default())
     }
+
+    fn get_runtime_cost(&self, _costs: RuntimeCosts) -> u64 {
+        0
+    }
 }
 
 impl IntoExtInfo<<MockExt as Ext>::Error> for MockExt {

--- a/core-backend/common/src/utils.rs
+++ b/core-backend/common/src/utils.rs
@@ -18,7 +18,7 @@
 
 use crate::StackEndError;
 use alloc::string::String;
-use gear_core::memory::{WasmPageNumber, PageU32Size};
+use gear_core::memory::{PageU32Size, WasmPageNumber};
 
 #[macro_export]
 macro_rules! assert_ok {

--- a/core-backend/common/src/utils.rs
+++ b/core-backend/common/src/utils.rs
@@ -18,7 +18,7 @@
 
 use crate::StackEndError;
 use alloc::string::String;
-use gear_core::memory::WasmPageNumber;
+use gear_core::memory::{WasmPageNumber, PageU32Size};
 
 #[macro_export]
 macro_rules! assert_ok {
@@ -52,16 +52,15 @@ pub(crate) fn smart_truncate(s: &mut String, max_bytes: usize) {
         s.truncate(last_byte);
     }
 }
+
 pub fn calc_stack_end(stack_end: Option<i32>) -> Result<Option<WasmPageNumber>, StackEndError> {
     use StackEndError::*;
     if let Some(stack_end) = stack_end {
-        if stack_end < 0 {
-            return Err(IsNegative(stack_end));
-        }
-        if stack_end as usize % WasmPageNumber::size() != 0 {
+        let stack_end = stack_end as u32;
+        if stack_end % WasmPageNumber::size() != 0 {
             return Err(IsNotAligned(stack_end));
         }
-        Ok(Some(WasmPageNumber::new_from_addr(stack_end as usize)))
+        Ok(Some(WasmPageNumber::from_offset(stack_end)))
     } else {
         Ok(None)
     }

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -293,8 +293,9 @@ where
                 lazy_pages_weights: LazyPagesWeights {
                     read: runtime.ext.get_runtime_cost(RuntimeCosts::LazyPagesRead),
                     write: runtime.ext.get_runtime_cost(RuntimeCosts::LazyPagesWrite),
-                    write_after_read: 100,
-                    update: runtime.ext.get_runtime_cost(RuntimeCosts::LazyPagesUpdate),
+                    write_after_read: runtime
+                        .ext
+                        .get_runtime_cost(RuntimeCosts::LazyPagesWriteAfterRead),
                 },
                 globals_access_ptr: instance.get_instance_ptr(),
                 globals_access_mod: GlobalsAccessMod::WasmRuntime,

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -40,7 +40,7 @@ use gear_core::{
     env::Ext,
     gas::GasAmount,
     lazy_pages::{GlobalsAccessMod, GlobalsCtx, LazyPagesWeights},
-    memory::WasmPageNumber,
+    memory::{WasmPageNumber, PageU32Size},
     message::DispatchKind,
 };
 use gear_wasm_instrument::{
@@ -205,7 +205,7 @@ where
         builder.add_func(ReservationSend, Funcs::reservation_send);
         builder.add_func(ReservationSendCommit, Funcs::reservation_send_commit);
 
-        let memory: DefaultExecutorMemory = match SandboxMemory::new(mem_size.0, None) {
+        let memory: DefaultExecutorMemory = match SandboxMemory::new(mem_size.raw(), None) {
             Ok(mem) => mem,
             Err(e) => return Err((ext.gas_amount(), CreateEnvMemory(e)).into()),
         };

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -40,7 +40,7 @@ use gear_core::{
     env::Ext,
     gas::GasAmount,
     lazy_pages::{GlobalsAccessMod, GlobalsCtx, LazyPagesWeights},
-    memory::{WasmPageNumber, PageU32Size},
+    memory::{PageU32Size, WasmPageNumber},
     message::DispatchKind,
 };
 use gear_wasm_instrument::{

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -43,9 +43,7 @@ use gear_core::{
     memory::{PageU32Size, WasmPageNumber},
     message::DispatchKind,
 };
-use gear_wasm_instrument::{
-    GLOBAL_NAME_ALLOWANCE, GLOBAL_NAME_GAS, IMPORT_NAME_OUT_OF_ALLOWANCE, IMPORT_NAME_OUT_OF_GAS,
-};
+use gear_wasm_instrument::{GLOBAL_NAME_ALLOWANCE, GLOBAL_NAME_GAS};
 use sp_sandbox::{
     default_executor::{EnvironmentDefinitionBuilder, Instance, Memory as DefaultExecutorMemory},
     HostFuncType, InstanceGlobals, ReturnValue, SandboxEnvironmentBuilder, SandboxInstance,

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -407,7 +407,7 @@ where
 
         ctx.run(|ctx| {
             ctx.ext
-                .free(page.into())
+                .free(page)
                 .map(|_| log::debug!("FREE: {:?}", page))
                 .map_err(|err| {
                     log::debug!("FREE ERROR: {}", err);

--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -34,7 +34,7 @@ use gear_core::{
     buffer::{RuntimeBuffer, RuntimeBufferSizeError},
     env::Ext,
     ids::ReservationId,
-    memory::Memory,
+    memory::{Memory, PageU32Size, WasmPageNumber},
     message::{HandlePacket, InitPacket, MessageWaitedType, PayloadSizeError, ReplyPacket},
 };
 use gear_core_errors::{CoreError, MemoryError};
@@ -329,7 +329,7 @@ where
         ctx.run(|ctx| {
             let length = match Self::validated(&mut ctx.ext, at, len) {
                 Ok(buffer) => {
-                    ctx.memory.write(buffer_ptr as usize, buffer)?;
+                    ctx.memory.write(buffer_ptr, buffer)?;
 
                     0u32
                 }
@@ -386,29 +386,29 @@ where
     pub fn alloc(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
         sys_trace!(target: "syscall::gear", "alloc, args = {}", args_to_str(args));
 
-        let pages = args.iter().read()?;
+        let pages = WasmPageNumber::new(args.iter().read()?).map_err(|_| HostError)?;
 
         let res = ctx.run_any(|ctx| {
             ctx.alloc(pages)
                 .map(|page| {
-                    log::debug!("ALLOC: {} pages at {:?}", pages, page);
-                    page.0
+                    log::debug!("ALLOC: {:?} pages at {:?}", pages, page);
+                    page
                 })
                 .map_err(Into::into)
         })?;
 
-        Ok(ReturnValue::Value(Value::I32(res as i32)))
+        Ok(ReturnValue::Value(Value::I32(res.raw() as i32)))
     }
 
     pub fn free(ctx: &mut Runtime<E>, args: &[Value]) -> SyscallOutput {
         sys_trace!(target: "syscall::gear", "free, args = {}", args_to_str(args));
 
-        let page: u32 = args.iter().read()?;
+        let page = WasmPageNumber::new(args.iter().read()?).map_err(|_| HostError)?;
 
         ctx.run(|ctx| {
             ctx.ext
                 .free(page.into())
-                .map(|_| log::debug!("FREE: {}", page))
+                .map(|_| log::debug!("FREE: {:?}", page))
                 .map_err(|err| {
                     log::debug!("FREE ERROR: {}", err);
                     FuncError::Core(err)

--- a/core-backend/sandbox/src/runtime.rs
+++ b/core-backend/sandbox/src/runtime.rs
@@ -86,16 +86,16 @@ impl<E: Ext> Runtime<E> {
 }
 
 impl<E: Ext> RuntimeCtx<E> for Runtime<E> {
-    fn alloc(&mut self, pages: u32) -> Result<WasmPageNumber, RuntimeCtxError<E::Error>> {
+    fn alloc(&mut self, pages: WasmPageNumber) -> Result<WasmPageNumber, RuntimeCtxError<E::Error>> {
         self.ext
-            .alloc(pages.into(), &mut self.memory)
+            .alloc(pages, &mut self.memory)
             .map_err(RuntimeCtxError::Ext)
     }
 
     fn read_memory(&self, ptr: u32, len: u32) -> Result<Vec<u8>, RuntimeCtxError<E::Error>> {
         let mut buf = RuntimeBuffer::try_new_default(len as usize)?;
 
-        self.memory.read(ptr as usize, buf.get_mut())?;
+        self.memory.read(ptr, buf.get_mut())?;
 
         Ok(buf.into_vec())
     }
@@ -105,7 +105,7 @@ impl<E: Ext> RuntimeCtx<E> for Runtime<E> {
         ptr: u32,
         buf: &mut [u8],
     ) -> Result<(), RuntimeCtxError<E::Error>> {
-        self.memory.read(ptr as usize, buf)?;
+        self.memory.read(ptr, buf)?;
 
         Ok(())
     }
@@ -120,7 +120,7 @@ impl<E: Ext> RuntimeCtx<E> for Runtime<E> {
     }
 
     fn write_output(&mut self, out_ptr: u32, buf: &[u8]) -> Result<(), RuntimeCtxError<E::Error>> {
-        self.memory.write(out_ptr as usize, buf).map_err(Into::into)
+        self.memory.write(out_ptr, buf).map_err(Into::into)
     }
 }
 

--- a/core-backend/sandbox/src/runtime.rs
+++ b/core-backend/sandbox/src/runtime.rs
@@ -86,7 +86,10 @@ impl<E: Ext> Runtime<E> {
 }
 
 impl<E: Ext> RuntimeCtx<E> for Runtime<E> {
-    fn alloc(&mut self, pages: WasmPageNumber) -> Result<WasmPageNumber, RuntimeCtxError<E::Error>> {
+    fn alloc(
+        &mut self,
+        pages: WasmPageNumber,
+    ) -> Result<WasmPageNumber, RuntimeCtxError<E::Error>> {
         self.ext
             .alloc(pages, &mut self.memory)
             .map_err(RuntimeCtxError::Ext)

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -42,7 +42,7 @@ use gear_core::{
     lazy_pages::{
         GlobalsAccessError, GlobalsAccessMod, GlobalsAccessTrait, GlobalsCtx, LazyPagesWeights,
     },
-    memory::{HostPointer, WasmPageNumber},
+    memory::{HostPointer, WasmPageNumber, PageU32Size},
     message::DispatchKind,
 };
 use gear_wasm_instrument::{GLOBAL_NAME_ALLOWANCE, GLOBAL_NAME_GAS};
@@ -175,7 +175,7 @@ where
 
         let mut linker: Linker<HostState<E>> = Linker::new();
 
-        let memory_type = MemoryType::new(mem_size.0, None);
+        let memory_type = MemoryType::new(mem_size.raw(), None);
         let memory = Memory::new(&mut store, memory_type)
             .map_err(|e| (ext.gas_amount(), CreateEnvMemory(e)))?;
 

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -36,11 +36,14 @@ use gear_backend_common::{
     STACK_END_EXPORT_NAME,
 };
 use gear_core::{
+    costs::RuntimeCosts,
     env::Ext,
     gas::GasAmount,
-    lazy_pages::{GlobalsAccessError, GlobalsAccessTrait, GlobalsCtx, LazyPagesWeights, GlobalsAccessMod},
+    lazy_pages::{
+        GlobalsAccessError, GlobalsAccessMod, GlobalsAccessTrait, GlobalsCtx, LazyPagesWeights,
+    },
     memory::{HostPointer, WasmPageNumber},
-    message::DispatchKind, costs::RuntimeCosts,
+    message::DispatchKind,
 };
 use gear_wasm_instrument::{GLOBAL_NAME_ALLOWANCE, GLOBAL_NAME_GAS};
 use wasmi::{
@@ -353,7 +356,10 @@ where
             (gas_amount!(store), WrongInjectedAllowance)
         })?;
 
-        let runtime = store.state_mut().take().expect("is set before in `new`; qed");
+        let runtime = store
+            .state_mut()
+            .take()
+            .expect("is set before in `new`; qed");
 
         let State {
             mut ext, err: trap, ..

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -267,10 +267,11 @@ where
             global_gas_name: GLOBAL_NAME_GAS.to_string(),
             global_allowance_name: GLOBAL_NAME_ALLOWANCE.to_string(),
             global_state_name: "gear_status".to_string(),
-            lazy_pages_costs: gear_core::lazy_pages::LazyPagesCosts {
-                read_page: 1,
-                write_page: 1,
-                update_page: 1,
+            lazy_pages_weights: gear_core::lazy_pages::LazyPagesWeights {
+                read: 1,
+                write: 1,
+                write_after_read: 1,
+                update: 1,
             },
             globals_access_ptr,
             globals_access_mod: gear_core::lazy_pages::GlobalsAccessMod::NativeRuntime,

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -138,6 +138,14 @@ impl<E: Ext + 'static> GlobalsAccessTrait for Lol<E> {
             .ok_or(GlobalsAccessError)
     }
 
+    fn get_i32(&self, _name: &str) -> Result<i32, GlobalsAccessError> {
+        todo!("Currently useless")
+    }
+
+    fn set_i32(&mut self, _name: &str, _value: i32) -> Result<(), GlobalsAccessError> {
+        todo!("Currently useless")
+    }
+
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -42,7 +42,7 @@ use gear_core::{
     lazy_pages::{
         GlobalsAccessError, GlobalsAccessMod, GlobalsAccessTrait, GlobalsCtx, LazyPagesWeights,
     },
-    memory::{HostPointer, WasmPageNumber, PageU32Size},
+    memory::{HostPointer, PageU32Size, WasmPageNumber},
     message::DispatchKind,
 };
 use gear_wasm_instrument::{GLOBAL_NAME_ALLOWANCE, GLOBAL_NAME_GAS};

--- a/core-backend/wasmi/src/funcs/mod.rs
+++ b/core-backend/wasmi/src/funcs/mod.rs
@@ -1150,7 +1150,7 @@ where
                 |ext| ext.reply_push_input(offset, len),
                 |res, mut mem_ref| {
                     let len = res.map(|_| 0).unwrap_or_else(|e| e);
-                    mem_ref.write(err_ptr as usize, &len.to_le_bytes())
+                    mem_ref.write(err_ptr, &len.to_le_bytes())
                 },
             )
         };
@@ -1280,7 +1280,7 @@ where
                 |ext| ext.send_push_input(handle, offset, len),
                 |res, mut mem_ref| {
                     let len = res.map(|_| 0).unwrap_or_else(|e| e);
-                    mem_ref.write(err_ptr as usize, &len.to_le_bytes())
+                    mem_ref.write(err_ptr, &len.to_le_bytes())
                 },
             )
         };

--- a/core-backend/wasmi/src/funcs/mod.rs
+++ b/core-backend/wasmi/src/funcs/mod.rs
@@ -671,7 +671,7 @@ where
 
             let mut caller = CallerWrap::prepare(caller, forbidden)?;
 
-            if let Err(e) = caller.host_state_mut().ext.free(page.into()) {
+            if let Err(e) = caller.host_state_mut().ext.free(page) {
                 log::debug!("FREE ERROR: {e}");
                 caller.host_state_mut().err = FuncError::Core(e);
 

--- a/core-backend/wasmi/src/memory.rs
+++ b/core-backend/wasmi/src/memory.rs
@@ -99,7 +99,7 @@ impl<E: Ext + IntoExtInfo<E::Error> + 'static> MemoryWrap<E> {
     pub fn new(memory: WasmiMemory, store: Store<HostState<E>>) -> Self {
         MemoryWrap { memory, store }
     }
-    pub fn drop(self) -> Store<HostState<E>> {
+    pub fn into_store(self) -> Store<HostState<E>> {
         self.store
     }
 }

--- a/core-backend/wasmi/src/memory.rs
+++ b/core-backend/wasmi/src/memory.rs
@@ -99,6 +99,9 @@ impl<E: Ext + IntoExtInfo<E::Error> + 'static> MemoryWrap<E> {
     pub fn new(memory: WasmiMemory, store: Store<HostState<E>>) -> Self {
         MemoryWrap { memory, store }
     }
+    pub fn drop(self) -> Store<HostState<E>> {
+        self.store
+    }
 }
 
 /// Memory interface for the allocator.

--- a/core-errors/src/lib.rs
+++ b/core-errors/src/lib.rs
@@ -149,7 +149,7 @@ pub enum WaitError {
 pub enum MemoryError {
     /// The error occurs when a program tries to allocate more memory  than
     /// allowed.
-    #[display(fmt = "Memory memory out of maximal bounds")]
+    #[display(fmt = "Memory access out of bounds")]
     OutOfBounds,
 
     /// The error occurs in attempt to free-up a memory page from static area or

--- a/core-errors/src/lib.rs
+++ b/core-errors/src/lib.rs
@@ -169,6 +169,11 @@ pub enum MemoryError {
     /// Memory size cannot be zero after grow is applied for memory
     #[display(fmt = "Memory unexpectedly has zero size after grow")]
     MemSizeIsZeroAfterGrow,
+
+    // TODO: make separate error for alloc in allocations context
+    /// Memory size cannot be zero after grow is applied for memory
+    #[display(fmt = "Allocated memory pages or memory size are incorrect")]
+    IncorrectAllocationsSetOrMemSize,
 }
 
 /// Execution error.

--- a/core-processor/Cargo.toml
+++ b/core-processor/Cargo.toml
@@ -14,6 +14,7 @@ codec = { package = "parity-scale-codec", version = "3.1.2", features = ["derive
 scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 derive_more = "0.99.17"
+static_assertions = "1"
 
 [features]
 strict = []

--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -408,7 +408,7 @@ pub struct ExecutionError {
 /// Operation related to gas charging.
 #[derive(Encode, Decode, TypeInfo, Debug, PartialEq, Eq, PartialOrd, Ord, derive_more::Display)]
 pub enum GasOperation {
-    /// Load exisisting memory.
+    /// Load existing memory.
     #[display(fmt = "load memory")]
     LoadMemory,
     /// Grow memory size.
@@ -479,6 +479,9 @@ pub enum ExecutionErrorReason {
     /// It's not allowed to set initial data for stack memory pages, if they are specified in WASM code.
     #[display(fmt = "Set initial data for stack pages is restricted")]
     StackPagesHaveInitialData,
+    /// Lazy page status must be set before contract execution.
+    #[display(fmt = "Lazy page status must be set before contract execution")]
+    LazyPagesStatusIsNone,
 }
 
 /// Actor.

--- a/core-processor/src/configs.rs
+++ b/core-processor/src/configs.rs
@@ -55,7 +55,7 @@ pub struct AllocationsConfig {
 impl Default for AllocationsConfig {
     fn default() -> Self {
         Self {
-            max_pages: WasmPageNumber(code::MAX_WASM_PAGE_COUNT),
+            max_pages: code::MAX_WASM_PAGE_COUNT.into(),
             init_cost: INIT_COST,
             alloc_cost: ALLOC_COST,
             mem_grow_cost: MEM_GROW_COST,

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -160,6 +160,10 @@ pub(crate) fn charge_gas_for_instantiation(
 
 /// Charge gas for pages init/load/grow and checks that there is enough gas for that.
 /// Returns size of wasm memory buffer which must be created in execution environment.
+// TODO: remove charging for pages access/write/read/upload. But we should charge for
+// potential situation when gas limit/allowance exceeded during lazy-pages handling,
+// but we should continue execution until the end of block. During that execution
+// another signals can occur, which also take some time to process them.
 pub(crate) fn charge_gas_for_pages(
     settings: &AllocationsConfig,
     gas_counter: &mut GasCounter,

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -40,7 +40,7 @@ use gear_core::{
     message::{
         GasLimit, HandlePacket, InitPacket, MessageContext, Packet, ReplyPacket, StatusCode,
     },
-    reservation::GasReserver, lazy_pages::GlobalsCtx,
+    reservation::GasReserver, lazy_pages::{GlobalsCtx, Status},
 };
 use gear_core_errors::{CoreError, ExecutionError, ExtError, MemoryError, MessageError, WaitError};
 
@@ -108,6 +108,9 @@ pub trait ProcessorExt {
 
     /// Lazy pages contract post execution actions
     fn lazy_pages_post_execution_actions(mem: &mut impl Memory);
+
+    /// Returns lazy pages status
+    fn lazy_pages_status() -> Option<Status>;
 }
 
 /// [`Ext`](Ext)'s error
@@ -220,6 +223,10 @@ impl ProcessorExt for Ext {
     }
 
     fn lazy_pages_post_execution_actions(_mem: &mut impl Memory) {
+        unreachable!()
+    }
+
+    fn lazy_pages_status() -> Option<Status> {
         unreachable!()
     }
 }

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -31,8 +31,9 @@ use gear_core::{
     charge_gas_token,
     costs::{HostFnWeights, RuntimeCosts},
     env::Ext as EnvExt,
-    gas::{ChargeResult, GasAllowanceCounter, GasAmount, GasCounter, ValueCounter, Token},
+    gas::{ChargeResult, GasAllowanceCounter, GasAmount, GasCounter, Token, ValueCounter},
     ids::{CodeId, MessageId, ProgramId, ReservationId},
+    lazy_pages::{GlobalsCtx, Status},
     memory::{
         AllocationsContext, GrowHandler, GrowHandlerNothing, Memory, PageBuf, PageNumber,
         WasmPageNumber,
@@ -40,7 +41,7 @@ use gear_core::{
     message::{
         GasLimit, HandlePacket, InitPacket, MessageContext, Packet, ReplyPacket, StatusCode,
     },
-    reservation::GasReserver, lazy_pages::{GlobalsCtx, Status},
+    reservation::GasReserver,
 };
 use gear_core_errors::{CoreError, ExecutionError, ExtError, MemoryError, MessageError, WaitError};
 

--- a/core/src/code.rs
+++ b/core/src/code.rs
@@ -141,7 +141,6 @@ impl Code {
             return Err(CodeError::StartSectionExists);
         }
 
-        // TODO: decode err info
         // get initial memory size from memory import.
         let static_pages = WasmPageNumber::new(
             module
@@ -157,7 +156,7 @@ impl Code {
                 })
                 .ok_or(CodeError::MemoryEntryNotFound)?,
         )
-        .map_err(|_| CodeError::Decode)?;
+        .map_err(|_| CodeError::InvalidStaticPageCount)?;
 
         if static_pages.raw() > MAX_WASM_PAGE_COUNT as u32 {
             return Err(CodeError::InvalidStaticPageCount);
@@ -222,7 +221,7 @@ impl Code {
                 })
                 .ok_or(CodeError::MemoryEntryNotFound)?,
         )
-        .map_err(|_| CodeError::Decode)?;
+        .map_err(|_| CodeError::InvalidStaticPageCount)?;
 
         let exports = get_exports(&module, false)?;
 

--- a/core/src/costs.rs
+++ b/core/src/costs.rs
@@ -172,6 +172,9 @@ pub struct HostFnWeights {
     /// Weight per one gear page write.
     pub lazy_pages_write: u64,
 
+    /// Weight per one write, which is after page read.
+    pub lazy_pages_write_after_read: u64,
+
     /// Weight per one gear page update in storage.
     pub lazy_pages_update: u64,
 }
@@ -278,9 +281,13 @@ pub enum RuntimeCosts {
     SendPushInput(u32),
     /// Weight of calling `gr_rereply_push`.
     ReplyPushInput(u32),
-
+    /// Weight of read access per one gear page.
     LazyPagesRead,
+    /// Weight of write access per one gear page.
     LazyPagesWrite,
+    /// Weight of write after read access per one gear page.
+    LazyPagesWriteAfterRead,
+    /// Weight of page update in storage after modification.
     LazyPagesUpdate,
 }
 
@@ -354,6 +361,7 @@ impl RuntimeCosts {
                 .saturating_add(s.gr_reply_push_input_per_byte.saturating_mul(len.into())),
             LazyPagesRead => s.lazy_pages_read,
             LazyPagesWrite => s.lazy_pages_write,
+            LazyPagesWriteAfterRead => s.lazy_pages_write_after_read,
             LazyPagesUpdate => s.lazy_pages_update,
         };
         RuntimeToken { weight }

--- a/core/src/costs.rs
+++ b/core/src/costs.rs
@@ -165,6 +165,10 @@ pub struct HostFnWeights {
 
     /// Weight per salt byte by `gr_create_program_wgas`.
     pub gr_create_program_wgas_salt_per_byte: u64,
+
+    pub lazy_pages_read: u64,
+    pub lazy_pages_write: u64,
+    pub lazy_pages_update: u64,
 }
 
 /// We need this access as a macro because sometimes hiding the lifetimes behind
@@ -269,6 +273,10 @@ pub enum RuntimeCosts {
     SendPushInput(u32),
     /// Weight of calling `gr_rereply_push`.
     ReplyPushInput(u32),
+
+    LazyPagesRead,
+    LazyPagesWrite,
+    LazyPagesUpdate,
 }
 
 impl RuntimeCosts {
@@ -339,6 +347,9 @@ impl RuntimeCosts {
             ReplyPushInput(len) => s
                 .gr_reply_push_input
                 .saturating_add(s.gr_reply_push_input_per_byte.saturating_mul(len.into())),
+            LazyPagesRead => s.lazy_pages_read,
+            LazyPagesWrite => s.lazy_pages_write,
+            LazyPagesUpdate => s.lazy_pages_update,
         };
         RuntimeToken { weight }
     }

--- a/core/src/costs.rs
+++ b/core/src/costs.rs
@@ -176,7 +176,7 @@ pub struct HostFnWeights {
     pub lazy_pages_write_after_read: u64,
 
     /// Weight per one gear page update in storage.
-    pub lazy_pages_update: u64,
+    pub update_page_in_storage: u64,
 }
 
 /// We need this access as a macro because sometimes hiding the lifetimes behind
@@ -288,7 +288,7 @@ pub enum RuntimeCosts {
     /// Weight of write after read access per one gear page.
     LazyPagesWriteAfterRead,
     /// Weight of page update in storage after modification.
-    LazyPagesUpdate,
+    UpdatePageInStorage,
 }
 
 impl RuntimeCosts {
@@ -362,7 +362,7 @@ impl RuntimeCosts {
             LazyPagesRead => s.lazy_pages_read,
             LazyPagesWrite => s.lazy_pages_write,
             LazyPagesWriteAfterRead => s.lazy_pages_write_after_read,
-            LazyPagesUpdate => s.lazy_pages_update,
+            UpdatePageInStorage => s.update_page_in_storage,
         };
         RuntimeToken { weight }
     }

--- a/core/src/costs.rs
+++ b/core/src/costs.rs
@@ -166,8 +166,13 @@ pub struct HostFnWeights {
     /// Weight per salt byte by `gr_create_program_wgas`.
     pub gr_create_program_wgas_salt_per_byte: u64,
 
+    /// Weight per one gear page read.
     pub lazy_pages_read: u64,
+
+    /// Weight per one gear page write.
     pub lazy_pages_write: u64,
+
+    /// Weight per one gear page update in storage.
     pub lazy_pages_update: u64,
 }
 

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -19,7 +19,7 @@
 //! Environment for running a module.
 
 use crate::{
-    costs::{RuntimeCosts, RuntimeToken},
+    costs::RuntimeCosts,
     ids::{MessageId, ProgramId, ReservationId},
     memory::{Memory, WasmPageNumber},
     message::{HandlePacket, InitPacket, ReplyPacket, StatusCode},
@@ -244,5 +244,6 @@ pub trait Ext {
     /// Handler for the case when gas allowance is out.
     fn out_of_allowance(&mut self) -> Self::Error;
 
+    /// Get runtime cost weight.
     fn get_runtime_cost(&self, costs: RuntimeCosts) -> u64;
 }

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -19,7 +19,7 @@
 //! Environment for running a module.
 
 use crate::{
-    costs::RuntimeCosts,
+    costs::{RuntimeCosts, RuntimeToken},
     ids::{MessageId, ProgramId, ReservationId},
     memory::{Memory, WasmPageNumber},
     message::{HandlePacket, InitPacket, ReplyPacket, StatusCode},
@@ -243,4 +243,6 @@ pub trait Ext {
 
     /// Handler for the case when gas allowance is out.
     fn out_of_allowance(&mut self) -> Self::Error;
+
+    fn get_runtime_cost(&self, costs: RuntimeCosts) -> u64;
 }

--- a/core/src/lazy_pages.rs
+++ b/core/src/lazy_pages.rs
@@ -18,7 +18,7 @@
 
 //! Globals access for lazy-pages.
 
-use core::fmt::Debug;
+use core::{fmt::Debug, convert::TryFrom};
 
 use crate::memory::HostPointer;
 use alloc::string::String;
@@ -56,3 +56,34 @@ pub trait GlobalsAccessTrait {
     fn set_i64(&mut self, name: &str, value: i64) -> Result<(), GlobalsAccessError>;
     fn as_any_mut(&mut self) -> &mut dyn Any;
 }
+
+// pub type StatusNo = u64;
+// pub const STATUS_NORMAL: StatusNo = 0;
+// pub const STATUS_GAS_LIMIT_EXCEEDED: StatusNo = 1;
+// pub const STATUS_GAS_ALLOWANCE_EXCEEDED: StatusNo = 2;
+// pub const STATUS_MEMORY_ACCESS_OUT_OF_BOUNDS: StatusNo = 3;
+
+#[derive(Debug, Clone, Copy, Encode, Decode)]
+#[repr(i64)]
+pub enum Status {
+    Normal = 0,
+    GasLimitExceeded,
+    GasAllowanceExceeded,
+    MemoryAccessOutOfBounds,
+}
+
+// #[derive(Debug)]
+// pub struct StatusWrongNo(StatusNo);
+
+// impl TryFrom<StatusNo> for Status {
+//     type Error = StatusWrongNo;
+//     fn try_from(value: StatusNo) -> Result<Status, StatusWrongNo> {
+//         match value {
+//             STATUS_NORMAL => Ok(Self::Normal),
+//             STATUS_GAS_LIMIT_EXCEEDED => Ok(Self::GasLimitExceeded),
+//             STATUS_GAS_ALLOWANCE_EXCEEDED => Ok(Self::GasAllowanceExceeded),
+//             STATUS_MEMORY_ACCESS_OUT_OF_BOUNDS => Ok(Self::MemoryAccessOutOfBounds),
+//             wrong => Err(StatusWrongNo(wrong)),
+//         }
+//     }
+// }

--- a/core/src/lazy_pages.rs
+++ b/core/src/lazy_pages.rs
@@ -99,3 +99,17 @@ pub enum Status {
     /// Skips signals processing until the end of execution, set termination reason as `gas allowance exceeded`.
     GasAllowanceExceeded,
 }
+
+/// Memory access error.
+#[derive(Debug, Clone, Copy, Decode, Encode, derive_more::Display)]
+pub enum AccessError {
+    /// Given access addr + size overflows u32.
+    #[display(fmt = "Access interval addr {:#x} + size {:#x} overflows u32::MAX", _0, _1)]
+    AddrPlusSizeOverflow(u32, u32),
+    /// Access size cannot be less then 1 byte.
+    #[display(fmt = "Access interval size is zero")]
+    AccessSizeIsZero,
+    /// Access is out of wasm memory.
+    #[display(fmt = "Access is out of wasm wasm memory")]
+    OutOfWasmMemoryAccess,
+}

--- a/core/src/lazy_pages.rs
+++ b/core/src/lazy_pages.rs
@@ -51,7 +51,7 @@ pub struct GlobalsAccessError;
 
 pub trait GlobalsAccessTrait {
     fn get_i64(&self, name: &str) -> Result<i64, GlobalsAccessError>;
-    fn set_i64(&self, name: &str, value: i64) -> Result<(), GlobalsAccessError>;
+    fn set_i64(&mut self, name: &str, value: i64) -> Result<(), GlobalsAccessError>;
 }
 
 pub struct GlobalAccessProvider<'a> {
@@ -69,7 +69,7 @@ impl<'a> GlobalsAccessTrait for GlobalAccessProvider<'a> {
         self.inner_access_provider.get_i64(name)
     }
 
-    fn set_i64(&self, name: &str, value: i64) -> Result<(), GlobalsAccessError> {
+    fn set_i64(&mut self, name: &str, value: i64) -> Result<(), GlobalsAccessError> {
         self.inner_access_provider.set_i64(name, value)
     }
 }

--- a/core/src/lazy_pages.rs
+++ b/core/src/lazy_pages.rs
@@ -48,6 +48,7 @@ pub struct GlobalsCtx {
     pub globals_access_mod: GlobalsAccessMod,
 }
 
+#[derive(Debug)]
 pub struct GlobalsAccessError;
 
 pub trait GlobalsAccessTrait {
@@ -55,27 +56,3 @@ pub trait GlobalsAccessTrait {
     fn set_i64(&mut self, name: &str, value: i64) -> Result<(), GlobalsAccessError>;
     fn as_any_mut(&mut self) -> &mut dyn Any;
 }
-
-// pub struct GlobalAccessProvider<'a> {
-//     pub inner_access_provider: &'a mut dyn GlobalsAccessTrait,
-// }
-
-// impl<'a> Debug for GlobalAccessProvider<'a> {
-//     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-//         f.debug_struct("GlobalAccessProvider").finish()
-//     }
-// }
-
-// impl<'a> GlobalsAccessTrait for GlobalAccessProvider<'a> {
-//     fn get_i64(&self, name: &str) -> Result<i64, GlobalsAccessError> {
-//         self.inner_access_provider.get_i64(name)
-//     }
-
-//     fn set_i64(&mut self, name: &str, value: i64) -> Result<(), GlobalsAccessError> {
-//         self.inner_access_provider.set_i64(name, value)
-//     }
-
-//     fn as_any_mut(&'static mut self) -> &mut dyn Any {
-//         self
-//     }
-// }

--- a/core/src/lazy_pages.rs
+++ b/core/src/lazy_pages.rs
@@ -43,8 +43,6 @@ pub struct LazyPagesWeights {
     pub write: u64,
     /// Write to one gear page weight, which has been already read accessed.
     pub write_after_read: u64,
-    /// Update modified gear page in storage weight.
-    pub update: u64,
 }
 
 /// Globals ctx for lazy-pages initialization.

--- a/core/src/lazy_pages.rs
+++ b/core/src/lazy_pages.rs
@@ -70,10 +70,14 @@ pub struct GlobalsAccessError;
 
 /// Globals access trait.
 pub trait GlobalsAccessTrait {
-    /// Returns i64 for global `name`, if `name` is I64 global export.
+    /// Returns global `name` value, if `name` is I64 global export.
     fn get_i64(&self, name: &str) -> Result<i64, GlobalsAccessError>;
     /// Set global `name` == `value`, if `name` is I64 global export.
     fn set_i64(&mut self, name: &str, value: i64) -> Result<(), GlobalsAccessError>;
+    /// Returns global `name` value, if `name` is I32 global export.
+    fn get_i32(&self, name: &str) -> Result<i32, GlobalsAccessError>;
+    /// Set global `name` == `value`, if `name` is I32 global export.
+    fn set_i32(&mut self, name: &str, value: i32) -> Result<(), GlobalsAccessError>;
     /// Returns as `&mut syn Any`.
     fn as_any_mut(&mut self) -> &mut dyn Any;
 }
@@ -91,7 +95,7 @@ pub trait GlobalsAccessTrait {
 #[repr(i64)]
 pub enum Status {
     /// Lazy-pages works in normal mode.
-    Normal = 0,
+    Normal = 0_i64,
     /// Skips signals processing until the end of execution, set termination reason as `gas limit exceeded`.
     GasLimitExceeded,
     /// Skips signals processing until the end of execution, set termination reason as `gas allowance exceeded`.

--- a/core/src/lazy_pages.rs
+++ b/core/src/lazy_pages.rs
@@ -16,74 +16,84 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! Globals access for lazy-pages.
+//! Core logic for usage both in runtime and in lazy-pages native part.
 
-use core::{fmt::Debug, convert::TryFrom};
+use core::fmt::Debug;
 
 use crate::memory::HostPointer;
 use alloc::string::String;
 use codec::{Decode, Encode};
 use core::any::Any;
 
+/// Informs lazy-pages whether they work with native or WASM runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
 pub enum GlobalsAccessMod {
+    /// Is wasm runtime.
     WasmRuntime,
+    /// Is native runtime.
     NativeRuntime,
 }
 
+/// Lazy-pages cases weights.
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
-pub struct LazyPagesCosts {
-    pub read_page: u64,
-    pub write_page: u64,
-    pub update_page: u64,
+pub struct LazyPagesWeights {
+    /// Read one gear page weight.
+    pub read: u64,
+    /// Write to one gear page weight.
+    pub write: u64,
+    /// Write to one gear page weight, which has been already read accessed.
+    pub write_after_read: u64,
+    /// Update modified gear page in storage weight.
+    pub update: u64,
 }
 
+/// Globals ctx for lazy-pages initialization.
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub struct GlobalsCtx {
+    /// Gas amount global name.
     pub global_gas_name: String,
+    /// Gas allowance amount global name.
     pub global_allowance_name: String,
+    /// Gear status global name.
     pub global_state_name: String,
-    pub lazy_pages_costs: LazyPagesCosts,
+    /// Lazy-pages access weights.
+    pub lazy_pages_weights: LazyPagesWeights,
+    /// Raw pointer to the globals access provider.
     pub globals_access_ptr: HostPointer,
+    /// Access mod, currently two: native or WASM runtime.
     pub globals_access_mod: GlobalsAccessMod,
 }
 
+/// Globals access error.
 #[derive(Debug)]
 pub struct GlobalsAccessError;
 
+/// Globals access trait.
 pub trait GlobalsAccessTrait {
+    /// Returns i64 for global `name`, if `name` is I64 global export.
     fn get_i64(&self, name: &str) -> Result<i64, GlobalsAccessError>;
+    /// Set global `name` == `value`, if `name` is I64 global export.
     fn set_i64(&mut self, name: &str, value: i64) -> Result<(), GlobalsAccessError>;
+    /// Returns as `&mut syn Any`.
     fn as_any_mut(&mut self) -> &mut dyn Any;
 }
 
-// pub type StatusNo = u64;
-// pub const STATUS_NORMAL: StatusNo = 0;
-// pub const STATUS_GAS_LIMIT_EXCEEDED: StatusNo = 1;
-// pub const STATUS_GAS_ALLOWANCE_EXCEEDED: StatusNo = 2;
-// pub const STATUS_MEMORY_ACCESS_OUT_OF_BOUNDS: StatusNo = 3;
-
+/// Lazy-pages status.
+/// By default in program initialization status is set as `Normal`.
+/// If nothing bad happens in lazy-pages, then status remains to be `Normal`.
+/// If gas limit exceed, then status is set as `GasLimitExceeded`, and lazy-pages
+/// starts to skips all signals processing until the end of execution.
+/// The same is for gas allowance exceed, except it sets status as `GasAllowanceExceed`.
+/// In the end of execution this status is checked and if it's not `Normal` then
+/// termination reason sets as `gas limit exceeded` or `gas allowance exceeded`, depending on status.
+/// NOTE: `repr(i64)` is important to be able add additional fields, without old runtimes separate support logic.
 #[derive(Debug, Clone, Copy, Encode, Decode)]
 #[repr(i64)]
 pub enum Status {
+    /// Lazy-pages works in normal mode.
     Normal = 0,
+    /// Skips signals processing until the end of execution, set termination reason as `gas limit exceeded`.
     GasLimitExceeded,
+    /// Skips signals processing until the end of execution, set termination reason as `gas allowance exceeded`.
     GasAllowanceExceeded,
-    MemoryAccessOutOfBounds,
 }
-
-// #[derive(Debug)]
-// pub struct StatusWrongNo(StatusNo);
-
-// impl TryFrom<StatusNo> for Status {
-//     type Error = StatusWrongNo;
-//     fn try_from(value: StatusNo) -> Result<Status, StatusWrongNo> {
-//         match value {
-//             STATUS_NORMAL => Ok(Self::Normal),
-//             STATUS_GAS_LIMIT_EXCEEDED => Ok(Self::GasLimitExceeded),
-//             STATUS_GAS_ALLOWANCE_EXCEEDED => Ok(Self::GasAllowanceExceeded),
-//             STATUS_MEMORY_ACCESS_OUT_OF_BOUNDS => Ok(Self::MemoryAccessOutOfBounds),
-//             wrong => Err(StatusWrongNo(wrong)),
-//         }
-//     }
-// }

--- a/core/src/lazy_pages.rs
+++ b/core/src/lazy_pages.rs
@@ -104,7 +104,11 @@ pub enum Status {
 #[derive(Debug, Clone, Copy, Decode, Encode, derive_more::Display)]
 pub enum AccessError {
     /// Given access addr + size overflows u32.
-    #[display(fmt = "Access interval addr {:#x} + size {:#x} overflows u32::MAX", _0, _1)]
+    #[display(
+        fmt = "Access interval addr {:#x} + size {:#x} overflows u32::MAX",
+        _0,
+        _1
+    )]
     AddrPlusSizeOverflow(u32, u32),
     /// Access size cannot be less then 1 byte.
     #[display(fmt = "Access interval size is zero")]

--- a/core/src/lazy_pages.rs
+++ b/core/src/lazy_pages.rs
@@ -23,6 +23,7 @@ use core::fmt::Debug;
 use crate::memory::HostPointer;
 use alloc::string::String;
 use codec::{Decode, Encode};
+use core::any::Any;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
 pub enum GlobalsAccessMod {
@@ -52,24 +53,29 @@ pub struct GlobalsAccessError;
 pub trait GlobalsAccessTrait {
     fn get_i64(&self, name: &str) -> Result<i64, GlobalsAccessError>;
     fn set_i64(&mut self, name: &str, value: i64) -> Result<(), GlobalsAccessError>;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
 }
 
-pub struct GlobalAccessProvider<'a> {
-    pub inner_access_provider: &'a mut dyn GlobalsAccessTrait,
-}
+// pub struct GlobalAccessProvider<'a> {
+//     pub inner_access_provider: &'a mut dyn GlobalsAccessTrait,
+// }
 
-impl<'a> Debug for GlobalAccessProvider<'a> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GlobalAccessProvider").finish()
-    }
-}
+// impl<'a> Debug for GlobalAccessProvider<'a> {
+//     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+//         f.debug_struct("GlobalAccessProvider").finish()
+//     }
+// }
 
-impl<'a> GlobalsAccessTrait for GlobalAccessProvider<'a> {
-    fn get_i64(&self, name: &str) -> Result<i64, GlobalsAccessError> {
-        self.inner_access_provider.get_i64(name)
-    }
+// impl<'a> GlobalsAccessTrait for GlobalAccessProvider<'a> {
+//     fn get_i64(&self, name: &str) -> Result<i64, GlobalsAccessError> {
+//         self.inner_access_provider.get_i64(name)
+//     }
 
-    fn set_i64(&mut self, name: &str, value: i64) -> Result<(), GlobalsAccessError> {
-        self.inner_access_provider.set_i64(name, value)
-    }
-}
+//     fn set_i64(&mut self, name: &str, value: i64) -> Result<(), GlobalsAccessError> {
+//         self.inner_access_provider.set_i64(name, value)
+//     }
+
+//     fn as_any_mut(&'static mut self) -> &mut dyn Any {
+//         self
+//     }
+// }

--- a/core/src/lazy_pages.rs
+++ b/core/src/lazy_pages.rs
@@ -1,0 +1,75 @@
+// This file is part of Gear.
+
+// Copyright (C) 2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Globals access for lazy-pages.
+
+use core::fmt::Debug;
+
+use crate::memory::HostPointer;
+use alloc::string::String;
+use codec::{Decode, Encode};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
+pub enum GlobalsAccessMod {
+    WasmRuntime,
+    NativeRuntime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct LazyPagesCosts {
+    pub read_page: u64,
+    pub write_page: u64,
+    pub update_page: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct GlobalsCtx {
+    pub global_gas_name: String,
+    pub global_allowance_name: String,
+    pub global_state_name: String,
+    pub lazy_pages_costs: LazyPagesCosts,
+    pub globals_access_ptr: HostPointer,
+    pub globals_access_mod: GlobalsAccessMod,
+}
+
+pub struct GlobalsAccessError;
+
+pub trait GlobalsAccessTrait {
+    fn get_i64(&self, name: &str) -> Result<i64, GlobalsAccessError>;
+    fn set_i64(&self, name: &str, value: i64) -> Result<(), GlobalsAccessError>;
+}
+
+pub struct GlobalAccessProvider<'a> {
+    pub inner_access_provider: &'a mut dyn GlobalsAccessTrait,
+}
+
+impl<'a> Debug for GlobalAccessProvider<'a> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GlobalAccessProvider").finish()
+    }
+}
+
+impl<'a> GlobalsAccessTrait for GlobalAccessProvider<'a> {
+    fn get_i64(&self, name: &str) -> Result<i64, GlobalsAccessError> {
+        self.inner_access_provider.get_i64(name)
+    }
+
+    fn set_i64(&self, name: &str, value: i64) -> Result<(), GlobalsAccessError> {
+        self.inner_access_provider.set_i64(name, value)
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -32,11 +32,11 @@ pub mod costs;
 pub mod env;
 pub mod gas;
 pub mod ids;
+pub mod lazy_pages;
 pub mod memory;
 pub mod message;
 pub mod program;
 pub mod reservation;
-pub mod lazy_pages;
 
 pub mod buffer;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -24,6 +24,7 @@
 #![warn(missing_docs)]
 #![cfg_attr(feature = "strict", deny(warnings))]
 #![doc(html_logo_url = "https://docs.gear.rs/logo.svg")]
+#![feature(step_trait)]
 
 extern crate alloc;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -36,6 +36,7 @@ pub mod memory;
 pub mod message;
 pub mod program;
 pub mod reservation;
+pub mod lazy_pages;
 
 pub mod buffer;
 

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -461,9 +461,9 @@ impl AllocationsContext {
         mem: &mut impl Memory,
     ) -> Result<AllocResult, Error> {
         let mem_size = mem.size();
-        let mut previous = self.static_pages();
+        let mut previous = self.static_pages;
         let mut start = None;
-        for &page in self.allocations().iter().chain([mem_size].iter()) {
+        for &page in self.allocations.iter().chain([mem_size].iter()) {
             if page
                 .sub(previous)
                 .map_err(|_| Error::IncorrectAllocationsSetOrMemSize)?
@@ -483,10 +483,10 @@ impl AllocationsContext {
 
             // Panic is safe, because we check, that last allocated page can be incremented in loop above.
             let start = self
-                .allocations()
+                .allocations
                 .last()
                 .map(|last| last.inc().expect("unreachable"))
-                .unwrap_or(self.static_pages());
+                .unwrap_or(self.static_pages);
             let end = start.add(pages).map_err(|_| Error::OutOfBounds)?;
             if end > self.max_pages {
                 return Err(Error::OutOfBounds);

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -20,7 +20,9 @@
 
 use core::{
     convert::TryFrom,
-    ops::{Add, Deref, DerefMut, Sub}, fmt::Debug,
+    fmt::Debug,
+    iter::Step,
+    ops::{Deref, DerefMut},
 };
 
 use alloc::{
@@ -33,7 +35,7 @@ use core::fmt;
 use scale_info::TypeInfo;
 
 /// A WebAssembly page has a constant size of 64KiB.
-const WASM_PAGE_SIZE: usize = 0x10000;
+pub const WASM_PAGE_SIZE: usize = 0x10000;
 
 /// A gear page size, currently 4KiB to fit the most common native page size.
 /// This is size of memory data pages in storage.
@@ -41,7 +43,7 @@ const WASM_PAGE_SIZE: usize = 0x10000;
 /// we can download just some number of gear pages instead of whole wasm page.
 /// The number of small pages, which must be downloaded, is depends on host
 /// native page size, so can vary.
-const GEAR_PAGE_SIZE: usize = 0x1000;
+pub const GEAR_PAGE_SIZE: usize = 0x1000;
 
 /// Pages data storage granularity (PSG) is a size and wasm addr alignment
 /// of a memory interval, for which the following conditions must be met:
@@ -60,9 +62,6 @@ const GEAR_PAGE_SIZE: usize = 0x1000;
 /// This constant is necessary for consensus between nodes with different
 /// native page sizes. You can see an example of using in crate `gear-lazy-pages`.
 pub const PAGE_STORAGE_GRANULARITY: usize = 0x4000;
-
-/// Number of gear pages in one wasm page
-const GEAR_PAGES_IN_ONE_WASM: u32 = (WASM_PAGE_SIZE / GEAR_PAGE_SIZE) as u32;
 
 static_assertions::const_assert_eq!(WASM_PAGE_SIZE % GEAR_PAGE_SIZE, 0);
 static_assertions::const_assert_eq!(WASM_PAGE_SIZE % PAGE_STORAGE_GRANULARITY, 0);
@@ -130,21 +129,36 @@ pub fn vec_page_data_map_to_page_buf_map(
     Ok(pages_data_res)
 }
 
-pub trait PageU32Size: Sized + Clone + Copy + PartialEq + Eq + PartialOrd + Ord {
+#[derive(Debug, Clone, derive_more::Display)]
+pub enum PageError {
+    #[display(fmt = "{} + {} overflows u32", _0, _1)]
+    AddOverflowU32(u32, u32),
+    #[display(fmt = "{} - {} overflows u32", _0, _1)]
+    SubOverflowU32(u32, u32),
+    #[display(fmt = "{} is too big to be number of page with size {}", _0, _1)]
+    OverflowU32MemorySize(u32, u32),
+}
+
+pub trait PageU32Size: Sized + Clone + Copy + PartialEq + Eq {
     fn size() -> u32;
     fn raw(&self) -> u32;
     unsafe fn new_unchecked(num: u32) -> Self;
 
     fn from_offset(offset: u32) -> Self {
-        unsafe {
-            Self::new_unchecked(offset / Self::size())
-        }
+        unsafe { Self::new_unchecked(offset / Self::size()) }
     }
-    fn new(num: u32) -> Option<Self> {
-        unsafe {
-            // Check that the end of page is less or equal then u32::MAX
-            num.checked_add(1)?.checked_mul(Self::size()).map(|_| Self::new_unchecked(num))
-        }
+    fn new(num: u32) -> Result<Self, PageError> {
+        let page_begin = num
+            .checked_mul(Self::size())
+            .ok_or(PageError::OverflowU32MemorySize(num, Self::size()))?;
+        // Suppose `- 1` safe, because zero size is unreachable case.
+        let last_byte_offset = Self::size() - 1;
+        // Check that the last page byte has index less or equal then u32::MAX
+        page_begin
+            .checked_add(last_byte_offset)
+            .ok_or(PageError::OverflowU32MemorySize(num, Self::size()))?;
+        // Now it is safe
+        unsafe { Ok(Self::new_unchecked(num)) }
     }
     fn offset(&self) -> u32 {
         self.raw() * Self::size()
@@ -153,33 +167,58 @@ pub trait PageU32Size: Sized + Clone + Copy + PartialEq + Eq + PartialOrd + Ord 
         (self.raw() + 1) * Self::size()
     }
     fn to_page<PAGE: PageU32Size>(&self) -> PAGE {
-        unsafe {
-            PAGE::new_unchecked(self.offset() / PAGE::size())
-        }
+        unsafe { PAGE::new_unchecked(self.offset() / PAGE::size()) }
     }
-    fn add(&self, other: Self) -> Option<Self> {
-        Self::new(self.raw().checked_add(other.raw())?)
+    fn add_raw(&self, raw: u32) -> Result<Self, PageError> {
+        self.raw()
+            .checked_add(raw)
+            .map(Self::new)
+            .ok_or(PageError::AddOverflowU32(self.raw(), raw))?
     }
-    fn sub(&self, other: Self) -> Option<Self> {
-        Self::new(self.raw().checked_sub(other.raw())?)
+    fn sub_raw(&self, raw: u32) -> Result<Self, PageError> {
+        self.raw()
+            .checked_sub(raw)
+            .map(Self::new)
+            .ok_or(PageError::SubOverflowU32(self.raw(), raw))?
     }
-    fn add_raw(&self, raw: u32) -> Option<Self> {
-        Self::new(self.raw().checked_add(raw)?)
+    fn add(&self, other: Self) -> Result<Self, PageError> {
+        self.add_raw(other.raw())
     }
-    fn sub_raw(&self, raw: u32) -> Option<Self> {
-        Self::new(self.raw().checked_sub(raw)?)
+    fn sub(&self, other: Self) -> Result<Self, PageError> {
+        self.sub_raw(other.raw())
     }
-    fn inc(&self) -> Option<Self> {
+    fn inc(&self) -> Result<Self, PageError> {
         self.add_raw(1)
     }
-    fn dec(&self) -> Option<Self> {
+    fn dec(&self) -> Result<Self, PageError> {
         self.sub_raw(1)
+    }
+    fn align_down(&self, size: u32) -> Self {
+        Self::from_offset((self.offset() / size) * size)
+    }
+    fn zero() -> Self {
+        unsafe { Self::new_unchecked(0) }
     }
 }
 
-pub fn to_page_iter<PAGE1: PageU32Size, PAGE2: PageU32Size>(page: PAGE1) -> impl Iterator<Item = PAGE2> {
+/// To another page iterator. For example: PAGE1 has size 4 and PAGE2 has size 2:
+/// ````
+/// Memory is splitted into PAGE1:
+/// [<====><====><====><====><====>]
+///  0     1     2     3     4
+/// Memory splitted into PAGE2:
+/// [<=><=><=><=><=><=><=><=><=><=>]
+///  0  1  2  3  4  5  6  7  8  9
+/// Then PAGE1 with number 2 contains [4, 5] pages of PAGE2,
+/// and we returns iterator over [4, 5] PAGE2.
+/// ````
+pub fn to_page_iter<PAGE1: PageU32Size, PAGE2: PageU32Size>(
+    page: PAGE1,
+) -> impl Iterator<Item = PAGE2> {
     unsafe {
-        (page.to_page::<PAGE2>().raw()..page.to_page::<PAGE2>().raw() + PAGE1::size() / PAGE2::size()).map(|raw| PAGE2::new_unchecked(raw))
+        (page.to_page::<PAGE2>().raw()
+            ..page.to_page::<PAGE2>().raw() + PAGE1::size() / PAGE2::size())
+            .map(|raw| PAGE2::new_unchecked(raw))
     }
 }
 
@@ -187,134 +226,82 @@ pub use gear_core_errors::MemoryError as Error;
 
 /// Page number.
 #[derive(
-    Clone,
-    Copy,
-    Debug,
-    Decode,
-    Encode,
-    derive_more::From,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    TypeInfo,
-    Default,
+    Clone, Copy, Debug, Decode, Encode, PartialEq, Eq, PartialOrd, Ord, Hash, TypeInfo, Default,
 )]
-pub struct PageNumber(pub u32);
+pub struct PageNumber(u32);
 
-impl PageNumber {
-    /// Creates new page from raw addr - pages which contains this addr
-    pub fn new_from_addr(addr: usize) -> Self {
-        Self((addr / Self::size()) as u32)
+impl PageU32Size for PageNumber {
+    fn size() -> u32 {
+        GEAR_PAGE_SIZE as u32
     }
 
-    /// Return page offset.
-    pub fn offset(&self) -> usize {
-        (self.0 as usize) * Self::size()
+    fn raw(&self) -> u32 {
+        self.0
     }
 
-    /// Returns wasm page number which contains this gear page.
-    pub fn to_wasm_page(&self) -> WasmPageNumber {
-        (self.0 / PageNumber::num_in_one_wasm_page()).into()
-    }
-
-    /// Return page size in bytes.
-    pub const fn size() -> usize {
-        GEAR_PAGE_SIZE
-    }
-
-    /// Number of gear pages in one wasm page
-    pub const fn num_in_one_wasm_page() -> u32 {
-        GEAR_PAGES_IN_ONE_WASM
-    }
-}
-
-impl Add for PageNumber {
-    type Output = Self;
-
-    fn add(self, other: Self) -> Self::Output {
-        Self(self.0 + other.0)
-    }
-}
-
-impl Sub for PageNumber {
-    type Output = Self;
-
-    fn sub(self, other: Self) -> Self::Output {
-        Self(self.0 - other.0)
+    unsafe fn new_unchecked(num: u32) -> Self {
+        Self(num)
     }
 }
 
 /// Wasm page number.
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Decode,
-    Encode,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    derive_more::From,
-    TypeInfo,
-    Default,
-)]
-pub struct WasmPageNumber(pub u32);
+#[derive(Clone, Copy, Debug, Decode, Encode, PartialEq, Eq, PartialOrd, Ord, TypeInfo, Default)]
+pub struct WasmPageNumber(u32);
 
-impl WasmPageNumber {
-    /// Returns new from raw addr - page which contains this addr.
-    pub fn new_from_addr(addr: usize) -> Self {
-        Self((addr / Self::size()) as u32)
+impl PageU32Size for WasmPageNumber {
+    fn size() -> u32 {
+        WASM_PAGE_SIZE as u32
     }
 
-    /// Returns page offset.
-    pub fn offset(&self) -> usize {
-        (self.0 as usize) * Self::size()
+    fn raw(&self) -> u32 {
+        self.0
     }
 
-    /// Amount of gear pages in current amount of wasm pages.
-    /// Or the same: number of first gear page in current wasm page.
-    pub fn to_gear_page(&self) -> PageNumber {
-        PageNumber::from(self.0 * PageNumber::num_in_one_wasm_page())
-    }
-
-    /// Saturating addition.
-    pub const fn saturating_add(self, other: Self) -> Self {
-        Self(self.0.saturating_add(other.0))
-    }
-
-    /// Saturating subtraction.
-    pub const fn saturating_sub(self, other: Self) -> Self {
-        Self(self.0.saturating_sub(other.0))
-    }
-
-    /// Return page size in bytes.
-    pub const fn size() -> usize {
-        WASM_PAGE_SIZE
-    }
-
-    /// Returns iterator over all gear pages which this wasm page contains.
-    pub fn to_gear_pages_iter(&self) -> impl Iterator<Item = PageNumber> {
-        let page = self.to_gear_page();
-        (page.0..page.0 + PageNumber::num_in_one_wasm_page()).map(PageNumber)
+    unsafe fn new_unchecked(num: u32) -> Self {
+        Self(num)
     }
 }
 
-impl Add for WasmPageNumber {
-    type Output = Self;
+impl Step for WasmPageNumber {
+    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+        u32::steps_between(&start.0, &end.0)
+    }
 
-    fn add(self, other: Self) -> Self::Output {
-        Self(self.0 + other.0)
+    fn forward_checked(start: Self, count: usize) -> Option<Self> {
+        Self::new(u32::forward_checked(start.0, count)?).ok()
+    }
+
+    fn backward_checked(start: Self, count: usize) -> Option<Self> {
+        Self::new(u32::backward_checked(start.0, count)?).ok()
     }
 }
 
-impl Sub for WasmPageNumber {
-    type Output = Self;
+impl From<u16> for WasmPageNumber {
+    fn from(value: u16) -> Self {
+        // u16::MAX * WasmPageNumber::size() - 1 == u32::MAX
+        WasmPageNumber(value as u32)
+    }
+}
 
-    fn sub(self, other: Self) -> Self::Output {
-        Self(self.0 - other.0)
+impl From<u16> for PageNumber {
+    fn from(value: u16) -> Self {
+        static_assertions::const_assert!(GEAR_PAGE_SIZE <= 0x10000);
+        // u16::MAX * PageNumber::size() - 1 <= u32::MAX
+        PageNumber(value as u32)
+    }
+}
+
+impl Step for PageNumber {
+    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+        u32::steps_between(&start.0, &end.0)
+    }
+
+    fn forward_checked(start: Self, count: usize) -> Option<Self> {
+        Self::new(u32::forward_checked(start.0, count)?).ok()
+    }
+
+    fn backward_checked(start: Self, count: usize) -> Option<Self> {
+        Self::new(u32::backward_checked(start.0, count)?).ok()
     }
 }
 
@@ -329,23 +316,20 @@ static_assertions::const_assert!(
 /// Backend wasm memory interface.
 pub trait Memory {
     /// Grow memory by number of pages.
-    fn grow(&mut self, pages: WasmPageNumber) -> Result<PageNumber, Error>;
+    fn grow(&mut self, pages: WasmPageNumber) -> Result<(), Error>;
 
     /// Return current size of the memory.
     fn size(&self) -> WasmPageNumber;
 
     /// Set memory region at specific pointer.
-    fn write(&mut self, offset: usize, buffer: &[u8]) -> Result<(), Error>;
+    fn write(&mut self, offset: u32, buffer: &[u8]) -> Result<(), Error>;
 
     /// Reads memory contents at the given offset into a buffer.
-    fn read(&self, offset: usize, buffer: &mut [u8]) -> Result<(), Error>;
-
-    /// Returns the byte length of this memory.
-    fn data_size(&self) -> usize;
+    fn read(&self, offset: u32, buffer: &mut [u8]) -> Result<(), Error>;
 
     /// Returns native addr of wasm memory buffer in wasm executor
     fn get_buffer_host_addr(&mut self) -> Option<HostPointer> {
-        if self.size() == 0.into() {
+        if self.size() == WasmPageNumber::zero() {
             None
         } else {
             // We call this method only in case memory size is not zero,
@@ -390,6 +374,12 @@ impl GrowHandler for GrowHandlerNothing {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AllocResult {
+    pub page: WasmPageNumber,
+    pub not_grown: WasmPageNumber,
+}
+
 impl AllocationsContext {
     /// New allocations context.
     ///
@@ -420,49 +410,69 @@ impl AllocationsContext {
         &mut self,
         pages: WasmPageNumber,
         mem: &mut impl Memory,
-    ) -> Result<WasmPageNumber, Error> {
-        let mut previous = None;
-        let mut current = None;
-
-        let mut at = None;
-
-        let last_static_page = (self.static_pages.0 != 0).then(|| self.static_pages - 1.into());
-        for page in last_static_page.iter().chain(self.allocations.iter()) {
-            if current.is_some() {
-                previous = current;
+    ) -> Result<AllocResult, Error> {
+        let mem_size = mem.size();
+        let mut previous = self.static_pages();
+        let mut start = None;
+        for &page in self.allocations().iter().chain([mem_size].iter()) {
+            if page
+                .sub(previous)
+                .map_err(|_| Error::IncorrectAllocationsSetOrMemSize)?
+                >= pages
+            {
+                start = Some(previous);
+                break;
             }
 
-            current = Some(page);
+            previous = page.inc().map_err(|_| Error::OutOfBounds)?;
+        }
 
-            if let Some(&previous) = previous {
-                if (*page).saturating_sub(previous) > pages {
-                    at = Some((previous).saturating_add(1.into()));
-                    break;
-                }
+        let (start, not_grown) = if let Some(start) = start {
+            (start, pages)
+        } else {
+            // If we cannot find interval between already allocated pages, then try to alloc new pages.
+
+            // Panic is safe, because we check, that last allocated page can be incremented in loop above.
+            let start = self
+                .allocations()
+                .last()
+                .map(|last| last.inc().expect("unreachable"))
+                .unwrap_or(self.static_pages());
+            let end = start.add(pages).map_err(|_| Error::OutOfBounds)?;
+            if end >= self.max_pages {
+                return Err(Error::OutOfBounds);
             }
-        }
 
-        let at = at
-            .or_else(|| current.map(|v| (*v).saturating_add(1.into())))
-            .unwrap_or(self.static_pages);
+            // Panic is safe, because in loop above we checked,
+            // that `mem_size` is bigger or equal than all allocated pages or static pages.
+            let extra_grow = end.sub(mem_size).expect("unreachable");
 
-        let final_page = at.saturating_add(pages);
-        if final_page > self.max_pages {
-            return Err(Error::OutOfBounds);
-        }
+            // Panic is safe, in other case we would found interval inside existed memory.
+            if extra_grow == WasmPageNumber::zero() {
+                unreachable!();
+            }
 
-        let extra_grow = final_page.saturating_sub(mem.size());
-        if extra_grow > 0.into() {
             let grow_handler = G::before_grow_action(mem);
             mem.grow(extra_grow)?;
             grow_handler.after_grow_action(mem)?;
+
+            // Panic is safe, `extra_grow` cannot be bigger then `pages`,
+            // because of way it's calculated.
+            let not_grown = pages.sub(extra_grow).expect("unreachable");
+
+            (start, not_grown)
+        };
+
+        // Panic is safe, we have calculated `start` is suitable for `pages`.
+        let end = start.add(pages).expect("unreachable");
+        for page in start..end {
+            self.allocations.insert(page);
         }
 
-        for page_num in at.0..final_page.0 {
-            self.allocations.insert(WasmPageNumber(page_num));
-        }
-
-        Ok(at)
+        Ok(AllocResult {
+            page: start,
+            not_grown,
+        })
     }
 
     /// Free specific page.
@@ -494,42 +504,30 @@ impl AllocationsContext {
 /// This module contains tests of PageNumber struct
 mod tests {
     use super::*;
+    use crate::memory::to_page_iter;
+
     use alloc::{vec, vec::Vec};
 
     #[test]
     /// Test that PageNumbers add up correctly
     fn page_number_addition() {
-        let sum = PageNumber(100) + PageNumber(200);
+        let sum = PageNumber::new(100)
+            .unwrap()
+            .add(PageNumber::new(200).unwrap())
+            .unwrap();
 
         assert_eq!(sum, PageNumber(300));
-
-        let sum = PageNumber(200) + PageNumber(100);
-
-        assert_eq!(sum, PageNumber(300));
-    }
-
-    #[cfg(debug_assertions)]
-    #[test]
-    #[should_panic(expected = "attempt to add with overflow")]
-    /// Test that PageNumbers addition causes panic on overflow
-    fn page_number_addition_with_overflow() {
-        let _ = PageNumber(u32::MAX) + PageNumber(1);
     }
 
     #[test]
     /// Test that PageNumbers subtract correctly
     fn page_number_subtraction() {
-        let subtraction = PageNumber(299) - PageNumber(199);
+        let subtraction = PageNumber::new(299)
+            .unwrap()
+            .sub(PageNumber::new(199).unwrap())
+            .unwrap();
 
-        assert_eq!(subtraction, PageNumber(100))
-    }
-
-    #[cfg(debug_assertions)]
-    #[test]
-    #[should_panic(expected = "attempt to subtract with overflow")]
-    /// Test that PageNumbers subtraction causes panic on overflow
-    fn page_number_subtraction_with_overflow() {
-        let _ = PageNumber(1) - PageNumber(u32::MAX);
+        assert_eq!(subtraction, PageNumber::new(100).unwrap())
     }
 
     #[test]
@@ -539,7 +537,7 @@ mod tests {
             [0u32, 10u32].iter().copied().map(WasmPageNumber).collect();
         let gear_pages: Vec<u32> = wasm_pages
             .iter()
-            .flat_map(|p| p.to_gear_pages_iter())
+            .flat_map(|&p| to_page_iter::<_, PageNumber>(p))
             .map(|p| p.0)
             .collect();
 
@@ -560,7 +558,7 @@ mod tests {
         .format_level(true)
         .try_init()
         .expect("cannot init logger");
-        let mut data = vec![199u8; PageNumber::size()];
+        let mut data = vec![199u8; PageNumber::size() as usize];
         data[1] = 2;
         let page_buf = PageBuf::new_from_vec(data).unwrap();
         log::debug!("page buff = {:?}", page_buf);

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -108,7 +108,7 @@ impl Program {
 /// and ProgramId's `fn from_slice(s: &[u8]) -> Self` constructor
 mod tests {
     use super::Program;
-    use crate::{code::Code, ids::ProgramId};
+    use crate::{code::Code, ids::ProgramId, memory::{WasmPageNumber, PageU32Size}};
     use alloc::vec::Vec;
     use gear_wasm_instrument::wasm_instrument::gas_metering::ConstantCostRules;
 
@@ -159,7 +159,7 @@ mod tests {
         let program = Program::new(ProgramId::from(1), code);
 
         // 2 static pages
-        assert_eq!(program.static_pages(), 2.into());
+        assert_eq!(program.static_pages(), WasmPageNumber::new(2).unwrap());
 
         // Has no allocations because we do not set them in new
         assert_eq!(program.allocations().len(), 0);

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -108,7 +108,7 @@ impl Program {
 /// and ProgramId's `fn from_slice(s: &[u8]) -> Self` constructor
 mod tests {
     use super::Program;
-    use crate::{code::Code, ids::ProgramId, memory::{WasmPageNumber, PageU32Size}};
+    use crate::{code::Code, ids::ProgramId};
     use alloc::vec::Vec;
     use gear_wasm_instrument::wasm_instrument::gas_metering::ConstantCostRules;
 
@@ -159,7 +159,7 @@ mod tests {
         let program = Program::new(ProgramId::from(1), code);
 
         // 2 static pages
-        assert_eq!(program.static_pages(), WasmPageNumber::new(2).unwrap());
+        assert_eq!(program.static_pages(), 2.into());
 
         // Has no allocations because we do not set them in new
         assert_eq!(program.allocations().len(), 0);

--- a/gear-test/spec/test_ping.yaml
+++ b/gear-test/spec/test_ping.yaml
@@ -29,3 +29,27 @@ fixtures:
             kind: utf-8
             value: PONG
 
+  - title: ping-pong wgas
+
+    messages:
+      - destination: 2
+        payload:
+          kind: utf-8
+          value: PING_REPLY_WITH_GAS
+      - destination: 2
+        payload:
+          kind: utf-8
+          value: PING_REPLY_COMMIT_WITH_GAS
+
+    expected:
+      - log:
+        - destination: 1000001
+          payload:
+            kind: utf-8
+            value: pong reply with gas message
+          gas_limit: 3001
+        - destination: 1000001
+          payload:
+            kind: utf-8
+            value: pong Part 1 pong Part 2
+          gas_limit: 3001

--- a/gear-test/spec/test_ping.yaml
+++ b/gear-test/spec/test_ping.yaml
@@ -29,27 +29,3 @@ fixtures:
             kind: utf-8
             value: PONG
 
-  - title: ping-pong wgas
-
-    messages:
-      - destination: 2
-        payload:
-          kind: utf-8
-          value: PING_REPLY_WITH_GAS
-      - destination: 2
-        payload:
-          kind: utf-8
-          value: PING_REPLY_COMMIT_WITH_GAS
-
-    expected:
-      - log:
-        - destination: 1000001
-          payload:
-            kind: utf-8
-            value: pong reply with gas message
-          gas_limit: 3001
-        - destination: 1000001
-          payload:
-            kind: utf-8
-            value: pong Part 1 pong Part 2
-          gas_limit: 3001

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -34,7 +34,7 @@ use gear_backend_common::Environment;
 use gear_core::{
     code::Code,
     ids::{CodeId, MessageId, ProgramId},
-    memory::{PageBuf, PageNumber, WasmPageNumber, PageU32Size},
+    memory::{PageBuf, PageNumber, PageU32Size, WasmPageNumber},
     message::*,
 };
 use log::{Log, Metadata, Record, SetLoggerError};
@@ -384,7 +384,10 @@ pub fn check_allocations(
                 }
             }
             AllocationExpectationKind::ExactPages(ref expected_pages) => {
-                let mut actual_pages = actual_pages.iter().map(|page| page.raw()).collect::<Vec<_>>();
+                let mut actual_pages = actual_pages
+                    .iter()
+                    .map(|page| page.raw())
+                    .collect::<Vec<_>>();
                 let mut expected_pages = expected_pages.clone();
 
                 actual_pages.sort_unstable();

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -34,7 +34,7 @@ use gear_backend_common::Environment;
 use gear_core::{
     code::Code,
     ids::{CodeId, MessageId, ProgramId},
-    memory::{PageBuf, PageNumber, WasmPageNumber},
+    memory::{PageBuf, PageNumber, WasmPageNumber, PageU32Size},
     message::*,
 };
 use log::{Log, Metadata, Record, SetLoggerError};
@@ -384,7 +384,7 @@ pub fn check_allocations(
                 }
             }
             AllocationExpectationKind::ExactPages(ref expected_pages) => {
-                let mut actual_pages = actual_pages.iter().map(|page| page.0).collect::<Vec<_>>();
+                let mut actual_pages = actual_pages.iter().map(|page| page.raw()).collect::<Vec<_>>();
                 let mut expected_pages = expected_pages.clone();
 
                 actual_pages.sort_unstable();
@@ -400,7 +400,7 @@ pub fn check_allocations(
                 for &expected_page in expected_pages {
                     if !actual_pages
                         .iter()
-                        .map(|page| page.0)
+                        .map(|page| page.raw())
                         .any(|actual_page| actual_page == expected_page)
                     {
                         errors.push(format!(
@@ -430,9 +430,9 @@ pub fn check_memory(
     for case in expected_memory {
         for (program_id, _data, memory) in actors_data {
             if *program_id == case.id.to_program_id() {
-                let page = PageNumber::new_from_addr(case.address);
+                let page = PageNumber::from_offset(case.address as u32);
                 if let Some(page_buf) = memory.get(&page) {
-                    let begin_byte = case.address - page.offset();
+                    let begin_byte = case.address - page.offset() as usize;
                     let end_byte = begin_byte + case.bytes.len();
                     if page_buf[begin_byte..end_byte] != case.bytes {
                         errors.push("Expectation error (Static memory doesn't match)".to_string());

--- a/gear-test/src/manager.rs
+++ b/gear-test/src/manager.rs
@@ -21,7 +21,7 @@ use core_processor::common::*;
 use gear_core::{
     code::{Code, CodeAndId},
     ids::{CodeId, MessageId, ProgramId, ReservationId},
-    memory::{PageBuf, PageNumber, WasmPageNumber, to_page_iter},
+    memory::{to_page_iter, PageBuf, PageNumber, WasmPageNumber},
     message::{Dispatch, DispatchKind, GasLimit, MessageWaitedType, StoredDispatch, StoredMessage},
     reservation::GasReserver,
 };

--- a/gear-test/src/manager.rs
+++ b/gear-test/src/manager.rs
@@ -21,7 +21,7 @@ use core_processor::common::*;
 use gear_core::{
     code::{Code, CodeAndId},
     ids::{CodeId, MessageId, ProgramId, ReservationId},
-    memory::{PageBuf, PageNumber, WasmPageNumber},
+    memory::{PageBuf, PageNumber, WasmPageNumber, to_page_iter},
     message::{Dispatch, DispatchKind, GasLimit, MessageWaitedType, StoredDispatch, StoredMessage},
     reservation::GasReserver,
 };
@@ -343,7 +343,7 @@ impl JournalHandler for InMemoryExtManager {
             for page in data
                 .allocations
                 .difference(&allocations)
-                .flat_map(|p| p.to_gear_pages_iter())
+                .flat_map(|&page| to_page_iter(page))
             {
                 memory_pages.remove(&page);
             }

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -33,7 +33,7 @@ use gear_backend_wasmi::WasmiEnvironment;
 use gear_core::{
     code::{Code, CodeAndId, InstrumentedCode, InstrumentedCodeAndId},
     ids::{CodeId, MessageId, ProgramId, ReservationId},
-    memory::{PageBuf, PageNumber, WasmPageNumber},
+    memory::{to_page_iter, PageBuf, PageNumber, WasmPageNumber},
     message::{
         Dispatch, DispatchKind, MessageWaitedType, Payload, ReplyMessage, ReplyPacket,
         StoredDispatch, StoredMessage,
@@ -874,7 +874,7 @@ impl JournalHandler for ExtManager {
                 program
                     .allocations()
                     .difference(&allocations)
-                    .flat_map(|p| p.to_gear_pages_iter())
+                    .flat_map(|&page| to_page_iter(page))
                     .for_each(|ref page| {
                         pages_data.remove(page);
                     });

--- a/lazy-pages/Cargo.toml
+++ b/lazy-pages/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/gear-tech/gear"
 
 [dependencies]
 log = "0.4.17"
-gear-core = { path = "../core" }
 sp-io = { version = "6.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 sp-std = { version = "4.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 sp-wasm-interface = { version = "6.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
@@ -21,6 +20,8 @@ derive_more = "0.99.17"
 static_assertions = "1.1"
 once_cell = "1.14"
 increment = "0.3.0"
+
+gear-core = { path = "../core" }
 
 [target."cfg(target_vendor = \"apple\")".dependencies.mach]
 version = "0.3.2"

--- a/lazy-pages/Cargo.toml
+++ b/lazy-pages/Cargo.toml
@@ -20,6 +20,7 @@ region = "3.0.0"
 derive_more = "0.99.17"
 static_assertions = "1.1"
 once_cell = "1.14"
+increment = "0.3.0"
 
 [target."cfg(target_vendor = \"apple\")".dependencies.mach]
 version = "0.3.2"
@@ -33,4 +34,4 @@ errno = "0.2"
 winapi = { version = "0.3.9", features = ["excpt", "memoryapi"] }
 
 [dev-dependencies]
-env_logger = "0.9.0"
+env_logger = "0.10.0"

--- a/lazy-pages/Cargo.toml
+++ b/lazy-pages/Cargo.toml
@@ -19,7 +19,6 @@ region = "3.0.0"
 derive_more = "0.99.17"
 static_assertions = "1.1"
 once_cell = "1.14"
-increment = "0.3.0"
 
 gear-core = { path = "../core" }
 
@@ -27,7 +26,7 @@ gear-core = { path = "../core" }
 version = "0.3.2"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.25"
+nix = "0.26.1"
 libc = "0.2"
 errno = "0.2"
 

--- a/lazy-pages/Cargo.toml
+++ b/lazy-pages/Cargo.toml
@@ -31,3 +31,6 @@ errno = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["excpt", "memoryapi"] }
+
+[dev-dependencies]
+env_logger = "0.9.0"

--- a/lazy-pages/Cargo.toml
+++ b/lazy-pages/Cargo.toml
@@ -13,6 +13,8 @@ log = "0.4.17"
 gear-core = { path = "../core" }
 sp-io = { version = "6.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 sp-std = { version = "4.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+sp-wasm-interface = { version = "6.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
+sc-executor-common = { version = "0.10.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 cfg-if = "1.0.0"
 region = "3.0.0"
 derive_more = "0.99.17"

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -99,7 +99,6 @@ pub enum Error {
     CannotChargeGasAllowance,
     DynGlobalsAccessorPointerIsInvalid,
     StatusIsNone,
-    SignalAfterOOM,
 }
 
 pub(crate) type WasmAddr = u32;

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -87,7 +87,10 @@ pub enum Error {
         expected,
         actual
     )]
-    InvalidPageDataSize { expected: usize, actual: u32 },
+    InvalidPageDataSize {
+        expected: usize,
+        actual: u32,
+    },
     /// Found a write signal from same page twice - see more in head comment.
     #[display(fmt = "Any page cannot be released twice: {_0:?}")]
     DoubleRelease(PageNumber),

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -143,8 +143,9 @@ pub(crate) struct LazyPagesExecutionContext {
     pub stack_end_wasm_addr: WasmAddr,
     /// Gear pages, which has been write accessed.
     pub released_pages: BTreeSet<PageNumber>,
-
+    /// Context to access globals and works with them: charge gas, set status global.
     pub globals_ctx: Option<GlobalsCtx>,
+    /// Lazy-pages status: indicates in which mod lazy-pages works actually.
     pub status: Option<Status>,
 }
 
@@ -304,26 +305,6 @@ pub fn unset_lazy_pages_protection() -> Result<(), MemoryProtectionError> {
         mprotect::mprotect_interval(addr, size, true, true)?;
         Ok(())
     })
-}
-
-/// Set end of stack addr in wasm memory.
-pub fn set_stack_end_wasm_addr(stack_end_wasm_addr: WasmAddr) {
-    LAZY_PAGES_CONTEXT.with(|ctx| ctx.borrow_mut().stack_end_wasm_addr = stack_end_wasm_addr);
-}
-
-/// Returns end of stack address in wasm memory.
-pub fn get_stack_end_wasm_addr() -> WasmAddr {
-    LAZY_PAGES_CONTEXT.with(|ctx| ctx.borrow().stack_end_wasm_addr)
-}
-
-/// Returns current wasm mem buffer pointer, if it's set.
-pub fn get_wasm_mem_addr() -> Option<usize> {
-    LAZY_PAGES_CONTEXT.with(|ctx| ctx.borrow().wasm_mem_addr)
-}
-
-/// Returns current wasm mem buffer size, if it's set
-pub fn get_wasm_mem_size() -> Option<u32> {
-    LAZY_PAGES_CONTEXT.with(|ctx| ctx.borrow().wasm_mem_size)
 }
 
 #[derive(derive_more::Display)]

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -97,6 +97,7 @@ pub enum Error {
     HostInstancePointerIsInvalid,
     CannotChargeGas,
     CannotChargeGasAllowance,
+    DynGlobalsAccessorPointerIsInvalid,
 }
 
 pub(crate) type WasmAddr = u32;

--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -228,7 +228,9 @@ pub fn initialize_for_program(
             // and wasm end addr fits usize.
             let addr = addr + stack_end;
             let size = size_in_bytes as usize - stack_end;
-            mprotect::mprotect_interval(addr, size, false, false)?;
+            if size != 0 {
+                mprotect::mprotect_interval(addr, size, false, false)?;
+            }
         }
 
         log::trace!("Initialize lazy-pages for current program: {:?}", ctx);

--- a/lazy-pages/src/sys.rs
+++ b/lazy-pages/src/sys.rs
@@ -303,7 +303,7 @@ pub(crate) unsafe fn process_lazy_pages(
 
     if let Some(last_page) = accessed_pages.last() {
         // Check that all pages are inside wasm memory.
-        if last_page.end_offset() > wasm_mem_size.offset() {
+        if last_page.end_offset() >= wasm_mem_size.offset() {
             return Err(Error::OutOfWasmMemoryAccess);
         }
     } else {
@@ -330,7 +330,7 @@ pub(crate) unsafe fn process_lazy_pages(
                 start = start.align_down(psg);
             }
             if !sp_io::storage::exists(prefix.calc_key_for_page(end.to_page())) {
-                // Make `end_offset()` aligned to `psg` page for `end`.
+                // Make page end aligned to `psg` for `end`.
                 // This operations are safe, because `psg` is power of two and smaller then `u32::MAX`.
                 // `LazyPage::size()` is less or equal then `psg` and `psg % LazyPage::size() == 0`.
                 end = LazyPage::from_offset((end.offset() / psg) * psg + (psg - LazyPage::size()));

--- a/lazy-pages/src/sys.rs
+++ b/lazy-pages/src/sys.rs
@@ -301,7 +301,6 @@ unsafe fn user_signal_handler_internal(
     match status {
         Status::Normal => {}
         Status::GasLimitExceeded | Status::GasAllowanceExceeded => return Ok(()),
-        Status::MemoryAccessOutOfBounds => return Err(Error::SignalAfterOOM),
     }
 
     if let Some(globals_ctx) = &ctx.globals_ctx {
@@ -339,9 +338,6 @@ unsafe fn user_signal_handler_internal(
             Status::GasLimitExceeded | Status::GasAllowanceExceeded => {
                 log::trace!("Gas limit or allowance exceed, so set exceed status and work in this mod until the end of execution");
                 return Ok(());
-            }
-            Status::MemoryAccessOutOfBounds => {
-                unreachable!("charge_gas function cannot return this status")
             }
         }
     }

--- a/lazy-pages/src/sys.rs
+++ b/lazy-pages/src/sys.rs
@@ -195,24 +195,31 @@ impl<'a> GlobalsAccessTrait for GlobalsAccessSandbox<'a> {
     fn get_i64(&self, name: &str) -> Result<i64, GlobalsAccessError> {
         self.instance
             .get_global_val(name)
-            .map(|value| {
+            .and_then(|value| {
                 if let Value::I64(value) = value {
                     Some(value)
                 } else {
                     None
                 }
             })
-            .flatten()
             .ok_or(GlobalsAccessError)
     }
 
     fn set_i64(&mut self, name: &str, value: i64) -> Result<(), GlobalsAccessError> {
         self.instance
-            .set_global_val(name, Value::I64(value as i64))
+            .set_global_val(name, Value::I64(value))
             .ok()
             .flatten()
             .ok_or(GlobalsAccessError)?;
         Ok(())
+    }
+
+    fn get_i32(&self, _name: &str) -> Result<i32, GlobalsAccessError> {
+        todo!("Currently useless")
+    }
+
+    fn set_i32(&mut self, _name: &str, _value: i32) -> Result<(), GlobalsAccessError> {
+        todo!("Currently useless")
     }
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
@@ -231,6 +238,14 @@ impl<'a, 'b> GlobalsAccessTrait for GlobalsAccessDyn<'a, 'b> {
 
     fn set_i64(&mut self, name: &str, value: i64) -> Result<(), GlobalsAccessError> {
         self.inner_access_provider.set_i64(name, value)
+    }
+
+    fn get_i32(&self, _name: &str) -> Result<i32, GlobalsAccessError> {
+        todo!("Currently useless")
+    }
+
+    fn set_i32(&mut self, _name: &str, _value: i32) -> Result<(), GlobalsAccessError> {
+        todo!("Currently useless")
     }
 
     fn as_any_mut(&mut self) -> &mut dyn Any {

--- a/lazy-pages/src/sys/mprotect.rs
+++ b/lazy-pages/src/sys/mprotect.rs
@@ -118,6 +118,7 @@ pub fn mprotect_mem_interval_except_pages(
     }
 }
 
+/// Mprotect all pages from `pages`.
 pub fn mprotect_pages(
     mem_addr: usize,
     mut pages: impl Iterator<Item = u32>,

--- a/lazy-pages/src/sys/mprotect.rs
+++ b/lazy-pages/src/sys/mprotect.rs
@@ -110,7 +110,7 @@ pub fn mprotect_mem_interval_except_pages(
         if page_offset > interval_offset {
             mprotect(interval_offset, page_offset)?;
         }
-        interval_offset = page.end_offset() as usize;
+        interval_offset = page.end_offset() as usize + 1;
     }
     if mem_size > interval_offset {
         mprotect(interval_offset, mem_size)

--- a/lazy-pages/src/sys/mprotect.rs
+++ b/lazy-pages/src/sys/mprotect.rs
@@ -1,0 +1,149 @@
+// This file is part of Gear.
+
+// Copyright (C) 2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Wrappers around system memory protections.
+
+use core::ops::RangeInclusive;
+use gear_core::memory::PageNumber;
+
+#[derive(Debug, derive_more::Display)]
+pub enum MprotectError {
+    #[display(
+        fmt = "Syscall mprotect error for interval {interval:#x?}, mask = {mask}, reason: {reason}"
+    )]
+    SyscallError {
+        interval: RangeInclusive<usize>,
+        mask: region::Protection,
+        reason: region::Error,
+    },
+    #[display(fmt = "Zero size is restricted for mprotect")]
+    ZeroSizeError,
+    #[display(fmt = "Offset {_0:#x} is bigger then wasm mem size {_1:#x}")]
+    OffsetOverflow(usize, usize),
+}
+
+/// Mprotect native memory interval [`addr`, `addr` + `size`].
+/// Protection mask is set according to protection arguments.
+unsafe fn sys_mprotect_interval(
+    addr: usize,
+    size: usize,
+    prot_read: bool,
+    prot_write: bool,
+    prot_exec: bool,
+) -> Result<(), MprotectError> {
+    if size == 0 {
+        return Err(MprotectError::ZeroSizeError);
+    }
+
+    let mut mask = region::Protection::NONE;
+    if prot_read {
+        mask |= region::Protection::READ;
+    }
+    if prot_write {
+        mask |= region::Protection::WRITE;
+    }
+    if prot_exec {
+        mask |= region::Protection::EXECUTE;
+    }
+    let res = region::protect(addr as *mut (), size, mask);
+    if let Err(reason) = res {
+        return Err(MprotectError::SyscallError {
+            interval: addr..=addr + size,
+            mask,
+            reason,
+        });
+    }
+    log::trace!("mprotect interval: {addr:#x}, size: {size:#x}, mask: {mask}");
+    Ok(())
+}
+
+/// Mprotect native memory interval [`addr`, `addr` + `size`].
+/// Protection mask is set according to protection arguments, `prot_exec` is set as false always.
+pub fn mprotect_interval(
+    addr: usize,
+    size: usize,
+    prot_read: bool,
+    prot_write: bool,
+) -> Result<(), MprotectError> {
+    unsafe { sys_mprotect_interval(addr, size, prot_read, prot_write, false) }
+}
+
+/// Protect all pages in memory interval, except pages from `except_pages`.
+/// If `protect` is true then restrict read/write access, else allow them.
+pub fn mprotect_mem_interval_except_pages(
+    mem_addr: usize,
+    start_offset: usize,
+    mem_size: usize,
+    except_pages: impl Iterator<Item = PageNumber>,
+    prot_read: bool,
+    prot_write: bool,
+) -> Result<(), MprotectError> {
+    let mprotect = |start, end| {
+        let addr = mem_addr + start;
+        let size = end - start;
+        unsafe { sys_mprotect_interval(addr, size, prot_read, prot_write, false) }
+    };
+
+    if start_offset > mem_size {
+        return Err(MprotectError::OffsetOverflow(start_offset, mem_size));
+    }
+
+    let mut interval_offset = start_offset;
+    for page in except_pages {
+        let page_offset = page.offset();
+        if page_offset > interval_offset {
+            mprotect(interval_offset, page_offset)?;
+        }
+        interval_offset = page_offset.saturating_add(PageNumber::size());
+    }
+    if mem_size > interval_offset {
+        mprotect(interval_offset, mem_size)
+    } else {
+        Ok(())
+    }
+}
+
+pub fn mprotect_pages(
+    mem_addr: usize,
+    mut pages: impl Iterator<Item = u32>,
+    page_size: u32,
+    prot_read: bool,
+    prot_write: bool,
+) -> Result<(), MprotectError> {
+    let mprotect = |start, end| {
+        let addr = mem_addr + (start * page_size) as usize;
+        let size = (end - start) * page_size;
+        unsafe { sys_mprotect_interval(addr, size as usize, prot_read, prot_write, false) }
+    };
+
+    let mut start = if let Some(start) = pages.next() {
+        start
+    } else {
+        return Ok(());
+    };
+    let mut end = start + 1;
+    for page in pages {
+        if end != page {
+            mprotect(start, end)?;
+            start = page;
+        }
+        end = page + 1;
+    }
+
+    mprotect(start, end)
+}

--- a/lazy-pages/src/sys/mprotect.rs
+++ b/lazy-pages/src/sys/mprotect.rs
@@ -90,8 +90,7 @@ pub fn mprotect_mem_interval_except_pages(
     mem_addr: usize,
     start_offset: usize,
     mem_size: usize,
-    except_pages: impl Iterator<Item = u32>,
-    page_size: u32,
+    except_pages: impl Iterator<Item = impl PageU32Size>,
     prot_read: bool,
     prot_write: bool,
 ) -> Result<(), MprotectError> {
@@ -107,11 +106,11 @@ pub fn mprotect_mem_interval_except_pages(
 
     let mut interval_offset = start_offset;
     for page in except_pages {
-        let page_offset = (page * page_size) as usize;
+        let page_offset = page.offset() as usize;
         if page_offset > interval_offset {
             mprotect(interval_offset, page_offset)?;
         }
-        interval_offset = page_offset.saturating_add(page_size as usize);
+        interval_offset = page.end_offset() as usize;
     }
     if mem_size > interval_offset {
         mprotect(interval_offset, mem_size)

--- a/lazy-pages/src/sys/unix.rs
+++ b/lazy-pages/src/sys/unix.rs
@@ -97,7 +97,7 @@ where
 
         if let Err(err) = H::handle(exc_info) {
             let old_sig_handler_works = match err {
-                Error::SignalFromUnknownMemory { .. } | Error::WasmMemAddrIsNotSet => {
+                Error::OutOfWasmMemoryAccess | Error::WasmMemAddrIsNotSet => {
                     old_sig_handler(sig, info, ucontext)
                 }
                 _ => false,

--- a/lazy-pages/src/tests.rs
+++ b/lazy-pages/src/tests.rs
@@ -16,7 +16,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{mprotect::{mprotect_mem_interval_except_pages, mprotect_pages}, ExceptionInfo, UserSignalHandler, Error, init, LazyPagesVersion};
+use crate::{
+    init,
+    mprotect::{mprotect_mem_interval_except_pages, mprotect_pages},
+    Error, ExceptionInfo, LazyPagesVersion, UserSignalHandler,
+};
 use region::Protection;
 
 #[test]

--- a/lazy-pages/src/tests.rs
+++ b/lazy-pages/src/tests.rs
@@ -178,13 +178,8 @@ fn test_mprotect_pages() {
         }
     }
 
-    mprotect_pages(
-        page_begin,
-        pages_protected.iter().copied(),
-        false,
-        false,
-    )
-    .expect("Must be correct");
+    mprotect_pages(page_begin, pages_protected.iter().copied(), false, false)
+        .expect("Must be correct");
 
     unsafe {
         for &p in pages_protected.iter() {
@@ -202,11 +197,6 @@ fn test_mprotect_pages() {
         }
     }
 
-    mprotect_pages(
-        page_begin,
-        pages_protected.iter().copied(),
-        true,
-        true,
-    )
-    .expect("Must be correct");
+    mprotect_pages(page_begin, pages_protected.iter().copied(), true, true)
+        .expect("Must be correct");
 }

--- a/lazy-pages/src/utils.rs
+++ b/lazy-pages/src/utils.rs
@@ -1,0 +1,60 @@
+// This file is part of Gear.
+
+// Copyright (C) 2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Utils.
+
+use std::{iter::Step, ops::RangeInclusive};
+
+#[derive(Debug, Clone, Copy, derive_more::Display)]
+pub enum WithInclusiveRangesError {
+    #[display(fmt = "forward_checked overflow")]
+    Overflow,
+    #[display(fmt = "Indexes must be sorted by ascending and be uniq")]
+    IndexesAreNotSorted,
+}
+
+/// Call `f` for all inclusive ranges from `indexes`.
+/// For example: `indexes` = {1,2,3,5,6,7,9}, then `f` will be called
+/// for 1..=3, 5..=7, 9..=9 consequently.
+/// `indexes` must be sorted and uniq.
+/// If `f` returns an Err then end execution without remain indexes handling.
+pub fn with_inclusive_ranges<T: Sized + Copy + Eq + Step, E>(
+    mut indexes: impl Iterator<Item = T>,
+    mut f: impl FnMut(RangeInclusive<T>) -> Result<(), E>,
+) -> Result<Result<(), E>, WithInclusiveRangesError> {
+    let mut start = if let Some(start) = indexes.next() {
+        start
+    } else {
+        return Ok(Ok(()));
+    };
+    let mut end = start;
+    for idx in indexes {
+        if end >= idx {
+            return Err(WithInclusiveRangesError::IndexesAreNotSorted);
+        }
+        if Step::forward_checked(end, 1).ok_or(WithInclusiveRangesError::Overflow)? != idx {
+            if let Err(err) = f(start..=end) {
+                return Ok(Err(err));
+            }
+            start = idx;
+        }
+        end = idx;
+    }
+
+    Ok(f(start..=end))
+}

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -59,7 +59,7 @@ gear-program = { path = "../../program", features = [ "cli" ], optional = true }
 substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 
 [features]
-default = ["gear-native", "vara-native", "lazy-pages", "program"]
+default = ["gear-native", "vara-native", "lazy-pages", "program", "runtime-benchmarks"]
 gear-native = [
 	"service/gear-native",
 	"gear-runtime-test-cli?/gear-native",

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -59,7 +59,7 @@ gear-program = { path = "../../program", features = [ "cli" ], optional = true }
 substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 
 [features]
-default = ["gear-native", "vara-native", "lazy-pages", "program", "runtime-benchmarks"]
+default = ["gear-native", "vara-native", "lazy-pages", "program"]
 gear-native = [
 	"service/gear-native",
 	"gear-runtime-test-cli?/gear-native",

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -59,7 +59,7 @@ gear-program = { path = "../../program", features = [ "cli" ], optional = true }
 substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-stable" }
 
 [features]
-default = ["gear-native", "vara-native", "lazy-pages", "program"]
+default = ["gear-native", "vara-native", "lazy-pages", "program", "runtime-test", "runtime-benchmarks"]
 gear-native = [
 	"service/gear-native",
 	"gear-runtime-test-cli?/gear-native",

--- a/pallets/gear-debug/src/lib.rs
+++ b/pallets/gear-debug/src/lib.rs
@@ -40,7 +40,7 @@ pub mod pallet {
     use frame_system::pallet_prelude::*;
     use gear_core::{
         ids::{CodeId, ProgramId},
-        memory::{PageNumber, WasmPageNumber},
+        memory::{PageNumber, WasmPageNumber, PageU32Size},
         message::{StoredDispatch, StoredMessage},
     };
     use primitive_types::H256;
@@ -224,7 +224,7 @@ pub mod pallet {
                 let code_id = CodeId::from_origin(active.code_hash);
                 let static_pages = match T::CodeStorage::get_code(code_id) {
                     Some(code) => code.static_pages(),
-                    None => WasmPageNumber(0),
+                    None => WasmPageNumber::zero(),
                 };
                 let persistent_pages = common::get_program_pages_data(id.into_origin(), &active)
                     .unwrap()

--- a/pallets/gear-debug/src/lib.rs
+++ b/pallets/gear-debug/src/lib.rs
@@ -40,7 +40,7 @@ pub mod pallet {
     use frame_system::pallet_prelude::*;
     use gear_core::{
         ids::{CodeId, ProgramId},
-        memory::{PageNumber, WasmPageNumber, PageU32Size},
+        memory::{PageNumber, PageU32Size, WasmPageNumber},
         message::{StoredDispatch, StoredMessage},
     };
     use primitive_types::H256;

--- a/pallets/gear-debug/src/tests.rs
+++ b/pallets/gear-debug/src/tests.rs
@@ -24,7 +24,7 @@ use frame_support::assert_ok;
 use gear_core::memory::{PageNumber, PAGE_STORAGE_GRANULARITY as PSG};
 use gear_core::{
     ids::{CodeId, MessageId, ProgramId},
-    memory::{PageBuf, WasmPageNumber},
+    memory::{PageBuf, PageU32Size, WasmPageNumber},
     message::{DispatchKind, StoredDispatch, StoredMessage},
 };
 use pallet_gear::{DebugInfo, Pallet as PalletGear};
@@ -104,7 +104,7 @@ fn debug_mode_works() {
 
         GearDebug::do_snapshot();
 
-        let static_pages = WasmPageNumber(16);
+        let static_pages = WasmPageNumber::new(16).unwrap();
 
         System::assert_last_event(
             crate::Event::DebugDataSnapshot(DebugData {
@@ -434,11 +434,11 @@ fn check_not_allocated_pages() {
 
         GearDebug::do_snapshot();
 
-        let gear_page0 = PageNumber::new_from_addr(0);
+        let gear_page0 = PageNumber::from_offset(0x0);
         let mut page0_data = PageBuf::new_zeroed();
         page0_data[0] = 0x42;
 
-        let gear_page7 = PageNumber::new_from_addr(0x70000);
+        let gear_page7 = PageNumber::from_offset(0x70000);
         let mut page7_data = PageBuf::new_zeroed();
         page7_data[0] = 0x42;
 
@@ -642,7 +642,7 @@ fn check_changed_pages_in_storage() {
         let origin = RuntimeOrigin::signed(1);
 
         // Code info. Must be in consensus with wasm code.
-        let static_pages = WasmPageNumber(8);
+        let static_pages = 8.into();
         let page1_accessed_addr = 0x10000;
         let page3_accessed_addr = 0x3fffd;
         let page4_accessed_addr = 0x40000;
@@ -806,8 +806,8 @@ fn check_gear_stack_end() {
         let mut persistent_pages = BTreeMap::new();
         let empty_data = PageBuf::new_zeroed();
 
-        let gear_page2 = WasmPageNumber(2).to_gear_page();
-        let gear_page3 = WasmPageNumber(3).to_gear_page();
+        let gear_page2 = WasmPageNumber::new(2).unwrap().to_page();
+        let gear_page3 = WasmPageNumber::new(3).unwrap().to_page();
         let mut page_data = empty_data.to_vec();
         page_data[0] = 0x42;
 
@@ -831,7 +831,7 @@ fn check_gear_stack_end() {
                 programs: vec![crate::ProgramDetails {
                     id: program_id,
                     state: crate::ProgramState::Active(crate::ProgramInfo {
-                        static_pages: WasmPageNumber(4),
+                        static_pages: WasmPageNumber::new(4).unwrap(),
                         persistent_pages,
                         code_hash: generate_code_hash(&code),
                     }),

--- a/pallets/gear-debug/src/tests.rs
+++ b/pallets/gear-debug/src/tests.rs
@@ -20,10 +20,11 @@ use super::*;
 use crate::mock::*;
 use common::{self, Origin as _};
 use frame_support::assert_ok;
+use gear_core::memory::WasmPageNumber;
 #[cfg(feature = "lazy-pages")]
 use gear_core::{
     ids::{CodeId, MessageId, ProgramId},
-    memory::{to_page_iter, GranularityPage, PageBuf, PageNumber, PageU32Size, WasmPageNumber},
+    memory::{to_page_iter, GranularityPage, PageBuf, PageNumber, PageU32Size},
     message::{DispatchKind, StoredDispatch, StoredMessage},
 };
 use pallet_gear::{DebugInfo, Pallet as PalletGear};
@@ -103,7 +104,7 @@ fn debug_mode_works() {
 
         GearDebug::do_snapshot();
 
-        let static_pages = WasmPageNumber::new(16).unwrap();
+        let static_pages = 16.into();
 
         System::assert_last_event(
             crate::Event::DebugDataSnapshot(DebugData {
@@ -803,8 +804,8 @@ fn check_gear_stack_end() {
         let mut persistent_pages = BTreeMap::new();
         let empty_data = PageBuf::new_zeroed();
 
-        let gear_page2 = WasmPageNumber::new(2).unwrap().to_page();
-        let gear_page3 = WasmPageNumber::new(3).unwrap().to_page();
+        let gear_page2 = WasmPageNumber::from(2).to_page();
+        let gear_page3 = WasmPageNumber::from(3).to_page();
         let mut page_data = empty_data.to_vec();
         page_data[0] = 0x42;
 
@@ -828,7 +829,7 @@ fn check_gear_stack_end() {
                 programs: vec![crate::ProgramDetails {
                     id: program_id,
                     state: crate::ProgramState::Active(crate::ProgramInfo {
-                        static_pages: WasmPageNumber::new(4).unwrap(),
+                        static_pages: 4.into(),
                         persistent_pages,
                         code_hash: generate_code_hash(&code),
                     }),

--- a/pallets/gear-program/src/benchmarking.rs
+++ b/pallets/gear-program/src/benchmarking.rs
@@ -25,7 +25,7 @@ use frame_support::traits::Currency;
 use frame_system::RawOrigin;
 use gear_core::{
     ids::ProgramId,
-    memory::{PageNumber, WasmPageNumber, to_page_iter},
+    memory::{to_page_iter, PageNumber, WasmPageNumber},
 };
 use sp_runtime::traits::UniqueSaturatedInto;
 use sp_std::vec::Vec;

--- a/pallets/gear-program/src/tests.rs
+++ b/pallets/gear-program/src/tests.rs
@@ -25,7 +25,7 @@ use frame_support::{assert_noop, assert_ok};
 use gear_core::{
     code::{Code, CodeAndId},
     ids::{CodeId, MessageId, ProgramId},
-    memory::{PageBuf, PageNumber, WasmPageNumber},
+    memory::{to_page_iter, PageBuf, PageNumber, PageU32Size, WasmPageNumber},
     message::{DispatchKind, StoredDispatch, StoredMessage},
 };
 use gear_wasm_instrument::wasm_instrument::gas_metering::ConstantCostRules;
@@ -45,22 +45,22 @@ fn pause_program_works() {
         let code_id = code_and_id.code_id();
         let code_hash = code_id.into_origin();
 
-        let wasm_static_pages = WasmPageNumber(16);
+        let wasm_static_pages = WasmPageNumber::new(16).unwrap();
         let memory_pages = {
             let mut pages = BTreeMap::new();
-            for page in wasm_static_pages.to_gear_pages_iter() {
+            for page in to_page_iter(wasm_static_pages) {
                 pages.insert(page, PageBuf::new_zeroed());
             }
-            for page in (wasm_static_pages + 2.into()).to_gear_pages_iter() {
+            for page in to_page_iter(wasm_static_pages.add_raw(2).unwrap()) {
                 pages.insert(page, PageBuf::new_zeroed());
             }
-            for i in 0..wasm_static_pages.to_gear_page().0 {
-                pages.insert(i.into(), PageBuf::new_zeroed());
+            for p in PageNumber::zero()..wasm_static_pages.to_page() {
+                pages.insert(p, PageBuf::new_zeroed());
             }
 
             pages
         };
-        let allocations = memory_pages.keys().map(|p| p.to_wasm_page()).collect();
+        let allocations = memory_pages.keys().map(|p| p.to_page()).collect();
         let pages_with_data = memory_pages.keys().copied().collect();
 
         let active_program = ActiveProgram {
@@ -209,7 +209,7 @@ fn pause_terminated_program_fails() {
 #[test]
 fn pause_uninitialized_program_works() {
     new_test_ext().execute_with(|| {
-        let static_pages = WasmPageNumber(16);
+        let static_pages = WasmPageNumber::new(16).unwrap();
         let CreateProgramResult {
             program_id,
             code_id,
@@ -260,7 +260,7 @@ fn resume_uninitialized_program_works() {
         .format_level(true)
         .try_init();
     new_test_ext().execute_with(|| {
-        let static_pages = WasmPageNumber(16);
+        let static_pages = WasmPageNumber::new(16).unwrap();
         let CreateProgramResult {
             program_id,
             init_msg,
@@ -322,7 +322,7 @@ fn resume_uninitialized_program_works() {
 #[test]
 fn resume_program_twice_fails() {
     new_test_ext().execute_with(|| {
-        let static_pages = WasmPageNumber(16);
+        let static_pages = WasmPageNumber::new(16).unwrap();
         let CreateProgramResult {
             program_id,
             memory_pages,
@@ -357,7 +357,7 @@ fn resume_program_twice_fails() {
 #[test]
 fn resume_program_wrong_memory_fails() {
     new_test_ext().execute_with(|| {
-        let static_pages = WasmPageNumber(16);
+        let static_pages = WasmPageNumber::new(16).unwrap();
         let CreateProgramResult {
             program_id,
             mut memory_pages,
@@ -372,7 +372,7 @@ fn resume_program_wrong_memory_fails() {
         assert_ok!(GearProgram::pause_program(program_id));
 
         run_to_block(100, None);
-        memory_pages.remove(&0.into());
+        memory_pages.remove(&PageNumber::zero());
         assert_noop!(
             GearProgram::resume_program_impl(
                 program_id,
@@ -389,7 +389,7 @@ fn resume_program_wrong_memory_fails() {
 #[test]
 fn resume_program_wrong_list_fails() {
     new_test_ext().execute_with(|| {
-        let static_pages = WasmPageNumber(16);
+        let static_pages = WasmPageNumber::new(16).unwrap();
         let CreateProgramResult {
             program_id,
             memory_pages,
@@ -458,19 +458,19 @@ mod utils {
 
         let memory_pages = {
             let mut pages = BTreeMap::new();
-            for page in wasm_static_pages.to_gear_pages_iter() {
+            for page in to_page_iter(wasm_static_pages) {
                 pages.insert(page, PageBuf::new_zeroed());
             }
-            for page in (wasm_static_pages + 2.into()).to_gear_pages_iter() {
+            for page in to_page_iter(wasm_static_pages.add_raw(2).unwrap()) {
                 pages.insert(page, PageBuf::new_zeroed());
             }
-            for i in 0..wasm_static_pages.to_gear_page().0 {
-                pages.insert(i.into(), PageBuf::new_zeroed());
+            for p in PageNumber::zero()..wasm_static_pages.to_page() {
+                pages.insert(p, PageBuf::new_zeroed());
             }
 
             pages
         };
-        let allocations = memory_pages.keys().map(|p| p.to_wasm_page()).collect();
+        let allocations = memory_pages.keys().map(|p| p.to_page()).collect();
         let pages_with_data = memory_pages.keys().copied().collect();
 
         let init_msg_id: MessageId = 3.into();

--- a/pallets/gear/src/benchmarking/code.rs
+++ b/pallets/gear/src/benchmarking/code.rs
@@ -117,7 +117,9 @@ impl ImportedMemory {
     where
         T: Config,
     {
-        Self { min_pages: max_pages::<T>() as u32 }
+        Self {
+            min_pages: max_pages::<T>() as u32,
+        }
     }
 }
 
@@ -457,7 +459,7 @@ pub mod body {
         mem_size: WasmPageNumber,
         mut head: Vec<Instruction>,
     ) -> Vec<Instruction> {
-        for page in (0.into()..mem_size).flat_map(|p| to_page_iter::<_, PageNumber>(p)) {
+        for page in (0.into()..mem_size).flat_map(to_page_iter::<_, PageNumber>) {
             head.push(Instruction::I32Const(page.offset() as i32));
             head.push(Instruction::I32Const(42));
             head.push(Instruction::I32Store(2, 0));
@@ -469,7 +471,7 @@ pub mod body {
         mem_size: WasmPageNumber,
         mut head: Vec<Instruction>,
     ) -> Vec<Instruction> {
-        for page in (0.into()..mem_size).flat_map(|p| to_page_iter::<_, PageNumber>(p)) {
+        for page in (0.into()..mem_size).flat_map(to_page_iter::<_, PageNumber>) {
             head.push(Instruction::I32Const(page.offset() as i32));
             head.push(Instruction::I32Load(2, 0));
             head.push(Instruction::Drop);

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -76,7 +76,7 @@ use gear_core::{
     code::{Code, CodeAndId},
     gas::{GasAllowanceCounter, GasCounter, ValueCounter},
     ids::{MessageId, ProgramId},
-    memory::{AllocationsContext, PageBuf, PageNumber, WasmPageNumber, PageU32Size},
+    memory::{AllocationsContext, PageBuf, PageNumber, PageU32Size, WasmPageNumber},
     message::{ContextSettings, MessageContext},
     reservation::GasReserver,
 };
@@ -334,7 +334,7 @@ benchmarks! {
         let WasmModule { code, .. } = WasmModule::<T>::sized(c * 1024, Location::Init);
     }: {
         let ext = Ext::new(default_processor_context::<T>());
-        ExecutionEnvironment::new(ext, &code, Default::default(), (max_pages::<T>() as u16).into()).unwrap();
+        ExecutionEnvironment::new(ext, &code, Default::default(), max_pages::<T>().into()).unwrap();
     }
 
     claim_value {
@@ -1101,7 +1101,7 @@ benchmarks! {
         // Warm up memory.
         let mut instrs = body::write_access_all_pages_instrs((mem_pages as u16).into(), vec![]);
         instrs = body::repeated_dyn_instr(r * INSTR_BENCHMARK_BATCH_SIZE, vec![
-                        RandomUnaligned(0, mem_pages * WasmPageNumber::size() as u32 - 8),
+                        RandomUnaligned(0, mem_pages * WasmPageNumber::size() - 8),
                         RandomI64Repeated(1),
                         Regular(Instruction::I64Store(3, 0))], instrs);
         let mut sbox = Sandbox::from(&WasmModule::<T>::from(ModuleDefinition {

--- a/pallets/gear/src/benchmarking/syscalls.rs
+++ b/pallets/gear/src/benchmarking/syscalls.rs
@@ -22,9 +22,9 @@ use frame_system::RawOrigin;
 use gear_core::{
     code::{Code, CodeAndId},
     ids::{CodeId, MessageId, ProgramId, ReservationId},
+    memory::WasmPageNumber,
     message::{Dispatch, DispatchKind, Message, ReplyDetails},
     reservation::GasReservationSlot,
-    memory::WasmPageNumber,
 };
 use gear_wasm_instrument::{parity_wasm::elements::Instruction, syscalls::syscall_signature};
 use sp_core::H256;
@@ -161,7 +161,7 @@ where
     let block_config = BlockConfig {
         block_info,
         allocations_config: AllocationsConfig {
-            max_pages: (T::Schedule::get().limits.memory_pages as u16).into(),
+            max_pages: T::Schedule::get().limits.memory_pages.into(),
             init_cost: T::Schedule::get().memory_weights.initial_cost,
             alloc_cost: T::Schedule::get().memory_weights.allocation_cost,
             mem_grow_cost: T::Schedule::get().memory_weights.grow_cost,
@@ -1439,7 +1439,7 @@ where
     }
 
     pub fn lazy_pages_write_access(wasm_pages: WasmPageNumber) -> Result<Exec<T>, &'static str> {
-        let mut instrs = body::read_access_all_pages_instrs((max_pages::<T>() as u16).into(), vec![]);
+        let mut instrs = body::read_access_all_pages_instrs(max_pages::<T>().into(), vec![]);
         instrs = body::write_access_all_pages_instrs(wasm_pages, instrs);
         let code = WasmModule::<T>::from(ModuleDefinition {
             memory: Some(ImportedMemory::max::<T>()),

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -25,7 +25,7 @@ use gear_core::{
     gas::GasAmount,
     ids::{MessageId, ProgramId, ReservationId},
     memory::{GrowHandler, Memory, PageNumber, WasmPageNumber},
-    message::{HandlePacket, InitPacket, ReplyPacket, StatusCode},
+    message::{HandlePacket, InitPacket, ReplyPacket, StatusCode}, lazy_pages::GlobalsCtx,
 };
 use gear_core_errors::{ExtError, MemoryError};
 use gear_lazy_pages_common as lazy_pages;
@@ -86,8 +86,9 @@ impl ProcessorExt for LazyPagesExt {
         mem: &mut impl Memory,
         prog_id: ProgramId,
         stack_end: Option<WasmPageNumber>,
+        globals_ctx: Option<GlobalsCtx>,
     ) {
-        lazy_pages::init_for_program(mem, prog_id, stack_end);
+        lazy_pages::init_for_program(mem, prog_id, stack_end, globals_ctx);
     }
 
     fn lazy_pages_post_execution_actions(mem: &mut impl Memory) {
@@ -333,5 +334,9 @@ impl EnvExt for LazyPagesExt {
 
     fn out_of_allowance(&mut self) -> Self::Error {
         self.inner.out_of_allowance()
+    }
+
+    fn get_runtime_cost(&self, costs: RuntimeCosts) -> u64 {
+        self.inner.get_runtime_cost(costs)
     }
 }

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -25,7 +25,7 @@ use gear_core::{
     gas::GasAmount,
     ids::{MessageId, ProgramId, ReservationId},
     memory::{GrowHandler, Memory, PageNumber, WasmPageNumber},
-    message::{HandlePacket, InitPacket, ReplyPacket, StatusCode}, lazy_pages::GlobalsCtx,
+    message::{HandlePacket, InitPacket, ReplyPacket, StatusCode}, lazy_pages::{GlobalsCtx, Status},
 };
 use gear_core_errors::{ExtError, MemoryError};
 use gear_lazy_pages_common as lazy_pages;
@@ -93,6 +93,10 @@ impl ProcessorExt for LazyPagesExt {
 
     fn lazy_pages_post_execution_actions(mem: &mut impl Memory) {
         lazy_pages::remove_lazy_pages_prot(mem);
+    }
+
+    fn lazy_pages_status() -> Option<Status> {
+        lazy_pages::get_status()
     }
 }
 

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -25,7 +25,7 @@ use gear_core::{
     gas::GasAmount,
     ids::{MessageId, ProgramId, ReservationId},
     lazy_pages::{GlobalsCtx, Status},
-    memory::{GrowHandler, Memory, PageNumber, WasmPageNumber},
+    memory::{GrowHandler, Memory, PageNumber, PageU32Size, WasmPageNumber},
     message::{HandlePacket, InitPacket, ReplyPacket, StatusCode},
 };
 use gear_core_errors::{ExtError, MemoryError};
@@ -44,7 +44,7 @@ impl IntoExtInfo<<LazyPagesExt as EnvExt>::Error> for LazyPagesExt {
             // Accessed pages are all pages, that had been released and are in allocations set or static.
             let mut accessed_pages = lazy_pages::get_released_pages();
             accessed_pages.retain(|p| {
-                let wasm_page = p.to_wasm_page();
+                let wasm_page = p.to_page();
                 wasm_page < static_pages || allocations.contains(&wasm_page)
             });
             log::trace!("accessed pages numbers = {:?}", accessed_pages);

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -24,8 +24,9 @@ use gear_core::{
     env::Ext as EnvExt,
     gas::GasAmount,
     ids::{MessageId, ProgramId, ReservationId},
+    lazy_pages::{GlobalsCtx, Status},
     memory::{GrowHandler, Memory, PageNumber, WasmPageNumber},
-    message::{HandlePacket, InitPacket, ReplyPacket, StatusCode}, lazy_pages::{GlobalsCtx, Status},
+    message::{HandlePacket, InitPacket, ReplyPacket, StatusCode},
 };
 use gear_core_errors::{ExtError, MemoryError};
 use gear_lazy_pages_common as lazy_pages;

--- a/pallets/gear/src/manager/journal.rs
+++ b/pallets/gear/src/manager/journal.rs
@@ -36,7 +36,7 @@ use frame_support::{
 use frame_system::pallet_prelude::BlockNumberFor;
 use gear_core::{
     ids::{CodeId, MessageId, ProgramId, ReservationId},
-    memory::{PageBuf, PageNumber},
+    memory::{PageBuf, PageNumber, to_page_iter},
     message::{Dispatch, MessageWaitedType, StoredDispatch},
     reservation::GasReserver,
 };
@@ -394,7 +394,7 @@ where
             .expect("page update guaranteed to be called only for existing and active program");
         if let Program::Active(mut program) = program {
             let removed_pages = program.allocations.difference(&allocations);
-            for page in removed_pages.flat_map(|p| p.to_gear_pages_iter()) {
+            for page in removed_pages.flat_map(|&page| to_page_iter(page)) {
                 if program.pages_with_data.remove(&page) {
                     common::remove_program_page_data(program_id, page);
                 }

--- a/pallets/gear/src/manager/journal.rs
+++ b/pallets/gear/src/manager/journal.rs
@@ -36,7 +36,7 @@ use frame_support::{
 use frame_system::pallet_prelude::BlockNumberFor;
 use gear_core::{
     ids::{CodeId, MessageId, ProgramId, ReservationId},
-    memory::{PageBuf, PageNumber, to_page_iter},
+    memory::{to_page_iter, PageBuf, PageNumber},
     message::{Dispatch, MessageWaitedType, StoredDispatch},
     reservation::GasReserver,
 };

--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -655,10 +655,10 @@ impl<T: Config> HostFnWeights<T> {
             gr_send_push_input_per_byte: self.gr_send_push_input_per_byte,
             gr_reply_push_input: self.gr_reply_push_input,
             gr_reply_push_input_per_byte: self.gr_reply_push_input_per_byte,
-            lazy_pages_read: 100,             // TODO
-            lazy_pages_write: 100,            // TODO
-            lazy_pages_write_after_read: 100, // TODO
-            lazy_pages_update: 100,           // TODO
+            lazy_pages_read: 100,             // TODO: #1893
+            lazy_pages_write: 100,            // TODO: #1893
+            lazy_pages_write_after_read: 100, // TODO: #1893
+            update_page_in_storage: 100,      // TODO: #1731
         }
     }
 }

--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -655,6 +655,9 @@ impl<T: Config> HostFnWeights<T> {
             gr_send_push_input_per_byte: self.gr_send_push_input_per_byte,
             gr_reply_push_input: self.gr_reply_push_input,
             gr_reply_push_input_per_byte: self.gr_reply_push_input_per_byte,
+            lazy_pages_read: 100, // TODO
+            lazy_pages_write: 100, // TODO
+            lazy_pages_update: 100, // TODO
         }
     }
 }

--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -140,7 +140,7 @@ pub struct Limits {
     pub parameters: u32,
 
     /// Maximum number of memory pages allowed for a program.
-    pub memory_pages: u32,
+    pub memory_pages: u16,
 
     /// Maximum number of elements allowed in a table.
     ///
@@ -168,7 +168,7 @@ pub struct Limits {
 impl Limits {
     /// The maximum memory size in bytes that a program can occupy.
     pub fn max_memory_size(&self) -> u32 {
-        self.memory_pages * 64 * 1024
+        self.memory_pages as u32 * 64 * 1024
     }
 }
 

--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -655,9 +655,10 @@ impl<T: Config> HostFnWeights<T> {
             gr_send_push_input_per_byte: self.gr_send_push_input_per_byte,
             gr_reply_push_input: self.gr_reply_push_input,
             gr_reply_push_input_per_byte: self.gr_reply_push_input_per_byte,
-            lazy_pages_read: 100, // TODO
-            lazy_pages_write: 100, // TODO
-            lazy_pages_update: 100, // TODO
+            lazy_pages_read: 100,             // TODO
+            lazy_pages_write: 100,            // TODO
+            lazy_pages_write_after_read: 100, // TODO
+            lazy_pages_update: 100,           // TODO
         }
     }
 }

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -64,7 +64,7 @@ use gear_backend_common::{StackEndError, TrapExplanation};
 use gear_core::{
     code::{self, Code},
     ids::{CodeId, MessageId, ProgramId},
-    memory::{WasmPageNumber, PageU32Size},
+    memory::{PageU32Size, WasmPageNumber},
 };
 use gear_core_errors::*;
 use sp_runtime::{traits::UniqueSaturatedInto, SaturatedConversion};
@@ -1213,7 +1213,7 @@ fn lazy_pages() {
             };
             if granularity > PageNumber::size() {
                 // `x` is a number of gear pages in granularity
-                let x = (granularity / PageNumber::size()) as u32;
+                let x = granularity / PageNumber::size();
                 // is first gear page in granularity interval
                 let first_gear_page = (p / x) * x;
                 // accessed gear pages range:
@@ -1227,16 +1227,16 @@ fn lazy_pages() {
         expected_released.extend(page_to_released(0, false));
 
         // released from 2 wasm page:
-        let first_page = (0x23ffe / PageNumber::size()) as u32;
-        let second_page = (0x24001 / PageNumber::size()) as u32;
+        let first_page = 0x23ffe / PageNumber::size();
+        let second_page = 0x24001 / PageNumber::size();
         expected_released.extend(page_to_released(first_page, true));
         expected_released.extend(page_to_released(second_page, true));
 
         // nothing for 5 wasm page, because it's just read access
 
         // released from 8 and 9 wasm pages, must be several gear pages:
-        let first_page = (0x8fffc / PageNumber::size()) as u32;
-        let second_page = (0x90003 / PageNumber::size()) as u32;
+        let first_page = 0x8fffc / PageNumber::size();
+        let second_page = 0x90003 / PageNumber::size();
         expected_released.extend(page_to_released(first_page, true));
         expected_released.extend(page_to_released(second_page, true));
 
@@ -1264,14 +1264,14 @@ fn lazy_pages() {
         expected_released.extend(page_to_released(0, false));
 
         // released from 2 wasm page:
-        let first_page = (0x23ffe / PageNumber::size()) as u32;
-        let second_page = (0x24001 / PageNumber::size()) as u32;
+        let first_page = 0x23ffe / PageNumber::size();
+        let second_page = 0x24001 / PageNumber::size();
         expected_released.extend(page_to_released(first_page, false));
         expected_released.extend(page_to_released(second_page, false));
 
         // released from 8 and 9 wasm pages, must be several gear pages:
-        let first_page = (0x8fffc / PageNumber::size()) as u32;
-        let second_page = (0x90003 / PageNumber::size()) as u32;
+        let first_page = 0x8fffc / PageNumber::size();
+        let second_page = 0x90003 / PageNumber::size();
         expected_released.extend(page_to_released(first_page, false));
         expected_released.extend(page_to_released(second_page, false));
 

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -2060,6 +2060,8 @@ fn claim_value_works() {
             GasPrice::gas_price(holding_duration * CostsPerBlockOf::<Test>::mailbox());
         // Gas left returns to sender from consuming of value tree while claiming.
         let expected_sender_balance = sender_balance - value_sent - gas_burned - burned_for_hold;
+        // dbg!(Balances::free_balance(USER_2), expected_sender_balance);
+        // dbg!();
         assert_eq!(Balances::free_balance(USER_2), expected_sender_balance);
         assert_eq!(
             Balances::free_balance(BLOCK_AUTHOR),

--- a/runtime-interface/Cargo.toml
+++ b/runtime-interface/Cargo.toml
@@ -23,10 +23,6 @@ region = { version = "3.0.0", optional = true }
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["memoryapi"] }
 
-[dev-dependencies]
-nix = "0.24"
-env_logger = "0.9.0"
-
 [features]
 default = ["std"]
 std = [

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -22,11 +22,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use gear_core::{
-    lazy_pages::{GlobalsCtx, Status},
+    lazy_pages::{GlobalsCtx, Status, AccessError},
     memory::HostPointer,
 };
 use sp_runtime_interface::runtime_interface;
-use sp_runtime_interface::Pointer;
 
 static_assertions::const_assert!(
     core::mem::size_of::<HostPointer>() >= core::mem::size_of::<usize>()
@@ -41,8 +40,8 @@ pub use sp_std::{convert::TryFrom, result::Result, vec::Vec};
 /// Note: name is expanded as gear_ri
 #[runtime_interface]
 pub trait GearRI {
-    fn func(reads: &[(u32, u32)], writes: &[(u32, u32)], gas_limit: u64, gas_allowance: u64) -> (u64, u64) {
-        (0, 0)
+    fn pre_process_memory_accesses(reads: &[(u32, u32)], writes: &[(u32, u32)]) -> Result<(), AccessError> {
+        lazy_pages::pre_process_memory_accesses(reads, writes, None, None)
     }
 
     fn get_lazy_pages_status() -> Option<Status> {
@@ -52,9 +51,9 @@ pub trait GearRI {
     /// Init lazy-pages.
     /// Returns whether initialization was successful.
     fn init_lazy_pages() -> bool {
-        use lazy_pages::{DefaultUserSignalHandler, LazyPagesVersion};
+        use lazy_pages::LazyPagesVersion;
 
-        lazy_pages::init::<DefaultUserSignalHandler>(LazyPagesVersion::Version1)
+        lazy_pages::init(LazyPagesVersion::Version1)
     }
 
     #[deprecated]

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -21,9 +21,11 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use core::ops::RangeInclusive;
-use gear_core::{memory::HostPointer, lazy_pages::Status};
+use gear_core::{
+    lazy_pages::{GlobalsCtx, Status},
+    memory::HostPointer,
+};
 use sp_runtime_interface::runtime_interface;
-use gear_core::lazy_pages::GlobalsCtx;
 
 static_assertions::const_assert!(
     core::mem::size_of::<HostPointer>() >= core::mem::size_of::<usize>()

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -36,7 +36,6 @@ use gear_lazy_pages as lazy_pages;
 
 pub use sp_std::{convert::TryFrom, result::Result, vec::Vec};
 
-
 /// Runtime interface for gear node and runtime.
 /// Note: name is expanded as gear_ri
 #[runtime_interface]

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -21,7 +21,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use core::ops::RangeInclusive;
-use gear_core::memory::HostPointer;
+use gear_core::{memory::HostPointer, lazy_pages::Status};
 use sp_runtime_interface::runtime_interface;
 use gear_core::lazy_pages::GlobalsCtx;
 
@@ -131,6 +131,10 @@ fn mprotect_mem_interval_except_pages(
 /// Note: name is expanded as gear_ri
 #[runtime_interface]
 pub trait GearRI {
+    fn get_lazy_pages_status() -> Option<Status> {
+        lazy_pages::get_status()
+    }
+
     /// Init lazy-pages.
     /// Returns whether initialization was successful.
     fn init_lazy_pages() -> bool {

--- a/runtime-interface/src/lib.rs
+++ b/runtime-interface/src/lib.rs
@@ -26,6 +26,7 @@ use gear_core::{
     memory::HostPointer,
 };
 use sp_runtime_interface::runtime_interface;
+use sp_runtime_interface::Pointer;
 
 static_assertions::const_assert!(
     core::mem::size_of::<HostPointer>() >= core::mem::size_of::<usize>()
@@ -40,6 +41,10 @@ pub use sp_std::{convert::TryFrom, result::Result, vec::Vec};
 /// Note: name is expanded as gear_ri
 #[runtime_interface]
 pub trait GearRI {
+    fn func(reads: &[(u32, u32)], writes: &[(u32, u32)], gas_limit: u64, gas_allowance: u64) -> (u64, u64) {
+        (0, 0)
+    }
+
     fn get_lazy_pages_status() -> Option<Status> {
         lazy_pages::get_status()
     }

--- a/utils/gear-runtime-test-cli/src/command.rs
+++ b/utils/gear-runtime-test-cli/src/command.rs
@@ -27,7 +27,7 @@ use frame_support::traits::ReservableCurrency;
 use gear_common::{storage::*, GasPrice, GasTree, Origin as _};
 use gear_core::{
     ids::{CodeId, ProgramId},
-    memory::vec_page_data_map_to_page_buf_map,
+    memory::{vec_page_data_map_to_page_buf_map, PageU32Size},
     message::{DispatchKind, GasLimit, StoredDispatch, StoredMessage},
 };
 use gear_core_processor::common::ExecutableActorData;
@@ -454,7 +454,7 @@ macro_rules! command {
                                 .persistent_pages
                                 .keys()
                                 .copied()
-                                .map(|p| p.to_wasm_page())
+                                .map(|p| p.to_page())
                                 .collect();
 
                             let memory =

--- a/utils/wasm-instrument/src/tests.rs
+++ b/utils/wasm-instrument/src/tests.rs
@@ -20,6 +20,7 @@ use super::*;
 use elements::Instruction::*;
 use gas_metering::ConstantCostRules;
 use parity_wasm::serialize;
+use gear_core::memory::{WasmPageNumber, PageU32Size};
 
 fn get_function_body(module: &elements::Module, index: usize) -> Option<&[elements::Instruction]> {
     module
@@ -636,7 +637,7 @@ fn test_sys_calls_table() {
 
     // Execute wasm and check success.
     let ext = MockExt::default();
-    let env = WasmiEnvironment::new(ext, &code, Default::default(), 0.into()).unwrap();
+    let env = WasmiEnvironment::new(ext, &code, Default::default(), WasmPageNumber::zero()).unwrap();
     let res = env
         .execute(&DispatchKind::Init, |_, _, _| -> Result<(), u32> { Ok(()) })
         .unwrap();

--- a/utils/wasm-instrument/src/tests.rs
+++ b/utils/wasm-instrument/src/tests.rs
@@ -638,7 +638,7 @@ fn test_sys_calls_table() {
     let ext = MockExt::default();
     let env = WasmiEnvironment::new(ext, &code, Default::default(), 0.into()).unwrap();
     let res = env
-        .execute(&DispatchKind::Init, |_, _| -> Result<(), u32> { Ok(()) })
+        .execute(&DispatchKind::Init, |_, _, _| -> Result<(), u32> { Ok(()) })
         .unwrap();
 
     assert_eq!(res.termination_reason, TerminationReason::Success);

--- a/utils/wasm-instrument/src/tests.rs
+++ b/utils/wasm-instrument/src/tests.rs
@@ -19,8 +19,8 @@
 use super::*;
 use elements::Instruction::*;
 use gas_metering::ConstantCostRules;
+use gear_core::memory::{PageU32Size, WasmPageNumber};
 use parity_wasm::serialize;
-use gear_core::memory::{WasmPageNumber, PageU32Size};
 
 fn get_function_body(module: &elements::Module, index: usize) -> Option<&[elements::Instruction]> {
     module
@@ -637,7 +637,8 @@ fn test_sys_calls_table() {
 
     // Execute wasm and check success.
     let ext = MockExt::default();
-    let env = WasmiEnvironment::new(ext, &code, Default::default(), WasmPageNumber::zero()).unwrap();
+    let env =
+        WasmiEnvironment::new(ext, &code, Default::default(), WasmPageNumber::zero()).unwrap();
     let res = env
         .execute(&DispatchKind::Init, |_, _, _| -> Result<(), u32> { Ok(()) })
         .unwrap();

--- a/utils/wasm-proc/src/main.rs
+++ b/utils/wasm-proc/src/main.rs
@@ -21,7 +21,7 @@ use gear_wasm_builder::optimize::{OptType, Optimizer};
 use parity_wasm::elements::External;
 use std::{collections::HashSet, fs, path::PathBuf};
 
-const RT_ALLOWED_IMPORTS: [&str; 50] = [
+const RT_ALLOWED_IMPORTS: [&str; 52] = [
     // From `Allocator` (substrate/primitives/io/src/lib.rs)
     "ext_allocator_free_version_1",
     "ext_allocator_malloc_version_1",
@@ -34,10 +34,11 @@ const RT_ALLOWED_IMPORTS: [&str; 50] = [
     "ext_crypto_sr25519_verify_version_2",
     "ext_crypto_start_batch_verify_version_1",
     // From `GearRI` (runtime-interface/scr/lib.rs)
+    "ext_gear_ri_get_lazy_pages_status_version_1",
     "ext_gear_ri_get_released_pages_version_1",
     "ext_gear_ri_init_lazy_pages_version_1",
     "ext_gear_ri_init_lazy_pages_for_program_version_1",
-    "ext_gear_ri_is_lazy_pages_enabled_version_1",
+    "ext_gear_ri_init_lazy_pages_for_program_version_2",
     "ext_gear_ri_mprotect_lazy_pages_version_1",
     "ext_gear_ri_set_wasm_mem_begin_addr_version_1",
     "ext_gear_ri_set_wasm_mem_size_version_1",
@@ -54,6 +55,7 @@ const RT_ALLOWED_IMPORTS: [&str; 50] = [
     "ext_misc_print_utf8_version_1",
     "ext_misc_runtime_version_version_1",
     // From `Sandbox` (substrate/primitives/io/src/lib.rs)
+    "ext_sandbox_get_instance_ptr_version_1",
     "ext_sandbox_get_buff_version_1",
     "ext_sandbox_get_global_val_version_1",
     "ext_sandbox_set_global_val_version_1",


### PR DESCRIPTION
Resolves #1731 

1) add globals access interfaces  in gear-core, to be able access globals in lazy-pages. 
2) update substrate to the version where host function `get_instance_ptr` exist.
3) add charging for lazy pages access read/write/write_after_read inside signal handler.
4) move memory pages protection logic from `gear-runtime-interface` to `gear-lazy-pages` in order to make it more optimised.
5) Add struct GlobalsCtx which is to transfer information from runtime to lazy-pages about how to access globals for current execution, how much to charge gas and e.t.c.
