### PR TITLE
gclient: Add `last_block_timestamp` function to API

### DIFF
--- a/gclient/src/api/error.rs
+++ b/gclient/src/api/error.rs
@@ -53,6 +53,8 @@ pub enum Error {
     EventNotFoundInIterator,
     #[error("Storage not found.")]
     StorageNotFound,
+    #[error("Timestamp not found in storage.")]
+    TimestampNotFound,
     #[error(transparent)]
     Codec(#[from] parity_scale_codec::Error),
 }

--- a/gclient/src/api/storage/block.rs
+++ b/gclient/src/api/storage/block.rs
@@ -82,6 +82,15 @@ impl GearApi {
         Ok(self.get_block_at(Some(block_hash)).await?.header.number)
     }
 
+    pub async fn last_block_timestamp(&self) -> Result<u64> {
+        let at = storage().timestamp().now();
+        self.0
+            .storage()
+            .fetch(&at, None)
+            .await?
+            .ok_or(Error::TimestampNotFound)
+    }
+
     pub async fn events_at(&self, block_hash: H256) -> Result<Vec<RuntimeEvent>> {
         self.get_events_at(Some(block_hash)).await
     }


### PR DESCRIPTION
- Part of #1962 
- Added `last_block_timestamp` function to API that returns timestamp in milliseconds since Unix epoch.

@gear-tech/dev 