### PR TITLE
Fix `Result` aliases and typos

### DIFF
--- a/gcli/scripts/update-readme.sh
+++ b/gcli/scripts/update-readme.sh
@@ -5,8 +5,8 @@ readonly ROOT_DIR="$(cd "$(dirname "$0")"/.. && pwd)"
 readonly README="${ROOT_DIR}/README.md"
 readonly LIB_RS="${ROOT_DIR}/src/lib.rs"
 
-#########################################
-# Conact `README.md` and `src/lib.rs`
+############################################
+# Concat `README.md` and `src/lib.rs`
 ############################################
 function main() {
     readme=$(cat ${README} | sed 's/^/\/\/\!/' | sed 's/\!\(\S\)/\! \1/')

--- a/gcli/src/metadata/result.rs
+++ b/gcli/src/metadata/result.rs
@@ -40,4 +40,4 @@ pub enum Error {
 }
 
 /// Metadata result
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/gcli/src/result.rs
+++ b/gcli/src/result.rs
@@ -72,4 +72,4 @@ impl From<schnorrkel::SignatureError> for Error {
 }
 
 /// Custom result
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/gcli/tests/common/result.rs
+++ b/gcli/tests/common/result.rs
@@ -30,4 +30,4 @@ pub enum Error {
     Io(#[from] std::io::Error),
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/gclient/src/node/result.rs
+++ b/gclient/src/node/result.rs
@@ -24,4 +24,4 @@ pub enum Error {
     Io(#[from] std::io::Error),
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/gclient/tests/node.rs
+++ b/gclient/tests/node.rs
@@ -6,7 +6,7 @@ const GEAR_PATH: &str = "../target/release/gear";
 /// Running this test requires gear node to be built in advance.
 #[tokio::test]
 async fn two_nodes_run_independently() {
-    let node_1 = Node::try_from_path(GEAR_PATH).expect("Unable to intsantiate dev node 1.");
+    let node_1 = Node::try_from_path(GEAR_PATH).expect("Unable to instantiate dev node 1.");
     let node_2 = Node::try_from_path(GEAR_PATH).expect("Unable to instantiate dev node 2.");
     let salt = gclient::now_in_micros().to_le_bytes();
 

--- a/gsdk/src/result.rs
+++ b/gsdk/src/result.rs
@@ -102,4 +102,4 @@ pub enum Error {
 }
 
 /// Custom Result
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/gstd/src/common/errors.rs
+++ b/gstd/src/common/errors.rs
@@ -25,7 +25,7 @@ use core::fmt;
 
 pub use gcore::error::*;
 
-pub type Result<T> = core::result::Result<T, ContractError>;
+pub type Result<T, E = ContractError> = core::result::Result<T, E>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ContractError {

--- a/utils/validator-checks/src/result.rs
+++ b/utils/validator-checks/src/result.rs
@@ -21,4 +21,4 @@ pub enum Error {
     BlocksProduction,
 }
 
-pub type Result<T> = StdResult<T, Error>;
+pub type Result<T, E = Error> = StdResult<T, E>;


### PR DESCRIPTION
- Fixed custom `Result` type aliases that allow using one `Result` type with both custom error and default one.
- Fixed some typos.

This PR allows avoiding such types of two `Result`s using:

https://github.com/gear-dapps/app/blob/master/src/contract.rs#L4
