### PR TITLE
Burn rewards minted in excess instead of sending them to Treasury

### DIFF
--- a/pallets/staking-rewards/src/mock.rs
+++ b/pallets/staking-rewards/src/mock.rs
@@ -307,7 +307,7 @@ impl pallet_staking::Config for Test {
     type CurrencyToVote = U128CurrencyToVote;
     type ElectionProvider = onchain::OnChainExecution<OnChainSeqPhragmen>;
     type GenesisElectionProvider = onchain::OnChainExecution<OnChainSeqPhragmen>;
-    type RewardRemainder = pallet_gear_staking_rewards::RewardsStash<Self, Treasury>;
+    type RewardRemainder = ();
     type RuntimeEvent = RuntimeEvent;
     type Slash = Treasury;
     type Reward = StakingRewards;

--- a/pallets/staking-rewards/src/tests.rs
+++ b/pallets/staking-rewards/src/tests.rs
@@ -176,7 +176,7 @@ fn validators_rewards_disbursement_works() {
         run_to_block(era_duration + 1);
 
         // We don't check the correctness of inflation calculation as it has been verified
-        let (expected_payout_0, expected_remainder) = compute_total_payout(
+        let (expected_payout_0, _expected_remainder) = compute_total_payout(
             0,
             initial_total_stakeable,
             initial_total_issuance,
@@ -194,6 +194,9 @@ fn validators_rewards_disbursement_works() {
 
         // Total issuance shouldn't have changed
         assert_eq!(total_issuance, initial_total_issuance);
+        // Overriding the `expected_remainder` with 0 since the remainder should've been burned
+        // TODO: remove the below when the `Treasury` part is no longer burnt
+        let expected_remainder = 0;
         // Treasury has been replenished
         assert_eq!(
             treasury_balance,
@@ -227,7 +230,7 @@ fn validators_rewards_disbursement_works() {
         let total_staked = num_validators as u128 * VALIDATOR_STAKE;
         assert_eq!(total_staked, Staking::eras_total_stake(1));
 
-        let (expected_payout_1, expected_remainder) = compute_total_payout(
+        let (expected_payout_1, _expected_remainder) = compute_total_payout(
             total_staked,
             initial_total_stakeable,
             initial_total_issuance,
@@ -261,6 +264,8 @@ fn validators_rewards_disbursement_works() {
 
         // Total issuance shouldn't have changed, again
         assert_eq!(total_issuance, initial_total_issuance);
+        // TODO: remove the below when the `Treasury` part is no longer burnt
+        let expected_remainder = 0;
         // Treasury has potentially been replenished
         assert_eq!(
             treasury_balance,
@@ -381,7 +386,7 @@ fn nominators_rewards_disbursement_works() {
         run_to_block(era_duration + 1);
 
         // We don't check the correctness of inflation calculation as it has been verified
-        let (expected_payout_0, expected_remainder) = compute_total_payout(
+        let (expected_payout_0, _expected_remainder) = compute_total_payout(
             0,
             initial_total_stakeable,
             initial_total_issuance,
@@ -399,6 +404,8 @@ fn nominators_rewards_disbursement_works() {
 
         // Total issuance shouldn't have changed
         assert_eq!(total_issuance, initial_total_issuance);
+        // TODO: remove the below when the `Treasury` part is no longer burnt
+        let expected_remainder = 0;
         // Treasury has been replenished
         assert_eq!(
             treasury_balance,
@@ -438,7 +445,7 @@ fn nominators_rewards_disbursement_works() {
         let total_staked = validators_own_stake + validators_other_stake;
         assert_eq!(total_staked, Staking::eras_total_stake(1));
 
-        let (expected_payout_1, expected_remainder) = compute_total_payout(
+        let (expected_payout_1, _expected_remainder) = compute_total_payout(
             total_staked,
             initial_total_stakeable,
             initial_total_issuance,
@@ -472,6 +479,8 @@ fn nominators_rewards_disbursement_works() {
 
         // Total issuance shouldn't have changed, again
         assert_eq!(total_issuance, initial_total_issuance);
+        // TODO: remove the below when the `Treasury` part is no longer burnt
+        let expected_remainder = 0;
         // Treasury has potentially been replenished
         assert_eq!(
             treasury_balance,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -458,7 +458,9 @@ impl pallet_staking::Config for Runtime {
     type CurrencyToVote = U128CurrencyToVote;
     type ElectionProvider = onchain::OnChainExecution<OnChainSeqPhragmen>;
     type GenesisElectionProvider = onchain::OnChainExecution<OnChainSeqPhragmen>;
-    type RewardRemainder = pallet_gear_staking_rewards::RewardsStash<Self, Treasury>;
+    // Burning the reward remainder for now.
+    // TODO: set remainder back to `RewardsStash<Self, Treasury>` to stop burning `Treasury` part.
+    type RewardRemainder = ();
     type RuntimeEvent = RuntimeEvent;
     type Slash = Treasury;
     type Reward = StakingRewards;


### PR DESCRIPTION
Since `Treasury` is not yet being used on Vara, stashing funds on its account is useless. This change can be reverted any time when having a Treasury starts making sense.