### PR TITLE
feat(utils): switch to `clap` arg parser instead of `structopt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,21 +1090,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
@@ -1115,9 +1100,9 @@ dependencies = [
  "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
- "textwrap 0.16.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -1141,7 +1126,7 @@ dependencies = [
  "anstyle",
  "bitflags",
  "clap_lex 0.4.1",
- "strsim 0.10.0",
+ "strsim",
 ]
 
 [[package]]
@@ -1150,7 +1135,7 @@ version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1163,7 +1148,7 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.13",
@@ -1775,7 +1760,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn 1.0.109",
 ]
 
@@ -2658,7 +2643,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3839,6 +3824,7 @@ version = "0.1.6"
 dependencies = [
  "anyhow",
  "arbitrary",
+ "clap 4.2.1",
  "dyn-clonable",
  "futures",
  "futures-timer",
@@ -3853,7 +3839,6 @@ dependencies = [
  "primitive-types",
  "rand 0.8.5",
  "reqwest",
- "structopt",
  "thiserror",
  "tokio",
  "tracing",
@@ -4553,15 +4538,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -5130,7 +5106,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baa6da1e4199c10d7b1d0a6e5e8bd8e55f351163b6f4b3cbb044672a69bd4c1c"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
@@ -5689,7 +5665,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d527d5827582abd44a6d80c07ff8b50b4ee238a8979e05998474179e79dc400"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "quote",
  "syn 1.0.109",
 ]
@@ -8191,7 +8167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck",
  "itertools",
  "lazy_static",
  "log",
@@ -8805,6 +8781,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arbitrary",
+ "clap 4.2.1",
  "frame-support",
  "frame-system",
  "gear-call-gen",
@@ -8829,7 +8806,6 @@ dependencies = [
  "sp-io",
  "sp-keyring",
  "sp-runtime",
- "structopt",
 ]
 
 [[package]]
@@ -11410,39 +11386,9 @@ checksum = "0873cb29201126440dcc78d0b1f5a13d917e78831778429a7920ca9c7f3dae1e"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "strum"
@@ -11459,7 +11405,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -11665,7 +11611,7 @@ checksum = "b8e86cb719003f1cedf2710a6e55ca4c37aba4c989bbd3b81dd1c52af9e4827e"
 dependencies = [
  "darling",
  "frame-metadata",
- "heck 0.4.1",
+ "heck",
  "hex",
  "jsonrpsee",
  "parity-scale-codec",
@@ -11774,7 +11720,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beca1b4eaceb4f2755df858b88d9b9315b7ccfd1ffd0d7a48a52602301f01a57"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -11828,15 +11774,6 @@ dependencies = [
  "gear-wasm-builder",
  "gstd",
  "parity-scale-codec",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -12480,12 +12417,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12658,12 +12589,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -12847,9 +12772,9 @@ dependencies = [
 name = "wasm-info"
 version = "0.1.0"
 dependencies = [
+ "clap 4.2.1",
  "hex",
  "parity-wasm 0.45.0",
- "structopt",
 ]
 
 [[package]]

--- a/utils/node-loader/Cargo.toml
+++ b/utils/node-loader/Cargo.toml
@@ -18,6 +18,7 @@ gear-utils.workspace = true
 # external dependencies
 anyhow.workspace = true
 arbitrary.workspace = true
+clap = { workspace = true, features = ["derive"] }
 dyn-clonable.workspace = true
 futures.workspace = true
 futures-timer.workspace = true
@@ -28,7 +29,6 @@ parking_lot.workspace = true
 primitive-types = { workspace = true, features = ["scale-info"] }
 rand = { workspace = true, features = ["small_rng"] }
 reqwest.workspace = true
-structopt = "0.3.26" # TODO: use clap instead
 thiserror.workspace = true
 tokio = { workspace = true, features = [ "macros", "rt-multi-thread" ] }
 tracing.workspace = true

--- a/utils/node-loader/src/args.rs
+++ b/utils/node-loader/src/args.rs
@@ -1,11 +1,11 @@
 //! CLI args for the `gear-node-loader`
 
 use anyhow::Error;
+use clap::Parser;
 use std::str::FromStr;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "node-loader")]
+#[derive(Debug, Parser)]
+#[clap(name = "node-loader")]
 pub enum Params {
     /// Dump the wasm program with provided seed to "out.wasm"
     Dump {
@@ -16,25 +16,25 @@ pub enum Params {
     Load(LoadParams),
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct LoadParams {
-    #[structopt(long, default_value = "ws://localhost:9944")]
+    #[arg(long, default_value = "ws://localhost:9944")]
     pub node: String,
 
     /// Node stopping service.
-    #[structopt(long, default_value = "http://localhost:5000/executions/start")]
+    #[arg(long, default_value = "http://localhost:5000/executions/start")]
     pub node_stopper: String,
 
     /// User name
-    #[structopt(long, default_value = "//Bob")]
+    #[arg(long, default_value = "//Bob")]
     pub user: String,
 
     /// Root account of the node
-    #[structopt(long, default_value = "//Alice")]
+    #[arg(long, default_value = "//Alice")]
     pub root: String,
 
     /// Starting seed for loading the network
-    #[structopt(long)]
+    #[arg(long)]
     pub loader_seed: Option<u64>,
 
     /// Seed used to generate random seeds for various internal generators.
@@ -44,25 +44,25 @@ pub struct LoadParams {
     /// used in every test, therefore generated input data (for example, program)
     /// for each test will be the same.
     /// Example value: `<seed_variant>=<seed_u64_value>`.
-    #[structopt(long)]
+    #[arg(long)]
     pub code_seed_type: Option<SeedVariant>,
 
     /// Desirable amount of workers in task pool.
-    #[structopt(long, short, default_value = "8")]
+    #[arg(long, short, default_value = "8")]
     pub workers: usize,
 
     /// Desirable amount of calls in the sending batch.
-    #[structopt(long, short, default_value = "4")]
+    #[arg(long, short, default_value = "4")]
     pub batch_size: usize,
 }
 
 pub fn parse_cli_params() -> Params {
-    Params::from_args()
+    Params::parse()
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum SeedVariant {
-    // TODO remove later (considering )
+    // TODO remove later (considering)
     Dynamic(u64),
     Constant(u64),
 }

--- a/utils/runtime-fuzzer/Cargo.toml
+++ b/utils/runtime-fuzzer/Cargo.toml
@@ -16,8 +16,7 @@ rand = { workspace = true, features = ["small_rng"] }
 
 # Temporary deps for the reproducing crash script until #2313 is implemented
 #
-# TODO: use clap instead
-structopt = "0.3.26"
+clap = { workspace = true, features = ["derive"] }
 
 gear-call-gen.workspace = true
 runtime-primitives.workspace = true
@@ -34,7 +33,7 @@ sp-io.workspace = true
 sp-keyring.workspace = true
 sp-runtime.workspace = true
 pallet-balances.workspace = true
-sp-consensus-slots = { workspace = true}
+sp-consensus-slots = { workspace = true }
 sp-consensus-babe.workspace = true
 sp-consensus-grandpa.workspace = true
 pallet-authorship.workspace = true

--- a/utils/runtime-fuzzer/Cargo.toml
+++ b/utils/runtime-fuzzer/Cargo.toml
@@ -15,7 +15,6 @@ parking_lot.workspace = true
 rand = { workspace = true, features = ["small_rng"] }
 
 # Temporary deps for the reproducing crash script until #2313 is implemented
-#
 clap = { workspace = true, features = ["derive"] }
 
 gear-call-gen.workspace = true

--- a/utils/runtime-fuzzer/src/bin/reproduce_fuzz.rs
+++ b/utils/runtime-fuzzer/src/bin/reproduce_fuzz.rs
@@ -35,7 +35,7 @@ use std::{
 #[derive(Debug, Parser)]
 pub struct Params {
     /// Path to the file, which contains seeds from previously run fuzzer.
-    #[arg(long)]
+    #[arg(short, long)]
     pub path: PathBuf,
 }
 

--- a/utils/runtime-fuzzer/src/bin/reproduce_fuzz.rs
+++ b/utils/runtime-fuzzer/src/bin/reproduce_fuzz.rs
@@ -25,24 +25,24 @@
 //! Just simply run `cargo run -- -p <path_to_fuzz_seeds>`.
 
 use anyhow::Result;
+use clap::Parser;
 use std::{
     fs::File,
     io::{BufRead, BufReader},
     path::PathBuf,
 };
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct Params {
     /// Path to the file, which contains seeds from previously run fuzzer.
-    #[structopt(short = "p", long, parse(from_os_str))]
+    #[arg(short = "p", long, parse(from_os_str))]
     pub path: PathBuf,
 }
 
 fn main() -> Result<()> {
     gear_utils::init_default_logger();
 
-    let file_reader = create_file_reader(Params::from_args().path)?;
+    let file_reader = create_file_reader(Params::parse().path)?;
 
     // Read seeds and run test against all of them.
     for line in file_reader.lines() {

--- a/utils/runtime-fuzzer/src/bin/reproduce_fuzz.rs
+++ b/utils/runtime-fuzzer/src/bin/reproduce_fuzz.rs
@@ -35,7 +35,7 @@ use std::{
 #[derive(Debug, Parser)]
 pub struct Params {
     /// Path to the file, which contains seeds from previously run fuzzer.
-    #[arg(short = "p", long, parse(from_os_str))]
+    #[arg(long)]
     pub path: PathBuf,
 }
 

--- a/utils/wasm-info/Cargo.toml
+++ b/utils/wasm-info/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+clap = { workspace = true, features = ["derive"] }
 hex = { workspace = true, features = ["std"] }
 parity-wasm.workspace = true
-structopt = "0.3.26" # TODO: use clap instead

--- a/utils/wasm-info/src/main.rs
+++ b/utils/wasm-info/src/main.rs
@@ -1,20 +1,20 @@
+use clap::Parser;
 use parity_wasm::elements::{Module, Section, Serialize};
 use std::{fs, path::PathBuf};
-use structopt::StructOpt;
 
 /// Parse info of wasm binaries
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct Info {
     /// Show code hex
-    #[structopt(short, long)]
+    #[arg(short = 'H', long)]
     pub hex: bool,
 
     /// Show code size
-    #[structopt(long)]
+    #[arg(long)]
     pub size: bool,
 
     /// Strip custom sections
-    #[structopt(short, long)]
+    #[arg(long)]
     pub strip_custom_sections: bool,
 
     /// Path or hex encoding of wasm binary
@@ -53,7 +53,7 @@ impl Info {
 }
 
 fn main() {
-    let info = Info::from_args();
+    let info = Info::parse();
 
     let mut module = info.module();
     println!("Module sections: {}", module.sections().len());


### PR DESCRIPTION
Resolves #2442.

Changes made due to the transition:
- In `wasm-info`, the shorthand for `--hex` has been changed to `-H` from `-h`. This has been done because it conflicts with the shorthand for help in current version of clap. Another option is to disable both `--help` and `-h`, but this requires further discussion.

Rework of PR #2510