### PR TITLE
Simplify fuzzer crash reproducing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8858,10 +8858,12 @@ dependencies = [
 name = "runtime-fuzzer-fuzz"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "env_logger",
  "gear-utils",
  "libfuzzer-sys",
  "log",
+ "once_cell",
  "runtime-fuzzer",
 ]
 

--- a/utils/runtime-fuzzer/fuzz/Cargo.toml
+++ b/utils/runtime-fuzzer/fuzz/Cargo.toml
@@ -13,6 +13,8 @@ runtime-fuzzer = { path = ".." }
 gear-utils = { path = "../../utils" }
 env_logger = "0.10"
 log = { version = "0.4.17" }
+once_cell = "1.17.0"
+chrono = "0.4.24"
 
 [[bin]]
 name = "main"

--- a/utils/runtime-fuzzer/fuzz/fuzz_targets/main.rs
+++ b/utils/runtime-fuzzer/fuzz/fuzz_targets/main.rs
@@ -18,13 +18,13 @@
 
 #![no_main]
 
+use chrono::NaiveDateTime;
 use libfuzzer_sys::fuzz_target;
+use once_cell::sync::OnceCell;
 use std::{
     fs::{self, OpenOptions},
     io::Write,
 };
-use chrono::NaiveDateTime;
-use once_cell::sync::OnceCell;
 
 const SEEDS_STORE_DIR: &str = "fuzzing-seeds-dir";
 const SEEDS_STORE_FILE: &str = "fuzzing-seeds";
@@ -46,7 +46,10 @@ fn dump_seed(seed: u64) -> Result<(), String> {
     let fuzzing_seeds_dir = RUN_DIR.get_or_init(|| {
         let date_time = NaiveDateTime::from_timestamp_millis(gear_utils::now_millis() as i64)
             .expect("timestamp is in i64 range");
-        let fuzzing_seeds_dir = format!("{SEEDS_STORE_DIR}-{}", date_time.format("%Y-%m-%dT%H:%M:%S"));
+        let fuzzing_seeds_dir = format!(
+            "{SEEDS_STORE_DIR}-{}",
+            date_time.format("%Y-%m-%dT%H:%M:%S")
+        );
         fs::create_dir_all(&fuzzing_seeds_dir)
             .map(|_| fuzzing_seeds_dir)
             .expect("internal error: can't create file")
@@ -57,8 +60,6 @@ fn dump_seed(seed: u64) -> Result<(), String> {
         .create(true)
         .append(true)
         .open(fuzzing_seeds_file)
-        .and_then(|mut file| {
-            writeln!(file, "{seed}")
-        })
+        .and_then(|mut file| writeln!(file, "{seed}"))
         .map_err(|e| e.to_string())
 }

--- a/utils/runtime-fuzzer/fuzz/fuzz_targets/main.rs
+++ b/utils/runtime-fuzzer/fuzz/fuzz_targets/main.rs
@@ -20,12 +20,16 @@
 
 use libfuzzer_sys::fuzz_target;
 use std::{
-    fs::{File, OpenOptions},
+    fs::{self, OpenOptions},
     io::Write,
-    path::Path,
 };
+use chrono::NaiveDateTime;
+use once_cell::sync::OnceCell;
 
-const SEEDS_STORE: &str = "fuzzing_seeds";
+const SEEDS_STORE_DIR: &str = "fuzzing-seeds-dir";
+const SEEDS_STORE_FILE: &str = "fuzzing-seeds";
+
+static RUN_DIR: OnceCell<String> = OnceCell::new();
 
 fuzz_target!(|seed: u64| {
     gear_utils::init_default_logger();
@@ -36,27 +40,25 @@ fuzz_target!(|seed: u64| {
     runtime_fuzzer::run(seed);
 });
 
-// Dumps seed to the file before running fuzz test.
-//
-// Puts in the beginning the timestamp string if file is new.
+// Dumps seed to the `SEEDS_STORE_FILE` file inside `SEEDS_STORE_DIR`
+// directory before running fuzz test.
 fn dump_seed(seed: u64) -> Result<(), String> {
-    let is_new_file = !Path::new(SEEDS_STORE).exists();
-    let dump_timestamp_if_new = |file: &mut File| {
-        if is_new_file {
-            writeln!(file, "Started fuzzing at {}", gear_utils::now_millis())
-        } else {
-            Ok(())
-        }
-    };
+    let fuzzing_seeds_dir = RUN_DIR.get_or_init(|| {
+        let date_time = NaiveDateTime::from_timestamp_millis(gear_utils::now_millis() as i64)
+            .expect("timestamp is in i64 range");
+        let fuzzing_seeds_dir = format!("{SEEDS_STORE_DIR}-{}", date_time.format("%Y-%m-%dT%H:%M:%S"));
+        fs::create_dir_all(&fuzzing_seeds_dir)
+            .map(|_| fuzzing_seeds_dir)
+            .expect("internal error: can't create file")
+    });
+    let fuzzing_seeds_file = format!("{fuzzing_seeds_dir}/{SEEDS_STORE_FILE}");
 
     OpenOptions::new()
         .create(true)
         .append(true)
-        .open(SEEDS_STORE)
-        .map_err(|e| e.to_string())
+        .open(fuzzing_seeds_file)
         .and_then(|mut file| {
-            dump_timestamp_if_new(&mut file)
-                .and_then(|_| writeln!(file, "{seed}"))
-                .map_err(|e| e.to_string())
+            writeln!(file, "{seed}")
         })
+        .map_err(|e| e.to_string())
 }

--- a/utils/runtime-fuzzer/fuzz/fuzz_targets/main.rs
+++ b/utils/runtime-fuzzer/fuzz/fuzz_targets/main.rs
@@ -52,7 +52,7 @@ fn dump_seed(seed: u64) -> Result<(), String> {
         );
         fs::create_dir_all(&fuzzing_seeds_dir)
             .map(|_| fuzzing_seeds_dir)
-            .expect("internal error: can't create file")
+            .expect("internal error: can't create dir")
     });
     let fuzzing_seeds_file = format!("{fuzzing_seeds_dir}/{SEEDS_STORE_FILE}");
 

--- a/utils/runtime-fuzzer/src/bin/reproduce_fuzz.rs
+++ b/utils/runtime-fuzzer/src/bin/reproduce_fuzz.rs
@@ -24,7 +24,7 @@
 //!
 //! Just simply run `cargo run -- -p <path_to_fuzz_seeds>`.
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use std::{
     fs::File,
     io::{BufRead, BufReader},
@@ -42,7 +42,7 @@ pub struct Params {
 fn main() -> Result<()> {
     gear_utils::init_default_logger();
 
-    let mut file_reader = create_file_reader(Params::from_args().path)?;
+    let file_reader = create_file_reader(Params::from_args().path)?;
 
     // Read seeds and run test against all of them.
     for line in file_reader.lines() {

--- a/utils/runtime-fuzzer/src/bin/reproduce_fuzz.rs
+++ b/utils/runtime-fuzzer/src/bin/reproduce_fuzz.rs
@@ -44,12 +44,6 @@ fn main() -> Result<()> {
 
     let mut file_reader = create_file_reader(Params::from_args().path)?;
 
-    // Read and check seeds file header.
-    let header = read_seeds_file_header(&mut file_reader)?;
-    if !header.contains("Started fuzzing at") {
-        return Err(anyhow!("Invalid seeds file format"));
-    }
-
     // Read seeds and run test against all of them.
     for line in file_reader.lines() {
         let seed: u64 = line?.trim().parse()?;
@@ -66,11 +60,4 @@ fn create_file_reader(path: PathBuf) -> Result<BufReader<File>> {
     let file = File::open(path)?;
 
     Ok(BufReader::new(file))
-}
-
-fn read_seeds_file_header(file_reader: &mut BufReader<File>) -> Result<String> {
-    let mut header = String::new();
-    file_reader.read_line(&mut header)?;
-
-    Ok(header)
 }


### PR DESCRIPTION
There was a demand for putting seeds file into the separate dir to make it easy to mount that dir to host machine from docker.
