### PR TITLE
Make `Memory::grow` unreachable

### DIFF
--- a/core-backend/sandbox/src/memory.rs
+++ b/core-backend/sandbox/src/memory.rs
@@ -18,7 +18,7 @@
 
 //! sp-sandbox extensions for memory.
 
-use gear_core::memory::{AllocError, HostPointer, Memory, PageU32Size, WasmPage};
+use gear_core::memory::{HostPointer, Memory, PageU32Size, WasmPage};
 use gear_core_errors::MemoryError;
 use sp_sandbox::{default_executor::Memory as DefaultExecutorMemory, SandboxMemory};
 
@@ -33,11 +33,10 @@ impl MemoryWrap {
 
 /// Memory interface for the allocator.
 impl Memory for MemoryWrap {
-    fn grow(&mut self, pages: WasmPage) -> Result<(), AllocError> {
-        self.0
-            .grow(pages.raw())
-            .map(|_| ())
-            .map_err(|_| AllocError::ProgramAllocOutOfBounds)
+    type GrowError = sp_sandbox::Error;
+
+    fn grow(&mut self, pages: WasmPage) -> Result<(), Self::GrowError> {
+        self.0.grow(pages.raw()).map(|_| ())
     }
 
     fn size(&self) -> WasmPage {
@@ -67,7 +66,7 @@ impl Memory for MemoryWrap {
 mod tests {
     use super::*;
     use gear_backend_common::{assert_err, assert_ok};
-    use gear_core::memory::{AllocInfo, AllocationsContext, NoopGrowHandler};
+    use gear_core::memory::{AllocError, AllocInfo, AllocationsContext, NoopGrowHandler};
 
     fn new_test_memory(static_pages: u16, max_pages: u16) -> (AllocationsContext, MemoryWrap) {
         use sp_sandbox::SandboxMemory as WasmMemory;

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -1122,7 +1122,7 @@ mod tests {
 
     mod property_tests {
         use super::*;
-        use gear_core::memory::HostPointer;
+        use gear_core::memory::{HostPointer, PageError};
         use proptest::{
             arbitrary::any,
             collection::size_range,
@@ -1134,11 +1134,10 @@ mod tests {
         struct TestMemory(WasmPage);
 
         impl Memory for TestMemory {
-            fn grow(&mut self, pages: WasmPage) -> Result<(), AllocError> {
-                self.0 = self
-                    .0
-                    .add(pages)
-                    .map_err(|_| AllocError::ProgramAllocOutOfBounds)?;
+            type GrowError = PageError;
+
+            fn grow(&mut self, pages: WasmPage) -> Result<(), Self::GrowError> {
+                self.0 = self.0.add(pages)?;
                 Ok(())
             }
 


### PR DESCRIPTION
Resolves #2257.
