### PR TITLE
Remove `unsafe` from `extern` functions

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -48,8 +48,9 @@ Here is a minimal program for a classic ping-pong contract:
 use gstd::{ext, msg};
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
-    let new_msg = String::from_utf8(msg::load_bytes().expect("Failed to load payload")).expect("Invalid message: should be utf-8");
+extern "C" fn handle() {
+    let new_msg = String::from_utf8(msg::load_bytes().expect("Failed to load payload"))
+        .expect("Invalid message: should be utf-8");
 
     if &new_msg == "PING" {
         msg::send_bytes(msg::source(), b"PONG", 0);
@@ -57,7 +58,7 @@ unsafe extern "C" fn handle() {
 }
 
 #[no_mangle]
-unsafe extern "C" fn init() {}
+extern "C" fn init() {}
 ```
 
 It will just send `PONG` back to the original sender (this can be you!)

--- a/examples/async-init/src/lib.rs
+++ b/examples/async-init/src/lib.rs
@@ -37,11 +37,13 @@ gstd::metadata! {
 async fn init() {
     let args: InputArgs = msg::load().expect("Failed to decode `InputArgs`");
 
-    APPROVER_FIRST = args.approver_first;
-    APPROVER_SECOND = args.approver_second;
-    APPROVER_THIRD = args.approver_third;
+    unsafe {
+        APPROVER_FIRST = args.approver_first;
+        APPROVER_SECOND = args.approver_second;
+        APPROVER_THIRD = args.approver_third;
+    }
 
-    let mut requests: Vec<_> = [APPROVER_FIRST, APPROVER_SECOND, APPROVER_THIRD]
+    let mut requests: Vec<_> = unsafe { [APPROVER_FIRST, APPROVER_SECOND, APPROVER_THIRD] }
         .iter()
         .map(|s| msg::send_bytes_for_reply(*s, b"", 0))
         .collect::<Result<_, _>>()
@@ -67,15 +69,11 @@ async fn main() {
         return;
     }
 
-    let requests: Vec<_> = [
-        unsafe { APPROVER_FIRST },
-        unsafe { APPROVER_SECOND },
-        unsafe { APPROVER_THIRD },
-    ]
-    .iter()
-    .map(|s| msg::send_bytes_for_reply(*s, b"", 0))
-    .collect::<Result<_, _>>()
-    .unwrap();
+    let requests: Vec<_> = unsafe { [APPROVER_FIRST, APPROVER_SECOND, APPROVER_THIRD] }
+        .iter()
+        .map(|s| msg::send_bytes_for_reply(*s, b"", 0))
+        .collect::<Result<_, _>>()
+        .unwrap();
 
     let _ = future::select_all(requests).await;
 

--- a/examples/async-multisig/src/lib.rs
+++ b/examples/async-multisig/src/lib.rs
@@ -35,19 +35,21 @@ gstd::metadata! {
 }
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let args: InputArgs = msg::load().expect("Failed to decode `InputArgs`");
 
-    DESTINATION = args.destination;
+    unsafe {
+        DESTINATION = args.destination;
 
-    args.signatories
-        .into_iter()
-        .filter(|s| !SIGNATORIES.contains(s))
-        .for_each(|s| SIGNATORIES.push(s));
+        args.signatories
+            .into_iter()
+            .filter(|s| !SIGNATORIES.contains(s))
+            .for_each(|s| SIGNATORIES.push(s));
 
-    THRESHOLD = usize::try_from(args.threshold)
-        .map(|t| t.clamp(1, SIGNATORIES.len()))
-        .unwrap_or(1);
+        THRESHOLD = usize::try_from(args.threshold)
+            .map(|t| t.clamp(1, SIGNATORIES.len()))
+            .unwrap_or(1);
+    }
 }
 
 #[gstd::async_main]

--- a/examples/async-recursion/src/lib.rs
+++ b/examples/async-recursion/src/lib.rs
@@ -14,13 +14,15 @@ fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
 }
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let input = String::from_utf8(msg::load_bytes().expect("Failed to load payload bytes"))
         .expect("Invalid message: should be utf-8");
-    DEST = ActorId::from_slice(
-        &decode_hex(&input).expect("Initialization failed: invalid program ID"),
-    )
-    .expect("Unable to create ActorId");
+    unsafe {
+        DEST = ActorId::from_slice(
+            &decode_hex(&input).expect("Initialization failed: invalid program ID"),
+        )
+        .expect("Unable to create ActorId");
+    }
 }
 
 /// Send message "PING" and wait for a reply, then recursively

--- a/examples/async-sign/src/lib.rs
+++ b/examples/async-sign/src/lib.rs
@@ -30,11 +30,13 @@ gstd::metadata! {
 }
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let args: InputArgs = msg::load().expect("Failed to decode `InputArgs`");
 
-    DESTINATION = args.destination;
-    SIGNATORY = args.signatory;
+    unsafe {
+        DESTINATION = args.destination;
+        SIGNATORY = args.signatory;
+    }
 }
 
 #[gstd::async_main]

--- a/examples/async/src/lib.rs
+++ b/examples/async/src/lib.rs
@@ -18,25 +18,27 @@ gstd::metadata! {
 }
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let input = String::from_utf8(msg::load_bytes().expect("Failed to load payload bytes"))
         .expect("Invalid message: should be utf-8");
     let dests: Vec<&str> = input.split(',').collect();
     if dests.len() != 3 {
         panic!("Invalid input, should be three IDs separated by comma");
     }
-    DEST_0 = ActorId::from_slice(
-        &decode_hex(dests[0]).expect("INTIALIZATION FAILED: INVALID PROGRAM ID"),
-    )
-    .expect("Unable to create ActorId");
-    DEST_1 = ActorId::from_slice(
-        &decode_hex(dests[1]).expect("INTIALIZATION FAILED: INVALID PROGRAM ID"),
-    )
-    .expect("Unable to create ActorId");
-    DEST_2 = ActorId::from_slice(
-        &decode_hex(dests[2]).expect("INTIALIZATION FAILED: INVALID PROGRAM ID"),
-    )
-    .expect("Unable to create ActorId");
+    unsafe {
+        DEST_0 = ActorId::from_slice(
+            &decode_hex(dests[0]).expect("INTIALIZATION FAILED: INVALID PROGRAM ID"),
+        )
+        .expect("Unable to create ActorId");
+        DEST_1 = ActorId::from_slice(
+            &decode_hex(dests[1]).expect("INTIALIZATION FAILED: INVALID PROGRAM ID"),
+        )
+        .expect("Unable to create ActorId");
+        DEST_2 = ActorId::from_slice(
+            &decode_hex(dests[2]).expect("INTIALIZATION FAILED: INVALID PROGRAM ID"),
+        )
+        .expect("Unable to create ActorId");
+    }
 }
 
 fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {

--- a/examples/binaries/async-tester/src/code.rs
+++ b/examples/binaries/async-tester/src/code.rs
@@ -5,7 +5,7 @@ use gstd::{
 };
 
 #[no_mangle]
-unsafe extern "C" fn init() {}
+extern "C" fn init() {}
 
 #[gstd::async_main]
 async fn main() {

--- a/examples/binaries/btree/src/lib.rs
+++ b/examples/binaries/btree/src/lib.rs
@@ -57,7 +57,7 @@ mod wasm {
     static mut STATE: Option<BTreeMap<u32, u32>> = None;
 
     #[no_mangle]
-    unsafe extern "C" fn handle() {
+    extern "C" fn handle() {
         let reply = match msg::load() {
             Ok(request) => process(request),
             Err(e) => {
@@ -88,8 +88,8 @@ mod wasm {
     }
 
     #[no_mangle]
-    unsafe extern "C" fn init() {
-        STATE = Some(BTreeMap::new());
+    extern "C" fn init() {
+        unsafe { STATE = Some(BTreeMap::new()) };
         msg::reply((), 0).unwrap();
     }
 }

--- a/examples/binaries/calc-hash/in-one-block/src/code.rs
+++ b/examples/binaries/calc-hash/in-one-block/src/code.rs
@@ -2,7 +2,7 @@ use crate::Package;
 use gstd::msg;
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let mut pkg = msg::load::<Package>().expect("Invalid initial data.");
 
     while !pkg.finished() {

--- a/examples/binaries/compose/src/lib.rs
+++ b/examples/binaries/compose/src/lib.rs
@@ -139,10 +139,10 @@ mod wasm {
     }
 
     #[no_mangle]
-    unsafe extern "C" fn init() {
+    extern "C" fn init() {
         let (contract_a, contract_b): (ActorId, ActorId) =
             msg::load().expect("Expecting two contract addresses");
-        STATE = State::new(contract_a, contract_b);
+        unsafe { STATE = State::new(contract_a, contract_b) };
         msg::reply_bytes([], 0).unwrap();
     }
 }

--- a/examples/binaries/contract-template/src/lib.rs
+++ b/examples/binaries/contract-template/src/lib.rs
@@ -220,10 +220,10 @@ mod wasm {
     }
 
     #[no_mangle]
-    unsafe extern "C" fn init() {
+    extern "C" fn init() {
         let programs: Vec<ActorId> =
             msg::load().expect("Malformed input: expecting vectors of program IDs and random IDs");
-        STATE = State::new(programs);
+        unsafe { STATE = State::new(programs) };
         msg::reply_bytes([], 0).unwrap();
         debug!(
             "[0x{} contract-template::init] Program initialized",

--- a/examples/binaries/distributor/src/lib.rs
+++ b/examples/binaries/distributor/src/lib.rs
@@ -202,20 +202,20 @@ mod wasm {
     }
 
     #[no_mangle]
-    unsafe extern "C" fn handle() {
+    extern "C" fn handle() {
         debug!("Handling sequence started");
         gstd::message_loop(Program::handle_request());
         debug!("Handling sequence terminated");
     }
 
     #[no_mangle]
-    unsafe extern "C" fn handle_reply() {
+    extern "C" fn handle_reply() {
         gstd::record_reply();
     }
 
     #[no_mangle]
-    unsafe extern "C" fn init() {
-        STATE = Some(ProgramState::default());
+    extern "C" fn init() {
+        unsafe { STATE = Some(Default::default()) };
         msg::reply((), 0).unwrap();
         debug!("Program initialized");
     }

--- a/examples/binaries/exit-handle-sender/src/lib.rs
+++ b/examples/binaries/exit-handle-sender/src/lib.rs
@@ -28,7 +28,7 @@ mod wasm {
     use gstd::{exec, msg};
 
     #[no_mangle]
-    unsafe extern "C" fn handle() {
+    extern "C" fn handle() {
         let input: Input = msg::load().unwrap();
 
         match input {

--- a/examples/binaries/exit-handle/src/lib.rs
+++ b/examples/binaries/exit-handle/src/lib.rs
@@ -14,12 +14,12 @@ mod wasm {
     use gstd::{exec, msg};
 
     #[no_mangle]
-    unsafe extern "C" fn handle() {
+    extern "C" fn handle() {
         exec::exit(msg::source());
         // should not be executed
         msg::reply(b"reply", 0).unwrap();
     }
 
     #[no_mangle]
-    unsafe extern "C" fn init() {}
+    extern "C" fn init() {}
 }

--- a/examples/binaries/exit-init/src/lib.rs
+++ b/examples/binaries/exit-init/src/lib.rs
@@ -15,10 +15,10 @@ mod wasm {
     use gstd::exec;
 
     #[no_mangle]
-    unsafe extern "C" fn handle() {}
+    extern "C" fn handle() {}
 
     #[no_mangle]
-    unsafe extern "C" fn init() {
+    extern "C" fn init() {
         let shall_reply_before_exit: bool = {
             let mut flag = [0u8];
             msg::read(&mut flag);

--- a/examples/binaries/gas-burned/src/lib.rs
+++ b/examples/binaries/gas-burned/src/lib.rs
@@ -18,7 +18,7 @@ const SHORT: usize = 100;
 const LONG: usize = 10000;
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let mut v = vec![0; SHORT];
     for (i, item) in v.iter_mut().enumerate() {
         *item = i * i;
@@ -27,7 +27,7 @@ unsafe extern "C" fn init() {
 }
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let mut v = vec![0; LONG];
     for (i, item) in v.iter_mut().enumerate() {
         *item = i * i;

--- a/examples/binaries/gasless-wasting/src/lib.rs
+++ b/examples/binaries/gasless-wasting/src/lib.rs
@@ -40,7 +40,7 @@ mod wasm {
     use gstd::{msg, ActorId};
 
     #[no_mangle]
-    unsafe extern "C" fn handle() {
+    extern "C" fn handle() {
         let input: InputArgs = msg::load().unwrap();
         msg::send_bytes(input.prog_to_waste, [], 0).unwrap();
         msg::send_bytes(input.prog_to_wait, [], 0).unwrap();

--- a/examples/binaries/init-with-value/src/lib.rs
+++ b/examples/binaries/init-with-value/src/lib.rs
@@ -58,7 +58,7 @@ mod wasm {
         hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a");
 
     #[no_mangle]
-    unsafe extern "C" fn init() {
+    extern "C" fn init() {
         let data: gstd::Vec<SendMessage> = msg::load().expect("provided invalid payload");
         let init = |wgas: bool, value: u128| {
             let submitted_code = CHILD_CODE_HASH.into();
@@ -66,18 +66,18 @@ mod wasm {
             let res = if wgas {
                 prog::create_program_with_gas(
                     submitted_code,
-                    COUNTER.to_le_bytes(),
+                    unsafe { COUNTER.to_le_bytes() },
                     [],
                     super::GAS_LIMIT,
                     value,
                 )
             } else {
-                prog::create_program(submitted_code, COUNTER.to_le_bytes(), [], value)
+                prog::create_program(submitted_code, unsafe { COUNTER.to_le_bytes() }, [], value)
             };
 
             match res {
                 Ok(_) => {
-                    COUNTER += 1;
+                    unsafe { COUNTER += 1 };
                 }
                 Err(ContractError::Ext(err)) => panic!("{}", err),
                 Err(err) => panic!("{}", err),

--- a/examples/binaries/meta/src/code.rs
+++ b/examples/binaries/meta/src/code.rs
@@ -2,7 +2,7 @@ use crate::{Id, MessageIn, MessageInitIn, MessageInitOut, MessageOut, Person, Wa
 use gstd::{msg, prelude::*};
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let message_in: MessageIn = msg::load().unwrap();
     let message_out: MessageOut = message_in.into();
 
@@ -10,8 +10,9 @@ unsafe extern "C" fn handle() {
 }
 
 #[no_mangle]
-unsafe extern "C" fn init() {
-    WALLETS.push(Wallet {
+extern "C" fn init() {
+    let wallets = unsafe { &mut WALLETS };
+    wallets.push(Wallet {
         id: Id {
             decimal: 1,
             hex: vec![1u8],
@@ -21,7 +22,7 @@ unsafe extern "C" fn init() {
             name: "SomeName".into(),
         },
     });
-    WALLETS.push(Wallet {
+    wallets.push(Wallet {
         id: Id {
             decimal: 2,
             hex: vec![2u8],
@@ -39,12 +40,11 @@ unsafe extern "C" fn init() {
 }
 
 #[no_mangle]
-unsafe extern "C" fn meta_state() -> *mut [i32; 2] {
+extern "C" fn meta_state() -> *mut [i32; 2] {
     let person: Option<Id> = msg::load().expect("failed to decode input argument");
     let encoded = match person {
-        None => WALLETS.encode(),
-        Some(lookup_id) => WALLETS
-            .iter()
+        None => unsafe { WALLETS.encode() },
+        Some(lookup_id) => unsafe { WALLETS.iter() }
             .filter(|w| w.id == lookup_id)
             .cloned()
             .collect::<Vec<Wallet>>()

--- a/examples/binaries/mul-by-const/src/lib.rs
+++ b/examples/binaries/mul-by-const/src/lib.rs
@@ -69,23 +69,26 @@ mod wasm {
     }
 
     #[no_mangle]
-    unsafe extern "C" fn handle() {
+    extern "C" fn handle() {
         let x: u64 = msg::load().expect("Expecting a u64 number");
 
-        msg::reply(STATE.unchecked_mul(x), 0).unwrap();
+        msg::reply(unsafe { STATE.unchecked_mul(x) }, 0).unwrap();
     }
 
     #[no_mangle]
-    unsafe extern "C" fn init() {
+    extern "C" fn init() {
         let val: u64 = msg::load().expect("Expecting a u64 number");
-        STATE = State::new(val);
-        DEBUG = DebugInfo {
-            me: hex::encode(exec::program_id()),
-        };
+        unsafe {
+            STATE = State::new(val);
+            DEBUG = DebugInfo {
+                me: hex::encode(exec::program_id()),
+            };
+        }
         msg::reply_bytes([], 0).unwrap();
         debug!(
             "[0x{} mul_by_const::init] Program initialized with input {}",
-            DEBUG.me, val
+            unsafe { &DEBUG.me },
+            val
         );
     }
 }

--- a/examples/binaries/ncompose/src/lib.rs
+++ b/examples/binaries/ncompose/src/lib.rs
@@ -160,10 +160,10 @@ mod wasm {
     }
 
     #[no_mangle]
-    unsafe extern "C" fn init() {
+    extern "C" fn init() {
         let (actor, max_iter): (ActorId, u16) =
             msg::load().expect("Malformed input: expecting a program ID and a number");
-        STATE = State::new(max_iter, actor);
+        unsafe { STATE = State::new(max_iter, actor) };
         msg::reply_bytes([], 0).unwrap();
         debug!(
             "[0x{} ncompose::init] Program initialized",

--- a/examples/binaries/node/src/lib.rs
+++ b/examples/binaries/node/src/lib.rs
@@ -84,7 +84,7 @@ struct NodeState {
 static mut STATE: Option<NodeState> = None;
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let reply = match msg::load() {
         Ok(request) => process(request),
         Err(e) => {
@@ -244,7 +244,7 @@ fn process(request: Request) -> Reply {
 }
 
 #[no_mangle]
-unsafe extern "C" fn handle_reply() {
+extern "C" fn handle_reply() {
     if let Some(ref mut transition) = state().transition {
         if msg::reply_to().unwrap() != transition.last_sent_message_id {
             return;
@@ -271,14 +271,16 @@ unsafe extern "C" fn handle_reply() {
 }
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let init: Initialization = msg::load().expect("Failed to decode init");
 
-    STATE = Some(NodeState {
-        status: init.status,
-        sub_nodes: BTreeSet::default(),
-        transition: None,
-    });
+    unsafe {
+        STATE = Some(NodeState {
+            status: init.status,
+            sub_nodes: BTreeSet::default(),
+            transition: None,
+        });
+    }
 
     msg::reply((), 0).unwrap();
 }

--- a/examples/binaries/program-factory/src/lib.rs
+++ b/examples/binaries/program-factory/src/lib.rs
@@ -56,18 +56,18 @@ mod wasm {
     static mut ORIGIN: Option<ActorId> = None;
 
     #[no_mangle]
-    unsafe extern "C" fn init() {
-        ORIGIN = Some(msg::source());
+    extern "C" fn init() {
+        unsafe { ORIGIN = Some(msg::source()) };
     }
 
     #[no_mangle]
-    unsafe extern "C" fn handle() {
+    extern "C" fn handle() {
         match msg::load().expect("provided invalid payload") {
             CreateProgram::Default => {
                 let submitted_code = CHILD_CODE_HASH.into();
                 let (_message_id, new_program_id) = prog::create_program_with_gas(
                     submitted_code,
-                    COUNTER.to_le_bytes(),
+                    unsafe { COUNTER.to_le_bytes() },
                     [],
                     10_000_000_000,
                     0,
@@ -75,7 +75,7 @@ mod wasm {
                 .unwrap();
                 msg::send_bytes(new_program_id, [], 0).unwrap();
 
-                COUNTER += 1;
+                unsafe { COUNTER += 1 };
             }
             CreateProgram::Custom(custom_child_data) => {
                 for (code_hash, salt, gas_limit) in custom_child_data {
@@ -90,9 +90,9 @@ mod wasm {
     }
 
     #[no_mangle]
-    unsafe extern "C" fn handle_reply() {
+    extern "C" fn handle_reply() {
         if msg::status_code().unwrap() != 0 {
-            let origin = ORIGIN.clone().unwrap();
+            let origin = unsafe { ORIGIN.clone().unwrap() };
             msg::send_bytes(origin, [], 0).unwrap();
         }
     }

--- a/examples/binaries/proxy-relay/src/lib.rs
+++ b/examples/binaries/proxy-relay/src/lib.rs
@@ -102,10 +102,11 @@ mod wasm {
     }
 
     #[no_mangle]
-    unsafe extern "C" fn handle() {
+    extern "C" fn handle() {
         use RelayCall::*;
+        let relay_call = unsafe { RELAY_CALL.as_ref().expect("Relay call is not initialized") };
 
-        match RELAY_CALL.as_ref().expect("Relay call is not initialized") {
+        match relay_call {
             Resend(d) => {
                 msg::send_input(*d, msg::value(), ..msg::size() as usize).expect("Resend failed");
             }
@@ -129,7 +130,7 @@ mod wasm {
     }
 
     #[no_mangle]
-    unsafe extern "C" fn init() {
-        RELAY_CALL = Some(msg::load().expect("Failed to decode `RelayCall'"));
+    extern "C" fn init() {
+        unsafe { RELAY_CALL = Some(msg::load().expect("Failed to decode `RelayCall'")) };
     }
 }

--- a/examples/binaries/proxy-with-gas/src/lib.rs
+++ b/examples/binaries/proxy-with-gas/src/lib.rs
@@ -44,37 +44,39 @@ mod wasm {
     static mut DELAY: u32 = 0;
 
     #[no_mangle]
-    unsafe extern "C" fn handle() {
+    extern "C" fn handle() {
         let gas_limit: u64 = msg::load().expect("Failed to decode `gas_limit: u64'");
         msg::send_with_gas_delayed(
-            DESTINATION,
+            unsafe { DESTINATION },
             b"proxied message",
             gas_limit,
             msg::value(),
-            DELAY,
+            unsafe { DELAY },
         )
         .expect("Failed to proxy message");
     }
 
     #[no_mangle]
-    unsafe extern "C" fn handle_reply() {
+    extern "C" fn handle_reply() {
         if msg::status_code().expect("Infallible") == 0 {
             let gas_limit: u64 = msg::load().expect("Failed to decode `gas_limit: u64'");
             msg::send_with_gas_delayed(
-                DESTINATION,
+                unsafe { DESTINATION },
                 b"proxied message",
                 gas_limit,
                 msg::value(),
-                DELAY,
+                unsafe { DELAY },
             )
             .expect("Failed to proxy message");
         }
     }
 
     #[no_mangle]
-    unsafe extern "C" fn init() {
+    extern "C" fn init() {
         let args: InputArgs = msg::load().expect("Failed to decode `InputArgs'");
-        DESTINATION = args.destination;
-        DELAY = args.delay;
+        unsafe {
+            DESTINATION = args.destination;
+            DELAY = args.delay;
+        }
     }
 }

--- a/examples/binaries/proxy/src/lib.rs
+++ b/examples/binaries/proxy/src/lib.rs
@@ -48,14 +48,15 @@ mod wasm {
     }
 
     #[no_mangle]
-    unsafe extern "C" fn handle() {
+    extern "C" fn handle() {
         let payload = msg::load_bytes().expect("failed to load bytes");
-        msg::send_bytes(DESTINATION, payload, msg::value()).expect("failed to send bytes");
+        msg::send_bytes(unsafe { DESTINATION }, payload, msg::value())
+            .expect("failed to send bytes");
     }
 
     #[no_mangle]
-    unsafe extern "C" fn init() {
+    extern "C" fn init() {
         let args: InputArgs = msg::load().expect("Failed to decode `InputArgs'");
-        DESTINATION = args.destination.into();
+        unsafe { DESTINATION = args.destination.into() };
     }
 }

--- a/examples/binaries/send-from-reservation/src/lib.rs
+++ b/examples/binaries/send-from-reservation/src/lib.rs
@@ -56,7 +56,7 @@ mod wasm {
     }
 
     #[no_mangle]
-    unsafe extern "C" fn handle() {
+    extern "C" fn handle() {
         let action: HandleAction = msg::load().expect("Failed to load handle payload");
         match action {
             HandleAction::SendToUser => {
@@ -142,7 +142,7 @@ mod wasm {
     }
 
     #[no_mangle]
-    unsafe extern "C" fn handle_reply() {
+    extern "C" fn handle_reply() {
         let action: ReplyAction = msg::load().expect("Failed to load handle payload");
         match action {
             ReplyAction::Receive(user) => {

--- a/examples/binaries/signal-entry/src/lib.rs
+++ b/examples/binaries/signal-entry/src/lib.rs
@@ -113,12 +113,12 @@ mod wasm {
                 exec::wait();
             }
             HandleAction::WaitAndExit => {
-                if DO_EXIT {
+                if unsafe { DO_EXIT } {
                     msg::send_bytes(msg::source(), b"wait_and_exit", 0).unwrap();
                     exec::exit(msg::source());
                 }
 
-                DO_EXIT = !DO_EXIT;
+                unsafe { DO_EXIT = !DO_EXIT };
 
                 exec::system_reserve_gas(900).unwrap();
                 // used to found message id in test

--- a/examples/binaries/sys-calls/src/lib.rs
+++ b/examples/binaries/sys-calls/src/lib.rs
@@ -119,22 +119,27 @@ mod wasm {
     static mut DO_PANIC: bool = false;
 
     #[no_mangle]
-    unsafe extern "C" fn init() {
+    extern "C" fn init() {
         let code_id_bytes: [u8; 32] = msg::load().expect("internal error: invalid payload");
 
-        CODE_ID = code_id_bytes.into();
+        unsafe { CODE_ID = code_id_bytes.into() };
     }
 
     #[no_mangle]
-    unsafe extern "C" fn handle() {
+    extern "C" fn handle() {
         match msg::load().expect("internal error: invalid payload") {
             Kind::CreateProgram(salt, gas_opt, (expected_mid, expected_pid)) => {
                 let salt = salt.to_le_bytes();
                 let res = match gas_opt {
-                    Some(gas) => {
-                        prog::create_program_with_gas_delayed(CODE_ID, salt, "payload", gas, 0, 0)
-                    }
-                    None => prog::create_program_delayed(CODE_ID, salt, "payload", 0, 0),
+                    Some(gas) => prog::create_program_with_gas_delayed(
+                        unsafe { CODE_ID },
+                        salt,
+                        "payload",
+                        gas,
+                        0,
+                        0,
+                    ),
+                    None => prog::create_program_delayed(unsafe { CODE_ID }, salt, "payload", 0, 0),
                 };
                 let (actual_mid, actual_pid) = res.expect("internal error: create program failed");
                 let actual_mid: [u8; 32] = actual_mid.into();
@@ -304,12 +309,14 @@ mod wasm {
                 exec::leave();
             }
             Kind::SignalDetails => {
-                if DO_PANIC {
+                if unsafe { DO_PANIC } {
                     // issue a signal
                     panic!();
                 } else {
-                    SIGNAL_DETAILS = (msg::id(), 1, msg::source());
-                    DO_PANIC = true;
+                    unsafe {
+                        SIGNAL_DETAILS = (msg::id(), 1, msg::source());
+                        DO_PANIC = true;
+                    }
                     exec::system_reserve_gas(1_000_000_000).unwrap();
                     let _ = msg::reply_delayed(b"payload", 0, 0);
                     exec::wait_for(2);
@@ -334,7 +341,7 @@ mod wasm {
             }
             Kind::Origin(expected_actor) => {
                 // The origin is set by the first call and then checked with the second
-                if ORIGIN.is_some() {
+                if unsafe { ORIGIN.is_some() } {
                     // is ser, perform check
                     let actual_actor: [u8; 32] = exec::origin().into();
                     assert_eq!(
@@ -342,7 +349,7 @@ mod wasm {
                         "Kind::Origin: actor test failed"
                     );
                 } else {
-                    ORIGIN = Some(exec::origin());
+                    unsafe { ORIGIN = Some(exec::origin()) };
                     // To prevent from sending to mailbox "ok" message
                     exec::leave();
                 }

--- a/examples/binaries/syscall-error/src/lib.rs
+++ b/examples/binaries/syscall-error/src/lib.rs
@@ -30,7 +30,7 @@ pub use code::WASM_BINARY_OPT as WASM_BINARY;
 use gstd::errors::{ContractError, ExtError, MessageError};
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let res = msg::send(ActorId::default(), "dummy", 250);
     assert_eq!(
         res,

--- a/examples/binaries/unchecked-mul/src/lib.rs
+++ b/examples/binaries/unchecked-mul/src/lib.rs
@@ -35,7 +35,7 @@ mod wasm {
     use gstd::{debug, exec, msg};
 
     #[no_mangle]
-    unsafe extern "C" fn handle() {
+    extern "C" fn handle() {
         let (x, y): (u64, u64) = msg::load().expect("Expected a pair of u64 numbers");
         let z: u64 = x.checked_mul(y).expect("Multiplication overflow");
         debug!(
@@ -47,7 +47,7 @@ mod wasm {
     }
 
     #[no_mangle]
-    unsafe extern "C" fn init() {
+    extern "C" fn init() {
         msg::reply_bytes([], 0).unwrap();
     }
 }

--- a/examples/binaries/value-sender/src/code.rs
+++ b/examples/binaries/value-sender/src/code.rs
@@ -2,7 +2,7 @@ use crate::SendingRequest;
 use gstd::msg;
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let SendingRequest {
         account_id,
         gas_limit,

--- a/examples/binaries/wait_wake/src/lib.rs
+++ b/examples/binaries/wait_wake/src/lib.rs
@@ -54,13 +54,13 @@ fn process_request(request: Request) {
 }
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     msg::reply((), 0).unwrap();
 }
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
-    if let Some(reply) = ECHOES.get_or_insert_with(BTreeMap::new).remove(&msg::id()) {
+extern "C" fn handle() {
+    if let Some(reply) = unsafe { ECHOES.get_or_insert_with(BTreeMap::new).remove(&msg::id()) } {
         msg::reply(reply, 0).unwrap();
     } else {
         msg::load::<Request>().map(process_request).unwrap();
@@ -68,7 +68,7 @@ unsafe extern "C" fn handle() {
 }
 
 #[no_mangle]
-unsafe extern "C" fn handle_reply() {}
+extern "C" fn handle_reply() {}
 
 #[cfg(test)]
 mod tests {

--- a/examples/binaries/waiting-proxy/src/lib.rs
+++ b/examples/binaries/waiting-proxy/src/lib.rs
@@ -44,9 +44,9 @@ mod wasm {
     }
 
     #[no_mangle]
-    unsafe extern "C" fn init() {
+    extern "C" fn init() {
         let dest: ActorId = msg::load().expect("Expecting a contract address");
-        DESTINATION = dest;
+        unsafe { DESTINATION = dest };
         msg::reply((), 0);
     }
 }

--- a/examples/block-info/src/lib.rs
+++ b/examples/block-info/src/lib.rs
@@ -4,7 +4,7 @@ use core::time::Duration;
 use gstd::{debug, exec, msg, prelude::*};
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let payload = String::from_utf8(msg::load_bytes().expect("Failed to load payload bytes"))
         .expect("Invalid message");
 
@@ -16,7 +16,7 @@ unsafe extern "C" fn handle() {
 }
 
 #[no_mangle]
-unsafe extern "C" fn meta_state() -> *mut [i32; 2] {
+extern "C" fn meta_state() -> *mut [i32; 2] {
     let timestamp = exec::block_timestamp();
     gstd::util::to_leak_ptr(timestamp.to_le_bytes())
 }

--- a/examples/capacitor/src/lib.rs
+++ b/examples/capacitor/src/lib.rs
@@ -4,39 +4,37 @@ use gstd::{debug, msg, prelude::*};
 
 // Begin of demo
 static mut CHARGE: u32 = 0;
-
 static mut LIMIT: u32 = 0;
-
 static mut DISCHARGE_HISTORY: Vec<u32> = Vec::new();
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let new_msg = String::from_utf8(msg::load_bytes().expect("Failed to load payload bytes"))
         .expect("Invalid message: should be utf-8");
-
     let to_add = u32::from_str(new_msg.as_ref()).expect("Invalid number");
 
-    CHARGE += to_add;
-
-    debug!("Charge capacitor with {}, new charge {}", to_add, CHARGE);
-
-    if CHARGE >= LIMIT {
-        debug!("Discharge #{} due to limit {}", CHARGE, LIMIT);
-
-        msg::send_bytes(msg::source(), format!("Discharged: {CHARGE}"), 0).unwrap();
-        DISCHARGE_HISTORY.push(CHARGE);
-        CHARGE = 0;
+    unsafe {
+        CHARGE += to_add;
+        debug!("Charge capacitor with {}, new charge {}", to_add, CHARGE);
+        if CHARGE >= LIMIT {
+            debug!("Discharge #{} due to limit {}", CHARGE, LIMIT);
+            msg::send_bytes(msg::source(), format!("Discharged: {CHARGE}"), 0).unwrap();
+            DISCHARGE_HISTORY.push(CHARGE);
+            CHARGE = 0;
+        }
     }
 }
 // End of demo
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let initstr = String::from_utf8(msg::load_bytes().expect("Failed to load payload bytes"))
         .expect("Invalid message: should be utf-8");
     let limit = u32::from_str(initstr.as_ref()).expect("Invalid number");
-
-    LIMIT = limit;
-
-    debug!("Init capacitor with limit capacity {}, {}", LIMIT, initstr);
+    unsafe { LIMIT = limit };
+    debug!(
+        "Init capacitor with limit capacity {}, {}",
+        unsafe { LIMIT },
+        initstr
+    );
 }

--- a/examples/chat/bot/src/lib.rs
+++ b/examples/chat/bot/src/lib.rs
@@ -30,7 +30,7 @@ impl State {
 static mut STATE: State = State { name: "" };
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     bot(msg::load().expect("Failed to decode incoming message"));
 }
 
@@ -59,7 +59,7 @@ fn bot(message: MemberMessage) {
 }
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let input = String::from_utf8(msg::load_bytes().expect("Failed to load payload bytes"))
         .expect("Invalid message: should be utf-8");
 
@@ -68,7 +68,7 @@ unsafe extern "C" fn init() {
         2 => {
             let (name, room_id) = (&split[0], &split[1]);
             let s: &'static str = Box::leak(name.to_string().into_boxed_str());
-            STATE.set_name(s);
+            unsafe { STATE.set_name(s) };
             let room_id = ActorId::from_slice(
                 &decode_hex(room_id).expect("INITIALIZATION FAILED: INVALID ROOM ID"),
             )
@@ -87,5 +87,5 @@ unsafe extern "C" fn init() {
         }
     }
 
-    debug!("BOT '{}' created", STATE.name());
+    debug!("BOT '{}' created", unsafe { STATE.name() });
 }

--- a/examples/collector/src/lib.rs
+++ b/examples/collector/src/lib.rs
@@ -10,11 +10,11 @@ static mut MY_COLLECTION: BTreeMap<usize, String> = BTreeMap::new();
 static mut COUNTER: usize = 0;
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let new_msg = String::from_utf8(msg::load_bytes().expect("Failed to load payload bytes"))
         .expect("Invalid message: should be utf-8");
     if new_msg == "log" {
-        let collapsed = mem::take(&mut MY_COLLECTION)
+        let collapsed = mem::take(unsafe { &mut MY_COLLECTION })
             .into_iter()
             .map(|(number, msg)| format!("{number}: {msg};"))
             .fold(String::new(), |mut acc, n| {
@@ -24,9 +24,11 @@ unsafe extern "C" fn handle() {
 
         msg::send_bytes(msg::source(), collapsed, 0).unwrap();
 
-        COUNTER = 0;
+        unsafe { COUNTER = 0 };
     } else {
-        COUNTER += 1;
-        MY_COLLECTION.insert(COUNTER, new_msg);
+        unsafe {
+            COUNTER += 1;
+            MY_COLLECTION.insert(COUNTER, new_msg);
+        }
     }
 }

--- a/examples/create-program/src/lib.rs
+++ b/examples/create-program/src/lib.rs
@@ -16,7 +16,7 @@ static mut COUNTER: i32 = 0;
 /// )"#;
 /// ```
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let command = String::from_utf8(msg::load_bytes().expect("Failed to load payload bytes"))
         .expect("Unable to decode string");
     let submitted_code: CodeId =
@@ -29,7 +29,7 @@ unsafe extern "C" fn handle() {
             // extrinsic and we got its hash. For more details please read README file.
             let (_message_id, new_program_id) = prog::create_program_with_gas(
                 submitted_code,
-                COUNTER.to_le_bytes(),
+                unsafe { COUNTER.to_le_bytes() },
                 b"unique",
                 10_000_000_000,
                 0,
@@ -40,12 +40,12 @@ unsafe extern "C" fn handle() {
             let msg_id = msg::send(new_program_id, b"", 0).unwrap();
             debug!("Sent to a new program message with id {:?}", msg_id);
 
-            COUNTER += 1;
+            unsafe { COUNTER += 1 };
         }
         "duplicate" => {
             let (_message_id, new_program_id) = prog::create_program_with_gas(
                 submitted_code,
-                (COUNTER - 1).to_le_bytes(),
+                unsafe { (COUNTER - 1).to_le_bytes() },
                 b"not_unique",
                 10_000_000_000,
                 0,

--- a/examples/decoder/src/lib.rs
+++ b/examples/decoder/src/lib.rs
@@ -3,7 +3,7 @@
 use gstd::{msg, prelude::*};
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let new_msg = String::from_utf8(gstd::msg::load_bytes().expect("Failed to load payload bytes"))
         .expect("Invalid message: should be utf-8");
 

--- a/examples/fib/src/lib.rs
+++ b/examples/fib/src/lib.rs
@@ -14,9 +14,9 @@ fn make_fib(n: usize) -> Vec<i32> {
 }
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let new_msg: i32 = msg::load().expect("Should be i32");
-    MESSAGE_LOG.push(format!("New msg: {new_msg:?}"));
+    unsafe { MESSAGE_LOG.push(format!("New msg: {new_msg:?}")) };
     debug!("fib gas_available: {}", exec::gas_available());
 
     if new_msg > 1000 {
@@ -30,9 +30,11 @@ unsafe extern "C" fn handle() {
     )
     .unwrap();
 
-    debug!("{:?} total message(s) stored: ", MESSAGE_LOG.len());
+    debug!("{:?} total message(s) stored: ", unsafe {
+        MESSAGE_LOG.len()
+    });
 
-    for log in MESSAGE_LOG.iter() {
+    for log in unsafe { MESSAGE_LOG.iter() } {
         debug!(log);
     }
 }

--- a/examples/fungible-token/src/lib.rs
+++ b/examples/fungible-token/src/lib.rs
@@ -235,56 +235,58 @@ gstd::metadata! {
 }
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let action: Action = msg::load().expect("Could not load Action");
+    let fungible_token = unsafe { &mut FUNGIBLE_TOKEN };
 
     match action {
         Action::Mint(mint_input) => {
             let to = ActorId::new(mint_input.account.to_fixed_bytes());
-            FUNGIBLE_TOKEN.mint(&to, mint_input.amount);
+            fungible_token.mint(&to, mint_input.amount);
         }
         Action::Burn(burn_input) => {
             let from = ActorId::new(burn_input.account.to_fixed_bytes());
-            FUNGIBLE_TOKEN.burn(&from, burn_input.amount);
+            fungible_token.burn(&from, burn_input.amount);
         }
         Action::Transfer(transfer_data) => {
             let from = ActorId::new(transfer_data.from.to_fixed_bytes());
             let to = ActorId::new(transfer_data.to.to_fixed_bytes());
-            FUNGIBLE_TOKEN.transfer(&from, &to, transfer_data.amount);
+            fungible_token.transfer(&from, &to, transfer_data.amount);
         }
         Action::Approve(approve_data) => {
             let owner = ActorId::new(approve_data.owner.to_fixed_bytes());
             let spender = ActorId::new(approve_data.spender.to_fixed_bytes());
-            FUNGIBLE_TOKEN.approve(&owner, &spender, approve_data.amount);
+            fungible_token.approve(&owner, &spender, approve_data.amount);
         }
         Action::TransferFrom(transfer_data) => {
             let owner = ActorId::new(transfer_data.owner.to_fixed_bytes());
             let from = ActorId::new(transfer_data.from.to_fixed_bytes());
             let to = ActorId::new(transfer_data.to.to_fixed_bytes());
-            FUNGIBLE_TOKEN.transfer_from(&owner, &from, &to, transfer_data.amount);
+            fungible_token.transfer_from(&owner, &from, &to, transfer_data.amount);
         }
         Action::IncreaseAllowance(approve_data) => {
             let owner = ActorId::new(approve_data.owner.to_fixed_bytes());
             let spender = ActorId::new(approve_data.spender.to_fixed_bytes());
-            FUNGIBLE_TOKEN.increase_allowance(&owner, &spender, approve_data.amount);
+            fungible_token.increase_allowance(&owner, &spender, approve_data.amount);
         }
         Action::DecreaseAllowance(approve_data) => {
             let owner = ActorId::new(approve_data.owner.to_fixed_bytes());
             let spender = ActorId::new(approve_data.spender.to_fixed_bytes());
-            FUNGIBLE_TOKEN.decrease_allowance(&owner, &spender, approve_data.amount)
+            fungible_token.decrease_allowance(&owner, &spender, approve_data.amount)
         }
     }
 }
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let config: InitConfig = msg::load().expect("Unable to decode InitConfig");
     debug!("FUNGIBLE_TOKEN {:?}", config);
-    FUNGIBLE_TOKEN.set_name(config.name);
-    FUNGIBLE_TOKEN.set_symbol(config.symbol);
+    let fungible_token = unsafe { &mut FUNGIBLE_TOKEN };
+    fungible_token.set_name(config.name);
+    fungible_token.set_symbol(config.symbol);
     debug!(
         "FUNGIBLE_TOKEN {} SYMBOL {} created",
-        FUNGIBLE_TOKEN.name(),
-        FUNGIBLE_TOKEN.symbol()
+        fungible_token.name(),
+        fungible_token.symbol()
     );
 }

--- a/examples/futures-unordered/src/lib.rs
+++ b/examples/futures-unordered/src/lib.rs
@@ -10,21 +10,23 @@ static mut DEMO_ASYNC: ActorId = ActorId::new([0u8; 32]);
 static mut DEMO_PING: ActorId = ActorId::new([0u8; 32]);
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let input = String::from_utf8(msg::load_bytes().expect("Failed to load payload bytes"))
         .expect("Invalid message: should be utf-8");
     let dests: Vec<&str> = input.split(',').collect();
     if dests.len() != 2 {
         panic!("Invalid input, should be three IDs separated by comma");
     }
-    DEMO_ASYNC = ActorId::from_slice(
-        &hex::decode(dests[0]).expect("INTIALIZATION FAILED: INVALID PROGRAM ID"),
-    )
-    .expect("Unable to create ActorId");
-    DEMO_PING = ActorId::from_slice(
-        &hex::decode(dests[1]).expect("INTIALIZATION FAILED: INVALID PROGRAM ID"),
-    )
-    .expect("Unable to create ActorId");
+    unsafe {
+        DEMO_ASYNC = ActorId::from_slice(
+            &hex::decode(dests[0]).expect("INTIALIZATION FAILED: INVALID PROGRAM ID"),
+        )
+        .expect("Unable to create ActorId");
+        DEMO_PING = ActorId::from_slice(
+            &hex::decode(dests[1]).expect("INTIALIZATION FAILED: INVALID PROGRAM ID"),
+        )
+        .expect("Unable to create ActorId");
+    }
 }
 
 #[gstd::async_main]

--- a/examples/guestbook/src/lib.rs
+++ b/examples/guestbook/src/lib.rs
@@ -26,15 +26,15 @@ gstd::metadata! {
 static mut MESSAGES: Vec<MessageIn> = Vec::new();
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let action: Action = msg::load().unwrap();
 
     match action {
         Action::AddMessage(message) => {
-            MESSAGES.push(message);
+            unsafe { MESSAGES.push(message) };
         }
         Action::ViewMessages => {
-            msg::reply(&MESSAGES, 0).unwrap();
+            msg::reply(unsafe { &MESSAGES }, 0).unwrap();
         }
     }
 }

--- a/examples/gui-test/src/lib.rs
+++ b/examples/gui-test/src/lib.rs
@@ -36,7 +36,7 @@ gstd::metadata! {
 type InitIncoming = Action<AStruct, Option<CustomStruct<u8>>, BTreeMap<String, u8>>;
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let incoming: InitIncoming = msg::load().expect("Unable to decode payload");
 
     let outgoing: Result<u8, Option<String>> = match incoming {
@@ -62,7 +62,7 @@ unsafe extern "C" fn init() {
 type HandleIncoming = (BTreeMap<String, u8>, Option<(Option<u8>, u128, [u8; 3])>);
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let incoming: HandleIncoming = msg::load().expect("Unable to decode payload");
 
     let outgoing = match incoming {

--- a/examples/incomplete_async_payloads/src/lib.rs
+++ b/examples/incomplete_async_payloads/src/lib.rs
@@ -3,7 +3,7 @@
 use core::num::ParseIntError;
 use gstd::{debug, msg, prelude::*, ActorId};
 
-static mut DEMO_PING: ActorId = ActorId::new([0u8; 32]);
+static mut DEMO_PING: ActorId = ActorId::zero();
 
 #[gstd::async_main]
 async fn main() {
@@ -83,10 +83,13 @@ fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
 }
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let input = String::from_utf8(msg::load_bytes().expect("Failed to load payload bytes"))
         .expect("Invalid message: should be utf-8");
-    DEMO_PING =
-        ActorId::from_slice(&decode_hex(&input).expect("INTIALIZATION FAILED: INVALID PROGRAM ID"))
-            .expect("Unable to create ActorId");
+    unsafe {
+        DEMO_PING = ActorId::from_slice(
+            &decode_hex(&input).expect("INTIALIZATION FAILED: INVALID PROGRAM ID"),
+        )
+        .expect("Unable to create ActorId")
+    };
 }

--- a/examples/loop/src/lib.rs
+++ b/examples/loop/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     gstd::debug!("Start loop");
 
     #[allow(clippy::empty_loop)]

--- a/examples/mem/src/lib.rs
+++ b/examples/mem/src/lib.rs
@@ -4,7 +4,7 @@ use gcore::msg;
 use gstd::prelude::*;
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let data = vec![0u8; 32768];
     msg::reply(&data, 0).unwrap();
     panic!()

--- a/examples/minimal/src/lib.rs
+++ b/examples/minimal/src/lib.rs
@@ -3,6 +3,6 @@
 use gstd::msg;
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     msg::reply(b"Hello world!", 0).unwrap();
 }

--- a/examples/multiping/src/lib.rs
+++ b/examples/multiping/src/lib.rs
@@ -6,7 +6,7 @@ use gstd::prelude::*;
 static mut COUNTER: usize = 0;
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let new_msg = String::from_utf8(gstd::msg::load_bytes().expect("Failed to load payload bytes"))
         .expect("Invalid message: should be utf-8");
 
@@ -16,7 +16,7 @@ unsafe extern "C" fn handle() {
         msg::reply_commit(0).unwrap();
     }
 
-    if new_msg == "PING PING PING" && COUNTER > 0 {
+    if new_msg == "PING PING PING" && unsafe { COUNTER } > 0 {
         let handle = msg::send_init().unwrap();
         msg::send_push(handle, b"PONG1").unwrap();
         msg::send_push(handle, b"PONG2").unwrap();
@@ -24,5 +24,5 @@ unsafe extern "C" fn handle() {
         msg::send_commit(handle, msg::source(), 0).unwrap();
     }
 
-    COUNTER += 1;
+    unsafe { COUNTER += 1 };
 }

--- a/examples/mutex/src/lib.rs
+++ b/examples/mutex/src/lib.rs
@@ -7,13 +7,15 @@ static mut PING_DEST: ActorId = ActorId::new([0u8; 32]);
 static MUTEX: Mutex<u32> = Mutex::new(0);
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let dest = String::from_utf8(msg::load_bytes().expect("Failed to load payload bytes"))
         .expect("Invalid message: should be utf-8");
-    PING_DEST = ActorId::from_slice(
-        &decode_hex(dest.as_ref()).expect("INTIALIZATION FAILED: INVALID DEST PROGRAM ID"),
-    )
-    .expect("Unable to create ActorId");
+    unsafe {
+        PING_DEST = ActorId::from_slice(
+            &decode_hex(dest.as_ref()).expect("INTIALIZATION FAILED: INVALID DEST PROGRAM ID"),
+        )
+        .expect("Unable to create ActorId")
+    };
 }
 
 fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {

--- a/examples/panicker/src/lib.rs
+++ b/examples/panicker/src/lib.rs
@@ -3,7 +3,7 @@
 use gstd::debug;
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     debug!("Starting panicker handle");
     panic!("I just panic every time")
 }

--- a/examples/piggy-bank/src/lib.rs
+++ b/examples/piggy-bank/src/lib.rs
@@ -3,7 +3,7 @@
 use gstd::{debug, exec, msg};
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let available_value = exec::value_available();
     debug!("inserted: {}, total: {}", msg::value(), available_value);
 

--- a/examples/ping-gas/src/lib.rs
+++ b/examples/ping-gas/src/lib.rs
@@ -3,7 +3,7 @@
 use gstd::{debug, msg, prelude::*};
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     debug!("Hello from ping handle");
 
     let new_msg = String::from_utf8(msg::load_bytes().expect("Failed to load payload bytes"))
@@ -23,6 +23,6 @@ unsafe extern "C" fn handle() {
 }
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     debug!("Hello from ping init");
 }

--- a/examples/ping/src/lib.rs
+++ b/examples/ping/src/lib.rs
@@ -9,7 +9,7 @@ use galloc::prelude::vec;
 use gcore::msg;
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let mut bytes = vec![0; msg::size()];
     msg::read(&mut bytes).unwrap();
 

--- a/examples/program-id/src/lib.rs
+++ b/examples/program-id/src/lib.rs
@@ -3,7 +3,7 @@
 use gstd::{debug, exec, msg};
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     debug!("Starting program id");
     let program_id = exec::program_id();
     debug!("My program id: {:?}", program_id);

--- a/examples/program_generator/src/lib.rs
+++ b/examples/program_generator/src/lib.rs
@@ -16,7 +16,7 @@ fn salt_uniqueness_test() {
 }
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let submitted_code: CodeId =
         hex_literal::hex!("abf3746e72a6e8740bd9e12b879fbdd59e052cb390f116454e9116c22021ae4a")
             .into();

--- a/examples/rwlock/src/lib.rs
+++ b/examples/rwlock/src/lib.rs
@@ -12,11 +12,13 @@ static mut PING_DEST: ActorId = ActorId::new([0u8; 32]);
 static RWLOCK: RwLock<u32> = RwLock::new(0);
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let dest = String::from_utf8(msg::load_bytes().expect("Failed to load payload bytes"))
         .expect("Invalid message: should be utf-8");
-    PING_DEST = ActorId::from_slice(&hex::decode(dest).expect("Invalid hex"))
-        .expect("Unable to create ActorId");
+    unsafe {
+        PING_DEST = ActorId::from_slice(&hex::decode(dest).expect("Invalid hex"))
+            .expect("Unable to create ActorId")
+    };
 }
 
 #[gstd::async_main]

--- a/examples/rwlock_write/src/lib.rs
+++ b/examples/rwlock_write/src/lib.rs
@@ -7,13 +7,15 @@ static mut PING_DEST: ActorId = ActorId::new([0u8; 32]);
 static RWLOCK: RwLock<u32> = RwLock::new(0);
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let dest = String::from_utf8(msg::load_bytes().expect("Failed to load payload bytes"))
         .expect("Invalid message: should be utf-8");
-    PING_DEST = ActorId::from_slice(
-        &decode_hex(dest.as_ref()).expect("INTIALIZATION FAILED: INVALID DEST PROGRAM ID"),
-    )
-    .expect("Unable to create ActorId");
+    unsafe {
+        PING_DEST = ActorId::from_slice(
+            &decode_hex(dest.as_ref()).expect("INTIALIZATION FAILED: INVALID DEST PROGRAM ID"),
+        )
+        .expect("Unable to create ActorId")
+    };
 }
 
 fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {

--- a/examples/state_rollback/src/lib.rs
+++ b/examples/state_rollback/src/lib.rs
@@ -9,13 +9,13 @@ fn value() -> String {
 }
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     if let Ok(message) = String::from_utf8(msg::load_bytes().expect("Failed to load payload bytes"))
     {
         // prev value
         msg::send_bytes(msg::source(), value(), 0).unwrap();
 
-        MESSAGE = Some(message.clone());
+        unsafe { MESSAGE = Some(message.clone()) };
 
         // new value
         msg::reply_bytes(value(), 0).unwrap();

--- a/examples/status-code/src/lib.rs
+++ b/examples/status-code/src/lib.rs
@@ -2,16 +2,19 @@
 
 use gstd::{msg, ActorId};
 
-static mut HOST: ActorId = ActorId::new([0u8; 32]);
-
 // It was containing the only handle_reply previously
 // what is just for testing and isn't valid at all
 // cause we can't receive reply on message if we never send it.
 // For this demo in real conditions handle_reply is unreachable.
 #[no_mangle]
-unsafe extern "C" fn handle() {}
+extern "C" fn handle() {}
 
 #[no_mangle]
-unsafe extern "C" fn handle_reply() {
-    msg::send_bytes(HOST, msg::status_code().unwrap().to_le_bytes(), 0).unwrap();
+extern "C" fn handle_reply() {
+    msg::send_bytes(
+        ActorId::zero(),
+        msg::status_code().unwrap().to_le_bytes(),
+        0,
+    )
+    .unwrap();
 }

--- a/examples/sum/src/lib.rs
+++ b/examples/sum/src/lib.rs
@@ -30,27 +30,29 @@ fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
 }
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let new_msg: i32 = msg::load().expect("Should be i32");
-    MESSAGE_LOG.push(format!("(sum) New msg: {new_msg:?}"));
+    unsafe { MESSAGE_LOG.push(format!("(sum) New msg: {new_msg:?}")) };
     debug!("sum gas_available: {}", exec::gas_available());
 
-    msg::send(STATE.send_to(), new_msg + new_msg, 0).unwrap();
+    msg::send(unsafe { STATE.send_to() }, new_msg + new_msg, 0).unwrap();
 
-    debug!("{:?} total message(s) stored: ", MESSAGE_LOG.len());
+    debug!("{:?} total message(s) stored: ", unsafe {
+        MESSAGE_LOG.len()
+    });
 
-    for log in MESSAGE_LOG.iter() {
+    for log in unsafe { MESSAGE_LOG.iter() } {
         debug!(log);
     }
 }
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let input = String::from_utf8(msg::load_bytes().expect("Failed to load payload bytes"))
         .expect("Invalid message: should be utf-8");
     let send_to = ActorId::from_slice(
         &decode_hex(&input).expect("INITIALIZATION FAILED: INVALID PROGRAM ID"),
     )
     .expect("Unable to create ActorId");
-    STATE.set_send_to(send_to);
+    unsafe { STATE.set_send_to(send_to) };
 }

--- a/examples/sync_duplicate/src/lib.rs
+++ b/examples/sync_duplicate/src/lib.rs
@@ -6,11 +6,13 @@ static mut DEST: ActorId = ActorId::new([0u8; 32]);
 static mut COUNTER: usize = 0;
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let dest = String::from_utf8(msg::load_bytes().expect("Failed to load payload bytes"))
         .expect("Invalid message: should be utf-8");
-    DEST = ActorId::from_slice(&hex::decode(dest).expect("Invalid hex"))
-        .expect("Unable to create ActorId");
+    unsafe {
+        DEST = ActorId::from_slice(&hex::decode(dest).expect("Invalid hex"))
+            .expect("Unable to create ActorId")
+    };
 }
 
 #[gstd::async_main]
@@ -27,8 +29,6 @@ async fn main() {
 
         msg::reply(unsafe { COUNTER } as i32, 0).unwrap();
 
-        unsafe {
-            COUNTER = 0;
-        }
+        unsafe { COUNTER = 0 };
     };
 }

--- a/examples/token-vendor/src/lib.rs
+++ b/examples/token-vendor/src/lib.rs
@@ -197,12 +197,12 @@ async fn main() {
 }
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     let config: InitConfig = msg::load().expect("Unable to decode InitConfig");
 
     debug!("Got InitConfig: {:?}", config);
 
-    if let Err(e) = STATE.init(msg::source(), config) {
+    if let Err(e) = unsafe { STATE.init(msg::source(), config) } {
         panic!("Failed to init State: {}", e);
     }
 

--- a/examples/token-vendor/workshop-example/src/lib.rs
+++ b/examples/token-vendor/workshop-example/src/lib.rs
@@ -30,20 +30,20 @@ impl State {
 static mut STATE: State = State { user_id: None };
 
 #[no_mangle]
-unsafe extern "C" fn init() {
-    STATE.set_user_id(msg::source());
+extern "C" fn init() {
+    unsafe { STATE.set_user_id(msg::source()) };
 
     debug!("CONTRACT: Inited successfully");
 }
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let payload: String = msg::load().expect("CONTRACT: Unable to decode handle input");
 
     debug!("CONTRACT: Got payload: '{}'", payload);
 
     if payload == "success" {
-        msg::reply(STATE.get_hex_id(), 0).unwrap();
+        msg::reply(unsafe { STATE.get_hex_id() }, 0).unwrap();
     } else if payload == "ping" {
         msg::reply("pong", 0).unwrap();
     } else {

--- a/examples/vec/src/lib.rs
+++ b/examples/vec/src/lib.rs
@@ -5,9 +5,9 @@ use gstd::{debug, msg, prelude::*};
 static mut MESSAGE_LOG: Vec<String> = vec![];
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let new_msg: i32 = msg::load().expect("Should be i32");
-    MESSAGE_LOG.push(format!("(vec) New msg: {new_msg:?}"));
+    unsafe { MESSAGE_LOG.push(format!("(vec) New msg: {new_msg:?}")) };
     let v = vec![1u8; new_msg as usize];
     debug!("v.len() = {:?}", v.len());
     debug!(
@@ -17,13 +17,15 @@ unsafe extern "C" fn handle() {
         v[new_msg as usize - 1]
     );
     msg::send(msg::source(), v.len() as i32, 0).unwrap();
-    debug!("{:?} total message(s) stored: ", MESSAGE_LOG.len());
+    debug!("{:?} total message(s) stored: ", unsafe {
+        MESSAGE_LOG.len()
+    });
 
     // The test idea is to allocate two wasm pages and check this allocation,
     // so we must skip `v` destruction.
     core::mem::forget(v);
 
-    for log in MESSAGE_LOG.iter() {
+    for log in unsafe { MESSAGE_LOG.iter() } {
         debug!(log);
     }
 }

--- a/examples/wait/src/lib.rs
+++ b/examples/wait/src/lib.rs
@@ -10,23 +10,24 @@ static mut MSG_ID_1: MessageId = MessageId([0; 32]);
 static mut MSG_ID_2: MessageId = MessageId([0; 32]);
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
-    gstd::debug!(STATE);
-    match STATE {
+extern "C" fn handle() {
+    let state = unsafe { &mut STATE };
+    gstd::debug!(state);
+    match *state {
         0 => {
-            STATE = 1;
-            MSG_ID_1 = msg::id();
+            *state = 1;
+            unsafe { MSG_ID_1 = msg::id() };
             exec::wait();
         }
         1 => {
-            STATE = 2;
-            MSG_ID_2 = msg::id();
+            *state = 2;
+            unsafe { MSG_ID_2 = msg::id() };
             exec::wait();
         }
         2 => {
-            STATE = 3;
-            exec::wake(MSG_ID_1).unwrap();
-            exec::wake(MSG_ID_2).unwrap();
+            *state = 3;
+            exec::wake(unsafe { MSG_ID_1 }).unwrap();
+            exec::wake(unsafe { MSG_ID_2 }).unwrap();
         }
         _ => {
             msg::send(msg::source(), b"WAITED", 0).unwrap();

--- a/gcore/src/msg.rs
+++ b/gcore/src/msg.rs
@@ -425,7 +425,7 @@ pub fn reply_commit_with_gas_delayed(gas_limit: u64, value: u128, delay: u32) ->
 /// ```
 /// use gcore::{exec, msg};
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     msg::reply_push(b"Hello,").expect("Unable to push");
 ///     msg::reply_push(b" world!").expect("Unable to push");
 ///     let resevation_id = exec::reserve_gas(5_000_000, 100).expect("Unable to reserves");

--- a/gstd/codegen/src/lib.rs
+++ b/gstd/codegen/src/lib.rs
@@ -159,7 +159,7 @@ fn generate_handle_reply_if_required(mut code: TokenStream, attr: Option<Path>) 
     if !reply_generated {
         let handle_reply: TokenStream = quote!(
             #[no_mangle]
-            unsafe extern "C" fn handle_reply() {
+            extern "C" fn handle_reply() {
                 gstd::record_reply();
                 #attr ();
             }
@@ -176,7 +176,7 @@ fn generate_handle_signal_if_required(mut code: TokenStream, attr: Option<Path>)
     if !signal_generated {
         let handle_signal: TokenStream = quote!(
             #[no_mangle]
-            unsafe extern "C" fn handle_signal() {
+            extern "C" fn handle_signal() {
                 gstd::handle_signal();
                 #attr ();
             }
@@ -240,7 +240,7 @@ pub fn async_main(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         #[no_mangle]
-        unsafe extern "C" fn handle() {
+        extern "C" fn handle() {
             __main_safe();
         }
     )
@@ -292,7 +292,7 @@ pub fn async_init(attr: TokenStream, item: TokenStream) -> TokenStream {
     let body = &function.block;
     let code: TokenStream = quote!(
         #[no_mangle]
-        unsafe extern "C" fn init() {
+        extern "C" fn init() {
             gstd::message_loop(async #body);
         }
     )

--- a/gstd/src/common/primitives.rs
+++ b/gstd/src/common/primitives.rs
@@ -292,12 +292,13 @@ impl TryFrom<&[u8]> for CodeId {
 ///
 /// static mut RESERVED: Option<ReservationId> = None;
 ///
-/// unsafe extern "C" fn init() {
-///     RESERVED = Some(ReservationId::reserve(50_000_000, 7));
+/// extern "C" fn init() {
+///     let reservation_id = ReservationId::reserve(50_000_000, 7).expect("Unable to reserve");
+///     unsafe { RESERVED = Some(reservation_id) };
 /// }
 ///
-/// unsafe extern "C" fn handle() {
-///     let reservation_id = RESERVED.take().expect("create in init()");
+/// extern "C" fn handle() {
+///     let reservation_id = unsafe { RESERVED.take().expect("create in init()") };
 ///     reservation_id.unreserve();
 /// }
 /// ```

--- a/gstd/src/exec.rs
+++ b/gstd/src/exec.rs
@@ -43,7 +43,7 @@
 //! use gstd::{exec, msg};
 //!
 //! // Send a reply after the block height reaches the number 1000
-//! unsafe extern "C" fn handle() {
+//! extern "C" fn handle() {
 //!     if exec::block_height() >= 1000 {
 //!         msg::reply(b"Block #1000 reached", 0).unwrap();
 //!     }
@@ -53,7 +53,7 @@
 //! use gstd::{exec, msg};
 //!
 //! // Send a reply after the block timestamp reaches the February 22, 2022
-//! unsafe extern "C" fn handle() {
+//! extern "C" fn handle() {
 //!     if exec::block_timestamp() >= 1645488000000 {
 //!         msg::reply(b"The current block is generated after February 22, 2022", 0).unwrap();
 //!     }
@@ -63,7 +63,7 @@
 //! use gstd::exec;
 //!
 //! // Perform work while `gas_available` is more than 1000
-//! unsafe extern "C" fn handle() {
+//! extern "C" fn handle() {
 //!     while exec::gas_available() > 1000 {
 //!         // ...
 //!     }
@@ -73,7 +73,7 @@
 //! use gstd::exec;
 //!
 //! // Get self value balance in program
-//! unsafe extern "C" fn handle() {
+//! extern "C" fn handle() {
 //!     let _my_balance = exec::value_available();
 //! }
 //! ```
@@ -98,7 +98,7 @@ pub use gcore::exec::{
 /// ```
 /// use gstd::{exec, msg};
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     exec::exit(msg::source());
 /// }
@@ -119,7 +119,7 @@ pub fn exit(value_destination: ActorId) -> ! {
 /// ```
 /// use gstd::{exec, msg};
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     let msg_id = msg::id();
 ///     exec::wake(msg_id);
@@ -141,7 +141,7 @@ pub fn wake_delayed(message_id: MessageId, delay: u32) -> Result<()> {
 /// ```
 /// use gstd::{exec, ActorId};
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     let me = exec::program_id();
 /// }
@@ -158,7 +158,7 @@ pub fn program_id() -> ActorId {
 /// ```
 /// use gstd::{exec, ActorId};
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     let _user = exec::origin();
 /// }

--- a/gstd/src/macros/export.rs
+++ b/gstd/src/macros/export.rs
@@ -24,7 +24,7 @@
 macro_rules! export {
     ($f:ident -> $val:expr) => {
         #[no_mangle]
-        unsafe extern "C" fn $f() -> *mut [i32; 2] {
+        extern "C" fn $f() -> *mut [i32; 2] {
             let buffer = $val.to_string();
             let result = $crate::util::to_wasm_ptr(buffer.as_bytes());
             core::mem::forget(buffer);

--- a/gstd/src/msg/basic.rs
+++ b/gstd/src/msg/basic.rs
@@ -60,7 +60,7 @@ use gstd_codegen::wait_for_reply;
 /// ```
 /// use gstd::msg;
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     let msg_handle = msg::send_init();
 /// }
@@ -170,7 +170,7 @@ impl From<gcore::MessageHandle> for MessageHandle {
 /// ```
 /// use gstd::msg;
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     let status_code = msg::status_code();
 /// }
@@ -189,7 +189,7 @@ pub fn status_code() -> Result<i32> {
 /// ```
 /// use gstd::msg;
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     let current_message_id = msg::id();
 /// }
 /// ```
@@ -207,7 +207,7 @@ pub fn id() -> MessageId {
 /// ```
 /// use gstd::msg;
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     let payload_bytes = msg::load_bytes().unwrap();
 /// }
 /// ```
@@ -292,7 +292,7 @@ pub fn reply_bytes_with_gas_delayed(
 /// ```
 /// use gstd::{exec, msg};
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     msg::reply_push(b"Part 1").unwrap();
 ///     // ...
@@ -332,7 +332,7 @@ pub fn reply_commit_delayed(value: u128, delay: u32) -> Result<MessageId> {
 /// ```
 /// use gstd::{exec, msg, ReservationId};
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     let id = ReservationId::reserve(5_000_000, 100).expect("enough gas");
 ///     // ...
@@ -369,7 +369,7 @@ pub fn reply_commit_delayed_from_reservation(
 /// ```
 /// use gstd::{exec, msg};
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     msg::reply_push(b"Part 1").unwrap();
 ///     // ...
@@ -407,7 +407,7 @@ pub fn reply_commit_with_gas_delayed(gas_limit: u64, value: u128, delay: u32) ->
 /// ```
 /// use gstd::msg;
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     msg::reply_push(b"Part 1").unwrap();
 ///     // ...
@@ -430,7 +430,7 @@ pub fn reply_push<T: AsRef<[u8]>>(payload: T) -> Result<()> {
 /// ```
 /// use gstd::msg;
 ///
-/// unsafe extern "C" fn handle_reply() {
+/// extern "C" fn handle_reply() {
 ///     // ...
 ///     let original_message_id = msg::reply_to().unwrap();
 /// }
@@ -494,7 +494,7 @@ pub fn send_push_input<Range: RangeBounds<usize>>(
 /// ```
 /// use gstd::{msg, ActorId};
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     let id = msg::source();
 ///
@@ -528,7 +528,7 @@ pub fn send_bytes_delayed<T: AsRef<[u8]>>(
 /// ```
 /// use gstd::{msg, ActorId};
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     let id = msg::source();
 ///
@@ -583,7 +583,7 @@ pub fn send_bytes_with_gas_delayed<T: AsRef<[u8]>>(
 /// ```
 /// use gstd::{msg, ActorId, ReservationId};
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     let id = ReservationId::reserve(5_000_000, 100).expect("enough gas");
 ///     let source_id = msg::source();
@@ -643,10 +643,10 @@ pub fn send_bytes_delayed_from_reservation<T: AsRef<[u8]>>(
 /// ```
 /// use gstd::{exec, msg};
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     let msg_handle = msg::send_init().unwrap();
-///     msg::send_push(&msg_handle, b"PING");
+///     msg::send_push(msg_handle, b"PING");
 ///     msg::send_commit(msg_handle, msg::source(), 42);
 /// }
 /// ```
@@ -680,10 +680,10 @@ pub fn send_commit_delayed(
 /// ```
 /// use gstd::{exec, msg};
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     let msg_handle = msg::send_init().unwrap();
-///     msg::send_push(&msg_handle, b"PING");
+///     msg::send_push(msg_handle, b"PING");
 ///     msg::send_commit_with_gas(msg_handle, msg::source(), 10_000_000, 42);
 /// }
 /// ```
@@ -728,10 +728,10 @@ pub fn send_commit_with_gas_delayed(
 /// ```
 /// use gstd::{exec, msg};
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     let msg_handle = msg::send_init().unwrap();
-///     msg::send_push(&msg_handle, b"PING");
+///     msg::send_push(msg_handle, b"PING");
 ///     msg::send_commit(msg_handle, msg::source(), 42);
 /// }
 /// ```
@@ -756,10 +756,10 @@ pub fn send_init() -> Result<MessageHandle> {
 /// ```
 /// use gstd::{exec, msg};
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     let msg_handle = msg::send_init().unwrap();
-///     msg::send_push(&msg_handle, b"PING");
+///     msg::send_push(msg_handle, b"PING");
 ///     msg::send_commit(msg_handle, msg::source(), 42);
 /// }
 /// ```
@@ -784,7 +784,7 @@ pub fn send_push<T: AsRef<[u8]>>(handle: MessageHandle, payload: T) -> Result<()
 /// ```
 /// use gstd::msg;
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     let payload_size = msg::size();
 /// }
 /// ```
@@ -802,7 +802,7 @@ pub fn size() -> usize {
 /// ```
 /// use gstd::msg;
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     let who_sends_message = msg::source();
 /// }
@@ -821,7 +821,7 @@ pub fn source() -> ActorId {
 /// ```
 /// use gstd::msg;
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     let amount_sent_with_message = msg::value();
 /// }

--- a/gstd/src/msg/encoded.rs
+++ b/gstd/src/msg/encoded.rs
@@ -101,7 +101,7 @@ pub fn reply_delayed_from_reservation<E: Encode>(
 /// ```
 /// use gstd::{exec, msg};
 ///
-/// unsafe extern "C" fn handle() {
+/// extern "C" fn handle() {
 ///     // ...
 ///     msg::reply_with_gas(b"PING", 0, 0).unwrap();
 /// }

--- a/program/src/template.rs
+++ b/program/src/template.rs
@@ -41,17 +41,16 @@ use gstd::{debug, msg, prelude::*};
 static mut MESSAGE_LOG: Vec<String> = vec![];
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     let new_msg = String::from_utf8(msg::load_bytes().unwrap()).expect("Invalid message");
 
     if new_msg == "PING" {
         msg::reply_bytes("PONG", 0).unwrap();
     }
 
-    MESSAGE_LOG.push(new_msg);
+    unsafe { MESSAGE_LOG.push(new_msg) };
 
-    debug!("{:?} total message(s) stored: ", MESSAGE_LOG.len());
-
+    debug!("{:?} total message(s) stored: ", unsafe { MESSAGE_LOG.len() });
 }
 "#;
 

--- a/utils/wasm-builder/test-program/src/lib.rs
+++ b/utils/wasm-builder/test-program/src/lib.rs
@@ -3,13 +3,13 @@
 use gstd::{debug, msg};
 
 #[no_mangle]
-unsafe extern "C" fn handle() {
+extern "C" fn handle() {
     debug!("handle()");
     msg::reply_bytes("Hello world!", 0).unwrap();
 }
 
 #[no_mangle]
-unsafe extern "C" fn init() {
+extern "C" fn init() {
     debug!("init()");
 }
 


### PR DESCRIPTION
- Removed `unsafe` from exported `extern` functions as it breaks Rust idiom (keep unsafe blocks as small as possible).

@gear-tech/dev 
