### PR TITLE
Increase fuzzer performance

### DIFF
--- a/docker/runtime-fuzzer/Dockerfile
+++ b/docker/runtime-fuzzer/Dockerfile
@@ -17,7 +17,7 @@ RUN rustup update nightly && rustup target add wasm32-unknown-unknown --toolchai
 RUN rustup default nightly
 
 # Clone gear repo
-RUN git clone https://github.com/gear-tech/gear.git
+RUN git clone -b st-increase-fuzzer-perf https://github.com/gear-tech/gear.git
 
 # Install cargo-fuzz
 RUN cd gear

--- a/docker/runtime-fuzzer/Dockerfile
+++ b/docker/runtime-fuzzer/Dockerfile
@@ -17,7 +17,7 @@ RUN rustup update nightly && rustup target add wasm32-unknown-unknown --toolchai
 RUN rustup default nightly
 
 # Clone gear repo
-RUN git clone -b st-increase-fuzzer-perf https://github.com/gear-tech/gear.git
+RUN git clone https://github.com/gear-tech/gear.git
 
 # Install cargo-fuzz
 RUN cd gear

--- a/utils/runtime-fuzzer/src/lib.rs
+++ b/utils/runtime-fuzzer/src/lib.rs
@@ -153,6 +153,7 @@ fn execute_gear_call(sender: AccountId, call: GearCall) -> DispatchResultWithPos
 }
 
 fn update_context(context: &ContextMutex) {
+    log::info!("Starting updating context");
     let mut initialized_programs: Vec<_> = System::events()
         .into_iter()
         .filter_map(|v| {
@@ -168,5 +169,8 @@ fn update_context(context: &ContextMutex) {
         })
         .collect();
 
+    log::info!("Collected all the programs");
+
     context.lock().programs.append(&mut initialized_programs);
+    log::info!("Context is stored");
 }

--- a/utils/runtime-fuzzer/src/lib.rs
+++ b/utils/runtime-fuzzer/src/lib.rs
@@ -153,7 +153,7 @@ fn execute_gear_call(sender: AccountId, call: GearCall) -> DispatchResultWithPos
 }
 
 fn update_context(context: &ContextMutex) {
-    log::info!("Starting updating context");
+    log::debug!("Starting updating context");
     let mut initialized_programs: Vec<_> = System::events()
         .into_iter()
         .filter_map(|v| {
@@ -169,8 +169,10 @@ fn update_context(context: &ContextMutex) {
         })
         .collect();
 
-    log::info!("Collected all the programs");
+    System::reset_events();
+
+    log::debug!("Collected all the programs");
 
     context.lock().programs.append(&mut initialized_programs);
-    log::info!("Context is stored");
+    log::debug!("Context is stored");
 }


### PR DESCRIPTION
After each run the events store grows bigger, so iterating on it becomes very expensive. Optimize that by removing events after processing them.
