### PR TITLE
change debug to traces in all syscalls

### DIFF
--- a/core-backend/sandbox/src/funcs.rs
+++ b/core-backend/sandbox/src/funcs.rs
@@ -344,11 +344,11 @@ where
             let res = ctx.process_alloc_func_result(res)?;
             let page = match res {
                 Ok(page) => {
-                    log::debug!("Alloc {pages:?} pages at {page:?}");
+                    log::trace!("Alloc {pages:?} pages at {page:?}");
                     page.raw()
                 }
                 Err(err) => {
-                    log::debug!("Alloc failed: {err}");
+                    log::trace!("Alloc failed: {err}");
                     u32::MAX
                 }
             };
@@ -368,10 +368,10 @@ where
 
             match &res {
                 Ok(()) => {
-                    log::debug!("Free {page:?}");
+                    log::trace!("Free {page:?}");
                 }
                 Err(err) => {
-                    log::debug!("Free failed: {err}");
+                    log::trace!("Free failed: {err}");
                 }
             };
 

--- a/core-backend/wasmi/src/funcs/mod.rs
+++ b/core-backend/wasmi/src/funcs/mod.rs
@@ -437,11 +437,11 @@ where
                 let res = state.process_alloc_func_result(res)?;
                 let page = match res {
                     Ok(page) => {
-                        log::debug!("Alloc {pages:?} pages at {page:?}");
+                        log::trace!("Alloc {pages:?} pages at {page:?}");
                         page.raw()
                     }
                     Err(err) => {
-                        log::debug!("Alloc failed: {err}");
+                        log::trace!("Alloc failed: {err}");
                         u32::MAX
                     }
                 };
@@ -465,10 +465,10 @@ where
 
                 match &res {
                     Ok(()) => {
-                        log::debug!("Free {page:?}");
+                        log::trace!("Free {page:?}");
                     }
                     Err(err) => {
-                        log::debug!("Free failed: {err}");
+                        log::trace!("Free failed: {err}");
                     }
                 };
 


### PR DESCRIPTION
May be the reason of "too longs" when contracts call `free` syscalls too many times, or also may be situation `alloc + free` the same page in one loop. Because we measure benchmarks without debug logs this can lead to time overflow.
