### PR TITLE
ci: Add check for runtime imports to CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -219,8 +219,11 @@ jobs:
       - name: "Build: WAT examples"
         run: ./scripts/gear.sh build wat-examples
 
-      - name: Check runtime imports
-        run: ./target/release/wasm-proc --check-runtime-imports target/release/wbuild/gear-runtime/gear_runtime.wasm
+      - name: "Check: Gear runtime imports"
+        run: ./target/release/wasm-proc --check-runtime-imports target/release/wbuild/gear-runtime/gear_runtime.compact.compressed.wasm
+
+      - name: "Check: Vara runtime imports"
+        run: ./target/release/wasm-proc --check-runtime-imports target/release/wbuild/vara-runtime/vara_runtime.compact.compressed.wasm
 
       - name: "Build: Split examples by .opt and .meta"
         run: ./scripts/gear.sh build examples-proc

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -220,10 +220,10 @@ jobs:
         run: ./scripts/gear.sh build wat-examples
 
       - name: "Check: Gear runtime imports"
-        run: ./target/release/wasm-proc --check-runtime-imports target/release/wbuild/gear-runtime/gear_runtime.compact.compressed.wasm
+        run: ./target/release/wasm-proc --check-runtime-imports target/release/wbuild/gear-runtime/gear_runtime.compact.wasm
 
       - name: "Check: Vara runtime imports"
-        run: ./target/release/wasm-proc --check-runtime-imports target/release/wbuild/vara-runtime/vara_runtime.compact.compressed.wasm
+        run: ./target/release/wasm-proc --check-runtime-imports target/release/wbuild/vara-runtime/vara_runtime.compact.wasm
 
       - name: "Build: Split examples by .opt and .meta"
         run: ./scripts/gear.sh build examples-proc


### PR DESCRIPTION
Resolves #2341.

- check compact WASMs for both runtimes Gear & Vara

@reviewer-or-team
