### PR TITLE
Stabilize fuzzer docker

### DIFF
--- a/docker/runtime-fuzzer/Dockerfile
+++ b/docker/runtime-fuzzer/Dockerfile
@@ -17,7 +17,7 @@ RUN rustup update nightly && rustup target add wasm32-unknown-unknown --toolchai
 RUN rustup default nightly
 
 # Clone gear repo
-RUN git clone https://github.com/gear-tech/gear.git
+RUN git clone --branch st-stabilize-fuzzer-docker https://github.com/gear-tech/gear.git
 
 # Install cargo-fuzz
 RUN cd gear

--- a/utils/runtime-fuzzer/fuzz/fuzz_targets/main.rs
+++ b/utils/runtime-fuzzer/fuzz/fuzz_targets/main.rs
@@ -26,7 +26,7 @@ use std::{
     path::Path,
 };
 
-const SEEDS_STORE_DIR: &str = "fuzzing-seeds-dir";
+const SEEDS_STORE_DIR: &str = "/fuzzing-seeds-dir";
 const SEEDS_STORE_FILE: &str = "fuzzing-seeds";
 
 static RUN_INTIALIZED: OnceCell<String> = OnceCell::new();
@@ -34,7 +34,8 @@ static RUN_INTIALIZED: OnceCell<String> = OnceCell::new();
 fuzz_target!(|seed: u64| {
     gear_utils::init_default_logger();
 
-    dump_seed(seed).expect("internal error: failed dumping seed");
+    dump_seed(seed)
+        .unwrap_or_else(|e| unreachable!("internal error: failed dumping seed: {e}"));
 
     log::info!("Running the seed {seed}");
     runtime_fuzzer::run(seed);

--- a/utils/runtime-fuzzer/fuzz/fuzz_targets/main.rs
+++ b/utils/runtime-fuzzer/fuzz/fuzz_targets/main.rs
@@ -48,10 +48,10 @@ fuzz_target!(|seed: u64| {
 fn dump_seed(seed: u64) -> Result<(), String> {
     let seeds_file = RUN_INTIALIZED.get_or_try_init(|| {
         let seeds_dir = Path::new(SEEDS_STORE_DIR);
-        if seeds_dir.exists() {
-            fs::remove_dir_all(seeds_dir).map_err(|e| e.to_string())?;
+        if !seeds_dir.exists() {
+            // fs::remove_dir_all(seeds_dir).map_err(|e| e.to_string())?;
+            fs::create_dir_all(seeds_dir).map_err(|e| e.to_string())?;
         }
-        fs::create_dir_all(seeds_dir).map_err(|e| e.to_string())?;
 
         Ok::<_, String>(format!("{SEEDS_STORE_DIR}/{SEEDS_STORE_FILE}"))
     })?;


### PR DESCRIPTION
Running fuzzer with docker was not successful - current version resulted in OS errors related to file access. Possibly that was because the directory which stored fuzzing seeds was removed by fuzzer, also it was mounted on the host machine. Later fuzzer re-created it in accordance to internal logic. That workflow seems to be buggy.

That was edited in the current PR, which introduces changes that doesn't remove fuzzing seeds directory.

TODO:
- [ ] Testing on the reference machine by @sergeyfilyanin 
