### PR TITLE
Revert "Take `SKIP_WASM_BUILD` env var into account (#2179)"

### DIFF
--- a/utils/wasm-builder/src/cargo_command.rs
+++ b/utils/wasm-builder/src/cargo_command.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use anyhow::{ensure, Context, Result};
+use anyhow::{ensure, Result};
 use std::{env, path::PathBuf, process::Command};
 
 use crate::builder_error::BuilderError;
@@ -79,11 +79,11 @@ impl CargoCommand {
             .arg("--")
             .args(&self.rustc_flags)
             .env("CARGO_TARGET_DIR", &self.target_dir)
-            .env(self.skip_pkg_build_env(), "1"); // Don't build the original crate recursively
+            .env(self.skip_build_env(), ""); // Don't build the original crate recursively
 
         self.remove_cargo_encoded_rustflags(&mut cargo);
 
-        let status = cargo.status().context("unable to execute cargo command")?;
+        let status = cargo.status()?;
         ensure!(
             status.success(),
             BuilderError::CargoRunFailed(status.to_string())
@@ -93,7 +93,7 @@ impl CargoCommand {
     }
 
     /// Generate a project specific environment variable that used to skip the build.
-    pub fn skip_pkg_build_env(&self) -> String {
+    pub fn skip_build_env(&self) -> String {
         format!(
             "SKIP_{}_WASM_BUILD",
             env::var("CARGO_PKG_NAME")

--- a/utils/wasm-builder/src/lib.rs
+++ b/utils/wasm-builder/src/lib.rs
@@ -67,26 +67,10 @@ impl WasmBuilder {
 
     /// Build the program and produce an output WASM binary.
     pub fn build(self) {
-        println!(
-            "cargo:rerun-if-env-changed={}",
-            self.cargo.skip_pkg_build_env()
-        );
-        println!("cargo:rerun-if-env-changed=SKIP_WASM_BUILD");
-
-        let check_env = |name: &str| {
-            let var = env::var(name).ok().as_deref().map(str::to_lowercase);
-            ["1", "true"].map(Some).contains(&var.as_deref())
-        };
-
-        let f = || {
-            if check_env(&self.cargo.skip_pkg_build_env()) || check_env("SKIP_WASM_BUILD") {
-                return self.wasm_project.write_wasm_binary_rs(None);
-            }
-
-            self.build_project()
-        };
-
-        if let Err(e) = f() {
+        if env::var(self.cargo.skip_build_env()).is_ok() {
+            return;
+        }
+        if let Err(e) = self.build_project() {
             eprintln!("error: {e}");
             e.chain()
                 .skip(1)

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -182,16 +182,14 @@ impl WasmProject {
         cargo_toml.insert("features".into(), features.into());
         cargo_toml.insert("workspace".into(), Table::new().into());
 
-        fs::write(self.manifest_path(), toml::to_string_pretty(&cargo_toml)?)
-            .context("unable to write Cargo.toml")?;
+        fs::write(self.manifest_path(), toml::to_string_pretty(&cargo_toml)?)?;
 
         let src_dir = self.out_dir.join("src");
         fs::create_dir_all(&src_dir)?;
         fs::write(
             src_dir.join("lib.rs"),
             "#![no_std] pub use orig_project::*;",
-        )
-        .context("unable to write lib.rs")?;
+        )?;
 
         // Copy original `Cargo.lock` if any
         let from_lock = self.original_dir.join("Cargo.lock");
@@ -207,71 +205,6 @@ impl WasmProject {
 
             fs::write(wasm_meta_hash_path, format!("{:?}", metadata.hash()))
                 .context("unable to write `.metahash`")?;
-        }
-
-        Ok(())
-    }
-
-    pub fn write_wasm_binary_rs(&self, paths: Option<(PathBuf, PathBuf, PathBuf)>) -> Result<()> {
-        let metadata = self
-            .project_type
-            .metadata()
-            .map(|m| {
-                format!(
-                    "#[allow(unused)] pub const WASM_METADATA: &[u8] = &{:?};\n",
-                    m.bytes()
-                )
-            })
-            .unwrap_or_default();
-
-        let wasm_binary_rs = self.out_dir.join("wasm_binary.rs");
-
-        let include_bytes = |path| format!(r#"include_bytes!("{}")"#, display_path(path));
-        let (to_path, to_opt_path, to_meta_path, exports) =
-            if let Some((to_path, to_opt_path, to_meta_path)) = paths {
-                (
-                    include_bytes(&to_path),
-                    include_bytes(&to_opt_path),
-                    include_bytes(&to_meta_path),
-                    Self::get_exports(to_meta_path)?,
-                )
-            } else {
-                (
-                    "&[]".to_string(),
-                    "&[]".to_string(),
-                    "&[]".to_string(),
-                    vec![],
-                )
-            };
-
-        if !self.project_type.is_metawasm() {
-            fs::write(
-                wasm_binary_rs,
-                format!(
-                    r#"#[allow(unused)]
-pub const WASM_BINARY: &[u8] = {to_path};
-#[allow(unused)]
-pub const WASM_BINARY_OPT: &[u8] = {to_opt_path};
-#[allow(unused)]
-pub const WASM_BINARY_META: &[u8] = {to_meta_path};
-{metadata}
-"#,
-                ),
-            )
-            .context("unable to write `wasm_binary.rs`")?;
-        } else {
-            fs::write(
-                wasm_binary_rs,
-                format!(
-                    r#"#[allow(unused)]
-pub const WASM_BINARY: &[u8] = {to_meta_path};
-#[allow(unused)]
-pub const WASM_EXPORTS: &[&str] = &{exports:?};
-
-"#,
-                ),
-            )
-            .context("unable to write `wasm_binary.rs`")?;
         }
 
         Ok(())
@@ -306,6 +239,17 @@ pub const WASM_EXPORTS: &[&str] = &{exports:?};
             // let _ = crate::optimize::optimize_wasm(to_path.clone(), "s", false);
         }
 
+        let metadata = self
+            .project_type
+            .metadata()
+            .map(|m| {
+                format!(
+                    "#[allow(unused)] pub const WASM_METADATA: &[u8] = &{:?};\n",
+                    m.bytes()
+                )
+            })
+            .unwrap_or_default();
+
         // Generate wasm binaries
         Self::generate_wasm(
             from_path,
@@ -326,7 +270,43 @@ pub const WASM_EXPORTS: &[&str] = &{exports:?};
                 .context("unable to write `.binpath`")?;
         }
 
-        self.write_wasm_binary_rs(Some((to_path, to_opt_path, to_meta_path)))?;
+        let wasm_binary_rs = self.out_dir.join("wasm_binary.rs");
+
+        if !self.project_type.is_metawasm() {
+            fs::write(
+                wasm_binary_rs,
+                format!(
+                    r#"#[allow(unused)]
+pub const WASM_BINARY: &[u8] = include_bytes!("{}");
+#[allow(unused)]
+pub const WASM_BINARY_OPT: &[u8] = include_bytes!("{}");
+#[allow(unused)]
+pub const WASM_BINARY_META: &[u8] = include_bytes!("{}");
+{}
+"#,
+                    display_path(to_path),
+                    display_path(to_opt_path),
+                    display_path(to_meta_path),
+                    metadata,
+                ),
+            )
+            .context("unable to write `wasm_binary.rs`")?;
+        } else {
+            fs::write(
+                wasm_binary_rs,
+                format!(
+                    r#"#[allow(unused)]
+pub const WASM_BINARY: &[u8] = include_bytes!("{}");
+#[allow(unused)]
+pub const WASM_EXPORTS: &[&str] = &{:?};
+
+"#,
+                    display_path(to_meta_path.clone()),
+                    Self::get_exports(to_meta_path)?,
+                ),
+            )
+            .context("unable to write `wasm_binary.rs`")?;
+        }
 
         Ok(())
     }
@@ -352,7 +332,7 @@ pub const WASM_EXPORTS: &[&str] = &{exports:?};
     }
 
     fn get_exports(file: PathBuf) -> Result<Vec<String>> {
-        let module = parity_wasm::deserialize_file(file).context("unable to deserialize module")?;
+        let module = parity_wasm::deserialize_file(file)?;
 
         let exports = module
             .export_section()
@@ -373,6 +353,6 @@ pub const WASM_EXPORTS: &[&str] = &{exports:?};
 }
 
 // Windows has path like `path\to\somewhere` which is incorrect for `include_*` Rust's macros
-fn display_path(path: &Path) -> String {
+fn display_path(path: PathBuf) -> String {
     path.display().to_string().replace('\\', "/")
 }

--- a/utils/wasm-builder/test-program/.gitignore
+++ b/utils/wasm-builder/test-program/.gitignore
@@ -1,3 +1,2 @@
 Cargo.lock
 .binpath
-.out_dir

--- a/utils/wasm-builder/test-program/build.rs
+++ b/utils/wasm-builder/test-program/build.rs
@@ -16,11 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{env, fs};
-
 fn main() {
     gear_wasm_builder::build();
-
-    let out_dir = env::var("OUT_DIR").unwrap();
-    fs::write(".out_dir", out_dir).unwrap();
 }

--- a/utils/wasm-builder/tests/smoke.rs
+++ b/utils/wasm-builder/tests/smoke.rs
@@ -16,83 +16,41 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use std::process::Command;
+
 use gear_wasm_builder::TARGET;
-use std::{fs, path::PathBuf, process::Command};
 
-struct CargoRunner(Command);
+fn run_cargo(args: &[&str]) -> bool {
+    let mut cmd = Command::new("cargo");
+    cmd.args(args);
+    cmd.arg("--color=always");
+    cmd.arg("--manifest-path=test-program/Cargo.toml");
 
-impl CargoRunner {
-    fn new() -> Self {
-        Self(Command::new("cargo"))
-    }
-
-    fn args<const SIZE: usize>(mut self, args: [&str; SIZE]) -> Self {
-        self.0.args(args);
-        self
-    }
-
-    fn env(mut self, k: &str, v: &str) -> Self {
-        self.0.env(k, v);
-        self
-    }
-
-    fn run(self) -> bool {
-        let mut cmd = self.0;
-        cmd.arg("--color=always");
-        cmd.arg("--manifest-path=test-program/Cargo.toml");
-
-        let status = cmd.status().expect("cargo run error");
-        status.success()
-    }
+    let status = cmd.status().expect("cargo run error");
+    status.success()
 }
 
 #[test]
 fn test_debug() {
-    assert!(CargoRunner::new().args(["test"]).run());
+    assert!(run_cargo(&["test"]));
 }
 
 #[test]
 fn build_debug() {
-    assert!(CargoRunner::new().args(["build"]).run());
+    assert!(run_cargo(&["build"]));
 }
 
 #[test]
 fn test_release() {
-    assert!(CargoRunner::new().args(["test", "--release"]).run());
+    assert!(run_cargo(&["test", "--release"]));
 }
 
 #[test]
 fn build_release() {
-    assert!(CargoRunner::new().args(["build", "--release"]).run());
+    assert!(run_cargo(&["build", "--release"]));
 }
 
 #[test]
 fn build_release_for_target() {
-    assert!(CargoRunner::new()
-        .args(["build", "--release", "--target", TARGET])
-        .run());
-}
-
-#[test]
-fn skip_wasm_build() {
-    fn wasm_binary_rs() -> String {
-        let out_dir = fs::read_to_string("test-program/.out_dir").unwrap();
-        let out_dir = PathBuf::from(out_dir);
-        let wasm_binary_rs = out_dir.join("wasm_binary.rs");
-        fs::read_to_string(wasm_binary_rs).unwrap()
-    }
-
-    assert!(CargoRunner::new()
-        .args(["build"])
-        .env("SKIP_WASM_BUILD", "1")
-        .run());
-
-    assert!(wasm_binary_rs().contains("WASM_BINARY: &[u8] = &[]"));
-
-    assert!(CargoRunner::new()
-        .args(["build"])
-        .env("SKIP_WASM_BUILD", "0")
-        .run());
-
-    assert!(wasm_binary_rs().contains("WASM_BINARY: &[u8] = include_bytes"));
+    assert!(run_cargo(&["build", "--release", "--target", TARGET]));
 }


### PR DESCRIPTION
This reverts commit e772a04bcf12e7c6b06148680e7cc674dfd66037.
