### PR TITLE
[skip ci] feat(ci): Introduce workflows for combining dependabot's prs

### DIFF
--- a/.github/workflows/combined-dependabot.yml
+++ b/.github/workflows/combined-dependabot.yml
@@ -145,7 +145,8 @@ jobs:
               const mergeFailedPRsString = mergeFailedPRs.join('\n');
               body += '\n\n⚠️ The following PRs were left out due to merge conflicts:\n' + mergeFailedPRsString
             }
-            await github.rest.pulls.create({
+
+            const pull = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: "deps: combine dependabot's PRs",
@@ -153,3 +154,15 @@ jobs:
               base: baseBranch,
               body: body
             });
+
+            // Try adding labels...
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pull.number,
+                labels: [ "A4-insubstantial", "E1-forcewindows", "E2-forcemacos" ]
+              });
+            } catch (e) {
+              console.log("Failed to add labels:", e);
+            }

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   upgrade:
-    runs-on: ubuntu
+    runs-on: ubuntu-latest
     steps:
       - name: "ACTIONS: Checkout"
         uses: actions/checkout@v3
@@ -39,4 +39,5 @@ jobs:
               [1]: https://github.com/peter-evans/create-pull-request
           labels: |
             A4-insubstantial
+            E1-forcewindows
             E2-forcemacos


### PR DESCRIPTION
Resolves #2479 


This PR introduces two workflows for checking and upgrading our dependencies


##  0. auto-run

> workflow: [.github/workflows/deps.yml](https://github.com/gear-tech/gear/blob/cl/dep-bot/.github/workflows/deps.yml)

run `cargo upgrade` at 05:00, only on Monday


## 1. manually run

> workflow: [.github/workflows/combined-dependabot.yml](https://github.com/gear-tech/gear/blob/cl/dep-bot/.github/workflows/combined-dependabot.yml)

combines the PRs of dependabot to new PRs, need to click manually, see https://www.hrvey.com/blog/combine-dependabot-prs


@gear-tech/dev 
