### PR TITLE
Refactor  gsdk

### DIFF
--- a/gcli/src/cmd/create.rs
+++ b/gcli/src/cmd/create.rs
@@ -58,7 +58,7 @@ impl Create {
         };
 
         // estimate gas
-        let gas_limit = signer.cmp_gas_limit(gas)?;
+        let gas_limit = signer.api().cmp_gas_limit(gas)?;
 
         // create program
         signer

--- a/gcli/src/cmd/info.rs
+++ b/gcli/src/cmd/info.rs
@@ -77,7 +77,7 @@ impl Info {
 
     /// Get balance of address
     pub async fn balance(signer: Signer, address: &str) -> Result<()> {
-        let info = signer.info(address).await?;
+        let info = signer.api().info(address).await?;
 
         println!("{info:#?}");
 
@@ -87,6 +87,7 @@ impl Info {
     /// Get mailbox of address
     pub async fn mailbox(signer: Signer, address: &str, count: u32) -> Result<()> {
         let mails = signer
+            .api()
             .mailbox(
                 AccountId32::from_ss58check(address).map_err(|_| Error::InvalidPublic)?,
                 count,

--- a/gcli/src/cmd/program.rs
+++ b/gcli/src/cmd/program.rs
@@ -77,7 +77,7 @@ impl Program {
         let program = api.gprog(pid).await?;
         let code_id = program.code_hash;
         let code = api.code_storage(code_id.0).await?;
-        let pages = api.gpages(pid, program).await?;
+        let pages = api.gpages(pid, &program).await?;
 
         // Query state
         let state = Metadata::read(

--- a/gcli/src/cmd/transfer.rs
+++ b/gcli/src/cmd/transfer.rs
@@ -43,7 +43,7 @@ pub struct Transfer {
 impl Transfer {
     /// Execute command transfer.
     pub async fn exec(&self, signer: Signer) -> Result<()> {
-        let address = signer.signer.account_id();
+        let address = signer.account_id();
 
         println!("From: {}", address.to_ss58check());
         println!("To: {}", self.destination);

--- a/gcli/src/cmd/upload_program.rs
+++ b/gcli/src/cmd/upload_program.rs
@@ -59,7 +59,7 @@ impl UploadProgram {
         };
 
         // estimate gas
-        let gas_limit = signer.cmp_gas_limit(gas)?;
+        let gas_limit = signer.api().cmp_gas_limit(gas)?;
 
         // upload program
         signer

--- a/gcli/tests/cmd/claim.rs
+++ b/gcli/tests/cmd/claim.rs
@@ -27,16 +27,16 @@ async fn test_command_claim_works() -> Result<()> {
     let node = common::create_messager().await?;
 
     // Check the mailbox of the testing account
-    let api = Api::new(Some(&node.ws())).await?.signer("//Alice", None)?;
-    let mailbox = api.mailbox(common::alice_account_id(), 10).await?;
+    let signer = Api::new(Some(&node.ws())).await?.signer("//Alice", None)?;
+    let mailbox = signer.api().mailbox(common::alice_account_id(), 10).await?;
 
     assert_eq!(mailbox.len(), 1);
     let id = hex::encode(mailbox[0].0.id.0);
 
     // Claim value from message id
-    let before = api.get_balance(ADDRESS).await?;
+    let before = signer.api().get_balance(ADDRESS).await?;
     let _ = common::gear(&["-e", &node.ws(), "claim", &id])?;
-    let after = api.get_balance(ADDRESS).await?;
+    let after = signer.api().get_balance(ADDRESS).await?;
 
     // # TODO
     //

--- a/gcli/tests/cmd/reply.rs
+++ b/gcli/tests/cmd/reply.rs
@@ -26,14 +26,14 @@ async fn test_command_reply_works() -> Result<()> {
     let node = common::create_messager().await?;
 
     // Get balance of the testing address
-    let api = Api::new(Some(&node.ws())).await?.signer("//Alice", None)?;
-    let mailbox = api.mailbox(common::alice_account_id(), 10).await?;
+    let signer = Api::new(Some(&node.ws())).await?.signer("//Alice", None)?;
+    let mailbox = signer.api().mailbox(common::alice_account_id(), 10).await?;
     assert_eq!(mailbox.len(), 1);
     let id = hex::encode(mailbox[0].0.id.0);
 
     // Send message to messager
     let _ = common::gear(&["-e", &node.ws(), "reply", &id, "0x", "20000000000"])?;
-    let mailbox = api.mailbox(common::alice_account_id(), 10).await?;
+    let mailbox = signer.api().mailbox(common::alice_account_id(), 10).await?;
     assert_eq!(mailbox.len(), 1);
     assert_eq!(mailbox[0].0.payload.0, messager::REPLY_REPLY.encode());
 

--- a/gcli/tests/cmd/send.rs
+++ b/gcli/tests/cmd/send.rs
@@ -26,14 +26,14 @@ async fn test_command_send_works() -> Result<()> {
     let node = common::create_messager().await?;
 
     // Get balance of the testing address
-    let api = Api::new(Some(&node.ws())).await?.signer("//Alice", None)?;
-    let mailbox = api.mailbox(common::alice_account_id(), 10).await?;
+    let signer = Api::new(Some(&node.ws())).await?.signer("//Alice", None)?;
+    let mailbox = signer.api().mailbox(common::alice_account_id(), 10).await?;
     assert_eq!(mailbox.len(), 1);
     let dest = hex::encode(mailbox[0].0.source.0);
 
     // Send message to messager
     let _ = common::gear(&["-e", &node.ws(), "send", &dest, "0x", "20000000000"])?;
-    let mailbox = api.mailbox(common::alice_account_id(), 10).await?;
+    let mailbox = signer.api().mailbox(common::alice_account_id(), 10).await?;
     assert_eq!(mailbox.len(), 2);
     assert!(mailbox
         .iter()

--- a/gcli/tests/cmd/transfer.rs
+++ b/gcli/tests/cmd/transfer.rs
@@ -40,14 +40,14 @@ async fn test_command_transfer_works() -> Result<()> {
     node.wait(logs::gear_node::IMPORTING_BLOCKS)?;
 
     // Get balance of the testing address
-    let api = Api::new(Some(&node.ws())).await?.signer(SURI, None)?;
-    let before = api.get_balance(ADDRESS).await.unwrap_or(0);
+    let signer = Api::new(Some(&node.ws())).await?.signer(SURI, None)?;
+    let before = signer.api().get_balance(ADDRESS).await.unwrap_or(0);
 
     // Run command transfer
     let value = 1_000_000_000u128;
     let _ = common::gear(&["-e", &node.ws(), "transfer", ADDRESS, &value.to_string()])?;
 
-    let after = api.get_balance(ADDRESS).await?;
+    let after = signer.api().get_balance(ADDRESS).await?;
     assert_eq!(after.saturating_sub(before), value);
 
     Ok(())

--- a/gcli/tests/cmd/upload.rs
+++ b/gcli/tests/cmd/upload.rs
@@ -27,14 +27,14 @@ async fn test_command_upload_works() {
     node.wait(logs::gear_node::IMPORTING_BLOCKS)
         .expect("node timeout");
 
-    let api = Api::new(Some(&node.ws()))
+    let signer = Api::new(Some(&node.ws()))
         .await
         .expect("build api failed")
         .signer("//Alice", None)
         .expect("get signer failed");
 
     let code_hash = common::hash(demo_meta::WASM_BINARY);
-    assert!(api.code_storage(code_hash).await.is_err());
+    assert!(signer.api().code_storage(code_hash).await.is_err());
 
     let _ = common::gear(&[
         "-e",
@@ -44,5 +44,5 @@ async fn test_command_upload_works() {
     ])
     .expect("run command upload failed");
 
-    assert!(api.code_storage(code_hash).await.is_ok());
+    assert!(signer.api().code_storage(code_hash).await.is_ok());
 }

--- a/gcli/tests/rpc/mod.rs
+++ b/gcli/tests/rpc/mod.rs
@@ -87,7 +87,7 @@ async fn test_calculate_handle_gas() -> Result<()> {
         )
         .await?;
 
-    assert!(signer.gprog(pid.into()).await.is_ok());
+    assert!(signer.api().gprog(pid.into()).await.is_ok());
 
     // 2. calculate handle gas and send message.
     let gas_info = signer
@@ -124,14 +124,14 @@ async fn test_calculate_reply_gas() -> Result<()> {
         )
         .await?;
 
-    assert!(signer.gprog(pid.into()).await.is_ok());
+    assert!(signer.api().gprog(pid.into()).await.is_ok());
 
     // 2. send wait message.
     signer
         .send_message(pid.into(), payload.encode(), 100_000_000_000, 0)
         .await?;
 
-    let mailbox = signer.mailbox(alice_account_id, 10).await?;
+    let mailbox = signer.api().mailbox(alice_account_id, 10).await?;
     assert_eq!(mailbox.len(), 1);
     let message_id = mailbox[0].0.id.clone().into();
 

--- a/gclient/src/api/calls.rs
+++ b/gclient/src/api/calls.rs
@@ -170,7 +170,7 @@ impl GearApi {
                     ..
                 }) => res.push(Ok((id.into(), destination.into()))),
                 Event::Utility(UtilityEvent::ItemFailed { error }) => {
-                    res.push(Err(self.0.decode_error(error).into()))
+                    res.push(Err(self.0.api().decode_error(error).into()))
                 }
                 _ => (),
             }
@@ -281,7 +281,7 @@ impl GearApi {
                     .flatten()
                     .expect("Data appearance guaranteed above"))),
                 Event::Utility(UtilityEvent::ItemFailed { error }) => {
-                    res.push(Err(self.0.decode_error(error).into()))
+                    res.push(Err(self.0.api().decode_error(error).into()))
                 }
                 _ => (),
             }
@@ -377,7 +377,7 @@ impl GearApi {
                     ..
                 }) => res.push(Ok((id.into(), destination.into()))),
                 Event::Utility(UtilityEvent::ItemFailed { error }) => {
-                    res.push(Err(self.0.decode_error(error).into()))
+                    res.push(Err(self.0.api().decode_error(error).into()))
                 }
                 _ => (),
             }
@@ -508,7 +508,7 @@ impl GearApi {
                         .expect("Data appearance guaranteed above"),
                 ))),
                 Event::Utility(UtilityEvent::ItemFailed { error }) => {
-                    res.push(Err(self.0.decode_error(error).into()))
+                    res.push(Err(self.0.api().decode_error(error).into()))
                 }
                 _ => (),
             }
@@ -600,7 +600,7 @@ impl GearApi {
                     res.push(Ok(id.into()));
                 }
                 Event::Utility(UtilityEvent::ItemFailed { error }) => {
-                    res.push(Err(self.0.decode_error(error).into()))
+                    res.push(Err(self.0.api().decode_error(error).into()))
                 }
                 _ => (),
             }
@@ -730,7 +730,7 @@ impl GearApi {
                     ..
                 }) => res.push(Ok((id.into(), destination.into()))),
                 Event::Utility(UtilityEvent::ItemFailed { error }) => {
-                    res.push(Err(self.0.decode_error(error).into()))
+                    res.push(Err(self.0.api().decode_error(error).into()))
                 }
                 _ => (),
             }

--- a/gclient/src/api/mod.rs
+++ b/gclient/src/api/mod.rs
@@ -102,7 +102,7 @@ impl GearApi {
     /// Create an [`EventListener`] to subscribe and handle continuously
     /// incoming events.
     pub async fn subscribe(&self) -> Result<EventListener> {
-        let events = self.0.finalized_blocks().await?;
+        let events = self.0.api().finalized_blocks().await?;
         Ok(EventListener(events))
     }
 
@@ -122,8 +122,9 @@ impl GearApi {
     /// Actually sends the `system_accountNextIndex` RPC to the node.
     pub async fn rpc_nonce(&self) -> Result<u32> {
         self.0
+            .api()
             .rpc()
-            .system_account_next_index(self.0.signer.account_id())
+            .system_account_next_index(self.0.account_id())
             .await
             .map_err(Into::into)
     }

--- a/gclient/src/api/rpc.rs
+++ b/gclient/src/api/rpc.rs
@@ -419,6 +419,7 @@ impl GearApi {
 
     async fn rpc_request<T: DeserializeOwned>(&self, method: &str, params: RpcParams) -> Result<T> {
         self.0
+            .api()
             .rpc()
             .request(method, params)
             .await

--- a/gclient/src/api/storage/mod.rs
+++ b/gclient/src/api/storage/mod.rs
@@ -52,6 +52,7 @@ impl GearApi {
     ) -> Result<Option<(StoredMessage, Interval<u32>)>> {
         let data: Option<(stored::StoredMessage, Interval<u32>)> = self
             .0
+            .api()
             .get_from_account_mailbox(account_id.into_account_id(), message_id)
             .await?;
         Ok(data.map(|(m, i)| (m.into(), i)))
@@ -60,6 +61,7 @@ impl GearApi {
     async fn account_data(&self, account_id: impl IntoAccountId32) -> Result<AccountData<u128>> {
         Ok(self
             .0
+            .api()
             .info(&account_id.into_account_id().to_ss58check())
             .await?
             .data)

--- a/gsdk/src/signer/calls.rs
+++ b/gsdk/src/signer/calls.rs
@@ -239,7 +239,7 @@ impl Signer {
                 .await
         };
 
-        if counter >= self.retry {
+        if counter >= self.api().retry {
             return process;
         }
 

--- a/gsdk/src/signer/mod.rs
+++ b/gsdk/src/signer/mod.rs
@@ -23,8 +23,6 @@ use crate::{
     Api,
 };
 pub use pair_signer::PairSigner;
-use std::ops::{Deref, DerefMut};
-
 use sp_core::{crypto::Ss58Codec, sr25519::Pair, Pair as PairT};
 use sp_runtime::AccountId32;
 
@@ -37,7 +35,7 @@ mod utils;
 pub struct Signer {
     api: Api,
     /// Current signer.
-    pub signer: PairSigner<GearConfig, Pair>,
+    signer: PairSigner<GearConfig, Pair>,
     nonce: Option<u32>,
 }
 
@@ -77,6 +75,11 @@ impl Signer {
     pub fn account_id(&self) -> &AccountId32 {
         self.signer.account_id()
     }
+
+    /// Get reference to inner unsigned api
+    pub fn api(&self) -> &Api {
+        &self.api
+    }
 }
 
 impl From<(Api, PairSigner<GearConfig, Pair>)> for Signer {
@@ -86,19 +89,5 @@ impl From<(Api, PairSigner<GearConfig, Pair>)> for Signer {
             signer,
             nonce: None,
         }
-    }
-}
-
-impl Deref for Signer {
-    type Target = Api;
-
-    fn deref(&self) -> &Self::Target {
-        &self.api
-    }
-}
-
-impl DerefMut for Signer {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.api
     }
 }

--- a/gsdk/src/signer/utils.rs
+++ b/gsdk/src/signer/utils.rs
@@ -23,7 +23,7 @@ use crate::{result::Result, signer::Signer};
 impl Signer {
     /// Get self balance
     pub async fn balance(&self) -> Result<u128> {
-        self.get_balance(&self.address()).await
+        self.api().get_balance(&self.address()).await
     }
 
     /// Logging balance spent

--- a/gsdk/src/storage.rs
+++ b/gsdk/src/storage.rs
@@ -65,7 +65,7 @@ impl Api {
 
     /// Get program pages from program id.
     pub async fn program_pages(&self, pid: H256) -> Result<types::GearPages> {
-        self.gpages(pid, self.gprog(pid).await?).await
+        self.gpages(pid, &self.gprog(pid).await?).await
     }
 }
 
@@ -198,9 +198,9 @@ impl Api {
     }
 
     /// Get pages of active program.
-    pub async fn gpages(&self, pid: H256, program: ActiveProgram) -> Result<types::GearPages> {
+    pub async fn gpages(&self, pid: H256, program: &ActiveProgram) -> Result<types::GearPages> {
         let mut pages = HashMap::new();
-        for page in program.pages_with_data {
+        for page in &program.pages_with_data {
             let addr = subxt::dynamic::storage(
                 "GearProgram",
                 "MemoryPageStorage",


### PR DESCRIPTION
This PR fixes usage of the Deref trait. Apparently, having own funcs around &self for a struct implementing the Deref trait is considered an anti-pattern. If there are such functions, they should have a signature like pub fn some_func(signer: &Signer, ...) so that conflicts can be avoided.

@reviewer-or-team
