### PR TITLE
[gclient] Get rid of GearApiWithNode

### DIFF
--- a/gclient/src/api/error.rs
+++ b/gclient/src/api/error.rs
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::node::result::Error as NodeError;
 use anyhow::Error as AError;
 use std::{io::Error as IOError, result::Result as StdResult};
 use subxt::error::Error as SubxtError;
@@ -85,4 +86,7 @@ pub enum Error {
     /// Occurs when being migrated program already exists in destination node.
     #[error("Program {0} already exists")]
     ProgramAlreadyExists(String),
+    /// Occurs when node spawining failed.
+    #[error(transparent)]
+    Node(#[from] NodeError),
 }

--- a/gclient/src/api/mod.rs
+++ b/gclient/src/api/mod.rs
@@ -83,7 +83,7 @@ impl GearApi {
     /// random port number. The node process uses a binary specified by the
     /// `path` param. Ideally, the binary should be downloaded by means of CI pipeline from <https://get.gear.rs>.
     pub async fn dev_from_path(path: impl AsRef<OsStr>) -> Result<Self> {
-        let node = Node::try_node_from_path(path, vec!["--dev"])?;
+        let node = Node::try_from_path(path, vec!["--dev"])?;
         let api = Self::init(node.ws_address().clone()).await?;
         Ok(Self(api.0, Some(Arc::new(node))))
     }
@@ -94,8 +94,7 @@ impl GearApi {
     /// process uses a binary specified by the `path` param. Ideally, the
     /// binary should be downloaded by means of CI pipeline from <https://get.gear.rs>.
     pub async fn vara_dev_from_path(path: impl AsRef<OsStr>) -> Result<Self> {
-        let node =
-            Node::try_node_from_path(path, vec!["--chain=vara-dev", "--validator", "--tmp"])?;
+        let node = Node::try_from_path(path, vec!["--chain=vara-dev", "--validator", "--tmp"])?;
         let api = Self::init(node.ws_address().clone()).await?;
         Ok(Self(api.0, Some(Arc::new(node))))
     }

--- a/gclient/src/api/mod.rs
+++ b/gclient/src/api/mod.rs
@@ -28,10 +28,11 @@ use crate::{
 };
 use error::*;
 use gsdk::{ext::sp_runtime::AccountId32, signer::Signer, Api};
-use std::ffi::OsStr;
+use std::{ffi::OsStr, sync::Arc};
 
 /// The API instance contains methods to access the node.
-pub struct GearApi(Signer, Option<Node>);
+#[derive(Clone)]
+pub struct GearApi(Signer, Option<Arc<Node>>);
 
 impl GearApi {
     /// Create and init a new `GearApi` specified by its `address` on behalf of
@@ -77,26 +78,26 @@ impl GearApi {
         Self::init(WSAddress::dev()).await
     }
 
-    /// Create and init a new `GearApi` instance via spawning a new node process in
-    /// development mode using the `--dev` flag and listening on an a random port number.
-    /// The node process uses a binary specified by the `path` param. Ideally, the binary
-    /// should be downloaded by means of CI pipeline from <https://get.gear.rs>.
+    /// Create and init a new `GearApi` instance via spawning a new node process
+    /// in development mode using the `--dev` flag and listening on an a
+    /// random port number. The node process uses a binary specified by the
+    /// `path` param. Ideally, the binary should be downloaded by means of CI pipeline from <https://get.gear.rs>.
     pub async fn dev_from_path(path: impl AsRef<OsStr>) -> Result<Self> {
         let node = Node::try_node_from_path(path, vec!["--dev"])?;
         let api = Self::init(node.ws_address().clone()).await?;
-        Ok(Self(api.0, Some(node)))
+        Ok(Self(api.0, Some(Arc::new(node))))
     }
 
-    /// Create and init a new `GearApi` instance via spawning a new node process in
-    /// development mode using the `--chain=vara-dev`, `--validator`, `--tmp` flags and
-    /// listening on an a random port number. The node process uses a binary specified by
-    /// the `path` param. Ideally, the binary should be downloaded by means of CI pipeline
-    /// from <https://get.gear.rs>.
+    /// Create and init a new `GearApi` instance via spawning a new node process
+    /// in development mode using the `--chain=vara-dev`, `--validator`,
+    /// `--tmp` flags and listening on an a random port number. The node
+    /// process uses a binary specified by the `path` param. Ideally, the
+    /// binary should be downloaded by means of CI pipeline from <https://get.gear.rs>.
     pub async fn vara_dev_from_path(path: impl AsRef<OsStr>) -> Result<Self> {
         let node =
             Node::try_node_from_path(path, vec!["--chain=vara-dev", "--validator", "--tmp"])?;
         let api = Self::init(node.ws_address().clone()).await?;
-        Ok(Self(api.0, Some(node)))
+        Ok(Self(api.0, Some(Arc::new(node))))
     }
 
     /// Create and init a new `GearApi` instance that will be used with the

--- a/gclient/src/lib.rs
+++ b/gclient/src/lib.rs
@@ -134,6 +134,5 @@ mod api;
 mod node;
 mod utils;
 
-pub use api::{calls::*, error::*, listener::*, GearApi, GearApiWithNode};
-pub use node::{ws::WSAddress, Node};
+pub use api::{calls::*, error::*, listener::*, GearApi};
 pub use utils::*;

--- a/gclient/src/lib.rs
+++ b/gclient/src/lib.rs
@@ -135,4 +135,5 @@ mod node;
 mod utils;
 
 pub use api::{calls::*, error::*, listener::*, GearApi};
+pub use node::ws::WSAddress;
 pub use utils::*;

--- a/gclient/src/node/mod.rs
+++ b/gclient/src/node/mod.rs
@@ -25,44 +25,23 @@ use std::{
 use ws::WSAddress;
 
 mod port;
-mod result;
-pub mod ws;
+pub(crate) mod result;
+pub(crate) mod ws;
 
 /// A struct representing a node running on local PC.
 #[derive(Debug)]
-pub struct Node {
+pub(crate) struct Node {
     process: Child,
     ws_address: WSAddress,
 }
 
 impl Node {
-    /// Instantiates a Gear node running in development mode (`--dev`) via
-    /// spawning its process using the specified `path` on a randomly picked
-    /// port. Waits for the node getting initialized before returning it to
-    /// a caller. Ideally, the node's binary should be downloaded by means
-    /// of CI pipeline from <https://get.gear.rs>.
-    pub fn try_from_path(path: impl AsRef<OsStr>) -> Result<Self> {
-        Self::try_node_from_path(path, vec!["--dev"])
-    }
-
-    /// Instantiates a Vara node running in development mode (`--dev`) via
-    /// spawning its process using the specified `path` on a randomly picked
-    /// port. Waits for the node getting initialized before returning it to
-    /// a caller. Ideally, the node's binary should be downloaded by means
-    /// of CI pipeline from <https://get.gear.rs>.
-    pub fn try_vara_from_path(path: impl AsRef<OsStr>) -> Result<Self> {
-        Self::try_node_from_path(
-            path,
-            vec!["--chain=vara-dev", "--validator", "--alice", "--tmp"],
-        )
-    }
-
     /// Returns Web Socket address the node is listening to.
     pub fn ws_address(&self) -> &WSAddress {
         &self.ws_address
     }
 
-    fn try_node_from_path(path: impl AsRef<OsStr>, args: Vec<&str>) -> Result<Self> {
+    pub fn try_node_from_path(path: impl AsRef<OsStr>, args: Vec<&str>) -> Result<Self> {
         let port = port::pick();
         let port_string = port.to_string();
 

--- a/gclient/src/node/mod.rs
+++ b/gclient/src/node/mod.rs
@@ -41,7 +41,7 @@ impl Node {
         &self.ws_address
     }
 
-    pub fn try_node_from_path(path: impl AsRef<OsStr>, args: Vec<&str>) -> Result<Self> {
+    pub fn try_from_path(path: impl AsRef<OsStr>, args: Vec<&str>) -> Result<Self> {
         let port = port::pick();
         let port_string = port.to_string();
 

--- a/gclient/tests/backend.rs
+++ b/gclient/tests/backend.rs
@@ -19,15 +19,14 @@
 //! Test for infinity loop, that it can't exceed block production time.
 
 use demo_backend_error::WASM_BINARY;
-use gclient::{EventProcessor, GearApi, Node};
+use gclient::{EventProcessor, GearApi};
 
 #[tokio::test]
 async fn backend_errors_handled_by_sandbox() -> anyhow::Result<()> {
     // Creating gear api.
     //
     // By default, login as Alice.
-    let node = Node::try_from_path("../target/release/gear")?;
-    let api = GearApi::node(&node).await?;
+    let api = GearApi::dev_from_path("../target/release/gear").await?;
 
     // Taking block gas limit constant.
     let gas_limit = api.block_gas_limit()?;

--- a/gclient/tests/keyhasher.rs
+++ b/gclient/tests/keyhasher.rs
@@ -18,7 +18,7 @@
 
 //! Test for infinity loop, that it can't exceed block production time.
 
-use gclient::{EventProcessor, GearApi, Node};
+use gclient::{EventProcessor, GearApi};
 
 const PATH: &str = "../target/wat-examples/large_scheduled.wasm";
 
@@ -27,8 +27,7 @@ async fn keyhasher_size_exceed() -> anyhow::Result<()> {
     // Creating gear api.
     //
     // By default, login as Alice.
-    let node = Node::try_from_path("../target/release/gear")?;
-    let api = GearApi::node(&node).await?;
+    let api = GearApi::dev_from_path("../target/release/gear").await?;
 
     // Taking block gas limit constant.
     let gas_limit = api.block_gas_limit()?;

--- a/gclient/tests/loop.rs
+++ b/gclient/tests/loop.rs
@@ -18,7 +18,7 @@
 
 //! Test for infinity loop, that it can't exceed block production time.
 
-use gclient::{EventProcessor, GearApi, Node};
+use gclient::{EventProcessor, GearApi};
 
 const PATH: &str = "../target/wasm32-unknown-unknown/release/demo_loop.opt.wasm";
 
@@ -27,8 +27,7 @@ async fn inf_loop() -> anyhow::Result<()> {
     // Creating gear api.
     //
     // By default, login as Alice.
-    let node = Node::try_from_path("../target/release/gear")?;
-    let api = GearApi::node(&node).await?;
+    let api = GearApi::dev_from_path("../target/release/gear").await?;
 
     // Taking block gas limit constant.
     let gas_limit = api.block_gas_limit()?;

--- a/gclient/tests/perf.rs
+++ b/gclient/tests/perf.rs
@@ -1,4 +1,4 @@
-use gclient::{GearApi, Node, Result};
+use gclient::{GearApi, Result};
 use gear_core::ids::ProgramId;
 use parity_scale_codec::Encode;
 use std::collections::HashMap;
@@ -239,8 +239,7 @@ async fn send_messages(api: &GearApi, progs: &HashMap<&str, ProgramId>) -> Resul
 async fn full_block_of_messages() -> Result<()> {
     env_logger::init();
 
-    let node = Node::try_from_path(GEAR_PATH).expect("Unable to instantiate dev node");
-    let api = GearApi::node(&node).await?;
+    let api = GearApi::dev_from_path(GEAR_PATH).await?;
 
     let progs = upload_programs(&api).await?;
 

--- a/gclient/tests/state.rs
+++ b/gclient/tests/state.rs
@@ -17,7 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use demo_meta_io::Wallet;
-use gclient::{EventProcessor, GearApi, Node};
+use gclient::{EventProcessor, GearApi};
 use parity_scale_codec::Decode;
 use tokio::fs;
 
@@ -28,8 +28,7 @@ const META_WASM_PATH: &str =
 
 #[tokio::test]
 async fn get_state() -> anyhow::Result<()> {
-    let node = Node::try_from_path("../target/release/gear")?;
-    let api = GearApi::node(&node).await?;
+    let api = GearApi::dev_from_path("../target/release/gear").await?;
 
     // Subscribe to events
     let mut listener = api.subscribe().await?;

--- a/gclient/tests/upload.rs
+++ b/gclient/tests/upload.rs
@@ -20,7 +20,7 @@
 
 use std::time::Duration;
 
-use gclient::{EventProcessor, GearApi, Node};
+use gclient::{EventProcessor, GearApi};
 
 const PATHS: [&str; 2] = [
     "../target/wat-examples/wrong_load.wasm",
@@ -84,8 +84,9 @@ async fn harmless_upload() -> anyhow::Result<()> {
     // Creating gear api.
     //
     // By default, login as Alice, than re-login as Bob.
-    let node = Node::try_from_path("../target/release/gear")?;
-    let api = GearApi::node(&node).await?.clone().with("//Bob")?;
+    let api = GearApi::dev_from_path("../target/release/gear")
+        .await?
+        .with("//Bob")?;
 
     upload_programs_and_check(&api, codes, None).await?;
 
@@ -110,8 +111,9 @@ async fn alloc_zero_pages() -> anyhow::Result<()> {
                 drop
             )
         )"#;
-    let node = Node::try_from_path("../target/release/gear")?;
-    let api = GearApi::node(&node).await?.clone().with("//Bob")?;
+    let api = GearApi::dev_from_path("../target/release/gear")
+        .await?
+        .with("//Bob")?;
     let codes = vec![wat::parse_str(wat_code).unwrap()];
     upload_programs_and_check(&api, codes, Some(Duration::from_secs(5))).await
 }
@@ -121,8 +123,9 @@ async fn get_mailbox() -> anyhow::Result<()> {
     // Creating gear api.
     //
     // By default, login as Alice, than re-login as Bob.
-    let node = Node::try_from_path("../target/release/gear")?;
-    let api = GearApi::node(&node).await?.clone().with("//Bob")?;
+    let api = GearApi::dev_from_path("../target/release/gear")
+        .await?
+        .with("//Bob")?;
 
     // Subscribe to events
     let mut listener = api.subscribe().await?;


### PR DESCRIPTION
Resolves #2397  .

`Node` has been moved insied `GearApi` as an option

@reviewer-or-team
