### PR TITLE
gclient: Split mailbox getters and add `account_id` method

### DIFF
--- a/gclient/src/api/calls.rs
+++ b/gclient/src/api/calls.rs
@@ -150,7 +150,7 @@ impl GearApi {
     /// `pallet_gear::claim_value`
     pub async fn claim_value(&self, message_id: MessageId) -> Result<(u128, H256)> {
         let value = self
-            .get_from_mailbox(self.0.account_id(), message_id)
+            .get_from_mailbox(message_id)
             .await?
             .map(|(message, _interval)| message.value());
 
@@ -181,7 +181,7 @@ impl GearApi {
         for message_id in message_ids.by_ref() {
             values.insert(
                 message_id,
-                self.get_from_mailbox(self.0.account_id(), message_id)
+                self.get_from_mailbox(message_id)
                     .await?
                     .map(|(message, _interval)| message.value()),
             );
@@ -334,9 +334,7 @@ impl GearApi {
     ) -> Result<(MessageId, u128, H256)> {
         let payload = payload.as_ref().to_vec();
 
-        let data = self
-            .get_from_mailbox(self.0.account_id(), reply_to_id)
-            .await?;
+        let data = self.get_from_mailbox(reply_to_id).await?;
 
         let tx = self
             .0
@@ -372,7 +370,7 @@ impl GearApi {
         for (message_id, _, _, _) in args.by_ref() {
             values.insert(
                 message_id,
-                self.get_from_mailbox(self.0.account_id(), message_id)
+                self.get_from_mailbox(message_id)
                     .await?
                     .map(|(message, _interval)| message.value()),
             );

--- a/gclient/src/api/mod.rs
+++ b/gclient/src/api/mod.rs
@@ -25,6 +25,7 @@ pub mod storage;
 use crate::{node::ws::WSAddress, EventListener};
 use error::*;
 use gp::api::{signer::Signer, Api};
+use subxt::ext::sp_runtime::AccountId32;
 
 #[derive(Clone)]
 pub struct GearApi(Signer);
@@ -88,5 +89,10 @@ impl GearApi {
             .system_account_next_index(self.0.signer.account_id())
             .await
             .map_err(Into::into)
+    }
+
+    /// Return the signer account address.
+    pub fn account_id(&self) -> &AccountId32 {
+        self.0.account_id()
     }
 }

--- a/gclient/src/api/storage/mod.rs
+++ b/gclient/src/api/storage/mod.rs
@@ -33,6 +33,14 @@ use subxt::ext::sp_runtime::AccountId32;
 impl GearApi {
     pub async fn get_from_mailbox(
         &self,
+        message_id: impl Borrow<MessageId>,
+    ) -> Result<Option<(StoredMessage, Interval<u32>)>> {
+        self.get_from_account_mailbox(self.0.account_id(), message_id)
+            .await
+    }
+
+    pub async fn get_from_account_mailbox(
+        &self,
         account_id: impl Borrow<AccountId32>,
         message_id: impl Borrow<MessageId>,
     ) -> Result<Option<(StoredMessage, Interval<u32>)>> {


### PR DESCRIPTION
- Part of #1962
- `get_from_mailbox` method has been split into `get_from_mailbox` (to get the message from the tester's mailbox) and `get_from_account_mailbox`(to get the message from any other account mailbox).
- Added the `GearApi::account_id` method to get the signer's address.

@gear-tech/dev
