### PR TITLE
[vara] Make the fellowship self-governed collective

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12610,6 +12610,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
+ "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",

--- a/runtime/vara/Cargo.toml
+++ b/runtime/vara/Cargo.toml
@@ -52,6 +52,7 @@ pallet-vesting = { version = "4.0.0-dev", default-features = false, git = "https
 pallet-whitelist = { version = "4.0.0-dev", default-features = false, git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.38" }
 
 # Primitives
+sp-arithmetic = { version = "6.0.0", default-features = false, git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.38" }
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.38" }
 sp-authority-discovery = { version = "4.0.0-dev", default-features = false, git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.38" }
 sp-block-builder = { git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.38", default-features = false, version = "4.0.0-dev" }
@@ -150,6 +151,7 @@ std = [
 	"runtime-primitives/std",
 	"scale-info/std",
 	"sp-api/std",
+	"sp-arithmetic/std",
 	"sp-authority-discovery/std",
 	"sp-block-builder/std",
 	"sp-consensus-babe/std",

--- a/runtime/vara/src/governance/fellowship.rs
+++ b/runtime/vara/src/governance/fellowship.rs
@@ -20,6 +20,8 @@
 //! that acts as an oracle to certify whether a proposal is good and can be
 //! submitted within an agile track yet being of high impact
 
+#![allow(clippy::identity_op)]
+
 use frame_support::traits::{MapSuccess, TryMapSuccess};
 use sp_arithmetic::traits::CheckedSub;
 use sp_runtime::{
@@ -41,7 +43,7 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
     type Id = u16;
     type RuntimeOrigin = <RuntimeOrigin as frame_support::traits::OriginTrait>::PalletsOrigin;
     fn tracks() -> &'static [(Self::Id, pallet_referenda::TrackInfo<Balance, BlockNumber>)] {
-        static DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 4] = [
+        static DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 10] = [
             (
                 0u16,
                 pallet_referenda::TrackInfo {
@@ -51,7 +53,7 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
                     prepare_period: 30 * MINUTES,
                     decision_period: 7 * DAYS,
                     confirm_period: 30 * MINUTES,
-                    min_enactment_period: MINUTES,
+                    min_enactment_period: 1 * MINUTES,
                     min_approval: pallet_referenda::Curve::LinearDecreasing {
                         length: Perbill::from_percent(100),
                         floor: Perbill::from_percent(50),
@@ -67,13 +69,13 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
             (
                 1u16,
                 pallet_referenda::TrackInfo {
-                    name: "fellows",
+                    name: "members",
                     max_deciding: 10,
                     decision_deposit: 10 * DOLLARS,
                     prepare_period: 30 * MINUTES,
                     decision_period: 7 * DAYS,
                     confirm_period: 30 * MINUTES,
-                    min_enactment_period: MINUTES,
+                    min_enactment_period: 1 * MINUTES,
                     min_approval: pallet_referenda::Curve::LinearDecreasing {
                         length: Perbill::from_percent(100),
                         floor: Perbill::from_percent(50),
@@ -89,13 +91,13 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
             (
                 2u16,
                 pallet_referenda::TrackInfo {
-                    name: "experts",
+                    name: "proficients",
                     max_deciding: 10,
-                    decision_deposit: DOLLARS,
+                    decision_deposit: 10 * DOLLARS,
                     prepare_period: 30 * MINUTES,
                     decision_period: 7 * DAYS,
                     confirm_period: 30 * MINUTES,
-                    min_enactment_period: MINUTES,
+                    min_enactment_period: 1 * MINUTES,
                     min_approval: pallet_referenda::Curve::LinearDecreasing {
                         length: Perbill::from_percent(100),
                         floor: Perbill::from_percent(50),
@@ -111,13 +113,145 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
             (
                 3u16,
                 pallet_referenda::TrackInfo {
-                    name: "masters",
+                    name: "fellows",
                     max_deciding: 10,
-                    decision_deposit: DOLLARS,
+                    decision_deposit: 10 * DOLLARS,
                     prepare_period: 30 * MINUTES,
                     decision_period: 7 * DAYS,
                     confirm_period: 30 * MINUTES,
-                    min_enactment_period: MINUTES,
+                    min_enactment_period: 1 * MINUTES,
+                    min_approval: pallet_referenda::Curve::LinearDecreasing {
+                        length: Perbill::from_percent(100),
+                        floor: Perbill::from_percent(50),
+                        ceil: Perbill::from_percent(100),
+                    },
+                    min_support: pallet_referenda::Curve::LinearDecreasing {
+                        length: Perbill::from_percent(100),
+                        floor: Perbill::from_percent(0),
+                        ceil: Perbill::from_percent(50),
+                    },
+                },
+            ),
+            (
+                4u16,
+                pallet_referenda::TrackInfo {
+                    name: "senior fellows",
+                    max_deciding: 10,
+                    decision_deposit: 10 * DOLLARS,
+                    prepare_period: 30 * MINUTES,
+                    decision_period: 7 * DAYS,
+                    confirm_period: 30 * MINUTES,
+                    min_enactment_period: 1 * MINUTES,
+                    min_approval: pallet_referenda::Curve::LinearDecreasing {
+                        length: Perbill::from_percent(100),
+                        floor: Perbill::from_percent(50),
+                        ceil: Perbill::from_percent(100),
+                    },
+                    min_support: pallet_referenda::Curve::LinearDecreasing {
+                        length: Perbill::from_percent(100),
+                        floor: Perbill::from_percent(0),
+                        ceil: Perbill::from_percent(50),
+                    },
+                },
+            ),
+            (
+                5u16,
+                pallet_referenda::TrackInfo {
+                    name: "experts",
+                    max_deciding: 10,
+                    decision_deposit: 1 * DOLLARS,
+                    prepare_period: 30 * MINUTES,
+                    decision_period: 7 * DAYS,
+                    confirm_period: 30 * MINUTES,
+                    min_enactment_period: 1 * MINUTES,
+                    min_approval: pallet_referenda::Curve::LinearDecreasing {
+                        length: Perbill::from_percent(100),
+                        floor: Perbill::from_percent(50),
+                        ceil: Perbill::from_percent(100),
+                    },
+                    min_support: pallet_referenda::Curve::LinearDecreasing {
+                        length: Perbill::from_percent(100),
+                        floor: Perbill::from_percent(0),
+                        ceil: Perbill::from_percent(50),
+                    },
+                },
+            ),
+            (
+                6u16,
+                pallet_referenda::TrackInfo {
+                    name: "senior experts",
+                    max_deciding: 10,
+                    decision_deposit: 1 * DOLLARS,
+                    prepare_period: 30 * MINUTES,
+                    decision_period: 7 * DAYS,
+                    confirm_period: 30 * MINUTES,
+                    min_enactment_period: 1 * MINUTES,
+                    min_approval: pallet_referenda::Curve::LinearDecreasing {
+                        length: Perbill::from_percent(100),
+                        floor: Perbill::from_percent(50),
+                        ceil: Perbill::from_percent(100),
+                    },
+                    min_support: pallet_referenda::Curve::LinearDecreasing {
+                        length: Perbill::from_percent(100),
+                        floor: Perbill::from_percent(0),
+                        ceil: Perbill::from_percent(50),
+                    },
+                },
+            ),
+            (
+                7u16,
+                pallet_referenda::TrackInfo {
+                    name: "masters",
+                    max_deciding: 10,
+                    decision_deposit: 1 * DOLLARS,
+                    prepare_period: 30 * MINUTES,
+                    decision_period: 7 * DAYS,
+                    confirm_period: 30 * MINUTES,
+                    min_enactment_period: 1 * MINUTES,
+                    min_approval: pallet_referenda::Curve::LinearDecreasing {
+                        length: Perbill::from_percent(100),
+                        floor: Perbill::from_percent(50),
+                        ceil: Perbill::from_percent(100),
+                    },
+                    min_support: pallet_referenda::Curve::LinearDecreasing {
+                        length: Perbill::from_percent(100),
+                        floor: Perbill::from_percent(0),
+                        ceil: Perbill::from_percent(50),
+                    },
+                },
+            ),
+            (
+                8u16,
+                pallet_referenda::TrackInfo {
+                    name: "senior masters",
+                    max_deciding: 10,
+                    decision_deposit: 1 * DOLLARS,
+                    prepare_period: 30 * MINUTES,
+                    decision_period: 7 * DAYS,
+                    confirm_period: 30 * MINUTES,
+                    min_enactment_period: 1 * MINUTES,
+                    min_approval: pallet_referenda::Curve::LinearDecreasing {
+                        length: Perbill::from_percent(100),
+                        floor: Perbill::from_percent(50),
+                        ceil: Perbill::from_percent(100),
+                    },
+                    min_support: pallet_referenda::Curve::LinearDecreasing {
+                        length: Perbill::from_percent(100),
+                        floor: Perbill::from_percent(0),
+                        ceil: Perbill::from_percent(50),
+                    },
+                },
+            ),
+            (
+                9u16,
+                pallet_referenda::TrackInfo {
+                    name: "grand masters",
+                    max_deciding: 10,
+                    decision_deposit: 1 * DOLLARS,
+                    prepare_period: 30 * MINUTES,
+                    decision_period: 7 * DAYS,
+                    confirm_period: 30 * MINUTES,
+                    min_enactment_period: 1 * MINUTES,
                     min_approval: pallet_referenda::Curve::LinearDecreasing {
                         length: Perbill::from_percent(100),
                         floor: Perbill::from_percent(50),
@@ -149,9 +283,15 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
 
         match Origin::try_from(id.clone()) {
             Ok(Origin::FellowshipInitiates) => Ok(0),
-            Ok(Origin::Fellowship1Dan) | Ok(Origin::Fellows) => Ok(1),
-            Ok(Origin::Fellowship2Dan) | Ok(Origin::FellowshipExperts) => Ok(2),
-            Ok(Origin::Fellowship3Dan) | Ok(Origin::FellowshipMasters) => Ok(3),
+            Ok(Origin::Fellowship1Dan) => Ok(1),
+            Ok(Origin::Fellowship2Dan) => Ok(2),
+            Ok(Origin::Fellowship3Dan) | Ok(Origin::Fellows) => Ok(3),
+            Ok(Origin::Fellowship4Dan) => Ok(4),
+            Ok(Origin::Fellowship5Dan) | Ok(Origin::FellowshipExperts) => Ok(5),
+            Ok(Origin::Fellowship6Dan) => Ok(6),
+            Ok(Origin::Fellowship7Dan | Origin::FellowshipMasters) => Ok(7),
+            Ok(Origin::Fellowship8Dan) => Ok(8),
+            Ok(Origin::Fellowship9Dan) => Ok(9),
             _ => Err(()),
         }
     }
@@ -208,12 +348,12 @@ impl pallet_ranked_collective::Config<FellowshipCollectiveInstance> for Runtime 
     // Demotion is by any of:
     // - Root can demote arbitrarily.
     // - the FellowshipAdmin origin (i.e. token holder referendum);
-    // - a vote by the rank *above* the current rank.
+    // - a vote by the rank two *above* the current rank.
     type DemoteOrigin = EitherOf<
         frame_system::EnsureRootWithSuccess<Self::AccountId, ConstU16<65535>>,
         EitherOf<
             MapSuccess<FellowshipAdmin, Replace<ConstU16<3>>>,
-            TryMapSuccess<origins::EnsureFellowship, CheckedReduceBy<ConstU16<1>>>,
+            TryMapSuccess<origins::EnsureFellowship, CheckedReduceBy<ConstU16<2>>>,
         >,
     >;
     type Polls = FellowshipReferenda;

--- a/runtime/vara/src/governance/origins.rs
+++ b/runtime/vara/src/governance/origins.rs
@@ -61,6 +61,18 @@ pub mod pallet_custom_origins {
         Fellowship2Dan,
         /// Origin commanded by rank 3 of the Vara Fellowship and with a success of 3.
         Fellowship3Dan,
+        /// Origin commanded by rank 4 of the Vara Fellowship and with a success of 4.
+        Fellowship4Dan,
+        /// Origin commanded by rank 5 of the Vara Fellowship and with a success of 5.
+        Fellowship5Dan,
+        /// Origin commanded by rank 6 of the Vara Fellowship and with a success of 6.
+        Fellowship6Dan,
+        /// Origin commanded by rank 7 of the Vara Fellowship and with a success of 7.
+        Fellowship7Dan,
+        /// Origin commanded by rank 8 of the Vara Fellowship and with a success of 8.
+        Fellowship8Dan,
+        /// Origin commanded by rank 9 of the Vara Fellowship and with a success of 9.
+        Fellowship9Dan,
     }
 
     macro_rules! decl_unit_ensures {
@@ -102,9 +114,9 @@ pub mod pallet_custom_origins {
         ReferendumKiller,
         WhitelistedCaller,
         FellowshipInitiates: u16 = 0,
-        Fellows: u16 = 1,
-        FellowshipExperts: u16 = 2,
-        FellowshipMasters: u16 = 3,
+        Fellows: u16 = 3,
+        FellowshipExperts: u16 = 5,
+        FellowshipMasters: u16 = 7,
     );
 
     macro_rules! decl_ensure {
@@ -145,6 +157,12 @@ pub mod pallet_custom_origins {
             Fellowship1Dan = 1,
             Fellowship2Dan = 2,
             Fellowship3Dan = 3,
+            Fellowship4Dan = 4,
+            Fellowship5Dan = 5,
+            Fellowship6Dan = 6,
+            Fellowship7Dan = 7,
+            Fellowship8Dan = 8,
+            Fellowship9Dan = 9,
         }
     }
 }

--- a/runtime/vara/src/governance/origins.rs
+++ b/runtime/vara/src/governance/origins.rs
@@ -47,46 +47,52 @@ pub mod pallet_custom_origins {
         ReferendumKiller,
         /// Origin able to dispatch a whitelisted call.
         WhitelistedCaller,
-        /// Origin commanded by any members of the Gear Fellowship (no grade needed).
+        /// Origin commanded by any members of the Vara Fellowship (no grade needed).
         FellowshipInitiates,
-        /// Origin commanded by Gear Fellows (1st grade or greater).
+        /// Origin commanded by Vara Fellows (1st grade or greater).
         Fellows,
-        /// Origin commanded by Gear Experts (2nd grade or greater).
+        /// Origin commanded by Vara Experts (2nd grade or greater).
         FellowshipExperts,
-        /// Origin commanded by Gear Masters (3rd grade of greater).
+        /// Origin commanded by Vara Masters (3rd grade of greater).
         FellowshipMasters,
+        /// Origin commanded by rank 1 of the Vara Fellowship and with a success of 1.
+        Fellowship1Dan,
+        /// Origin commanded by rank 2 of the Vara Fellowship and with a success of 2.
+        Fellowship2Dan,
+        /// Origin commanded by rank 3 of the Vara Fellowship and with a success of 3.
+        Fellowship3Dan,
     }
 
     macro_rules! decl_unit_ensures {
-		( $name:ident: $success_type:ty = $success:expr ) => {
-			pub struct $name;
-			impl<O: Into<Result<Origin, O>> + From<Origin>>
-				EnsureOrigin<O> for $name
-			{
-				type Success = $success_type;
-				fn try_origin(o: O) -> Result<Self::Success, O> {
-					o.into().and_then(|o| match o {
-						Origin::$name => Ok($success),
-						r => Err(O::from(r)),
-					})
-				}
-				#[cfg(feature = "runtime-benchmarks")]
-				fn try_successful_origin() -> Result<O, ()> {
-					Ok(O::from(Origin::$name))
-				}
-			}
-		};
-		( $name:ident ) => { decl_unit_ensures! { $name : () = () } };
-		( $name:ident: $success_type:ty = $success:expr, $( $rest:tt )* ) => {
-			decl_unit_ensures! { $name: $success_type = $success }
-			decl_unit_ensures! { $( $rest )* }
-		};
-		( $name:ident, $( $rest:tt )* ) => {
-			decl_unit_ensures! { $name }
-			decl_unit_ensures! { $( $rest )* }
-		};
-		() => {}
-	}
+        ( $name:ident: $success_type:ty = $success:expr ) => {
+            pub struct $name;
+            impl<O: Into<Result<Origin, O>> + From<Origin>>
+                EnsureOrigin<O> for $name
+            {
+                type Success = $success_type;
+                fn try_origin(o: O) -> Result<Self::Success, O> {
+                    o.into().and_then(|o| match o {
+                        Origin::$name => Ok($success),
+                        r => Err(O::from(r)),
+                    })
+                }
+                #[cfg(feature = "runtime-benchmarks")]
+                fn try_successful_origin() -> Result<O, ()> {
+                    Ok(O::from(Origin::$name))
+                }
+            }
+        };
+        ( $name:ident ) => { decl_unit_ensures! { $name : () = () } };
+        ( $name:ident: $success_type:ty = $success:expr, $( $rest:tt )* ) => {
+            decl_unit_ensures! { $name: $success_type = $success }
+            decl_unit_ensures! { $( $rest )* }
+        };
+        ( $name:ident, $( $rest:tt )* ) => {
+            decl_unit_ensures! { $name }
+            decl_unit_ensures! { $( $rest )* }
+        };
+        () => {}
+    }
     decl_unit_ensures!(
         StakingAdmin,
         Treasurer,
@@ -100,4 +106,45 @@ pub mod pallet_custom_origins {
         FellowshipExperts: u16 = 2,
         FellowshipMasters: u16 = 3,
     );
+
+    macro_rules! decl_ensure {
+        (
+            $vis:vis type $name:ident: EnsureOrigin<Success = $success_type:ty> {
+                $( $item:ident = $success:expr, )*
+            }
+        ) => {
+            $vis struct $name;
+            impl<O: Into<Result<Origin, O>> + From<Origin>>
+                EnsureOrigin<O> for $name
+            {
+                type Success = $success_type;
+                fn try_origin(o: O) -> Result<Self::Success, O> {
+                    o.into().and_then(|o| match o {
+                        $(
+                            Origin::$item => Ok($success),
+                        )*
+                        r => Err(O::from(r)),
+                    })
+                }
+                #[cfg(feature = "runtime-benchmarks")]
+                fn try_successful_origin() -> Result<O, ()> {
+                    // By convention the more privileged origins go later, so for greatest chance
+                    // of success, we want the last one.
+                    let _result: Result<O, ()> = Err(());
+                    $(
+                        let _result: Result<O, ()> = Ok(O::from(Origin::$item));
+                    )*
+                    _result
+                }
+            }
+        }
+    }
+
+    decl_ensure! {
+        pub type EnsureFellowship: EnsureOrigin<Success = u16> {
+            Fellowship1Dan = 1,
+            Fellowship2Dan = 2,
+            Fellowship3Dan = 3,
+        }
+    }
 }


### PR DESCRIPTION
Fellowship members can have their rank as origin now (`Fellowship1Dan`, `Fellowship2Dan`, `Fellowship3Dan` .. up to 9 Dan).

To add a new member or promote existing submit proposal with origin FellowshipDan with the rank above the new rank.
For example new members rank would be 0 - submit proposal with `1 / Candidates / Origin / Fellowship1Dan` Origin.
To promote user from 1 to 2 rank - submit proposal with `3 / Fellows / Origin / Fellowship3Dan` Origin.

To demote user proposal origin should be 2 rank above the current rank.

@gear-tech/dev 
