### PR TITLE
Implement Gear stack end in `wasm-gen`

### DIFF
--- a/utils/wasm-gen/src/lib.rs
+++ b/utils/wasm-gen/src/lib.rs
@@ -321,6 +321,10 @@ impl<'a> WasmGen<'a> {
         }
         mem_section_idx.map(|index| module.sections_mut().remove(index));
 
+        // TODO(MIKITA)
+        module = builder::from_module(module).global().value_type().i32().init_expr(Instruction::I32Const(10)).build().build();
+        module.export_section().unwrap().entries_mut().push()
+
         let mem_size = self.u.int_in_range(0..=self.config.max_mem_size).unwrap();
         let mem_size_upper_bound = if self.config.has_mem_upper_bound.get(self.u) {
             Some(if self.config.upper_bound_can_be_less_then.get(self.u) {

--- a/utils/wasm-gen/src/lib.rs
+++ b/utils/wasm-gen/src/lib.rs
@@ -391,11 +391,21 @@ impl<'a> WasmGen<'a> {
 
         let gear_stack_end_seed = self.get_gear_stack_end_seed(mem_size);
         if let GearStackEndExportSeed::GenerateValue(gear_stack_val) = gear_stack_end_seed {
+            let mut module = builder::from_module(module)
+                .global()
+                .value_type()
+                .i32()
+                .init_expr(Instruction::I32Const(gear_stack_val as i32))
+                .build()
+                .build();
+
+            let last_element_num = module.global_section_mut().unwrap().entries_mut().len() - 1;
+
             return builder::from_module(module)
                 .export()
                 .field("__gear_stack_end")
                 .internal()
-                .global(gear_stack_val)
+                .global(last_element_num.try_into().unwrap())
                 .build()
                 .build();
         }

--- a/utils/wasm-gen/src/lib.rs
+++ b/utils/wasm-gen/src/lib.rs
@@ -124,6 +124,7 @@ pub struct GearConfig {
     pub sys_call_freq: Ratio,
     pub sys_calls: SyscallsConfig,
     pub print_test_info: Option<String>,
+    pub max_percentage_seed: u32,
 }
 
 impl GearConfig {
@@ -142,6 +143,7 @@ impl GearConfig {
             sys_call_freq: (1, 1000).into(),
             sys_calls: Default::default(),
             print_test_info: None,
+            max_percentage_seed: 100,
         }
     }
     pub fn new_for_rare_cases() -> Self {
@@ -159,6 +161,7 @@ impl GearConfig {
             sys_call_freq: (1, 1000).into(),
             sys_calls: Default::default(),
             print_test_info: None,
+            max_percentage_seed: 5,
         }
     }
     pub fn new_valid() -> Self {
@@ -177,6 +180,7 @@ impl GearConfig {
             sys_call_freq: (1, 1000).into(),
             sys_calls: Default::default(),
             print_test_info: None,
+            max_percentage_seed: 100,
         }
     }
 }
@@ -321,14 +325,16 @@ impl<'a> WasmGen<'a> {
     // ~1% of cases stack size is not generated at all
     // all other cases should be valid
     fn get_gear_stack_end_seed(&mut self, min_memory_size_pages: u32) -> GearStackEndExportSeed {
-        const MAX_SEED: u32 = 100;
         const NOT_GENERATE_SEED: u32 = 0;
         const NOT_WASM_PAGE_SEED: u32 = 1;
         const BIGGER_THAN_MEMORY_SEED: u32 = 2;
 
         const WASM_PAGE_SIZE_BYTES: u32 = 64 * 1024;
 
-        let seed = self.u.int_in_range(0..=MAX_SEED).unwrap();
+        let seed = self
+            .u
+            .int_in_range(0..=self.config.max_percentage_seed)
+            .unwrap();
         match seed {
             NOT_GENERATE_SEED => GearStackEndExportSeed::NotGenerate,
             NOT_WASM_PAGE_SEED => {

--- a/utils/wasm-gen/src/lib.rs
+++ b/utils/wasm-gen/src/lib.rs
@@ -282,6 +282,11 @@ struct WasmGen<'a> {
     calls_indexes: Vec<FuncIdx>,
 }
 
+enum GearStackEndExportSeed {
+    NotGenerate,
+    GenerateValue(u32),
+}
+
 impl<'a> WasmGen<'a> {
     fn initial_calls_indexes(module: &Module) -> Vec<FuncIdx> {
         let mut calls_indexes = Vec::new();
@@ -311,6 +316,45 @@ impl<'a> WasmGen<'a> {
         }
     }
 
+    // ~1% of cases with invalid stack size not a multiple of the page size
+    // ~1% of cases with invalid stask size that is biger than import memory
+    // ~1% of cases stack size is not generated at all
+    // all other cases should be valid
+    fn get_gear_stack_end_seed(&mut self, min_memory_size_pages: u32) -> GearStackEndExportSeed {
+        const MAX_SEED: u32 = 100;
+        const NOT_GENERATE_SEED: u32 = 0;
+        const NOT_WASM_PAGE_SEED: u32 = 1;
+        const BIGGER_THAN_MEMORY_SEED: u32 = 2;
+
+        const WASM_PAGE_SIZE_BYTES: u32 = 64 * 1024;
+
+        let seed = self.u.int_in_range(0..=MAX_SEED).unwrap();
+        match seed {
+            NOT_GENERATE_SEED => return GearStackEndExportSeed::NotGenerate,
+            NOT_WASM_PAGE_SEED => {
+                let max_size = min_memory_size_pages * WASM_PAGE_SIZE_BYTES;
+                // More likely value is not multiple of WASM_PAGE_SIZE_BYTES
+                let value = self.u.int_in_range(0..=max_size).unwrap();
+                return GearStackEndExportSeed::GenerateValue(value);
+            }
+            BIGGER_THAN_MEMORY_SEED => {
+                let value_pages = self
+                    .u
+                    .int_in_range(min_memory_size_pages..=10 * min_memory_size_pages)
+                    .unwrap();
+                // Make value a multiple of WASM_PAGE_SIZE_BYTES but bigger than min_memory_size
+                let value_bytes = (value_pages + 1) * WASM_PAGE_SIZE_BYTES;
+                return GearStackEndExportSeed::GenerateValue(value_bytes);
+            }
+            _ => {
+                let correct_value_pages = self.u.int_in_range(0..=min_memory_size_pages).unwrap();
+                // Make value a multiple of WASM_PAGE_SIZE_BYTES but less than min_memory_size
+                let correct_value_bytes = correct_value_pages * WASM_PAGE_SIZE_BYTES;
+                return GearStackEndExportSeed::GenerateValue(correct_value_bytes);
+            }
+        }
+    }
+
     pub fn gen_mem_export(&mut self, mut module: Module) -> Module {
         let mut mem_section_idx = None;
         for (idx, section) in module.sections().iter().enumerate() {
@@ -322,8 +366,8 @@ impl<'a> WasmGen<'a> {
         mem_section_idx.map(|index| module.sections_mut().remove(index));
 
         // TODO(MIKITA)
-        module = builder::from_module(module).global().value_type().i32().init_expr(Instruction::I32Const(10)).build().build();
-        module.export_section().unwrap().entries_mut().push()
+        // module = builder::from_module(module).global().value_type().i32().init_expr(Instruction::I32Const(10)).build().build();
+        // module.export_section().unwrap().entries_mut().push()
 
         let mem_size = self.u.int_in_range(0..=self.config.max_mem_size).unwrap();
         let mem_size_upper_bound = if self.config.has_mem_upper_bound.get(self.u) {
@@ -340,14 +384,27 @@ impl<'a> WasmGen<'a> {
             None
         };
 
-        builder::from_module(module)
+        let module = builder::from_module(module)
             .import()
             .module("env")
             .field("memory")
             .external()
             .memory(mem_size, mem_size_upper_bound)
             .build()
-            .build()
+            .build();
+
+        let gear_stack_end_seed = self.get_gear_stack_end_seed(mem_size);
+        if let GearStackEndExportSeed::GenerateValue(gear_stack_val) = gear_stack_end_seed {
+            return builder::from_module(module)
+                .import()
+                .module("env")
+                .field("__gear_stack_end")
+                .external()
+                .memory(gear_stack_val, None)
+                .build()
+                .build();
+        }
+        module
     }
 
     fn insert_instructions_in_random_place(

--- a/utils/wasm-gen/src/test.rs
+++ b/utils/wasm-gen/src/test.rs
@@ -34,8 +34,7 @@ fn gen_wasm_normal() {
         rng.fill_bytes(&mut buf);
         let mut u = Unstructured::new(&buf);
         let code = gen_gear_program_code(&mut u, GearConfig::new_normal());
-        let wat = wasmprinter::print_bytes(code).unwrap();
-        print!("{wat}");
+        let _wat = wasmprinter::print_bytes(code).unwrap();
     }
 }
 

--- a/utils/wasm-gen/src/test.rs
+++ b/utils/wasm-gen/src/test.rs
@@ -31,7 +31,8 @@ fn gen_wasm_normal() {
         rng.fill_bytes(&mut buf);
         let mut u = Unstructured::new(&buf);
         let code = gen_gear_program_code(&mut u, GearConfig::new_normal());
-        let _wat = wasmprinter::print_bytes(code).unwrap();
+        let wat = wasmprinter::print_bytes(code).unwrap();
+        println!("{wat}");
     }
 }
 

--- a/utils/wasm-gen/src/test.rs
+++ b/utils/wasm-gen/src/test.rs
@@ -23,11 +23,14 @@ use rand::{rngs::SmallRng, RngCore, SeedableRng};
 #[allow(unused)]
 use indicatif::ProgressIterator;
 
+const MODULES_AMOUNT : usize = 100;
+const TEST_THRESHOLD : usize = 1000000;
+
 #[test]
 fn gen_wasm_normal() {
     let mut rng = SmallRng::seed_from_u64(1234);
-    for _ in 0..100 {
-        let mut buf = vec![0; 1000000];
+    for _ in 0..MODULES_AMOUNT {
+        let mut buf = vec![0; TEST_THRESHOLD];
         rng.fill_bytes(&mut buf);
         let mut u = Unstructured::new(&buf);
         let code = gen_gear_program_code(&mut u, GearConfig::new_normal());
@@ -39,8 +42,8 @@ fn gen_wasm_normal() {
 #[test]
 fn gen_wasm_rare() {
     let mut rng = SmallRng::seed_from_u64(12345);
-    for _ in 0..100 {
-        let mut buf = vec![0; 1000000];
+    for _ in 0..MODULES_AMOUNT {
+        let mut buf = vec![0; TEST_THRESHOLD];
         rng.fill_bytes(&mut buf);
         let mut u = Unstructured::new(&buf);
         let code = gen_gear_program_code(&mut u, GearConfig::new_for_rare_cases());
@@ -53,8 +56,8 @@ fn gen_wasm_valid() {
     let mut rng = SmallRng::seed_from_u64(33333);
     let mut config = GearConfig::new_valid();
     config.print_test_info = Some("HEY GEAR".to_owned());
-    for _ in 0..100 {
-        let mut buf = vec![0; 1000000];
+    for _ in 0..MODULES_AMOUNT {
+        let mut buf = vec![0; TEST_THRESHOLD];
         rng.fill_bytes(&mut buf);
         let mut u = Unstructured::new(&buf);
         let code = gen_gear_program_code(&mut u, config.clone());

--- a/utils/wasm-gen/src/test.rs
+++ b/utils/wasm-gen/src/test.rs
@@ -24,13 +24,13 @@ use rand::{rngs::SmallRng, RngCore, SeedableRng};
 use indicatif::ProgressIterator;
 
 const MODULES_AMOUNT: usize = 100;
-const TEST_THRESHOLD: usize = 1000000;
+const UNSTRUCTURED_SIZE: usize = 1000000;
 
 #[test]
 fn gen_wasm_normal() {
     let mut rng = SmallRng::seed_from_u64(1234);
     for _ in 0..MODULES_AMOUNT {
-        let mut buf = vec![0; TEST_THRESHOLD];
+        let mut buf = vec![0; UNSTRUCTURED_SIZE];
         rng.fill_bytes(&mut buf);
         let mut u = Unstructured::new(&buf);
         let code = gen_gear_program_code(&mut u, GearConfig::new_normal());
@@ -42,7 +42,7 @@ fn gen_wasm_normal() {
 fn gen_wasm_rare() {
     let mut rng = SmallRng::seed_from_u64(12345);
     for _ in 0..MODULES_AMOUNT {
-        let mut buf = vec![0; TEST_THRESHOLD];
+        let mut buf = vec![0; UNSTRUCTURED_SIZE];
         rng.fill_bytes(&mut buf);
         let mut u = Unstructured::new(&buf);
         let code = gen_gear_program_code(&mut u, GearConfig::new_for_rare_cases());
@@ -56,7 +56,7 @@ fn gen_wasm_valid() {
     let mut config = GearConfig::new_valid();
     config.print_test_info = Some("HEY GEAR".to_owned());
     for _ in 0..MODULES_AMOUNT {
-        let mut buf = vec![0; TEST_THRESHOLD];
+        let mut buf = vec![0; UNSTRUCTURED_SIZE];
         rng.fill_bytes(&mut buf);
         let mut u = Unstructured::new(&buf);
         let code = gen_gear_program_code(&mut u, config.clone());

--- a/utils/wasm-gen/src/test.rs
+++ b/utils/wasm-gen/src/test.rs
@@ -23,8 +23,8 @@ use rand::{rngs::SmallRng, RngCore, SeedableRng};
 #[allow(unused)]
 use indicatif::ProgressIterator;
 
-const MODULES_AMOUNT : usize = 100;
-const TEST_THRESHOLD : usize = 1000000;
+const MODULES_AMOUNT: usize = 100;
+const TEST_THRESHOLD: usize = 1000000;
 
 #[test]
 fn gen_wasm_normal() {
@@ -35,7 +35,7 @@ fn gen_wasm_normal() {
         let mut u = Unstructured::new(&buf);
         let code = gen_gear_program_code(&mut u, GearConfig::new_normal());
         let wat = wasmprinter::print_bytes(code).unwrap();
-        println!("{wat}");
+        print!("{wat}");
     }
 }
 


### PR DESCRIPTION
Resolves #2050 

Add gear stack end to wasm-gen to test all cases depending on this

~1% of cases with invalid stack size not a multiple of the page size
~1% of cases with invalid stack size that is bigger than import memory
~1% of cases stack size is not generated at all
all other cases should be valid
