### PR TITLE
Increase `runtime-fuzzer` performance

### DIFF
--- a/scripts/src/test.sh
+++ b/scripts/src/test.sh
@@ -117,7 +117,7 @@ run_fuzzer() {
 
   # Run fuzzer
   RUST_LOG="debug,runtime_fuzzer_fuzz=debug,wasmi,libfuzzer_sys,node_fuzzer=debug,gear,pallet_gear,gear-core-processor,gear-backend-wasmi,gwasm'" \
-  cargo fuzz run --release --sanitizer=none main
+  cargo fuzz run --release --sanitizer=none main -- -rss_limit_mb=8192
 }
 
 # TODO this is likely to be merged with `pallet_test` or `workspace_test` in #1802

--- a/utils/runtime-fuzzer/src/lib.rs
+++ b/utils/runtime-fuzzer/src/lib.rs
@@ -120,6 +120,7 @@ fn generate_gear_call<Rng: CallGenRng>(seed: u64, context: &ContextMutex) -> Gea
 fn fuzzer_config() -> GearProgGenConfig {
     let mut config = GearProgGenConfig::new_normal();
     config.remove_recursion = (1, 1).into();
+    config.call_indirect_enabled = false;
 
     config
 }


### PR DESCRIPTION
1. Removing `call_indirect` gives us less congestion due to undesired recursions. So it increases the speed.
2. Introducing `rss_limit_mb` gives fuzzer more RAM for storing all the needed data for fuzzing, i.e. increases fuzzing duration.