### PR TITLE
Fix fuzzing tests being non-reproducible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3854,6 +3854,7 @@ dependencies = [
  "arbitrary",
  "gear-wasm-instrument",
  "indicatif",
+ "proptest",
  "rand 0.8.5",
  "wasm-smith",
  "wasmparser 0.99.0",

--- a/utils/wasm-gen/Cargo.toml
+++ b/utils/wasm-gen/Cargo.toml
@@ -16,3 +16,4 @@ rand = { version = "0.8.0", features = ["small_rng"] }
 wasmparser = { version = "0.99.0" }
 wat = "1.0.58"
 indicatif = "*"
+proptest = "1.0.0"

--- a/utils/wasm-gen/src/lib.rs
+++ b/utils/wasm-gen/src/lib.rs
@@ -35,7 +35,7 @@ mod syscalls;
 use syscalls::{sys_calls_table, Parameter, SysCallInfo, SyscallsConfig};
 
 #[cfg(test)]
-mod test;
+mod tests;
 
 pub mod utils;
 pub mod wasm;

--- a/utils/wasm-gen/src/tests.rs
+++ b/utils/wasm-gen/src/tests.rs
@@ -19,6 +19,7 @@
 use crate::{gen_gear_program_code, utils, GearConfig};
 use arbitrary::Unstructured;
 use gear_wasm_instrument::parity_wasm::{self, elements};
+use proptest::prelude::{proptest, ProptestConfig};
 use rand::{rngs::SmallRng, RngCore, SeedableRng};
 
 #[allow(unused)]
@@ -113,4 +114,24 @@ fn remove_trivial_recursions() {
 
     let wat = wasmprinter::print_bytes(&wasm).unwrap();
     println!("wat = {wat}");
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(650))]
+    #[test]
+    fn test_gen_reproduction(seed in 0..u64::MAX) {
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let mut buf = vec![0; 100_000];
+        rng.fill_bytes(&mut buf);
+
+        let mut u = Unstructured::new(&buf);
+        let mut u2 = Unstructured::new(&buf);
+
+        let gear_config = GearConfig::new_normal();
+
+        let first = gen_gear_program_code(&mut u, gear_config.clone());
+        let second = gen_gear_program_code(&mut u2, gear_config);
+
+        assert!(first == second);
+    }
 }

--- a/utils/wasm-gen/src/utils.rs
+++ b/utils/wasm-gen/src/utils.rs
@@ -20,7 +20,7 @@ use gear_wasm_instrument::parity_wasm::{
     builder,
     elements::{self, FuncBody, ImportCountType, Instruction, Module, Type, ValueType},
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 const PREALLOCATE: usize = 1_000;
 
@@ -45,7 +45,7 @@ where
 
     let import_count = module.import_count(ImportCountType::Function);
 
-    let mut colored_list = Vec::<HashMap<_, _>>::with_capacity(function_bodies.len());
+    let mut colored_list = Vec::<BTreeMap<_, _>>::with_capacity(function_bodies.len());
     let mut path = Vec::with_capacity(PREALLOCATE);
 
     for i in 0..function_bodies.len() {
@@ -75,7 +75,7 @@ fn find_recursion_impl<Callback>(
     call_index: usize,
     import_count: usize,
     function_bodies: &[FuncBody],
-    colored: &mut HashMap<usize, Color>,
+    colored: &mut BTreeMap<usize, Color>,
     path: &mut Vec<usize>,
     callback: &mut Callback,
 ) where
@@ -124,8 +124,8 @@ pub fn remove_recursion(module: Module) -> Module {
         return module;
     }
 
-    let mut calls_to_change = HashMap::<_, HashSet<_>>::with_capacity(PREALLOCATE);
-    let mut call_substitutions = HashMap::<_, _>::with_capacity(PREALLOCATE);
+    let mut calls_to_change = BTreeMap::<_, BTreeSet<_>>::new();
+    let mut call_substitutions = BTreeMap::<_, _>::new();
     find_recursion(&module, |path, call| {
         let call_to_change = path.last().unwrap();
 
@@ -135,7 +135,7 @@ pub fn remove_recursion(module: Module) -> Module {
                 calls.insert(call as u32);
             }
             None => {
-                let mut calls = HashSet::with_capacity(PREALLOCATE);
+                let mut calls = BTreeSet::new();
                 calls.insert(call as u32);
 
                 calls_to_change.insert(*call_to_change, calls);


### PR DESCRIPTION
Resolves #2170.

Bug was basically with using `HashMap`/`HashSet` as during the iteration these types do not give guarantee on the order, so for the same input seed we will receive different iteration order of the same data. 