### PR TITLE
prune locks map in gstd

### DIFF
--- a/gstd/src/async_runtime/futures.rs
+++ b/gstd/src/async_runtime/futures.rs
@@ -68,6 +68,7 @@ where
 
     if Pin::new(&mut task.future).poll(&mut cx).is_ready() {
         super::futures().remove(&msg_id);
+        super::locks().remove_message_entry(msg_id);
     } else {
         super::locks().wait(msg_id);
     }

--- a/gstd/src/async_runtime/locks.rs
+++ b/gstd/src/async_runtime/locks.rs
@@ -20,9 +20,8 @@
 use crate::{
     config::WaitType,
     errors::{ContractError, Result},
-    exec, Config, MessageId,
+    exec, BTreeMap, Config, MessageId,
 };
-use alloc::collections::BTreeMap;
 use core::cmp::Ordering;
 use hashbrown::HashMap;
 
@@ -157,7 +156,7 @@ impl LocksMap {
         // Locks with `deadline < now`, they should already been removed since
         // the node will trigger timeout when locks reaching their deadline.
         //
-        // Locks with `deadline == now`, they will be removed in the following pollings.
+        // Locks with `deadline <= now`, they will be removed in the following polling.
         let now = exec::block_height();
         map.iter()
             .filter_map(|(_, lock)| (lock.deadline() > now).then_some(lock))

--- a/gstd/src/async_runtime/locks.rs
+++ b/gstd/src/async_runtime/locks.rs
@@ -180,11 +180,11 @@ impl LocksMap {
 
     pub fn remove_message_entry(&mut self, message_id: MessageId) {
         self.0.remove(&message_id);
-        // Question for reviewers: how map for message can be not empty at this point ?!!!
-        // .map(|locks| {
+        // Question for reviewers: how map for message can be not empty at this
+        // point ?!!! .map(|locks| {
         //     if !locks.is_empty() {
-        //         // unreachable!("Wanna to remove locks map for message, but the map is not empty: {:?}", locks);
-        //     }
+        //         // unreachable!("Wanna to remove locks map for message, but
+        // the map is not empty: {:?}", locks);     }
         // });
     }
 

--- a/gstd/src/async_runtime/locks.rs
+++ b/gstd/src/async_runtime/locks.rs
@@ -178,13 +178,8 @@ impl LocksMap {
     }
 
     pub fn remove_message_entry(&mut self, message_id: MessageId) {
+        // TODO: check this place #2385
         self.0.remove(&message_id);
-        // Question for reviewers: how map for message can be not empty at this
-        // point ?!!! .map(|locks| {
-        //     if !locks.is_empty() {
-        //         // unreachable!("Wanna to remove locks map for message, but
-        // the map is not empty: {:?}", locks);     }
-        // });
     }
 
     /// Check if message is timed out.

--- a/gstd/src/async_runtime/mod.rs
+++ b/gstd/src/async_runtime/mod.rs
@@ -56,5 +56,7 @@ pub fn record_reply() {
 }
 
 pub fn handle_signal() {
-    futures().remove(&crate::msg::id());
+    let msg_id = crate::msg::id();
+    futures().remove(&msg_id);
+    locks().remove_message_entry(msg_id);
 }

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -31,6 +31,8 @@
 #[cfg(target_arch = "wasm32")]
 extern crate galloc;
 
+extern crate alloc;
+
 mod async_runtime;
 mod common;
 mod config;

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -31,8 +31,6 @@
 #[cfg(target_arch = "wasm32")]
 extern crate galloc;
 
-extern crate alloc;
-
 mod async_runtime;
 mod common;
 mod config;


### PR DESCRIPTION
without this patch locks map will grows forever for any contract with asyncs 

Change internal map for locks back to BTreeMap, because I think is more probably, that internal map for messages is small, so it's more effective to use BTreeMap than HashMap for small data
