### PR TITLE
Rework block authorship

### DIFF
--- a/gclient/src/api/listener/iterator.rs
+++ b/gclient/src/api/listener/iterator.rs
@@ -109,27 +109,28 @@ impl EventListener {
         Err(Self::not_waited())
     }
 
-    /// Check whether at least one new block has been produced after the
-    /// `previous` block.
-    pub async fn blocks_running_since(&mut self, previous: H256) -> Result<bool> {
-        let current = self
+    /// Reads the next event from the stream and returns the repsective block
+    /// hash.
+    pub async fn next_block_hash(&mut self) -> Result<H256> {
+        Ok(self
             .0
             .next_events()
             .await
             .ok_or(Error::EventNotFound)??
-            .block_hash();
+            .block_hash())
+    }
+
+    /// Check whether at least one new block has been produced after the
+    /// `previous` block.
+    pub async fn blocks_running_since(&mut self, previous: H256) -> Result<bool> {
+        let current = self.next_block_hash().await?;
 
         Ok(current != previous)
     }
 
     /// Check whether new blocks are produced as expected.
     pub async fn blocks_running(&mut self) -> Result<bool> {
-        let previous = self
-            .0
-            .next_events()
-            .await
-            .ok_or(Error::EventNotFound)??
-            .block_hash();
+        let previous = self.next_block_hash().await?;
 
         self.blocks_running_since(previous).await
     }

--- a/gclient/src/api/storage/block.rs
+++ b/gclient/src/api/storage/block.rs
@@ -17,7 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::{GearApi, Result};
-use crate::Error;
+use crate::{api::listener::EventListener, Error};
 use gp::api::{
     config::GearConfig,
     generated::api::{runtime_types::gear_runtime::RuntimeEvent, storage},
@@ -151,8 +151,29 @@ impl GearApi {
     }
 
     /// Check whether the message queue processing is stopped or not.
-    pub async fn queue_processing_stopped(&self) -> Result<bool> {
+    pub async fn queue_processing_enabled(&self) -> Result<bool> {
         let at = storage().gear().execute_inherent();
-        Ok(!self.0.storage().fetch_or_default(&at, None).await?)
+        Ok(self.0.storage().fetch_or_default(&at, None).await?)
+    }
+
+    /// Looks at two blocks from the stream and checks if the Gear block number
+    /// has grown from block to block or not.
+    pub async fn queue_processing_stalled(&self, listener: &mut EventListener) -> Result<bool> {
+        let at = storage().gear().block_number();
+
+        let current = listener.next_block_hash().await?;
+        let gear_current = self
+            .0
+            .storage()
+            .fetch_or_default(&at, Some(current))
+            .await?;
+
+        let mut next = current;
+        while next == current {
+            next = listener.next_block_hash().await?;
+        }
+        let gear_next = self.0.storage().fetch_or_default(&at, Some(next)).await?;
+
+        Ok(gear_next <= gear_current)
     }
 }

--- a/gclient/src/api/storage/block.rs
+++ b/gclient/src/api/storage/block.rs
@@ -20,10 +20,7 @@ use super::{GearApi, Result};
 use crate::Error;
 use gp::api::{
     config::GearConfig,
-    generated::api::{
-        runtime_types::{gear_runtime::RuntimeEvent, pallet_gear::ProcessStatus},
-        storage,
-    },
+    generated::api::{runtime_types::gear_runtime::RuntimeEvent, storage},
 };
 use subxt::{ext::sp_core::H256, rpc::ChainBlock};
 
@@ -155,12 +152,7 @@ impl GearApi {
 
     /// Check whether the message queue processing is stopped or not.
     pub async fn queue_processing_stopped(&self) -> Result<bool> {
-        let at = storage().gear().queue_state();
-        self.0
-            .storage()
-            .fetch(&at, None)
-            .await?
-            .ok_or(Error::StorageNotFound)
-            .map(|queue_state| matches!(queue_state, ProcessStatus::SkippedOrFailed))
+        let at = storage().gear().execute_inherent();
+        Ok(!self.0.storage().fetch_or_default(&at, None).await?)
     }
 }

--- a/gclient/tests/keyhasher.rs
+++ b/gclient/tests/keyhasher.rs
@@ -50,7 +50,7 @@ async fn keyhasher_size_exceed() -> Result<()> {
     assert!(listener.message_processed(mid).await?.succeed());
 
     // Check no runtime panic occurred
-    assert!(!api.queue_processing_stopped().await?);
+    assert!(!api.queue_processing_stalled(&mut listener).await?);
 
     Ok(())
 }

--- a/gclient/tests/loop.rs
+++ b/gclient/tests/loop.rs
@@ -59,7 +59,7 @@ async fn inf_loop() -> Result<()> {
     assert!(listener.message_processed(mid).await?.failed());
 
     // Checking that blocks still running.
-    assert!(!api.queue_processing_stopped().await?);
+    assert!(!api.queue_processing_stalled(&mut listener).await?);
 
     Ok(())
 }

--- a/gclient/tests/upload.rs
+++ b/gclient/tests/upload.rs
@@ -77,7 +77,7 @@ async fn upload_programs_and_check(
     );
 
     // Check no runtime panic occurred
-    assert!(!api.queue_processing_stopped().await?);
+    assert!(!api.queue_processing_stalled(&mut listener).await?);
 
     Ok(())
 }

--- a/node/authorship/src/authorship.rs
+++ b/node/authorship/src/authorship.rs
@@ -528,8 +528,8 @@ where
                 warn!(target: "gear::authorship", "⚠️  Dropping terminal extrinsic from an overweight block.")
             }
             Err(e) => {
-                warn!(target: "gear::authorship",
-                    "❗️ Terminal extrinsic returned unexpected error: {}. Dropping.",
+                error!(target: "gear::authorship",
+                    "❗️ Terminal extrinsic returned an error: {}. Dropping.",
                     e
                 );
             }

--- a/node/service/src/chain_spec/gear.rs
+++ b/node/service/src/chain_spec/gear.rs
@@ -18,8 +18,8 @@
 
 use crate::chain_spec::{get_account_id_from_seed, get_from_seed, AccountId, Extensions};
 use gear_runtime::{
-    BabeConfig, BalancesConfig, GearConfig, GenesisConfig, GrandpaConfig, SessionConfig,
-    SessionKeys, SudoConfig, SystemConfig, WASM_BINARY,
+    BabeConfig, BalancesConfig, GenesisConfig, GrandpaConfig, SessionConfig, SessionKeys,
+    SudoConfig, SystemConfig, WASM_BINARY,
 };
 use hex_literal::hex;
 use sc_service::ChainType;
@@ -269,8 +269,5 @@ fn testnet_genesis(
             key: Some(root_key),
         },
         transaction_payment: Default::default(),
-        gear: GearConfig {
-            force_queue: Default::default(),
-        },
     }
 }

--- a/node/service/src/chain_spec/vara.rs
+++ b/node/service/src/chain_spec/vara.rs
@@ -23,8 +23,8 @@ use sp_consensus_babe::AuthorityId as BabeId;
 use sp_core::{crypto::UncheckedInto, sr25519};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
 use vara_runtime::{
-    BabeConfig, BalancesConfig, GearConfig, GenesisConfig, GrandpaConfig, SessionConfig,
-    SessionKeys, SudoConfig, SystemConfig, WASM_BINARY,
+    BabeConfig, BalancesConfig, GenesisConfig, GrandpaConfig, SessionConfig, SessionKeys,
+    SudoConfig, SystemConfig, WASM_BINARY,
 };
 
 // The URL for the telemetry server.
@@ -269,8 +269,5 @@ fn testnet_genesis(
             key: Some(root_key),
         },
         transaction_payment: Default::default(),
-        gear: GearConfig {
-            force_queue: Default::default(),
-        },
     }
 }

--- a/pallets/gear-debug/src/mock.rs
+++ b/pallets/gear-debug/src/mock.rs
@@ -17,13 +17,15 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate as pallet_gear_debug;
-use common::QueueRunner;
+use common::storage::Limiter;
 use frame_support::{
     construct_runtime, parameter_types,
-    traits::{FindAuthor, OnFinalize, OnInitialize},
+    traits::{FindAuthor, Get, OnFinalize, OnInitialize},
+    weights::Weight,
 };
 use frame_support_test::TestRandomness;
-use frame_system as system;
+use frame_system::{self as system, limits::BlockWeights};
+use pallet_gear::GasAllowanceOf;
 use primitive_types::H256;
 use sp_core::ConstU128;
 use sp_runtime::{
@@ -204,7 +206,6 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
     let mut ext = sp_io::TestExternalities::new(t);
     ext.execute_with(|| {
-        Gear::force_always();
         System::set_block_number(1);
         Gear::on_initialize(System::block_number());
     });
@@ -219,11 +220,19 @@ pub fn run_to_block(n: u64, remaining_weight: Option<u64>) {
         GearGas::on_initialize(System::block_number());
         GearMessenger::on_initialize(System::block_number());
         Gear::on_initialize(System::block_number());
-        let remaining_weight =
-            remaining_weight.unwrap_or(pallet_gear::BlockGasLimitOf::<Test>::get());
 
-        Gear::run_queue(remaining_weight);
-        Gear::processing_completed();
+        if let Some(remaining_weight) = remaining_weight {
+            GasAllowanceOf::<Test>::put(remaining_weight);
+            let max_block_weight =
+                <<Test as frame_system::Config>::BlockWeights as Get<BlockWeights>>::get()
+                    .max_block;
+            System::register_extra_weight_unchecked(
+                max_block_weight.saturating_sub(Weight::from_ref_time(remaining_weight)),
+                frame_support::dispatch::DispatchClass::Normal,
+            );
+        }
+
+        Gear::run(frame_support::dispatch::RawOrigin::None.into()).unwrap();
         Gear::on_finalize(System::block_number());
 
         assert!(!System::events().iter().any(|e| {

--- a/pallets/gear-scheduler/src/mock.rs
+++ b/pallets/gear-scheduler/src/mock.rs
@@ -17,7 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate as pallet_gear_scheduler;
-use common::QueueRunner;
+use common::storage::Limiter;
 use frame_support::{
     construct_runtime,
     pallet_prelude::*,
@@ -26,8 +26,8 @@ use frame_support::{
     weights::constants::RocksDbWeight,
 };
 use frame_support_test::TestRandomness;
-use frame_system as system;
-use pallet_gear::BlockGasLimitOf;
+use frame_system::{self as system, limits::BlockWeights};
+use pallet_gear::GasAllowanceOf;
 use sp_core::{ConstU128, H256};
 use sp_runtime::{
     testing::Header,
@@ -210,7 +210,6 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
     let mut ext = sp_io::TestExternalities::new(t);
     ext.execute_with(|| {
-        Gear::force_always();
         System::set_block_number(1);
         Gear::on_initialize(System::block_number());
     });
@@ -226,15 +225,18 @@ pub fn run_to_block(n: u64, remaining_weight: Option<u64>) {
         GearMessenger::on_initialize(System::block_number());
         Gear::on_initialize(System::block_number());
 
-        let remaining_weight = remaining_weight.unwrap_or(BlockGasLimitOf::<Test>::get());
-        log::debug!(
-            "🧱 Running run #{} with weight {}",
-            System::block_number(),
-            remaining_weight
-        );
+        if let Some(remaining_weight) = remaining_weight {
+            GasAllowanceOf::<Test>::put(remaining_weight);
+            let max_block_weight =
+                <<Test as frame_system::Config>::BlockWeights as Get<BlockWeights>>::get()
+                    .max_block;
+            System::register_extra_weight_unchecked(
+                max_block_weight.saturating_sub(Weight::from_ref_time(remaining_weight)),
+                DispatchClass::Normal,
+            );
+        }
 
-        Gear::run_queue(remaining_weight);
-        Gear::processing_completed();
+        Gear::run(frame_support::dispatch::RawOrigin::None.into()).unwrap();
         Gear::on_finalize(System::block_number());
 
         assert!(!System::events().iter().any(|e| {

--- a/pallets/gear/rpc/runtime-api/src/lib.rs
+++ b/pallets/gear/rpc/runtime-api/src/lib.rs
@@ -28,7 +28,7 @@ sp_api::decl_runtime_apis! {
         #[allow(clippy::too_many_arguments)]
         fn calculate_gas_info(source: H256, kind: HandleKind, payload: Vec<u8>, value: u128, allow_other_panics: bool, initial_gas: Option<u64>,) -> Result<GasInfo, Vec<u8>>;
 
-        /// Generate inherent-like extrinsic the runs message queue processing.
+        /// Generate inherent-like extrinsic that runs message queue processing.
         fn gear_run_extrinsic() -> <Block as BlockT>::Extrinsic;
 
         fn read_state(program_id: H256) -> Result<Vec<u8>, Vec<u8>>;

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -62,7 +62,7 @@ use codec::Encode;
 use common::{
     self, benchmarking,
     storage::{Counter, *},
-    CodeMetadata, CodeStorage, GasPrice, GasTree, Origin, QueueRunner,
+    CodeMetadata, CodeStorage, GasPrice, GasTree, Origin,
 };
 use core::ops::Range;
 use core_processor::{

--- a/pallets/gear/src/mock.rs
+++ b/pallets/gear/src/mock.rs
@@ -18,20 +18,20 @@
 
 use crate as pallet_gear;
 use crate::*;
-use common::QueueRunner;
 use frame_support::{
     construct_runtime,
     pallet_prelude::*,
     parameter_types,
-    traits::{ConstU64, FindAuthor},
+    traits::{ConstU64, FindAuthor, Get},
     weights::RuntimeDbWeight,
 };
 use frame_support_test::TestRandomness;
-use frame_system as system;
+use frame_system::{self as system, limits::BlockWeights};
 use sp_core::{ConstU128, H256};
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
+    Perbill,
 };
 use sp_std::convert::{TryFrom, TryInto};
 
@@ -39,11 +39,15 @@ type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 type AccountId = u64;
 
+type BlockWeightsOf<T> = <T as frame_system::Config>::BlockWeights;
+
 pub(crate) const USER_1: AccountId = 1;
 pub(crate) const USER_2: AccountId = 2;
 pub(crate) const USER_3: AccountId = 3;
 pub(crate) const LOW_BALANCE_USER: AccountId = 4;
 pub(crate) const BLOCK_AUTHOR: AccountId = 255;
+const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
+const MAX_BLOCK: u64 = 100_000_000_000;
 
 macro_rules! dry_run {
     (
@@ -93,6 +97,10 @@ impl pallet_balances::Config for Test {
 
 parameter_types! {
     pub const BlockHashCount: u64 = 250;
+    pub RuntimeBlockWeights: BlockWeights = BlockWeights::with_sensible_defaults(
+        Weight::from_parts(MAX_BLOCK, u64::MAX),
+        NORMAL_DISPATCH_RATIO,
+    );
     pub const SS58Prefix: u8 = 42;
     pub const ExistentialDeposit: u64 = 500;
     pub const DbWeight: RuntimeDbWeight = RuntimeDbWeight { read: 1110, write: 2300 };
@@ -100,7 +108,7 @@ parameter_types! {
 
 impl system::Config for Test {
     type BaseCallFilter = frame_support::traits::Everything;
-    type BlockWeights = ();
+    type BlockWeights = RuntimeBlockWeights;
     type BlockLength = ();
     type DbWeight = DbWeight;
     type RuntimeOrigin = RuntimeOrigin;
@@ -134,7 +142,8 @@ impl common::GasPrice for GasConverter {
 impl pallet_gear_program::Config for Test {}
 
 parameter_types! {
-    pub const BlockGasLimit: u64 = 100_000_000_000;
+    // Match the default `max_block` set in frame_system::limits::BlockWeights::with_sensible_defaults()
+    pub const BlockGasLimit: u64 = MAX_BLOCK;
     pub const OutgoingLimit: u32 = 1024;
     pub GearSchedule: pallet_gear::Schedule<Test> = <pallet_gear::Schedule<Test>>::default();
 }
@@ -225,7 +234,6 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
     let mut ext = sp_io::TestExternalities::new(t);
     ext.execute_with(|| {
-        Gear::force_always();
         System::set_block_number(1);
         Gear::on_initialize(System::block_number());
     });
@@ -266,16 +274,16 @@ pub fn run_to_block(n: u64, remaining_weight: Option<u64>) {
         GearMessenger::on_initialize(System::block_number());
         Gear::on_initialize(System::block_number());
 
-        let remaining_weight = remaining_weight.unwrap_or(BlockGasLimitOf::<Test>::get());
-        log::debug!(
-            "🧱 Running run #{} (gear #{}) with weight {}",
-            System::block_number(),
-            Gear::block_number(),
-            remaining_weight
-        );
+        if let Some(remaining_weight) = remaining_weight {
+            GasAllowanceOf::<Test>::put(remaining_weight);
+            let max_block_weight = <BlockWeightsOf<Test> as Get<BlockWeights>>::get().max_block;
+            System::register_extra_weight_unchecked(
+                max_block_weight.saturating_sub(Weight::from_ref_time(remaining_weight)),
+                DispatchClass::Normal,
+            );
+        }
 
-        Gear::run_queue(remaining_weight);
-        Gear::processing_completed();
+        Gear::run(frame_support::dispatch::RawOrigin::None.into()).unwrap();
         Gear::on_finalize(System::block_number());
 
         assert!(!System::events().iter().any(|e| {

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -1354,8 +1354,8 @@ fn spent_gas_to_reward_block_author_works() {
         // the `gas_charge` incurred while processing the `InitProgram` message
         let gas_spent = GasPrice::gas_price(
             BlockGasLimitOf::<Test>::get()
-                - GasAllowanceOf::<Test>::get()
-                - minimal_weight.ref_time(),
+                .saturating_sub(GasAllowanceOf::<Test>::get())
+                .saturating_sub(minimal_weight.ref_time()),
         );
         assert_eq!(
             Balances::free_balance(BLOCK_AUTHOR),
@@ -1411,8 +1411,8 @@ fn unused_gas_released_back_works() {
 
         let user1_actual_msgs_spends = GasPrice::gas_price(
             BlockGasLimitOf::<Test>::get()
-                - GasAllowanceOf::<Test>::get()
-                - minimal_weight.ref_time(),
+                .saturating_sub(GasAllowanceOf::<Test>::get())
+                .saturating_sub(minimal_weight.ref_time()),
         );
 
         assert!(user1_potential_msgs_spends > user1_actual_msgs_spends);
@@ -1947,7 +1947,9 @@ fn initial_pages_cheaper_than_allocated_pages() {
             run_to_block(block_number, None);
             assert_last_dequeued(1);
 
-            GasPrice::gas_price(BlockGasLimitOf::<Test>::get() - GasAllowanceOf::<Test>::get())
+            GasPrice::gas_price(
+                BlockGasLimitOf::<Test>::get().saturating_sub(GasAllowanceOf::<Test>::get()),
+            )
         };
 
         let spent_for_initial_pages = gas_spent(wat_initial);

--- a/pallets/payment/src/mock.rs
+++ b/pallets/payment/src/mock.rs
@@ -257,7 +257,6 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
     let mut ext = sp_io::TestExternalities::new(t);
     ext.execute_with(|| {
-        Gear::force_always();
         System::set_block_number(1);
         Gear::on_initialize(System::block_number());
     });

--- a/utils/test-runtime/client/src/block_builder_ext.rs
+++ b/utils/test-runtime/client/src/block_builder_ext.rs
@@ -26,9 +26,9 @@ use sc_block_builder::BlockBuilderApi;
 // Extension trait for test block builder.
 pub trait BlockBuilderExt {
     // Add submit extrinsic to the block.
-    fn push_submit(&mut self, message: test_runtime::Message) -> Result<(), sp_blockchain::Error>;
+    fn push_signed(&mut self, message: test_runtime::Message) -> Result<(), sp_blockchain::Error>;
     // Add storage change extrinsic to the block.
-    fn push_storage_change(
+    fn push_custom(
         &mut self,
         key: Vec<u8>,
         value: Option<Vec<u8>>,
@@ -42,15 +42,15 @@ where
         + ApiExt<test_runtime::Block, StateBackend = backend::StateBackendFor<B, test_runtime::Block>>,
     B: backend::Backend<test_runtime::Block>,
 {
-    fn push_submit(&mut self, message: test_runtime::Message) -> Result<(), sp_blockchain::Error> {
+    fn push_signed(&mut self, message: test_runtime::Message) -> Result<(), sp_blockchain::Error> {
         self.push(message.into_signed_tx())
     }
 
-    fn push_storage_change(
+    fn push_custom(
         &mut self,
         key: Vec<u8>,
         value: Option<Vec<u8>>,
     ) -> Result<(), sp_blockchain::Error> {
-        self.push(test_runtime::Extrinsic::StorageChange(key, value))
+        self.push(test_runtime::Extrinsic::Custom(key, value))
     }
 }

--- a/utils/test-runtime/client/src/trait_tests.rs
+++ b/utils/test-runtime/client/src/trait_tests.rs
@@ -111,7 +111,7 @@ where
 
     // this push is required as otherwise B2 has the same hash as A2 and won't get imported
     builder
-        .push_submit(Message {
+        .push_signed(Message {
             from: AccountKeyring::Alice.into(),
             item: 41,
             nonce: 0,
@@ -148,7 +148,7 @@ where
         .unwrap();
     // this push is required as otherwise C3 has the same hash as B3 and won't get imported
     builder
-        .push_submit(Message {
+        .push_signed(Message {
             from: AccountKeyring::Alice.into(),
             item: 1,
             nonce: 1,
@@ -167,7 +167,7 @@ where
         .unwrap();
     // this push is required as otherwise D2 has the same hash as B2 and won't get imported
     builder
-        .push_submit(Message {
+        .push_signed(Message {
             from: AccountKeyring::Alice.into(),
             item: 1,
             nonce: 0,
@@ -246,7 +246,7 @@ where
         .unwrap();
     // this push is required as otherwise B2 has the same hash as A2 and won't get imported
     builder
-        .push_submit(Message {
+        .push_signed(Message {
             from: AccountKeyring::Alice.into(),
             item: 41,
             nonce: 0,
@@ -279,7 +279,7 @@ where
         .unwrap();
     // this push is required as otherwise C3 has the same hash as B3 and won't get imported
     builder
-        .push_submit(Message {
+        .push_signed(Message {
             from: AccountKeyring::Alice.into(),
             item: 1,
             nonce: 1,
@@ -294,7 +294,7 @@ where
         .unwrap();
     // this push is required as otherwise D2 has the same hash as B2 and won't get imported
     builder
-        .push_submit(Message {
+        .push_signed(Message {
             from: AccountKeyring::Alice.into(),
             item: 1,
             nonce: 0,
@@ -381,7 +381,7 @@ where
         .unwrap();
     // this push is required as otherwise B2 has the same hash as A2 and won't get imported
     builder
-        .push_submit(Message {
+        .push_signed(Message {
             from: AccountKeyring::Alice.into(),
             item: 41,
             nonce: 0,
@@ -414,7 +414,7 @@ where
         .unwrap();
     // this push is required as otherwise C3 has the same hash as B3 and won't get imported
     builder
-        .push_submit(Message {
+        .push_signed(Message {
             from: AccountKeyring::Alice.into(),
             item: 1,
             nonce: 1,
@@ -429,7 +429,7 @@ where
         .unwrap();
     // this push is required as otherwise D2 has the same hash as B2 and won't get imported
     builder
-        .push_submit(Message {
+        .push_signed(Message {
             from: AccountKeyring::Alice.into(),
             item: 1,
             nonce: 0,


### PR DESCRIPTION
Resolves the issue with a flaky machinery of deciding wether the message queue should be processed in the end of each block depending on the outcome of previous runs.

The old mechanism relied on the inherent-like extrinsic signalling a successful completion of the message queue processing by setting some storage value to a specific status. If not set, this was deemed as a panic having occurred during one of the previous runs so that a new attempt wouldn't (by default) take place. This creates an attack vector of a malicious validator opting for deliberately not including this inherent into a block thereby blocking the queue processing in all the blocks thereafter, until the issue would have been investigated and fixed via a runtime upgrade which would render the network useless in the meantime.

The proposed solution changes this approach so that the inherent-like extrinsic is always included in a block; however, there is another storage value - `ExecuteInherent`, that is checked inside this extrinsic: if set to `false`, an error is returned thereby causing the block builder to drop this extrinsic. This value can only be altered by a `root origin`. This is useful to manually disable queue processing in case it panics and re-enable once the issue has been fixed.

**Issues**: since queue processing is run inside an unsigned extrinsic (a pseudo-inherent) it suffers from the same problems normal inherents do: a malicious validator may alter its behaviour, and there is no way to distinguish between a legitimate exclusion of this extrinsic due to a panic or an error and a deliberate dropping by validator.

For an external observer the following signals are available:
```
                                |      ExecuteInherent == true     |      ExecuteInherent == false
--------------------------------------------------------------------------------------------------------
                                |   Gear::BlockNumber::<T> keeps   |
                                |        growing every block       |
  Gear::run() gets into block   |                                  |                 N/ A
                                | Event::MessgesDispatched emited  |
                                |      (if total_handled > 0)      |
--------------------------------------------------------------------------------------------------------
               |      error     |   Gear::BlockNumber::<T> stalls  | 
  Gear::run()  | - - - - - - - -|     as chain blocks progress     |   Gear::BlockNumber::<T> stalls
    dropped    |      panic     |                                  |     as chain blocks progress
  from block   | - - - - - - - -|  Event::QueueProcessingReverted  |
               |   intentional  |      emited at every block       |
```