### PR TITLE
Fix sudo call encoding

### DIFF
--- a/gsdk/src/metadata/impls.rs
+++ b/gsdk/src/metadata/impls.rs
@@ -164,7 +164,7 @@ impl From<RuntimeCall> for Value {
             RuntimeCall::Gear(gear_call) => gear_call_to_scale_value(gear_call),
             RuntimeCall::Sudo(sudo_call) => sudo_call_to_scale_value(sudo_call),
             RuntimeCall::Balances(balances_call) => balances_call_to_scale_value(balances_call),
-            _ => unimplemented!("only support calls from pallet-gear for now."),
+            _ => unimplemented!("other calls aren't supported for now."),
         }
     }
 }

--- a/gsdk/src/metadata/impls.rs
+++ b/gsdk/src/metadata/impls.rs
@@ -252,7 +252,13 @@ fn sudo_call_to_scale_value(call: SudoCall) -> Value {
             "sudo_unchecked_weight",
             [
                 ("call", (*call).into()),
-                ("weight", Value::from_bytes(weight.encode())),
+                (
+                    "weight",
+                    Value::named_composite([
+                        ("ref_time", Value::u128(weight.ref_time as u128)),
+                        ("proof_size", Value::u128(weight.proof_size as u128)),
+                    ]),
+                ),
             ],
         ),
         _ => unimplemented!("calls that won't be used in batch call"),

--- a/gsdk/src/signer/calls.rs
+++ b/gsdk/src/signer/calls.rs
@@ -183,10 +183,7 @@ impl Signer {
         let tx = subxt::dynamic::tx(
             "Sudo",
             "sudo_unchecked_weight",
-            vec![
-                Value::from_bytes(call.encode()),
-                Value::from_bytes(weight.encode()),
-            ],
+            vec![call.into(), Value::from_bytes(weight.encode())],
         );
 
         self.process(tx).await

--- a/gsdk/src/signer/calls.rs
+++ b/gsdk/src/signer/calls.rs
@@ -178,11 +178,12 @@ impl Signer {
 
 // pallet-sudo
 impl Signer {
-    /// `pallet_utility::force_batch`
+    /// `pallet_sudo::sudo_unchecked_weight`
     pub async fn sudo_unchecked_weight(&self, call: RuntimeCall, weight: Weight) -> InBlock {
         let tx = subxt::dynamic::tx(
             "Sudo",
             "sudo_unchecked_weight",
+            // As `call` implements conversion to `Value`.
             vec![call.into(), Value::from_bytes(weight.encode())],
         );
 

--- a/gsdk/src/signer/calls.rs
+++ b/gsdk/src/signer/calls.rs
@@ -26,7 +26,6 @@ use crate::{
 use anyhow::anyhow;
 use async_recursion::async_recursion;
 use gear_core::ids::{CodeId, MessageId, ProgramId};
-use parity_scale_codec::Encode;
 use sp_runtime::AccountId32;
 use subxt::{
     dynamic::Value,
@@ -184,7 +183,13 @@ impl Signer {
             "Sudo",
             "sudo_unchecked_weight",
             // As `call` implements conversion to `Value`.
-            vec![call.into(), Value::from_bytes(weight.encode())],
+            vec![
+                call.into(),
+                Value::named_composite([
+                    ("ref_time", Value::u128(weight.ref_time as u128)),
+                    ("proof_size", Value::u128(weight.proof_size as u128)),
+                ]),
+            ],
         );
 
         self.process(tx).await

--- a/utils/node-loader/Cargo.toml
+++ b/utils/node-loader/Cargo.toml
@@ -30,7 +30,7 @@ rand = { version = "0.8.5", features = ["small_rng"] }
 reqwest = { version = "0.11.14", default-features = false }
 structopt = "0.3.26"
 thiserror = "1.0.38"
-tokio = { version = "1.25.0", features = [ "macros" ] }
+tokio = { version = "1.25.0", features = [ "macros", "rt-multi-thread" ] }
 tracing = "0.1.37"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3.16", features = [ "env-filter", "json" ] }

--- a/utils/node-loader/src/batch_pool.rs
+++ b/utils/node-loader/src/batch_pool.rs
@@ -299,12 +299,20 @@ async fn create_renew_balance_task(
                     root_target_balance + user_balance_demand,
                     0,
                 )
-                .await?;
+                .await
+                .map_err(|e| {
+                    tracing::info!("Failed to set balance of the root address: {e}");
+                    e
+                })?;
             root_api
                 .transfer(ProgramId::from(user_address.as_ref()), user_balance_demand)
-                .await?;
+                .await
+                .map_err(|e| {
+                    tracing::info!("Failed to transfer to user address: {e}");
+                    e
+                })?;
 
-            tracing::info!("Renewed balances!");
+            tracing::info!("Successfully renewed balances!");
         }
     })
 }


### PR DESCRIPTION
Balance update task on loader was failing due to invalid encoding of the dynamic tx. Fixed that by introducing conversion to `scale_value::Value` for related runtime calls.