### PR TITLE
gmeta: Fix deprecation warning when using `metawasm` attribute

### DIFF
--- a/gmeta/codegen/src/lib.rs
+++ b/gmeta/codegen/src/lib.rs
@@ -499,6 +499,6 @@ fn register_type(ty: impl ToTokens) -> proc_macro2::TokenStream {
     let ty = ty.to_token_stream();
 
     quote! {
-        Some(registry.register_type(&::gmeta::MetaType::new::<#ty>()).id())
+        Some(registry.register_type(&::gmeta::MetaType::new::<#ty>()).id)
     }
 }


### PR DESCRIPTION
- Fixed a deprecation warning due to the update `scale-info` to v2.5 in `gmeta`

```
error: use of deprecated method `gstd::scale_info::interner::UntrackedSymbol::<T>::id`: Prefer to access the fields directly; this getter will be removed in the next major version
  --> state/src/lib.rs:10:1
   |
10 | #[metawasm]
   | ^^^^^^^^^^^
   |
   = note: `-D deprecated` implied by `-D warnings`
   = note: this error originates in the attribute macro `metawasm` (in Nightly builds, run with -Z macro-backtrace for more info)
```

@gear-tech/dev 
