### PR TITLE
gclient: Add functions for state reading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,6 +3050,7 @@ dependencies = [
  "anyhow",
  "async-std",
  "async-trait",
+ "demo-meta-io",
  "env_logger 0.10.0",
  "futures",
  "futures-timer",

--- a/gclient/Cargo.toml
+++ b/gclient/Cargo.toml
@@ -24,6 +24,7 @@ wat = "1.0.52"
 async-std = "1.12"
 env_logger = "0.10"
 log = "0.4"
+demo-meta-io = { path = "../examples/binaries/new-meta/io" }
 
 [features]
 default = [ "gear" ]

--- a/gclient/src/api/error.rs
+++ b/gclient/src/api/error.rs
@@ -45,6 +45,8 @@ pub enum Error {
     BalanceOverflow,
     #[error("Block data not found")]
     BlockDataNotFound,
+    #[error("Block hash not found")]
+    BlockHashNotFound,
     #[error("Some of extrinsics wasn't processed within the batch")]
     IncompleteBatchResult(usize, usize),
     #[error("Max depth reached, but queried block wasn't found")]

--- a/gclient/src/api/storage/block.rs
+++ b/gclient/src/api/storage/block.rs
@@ -80,12 +80,11 @@ impl GearApi {
 
     /// Get a hash of a block identified by its `block_number`.
     pub async fn get_block_hash(&self, block_number: u32) -> Result<H256> {
-        Ok(self
-            .0
+        self.0
             .rpc()
             .block_hash(Some(block_number.into()))
             .await?
-            .ok_or(Error::BlockHashNotFound)?)
+            .ok_or(Error::BlockHashNotFound)
     }
 
     pub async fn last_block_timestamp(&self) -> Result<u64> {

--- a/gclient/src/api/storage/block.rs
+++ b/gclient/src/api/storage/block.rs
@@ -78,6 +78,16 @@ impl GearApi {
         Ok(self.get_block_at(Some(block_hash)).await?.header.number)
     }
 
+    /// Get a hash of a block identified by its `block_number`.
+    pub async fn get_block_hash(&self, block_number: u32) -> Result<H256> {
+        Ok(self
+            .0
+            .rpc()
+            .block_hash(Some(block_number.into()))
+            .await?
+            .ok_or(Error::BlockHashNotFound)?)
+    }
+
     pub async fn last_block_timestamp(&self) -> Result<u64> {
         let at = storage().timestamp().now();
         self.0

--- a/gclient/tests/state.rs
+++ b/gclient/tests/state.rs
@@ -1,0 +1,83 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use demo_meta_io::Wallet;
+use gclient::{EventProcessor, GearApi, Result};
+use parity_scale_codec::Decode;
+use tokio::fs;
+
+const WASM_PATH: &str = "../target/wasm32-unknown-unknown/release/demo_new_meta.opt.wasm";
+const METAHASH_PATH: &str = "../examples/binaries/new-meta/.metahash";
+const META_WASM_PATH: &str =
+    "../target/wasm32-unknown-unknown/release/demo_meta_state_v1.meta.wasm";
+
+#[tokio::test]
+async fn get_state() -> Result<()> {
+    let api = GearApi::dev().await?;
+
+    // Subscribe to events
+    let mut listener = api.subscribe().await?;
+
+    // Check that blocks are still running
+    assert!(listener.blocks_running().await?);
+
+    // Calculate gas amount needed for initialization
+    let gas_info = api
+        .calculate_upload_gas(None, gclient::code_from_os(WASM_PATH)?, vec![], 0, true)
+        .await?;
+
+    // Upload and init the program
+    let (message_id, program_id, _hash) = api
+        .upload_program_bytes_by_path(
+            WASM_PATH,
+            gclient::bytes_now(),
+            vec![],
+            gas_info.min_limit,
+            0,
+        )
+        .await?;
+
+    assert!(listener.message_processed(message_id).await?.succeed());
+
+    // Read and check `metahash`
+    let metahash = api.read_metahash(program_id).await?;
+    let file_metahash = fs::read_to_string(METAHASH_PATH).await?;
+    assert_eq!(format!("{:?}", metahash.as_bytes()), file_metahash);
+
+    // Read state bytes
+    let state = api.read_state_bytes(program_id).await?;
+    let wallets = Vec::<Wallet>::decode(&mut state.as_ref()).expect("Unable to decode");
+    assert_eq!(wallets.len(), 2);
+
+    // Read state using Wasm
+    let wallet: Option<Wallet> = api
+        .read_state_using_wasm_by_path(
+            program_id,
+            "first_wallet",
+            META_WASM_PATH,
+            <Option<()>>::None,
+        )
+        .await?;
+    let wallet = wallet.expect("No wallet");
+
+    assert_eq!(wallet.id.decimal, 1);
+    assert_eq!(wallet.person.surname, "SomeSurname");
+    assert_eq!(wallet.person.name, "SomeName");
+
+    Ok(())
+}


### PR DESCRIPTION
- Part of #1962

- Added wrappers around three RPC calls: `gear_readState`, `gear_readStateUsingWasm`, `gear_readStateUsingWasm` 

@gear-tech/dev 