### PR TITLE
Fix zero value send handling

### DIFF
--- a/gclient/src/api/calls.rs
+++ b/gclient/src/api/calls.rs
@@ -65,6 +65,11 @@ impl GearApi {
             }
         }
 
+        // Sending zero value is a no-op, so now event occurres.
+        if value == 0 {
+            return Ok(tx.block_hash());
+        }
+
         Err(Error::EventNotFound)
     }
 


### PR DESCRIPTION
`gclient` returns error on a legit case, when zero value is transferred. 