### PR TITLE
Fix debug binary after transition to clap version 4

### DIFF
--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -20,6 +20,7 @@ use clap::Parser;
 
 #[allow(missing_docs)]
 #[derive(Debug, Parser)]
+#[group(skip)]
 pub struct RunCmd {
     #[allow(missing_docs)]
     #[command(flatten)]


### PR DESCRIPTION
Added `#[group(skip)]` macro to the `RunCmd` command definition to disable implicit clap `ArgGroup` creation and avoid groups names clash (since there is already a group with such name for the `sc_cli::RunCmd` struct).