### PR TITLE
chore(clippy): remove `-A clippy::uninlined-format-args` in scripts

### DIFF
--- a/scripts/src/clippy.sh
+++ b/scripts/src/clippy.sh
@@ -19,13 +19,8 @@ clippy_usage() {
 EOF
 }
 
-# TODO
-#
-# remove `clippy::uninlined-format-args` after #1956
 gear_clippy() {
-  SKIP_WASM_BUILD=1 cargo +nightly clippy --workspace "$@" -- --no-deps \
-    -A clippy::uninlined-format-args \
-    -D warnings
+  SKIP_WASM_BUILD=1 cargo +nightly clippy --workspace "$@" -- --no-deps -D warnings
 }
 
 # $1 - ROOT DIR
@@ -33,7 +28,6 @@ examples_clippy() {
   cd "$1"/examples
   SKIP_WASM_BUILD=1 cargo +nightly hack clippy --workspace --release -- --no-deps \
 	  -A clippy::stable_sort_primitive \
-    -A clippy::uninlined-format-args \
     -D warnings
   cd "$1"
 }


### PR DESCRIPTION
Resolves #1956 

@gear-tech/dev 
