### PR TITLE
Add production profile to demos built with `wasm-builder`

### DIFF
--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -123,9 +123,13 @@ impl WasmProject {
         release_profile.insert("lto".into(), true.into());
         release_profile.insert("opt-level".into(), "s".into());
 
+        let mut production_profile = Table::new();
+        production_profile.insert("inherits".into(), "release".into());
+
         let mut profile = Table::new();
         profile.insert("dev".into(), release_profile.clone().into());
         profile.insert("release".into(), release_profile.into());
+        profile.insert("production".into(), production_profile.into());
 
         let mut crate_package = Table::new();
         crate_package.insert("package".into(), crate_info.name.into());


### PR DESCRIPTION
Fixes this https://github.com/gear-tech/gear/actions/runs/3592342346/jobs/6047937784

Test with `cargo build -p gear-cli --profile production`