### PR TITLE
Migrate to `Weight::from_parts` (closes #2531)

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -149,7 +149,7 @@ pub trait GasPrice {
     /// In general case, this doesn't necessarily has to be constant.
     fn gas_price(gas: u64) -> Self::Balance {
         ConstantMultiplier::<Self::Balance, Self::GasToBalanceMultiplier>::weight_to_fee(
-            &Weight::from_ref_time(gas),
+            &Weight::from_parts(gas, 0),
         )
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -17,8 +17,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-// (issue #2531)
-#![allow(deprecated)]
 
 #[macro_use]
 extern crate gear_common_codegen;

--- a/pallets/airdrop/src/weights.rs
+++ b/pallets/airdrop/src/weights.rs
@@ -57,7 +57,7 @@ pub trait WeightInfo {
 pub struct AirdropWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for AirdropWeight<T> {
 	fn transfer() -> Weight {
-		(Weight::from_ref_time(18_000_000))
+		(Weight::from_parts(18_000_000, 0))
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}

--- a/pallets/airdrop/src/weights.rs
+++ b/pallets/airdrop/src/weights.rs
@@ -41,8 +41,6 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(unused_parens)]
 #![allow(unused_imports)]
-
-// (issue #2531)
 #![allow(deprecated)]
 
 use frame_support::{traits::Get, weights::{constants::RocksDbWeight, Weight}};

--- a/pallets/airdrop/src/weights.rs
+++ b/pallets/airdrop/src/weights.rs
@@ -41,7 +41,6 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(unused_parens)]
 #![allow(unused_imports)]
-#![allow(deprecated)]
 
 use frame_support::{traits::Get, weights::{constants::RocksDbWeight, Weight}};
 use sp_std::marker::PhantomData;

--- a/pallets/gear-debug/src/mock.rs
+++ b/pallets/gear-debug/src/mock.rs
@@ -230,7 +230,7 @@ pub fn run_to_block(n: u64, remaining_weight: Option<u64>) {
                 <<Test as frame_system::Config>::BlockWeights as Get<BlockWeights>>::get()
                     .max_block;
             System::register_extra_weight_unchecked(
-                max_block_weight.saturating_sub(Weight::from_ref_time(remaining_weight)),
+                max_block_weight.saturating_sub(Weight::from_parts(remaining_weight, 0)),
                 frame_support::dispatch::DispatchClass::Normal,
             );
         }

--- a/pallets/gear-debug/src/mock.rs
+++ b/pallets/gear-debug/src/mock.rs
@@ -16,9 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-// (issue #2531)
-#![allow(deprecated)]
-
 use crate as pallet_gear_debug;
 use common::storage::Limiter;
 use frame_support::{

--- a/pallets/gear-debug/src/weights.rs
+++ b/pallets/gear-debug/src/weights.rs
@@ -40,6 +40,7 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 #![allow(clippy::unnecessary_cast)]
+#![allow(deprecated)]
 
 use frame_support::{
     traits::Get,

--- a/pallets/gear-debug/src/weights.rs
+++ b/pallets/gear-debug/src/weights.rs
@@ -40,7 +40,6 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 #![allow(clippy::unnecessary_cast)]
-#![allow(deprecated)]
 
 use frame_support::{
     traits::Get,

--- a/pallets/gear-scheduler/src/mock.rs
+++ b/pallets/gear-scheduler/src/mock.rs
@@ -16,9 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-// (issue #2531)
-#![allow(deprecated)]
-
 use crate as pallet_gear_scheduler;
 use common::storage::Limiter;
 use frame_support::{

--- a/pallets/gear-scheduler/src/mock.rs
+++ b/pallets/gear-scheduler/src/mock.rs
@@ -234,7 +234,7 @@ pub fn run_to_block(n: u64, remaining_weight: Option<u64>) {
                 <<Test as frame_system::Config>::BlockWeights as Get<BlockWeights>>::get()
                     .max_block;
             System::register_extra_weight_unchecked(
-                max_block_weight.saturating_sub(Weight::from_ref_time(remaining_weight)),
+                max_block_weight.saturating_sub(Weight::from_parts(remaining_weight, 0)),
                 DispatchClass::Normal,
             );
         }

--- a/pallets/gear/src/benchmarking/tests/utils.rs
+++ b/pallets/gear/src/benchmarking/tests/utils.rs
@@ -68,8 +68,9 @@ where
             let max_block_weight =
                 <<T as frame_system::Config>::BlockWeights as Get<BlockWeights>>::get().max_block;
             SystemPallet::<T>::register_extra_weight_unchecked(
-                max_block_weight.saturating_sub(frame_support::weights::Weight::from_ref_time(
+                max_block_weight.saturating_sub(frame_support::weights::Weight::from_parts(
                     remaining_weight,
+                    0,
                 )),
                 frame_support::dispatch::DispatchClass::Normal,
             );

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -1638,7 +1638,7 @@ pub mod pallet {
 
             Ok(PostDispatchInfo {
                 actual_weight: Some(
-                    Weight::from_ref_time(actual_weight)
+                    Weight::from_parts(actual_weight, 0)
                         .saturating_add(T::DbWeight::get().writes(1)),
                 ),
                 pays_fee: Pays::No,

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -18,8 +18,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "runtime-benchmarks", recursion_limit = "512")]
-// (issue #2531)
-#![allow(deprecated)]
 
 extern crate alloc;
 

--- a/pallets/gear/src/mock.rs
+++ b/pallets/gear/src/mock.rs
@@ -243,7 +243,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 pub fn get_min_weight() -> Weight {
     new_test_ext().execute_with(|| {
         dry_run!(weight, BlockGasLimitOf::<Test>::get());
-        Weight::from_ref_time(weight)
+        Weight::from_parts(weight, 0)
     })
 }
 
@@ -261,7 +261,7 @@ pub fn get_weight_of_adding_task() -> Weight {
         )
         .unwrap_or_else(|e| unreachable!("Scheduling logic invalidated! {:?}", e));
 
-        Weight::from_ref_time(gas_allowance - GasAllowanceOf::<Test>::get())
+        Weight::from_parts(gas_allowance - GasAllowanceOf::<Test>::get(), 0)
     }) - minimal_weight
 }
 
@@ -278,7 +278,7 @@ pub fn run_to_block(n: u64, remaining_weight: Option<u64>) {
             GasAllowanceOf::<Test>::put(remaining_weight);
             let max_block_weight = <BlockWeightsOf<Test> as Get<BlockWeights>>::get().max_block;
             System::register_extra_weight_unchecked(
-                max_block_weight.saturating_sub(Weight::from_ref_time(remaining_weight)),
+                max_block_weight.saturating_sub(Weight::from_parts(remaining_weight, 0)),
                 DispatchClass::Normal,
             );
         }

--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -641,7 +641,7 @@ macro_rules! cost_byte_batched {
 
 macro_rules! to_weight {
     ($ref_time:expr $(, $proof_size:expr )?) => {
-        Weight::from_ref_time($ref_time)$(.set_proof_size($proof_size))?
+        Weight::from_parts($ref_time, 0)$(.set_proof_size($proof_size))?
     };
 }
 
@@ -949,8 +949,8 @@ impl<T: Config> Default for MemoryWeights<T> {
                 .saturating_mul(kb_number_in_one_gear_page)
                 .saturating_sub(T::DbWeight::get().writes(1).ref_time(),)),
             // TODO: make benches to calculate static page cost and mem grow cost (issue #2226)
-            static_page: Weight::from_ref_time(100),
-            mem_grow: Weight::from_ref_time(100),
+            static_page: Weight::from_parts(100, 0),
+            mem_grow: Weight::from_parts(100, 0),
             // TODO: make it non-zero for para-chains (issue #2225)
             parachain_read_heuristic: Weight::zero(),
             _phantom: PhantomData,

--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -20,8 +20,6 @@
 //! sane default schedule from a `WeightInfo` implementation.
 
 #![allow(unused_parens)]
-// (issue #2531)
-#![allow(deprecated)]
 
 use crate::{weights::WeightInfo, Config};
 use core_processor::configs::PageCosts;

--- a/pallets/gear/src/weights.rs
+++ b/pallets/gear/src/weights.rs
@@ -31,7 +31,6 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 #![allow(clippy::unnecessary_cast)]
-#![allow(deprecated)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
 use sp_std::marker::PhantomData;

--- a/pallets/gear/src/weights.rs
+++ b/pallets/gear/src/weights.rs
@@ -31,8 +31,6 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 #![allow(clippy::unnecessary_cast)]
-
-// (issue #2531)
 #![allow(deprecated)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};

--- a/pallets/gear/src/weights.rs
+++ b/pallets/gear/src/weights.rs
@@ -220,9 +220,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 714 nanoseconds.
-        Weight::from_ref_time(762_000)
+        Weight::from_parts(762_000, 0)
             // Standard Error: 916
-            .saturating_add(Weight::from_ref_time(249_959).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(249_959, 0).saturating_mul(c.into()))
             .saturating_add(T::DbWeight::get().writes(1_u64))
     }
     /// The range of component `c` is `[0, 512]`.
@@ -233,7 +233,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 2_591 nanoseconds.
         Weight::from_parts(2_658_000, 2546)
             // Standard Error: 1_587
-            .saturating_add(Weight::from_ref_time(691_791).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(691_791, 0).saturating_mul(c.into()))
             .saturating_add(T::DbWeight::get().reads(1_u64))
             .saturating_add(Weight::from_proof_size(1024).saturating_mul(c.into()))
     }
@@ -243,9 +243,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 47_048 nanoseconds.
-        Weight::from_ref_time(80_532_528)
+        Weight::from_parts(80_532_528, 0)
             // Standard Error: 4_561
-            .saturating_add(Weight::from_ref_time(2_208_073).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(2_208_073, 0).saturating_mul(c.into()))
     }
     fn claim_value() -> Weight {
         // Proof Size summary in bytes:
@@ -264,7 +264,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 55_252 nanoseconds.
         Weight::from_parts(39_508_166, 3010)
             // Standard Error: 54_990
-            .saturating_add(Weight::from_ref_time(53_653_596).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(53_653_596, 0).saturating_mul(c.into()))
             .saturating_add(T::DbWeight::get().reads(2_u64))
             .saturating_add(T::DbWeight::get().writes(4_u64))
     }
@@ -276,7 +276,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 45_837 nanoseconds.
         Weight::from_parts(67_499_867, 17714)
             // Standard Error: 0
-            .saturating_add(Weight::from_ref_time(2_312).saturating_mul(s.into()))
+            .saturating_add(Weight::from_parts(2_312, 0).saturating_mul(s.into()))
             .saturating_add(T::DbWeight::get().reads(10_u64))
             .saturating_add(T::DbWeight::get().writes(8_u64))
     }
@@ -289,9 +289,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 9_772_476 nanoseconds.
         Weight::from_parts(137_998_681, 13432)
             // Standard Error: 153_459
-            .saturating_add(Weight::from_ref_time(54_040_008).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(54_040_008, 0).saturating_mul(c.into()))
             // Standard Error: 9
-            .saturating_add(Weight::from_ref_time(2_271).saturating_mul(s.into()))
+            .saturating_add(Weight::from_parts(2_271, 0).saturating_mul(s.into()))
             .saturating_add(T::DbWeight::get().reads(10_u64))
             .saturating_add(T::DbWeight::get().writes(12_u64))
     }
@@ -303,7 +303,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 47_594 nanoseconds.
         Weight::from_parts(39_261_875, 14759)
             // Standard Error: 0
-            .saturating_add(Weight::from_ref_time(1_154).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_154, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads(9_u64))
             .saturating_add(T::DbWeight::get().writes(8_u64))
     }
@@ -315,7 +315,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 69_752 nanoseconds.
         Weight::from_parts(56_435_092, 30879)
             // Standard Error: 1
-            .saturating_add(Weight::from_ref_time(1_169).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_169, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads(13_u64))
             .saturating_add(T::DbWeight::get().writes(10_u64))
     }
@@ -327,7 +327,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 257_221 nanoseconds.
         Weight::from_parts(266_363_888, 40731)
             // Standard Error: 927
-            .saturating_add(Weight::from_ref_time(13_060).saturating_mul(q.into()))
+            .saturating_add(Weight::from_parts(13_060, 0).saturating_mul(q.into()))
             .saturating_add(T::DbWeight::get().reads(24_u64))
             .saturating_add(T::DbWeight::get().writes(21_u64))
     }
@@ -339,7 +339,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 272_686 nanoseconds.
         Weight::from_parts(284_450_996, 40581)
             // Standard Error: 786
-            .saturating_add(Weight::from_ref_time(260).saturating_mul(q.into()))
+            .saturating_add(Weight::from_parts(260, 0).saturating_mul(q.into()))
             .saturating_add(T::DbWeight::get().reads(24_u64))
             .saturating_add(T::DbWeight::get().writes(21_u64))
     }
@@ -351,7 +351,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 40_325 nanoseconds.
         Weight::from_parts(40_776_000, 2973)
             // Standard Error: 26_634
-            .saturating_add(Weight::from_ref_time(51_482_330).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(51_482_330, 0).saturating_mul(c.into()))
             .saturating_add(T::DbWeight::get().reads(1_u64))
             .saturating_add(T::DbWeight::get().writes(2_u64))
             .saturating_add(Weight::from_proof_size(2150).saturating_mul(c.into()))
@@ -362,9 +362,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_124 nanoseconds.
-        Weight::from_ref_time(56_808_831)
+        Weight::from_parts(56_808_831, 0)
             // Standard Error: 286_293
-            .saturating_add(Weight::from_ref_time(121_779_133).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(121_779_133, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn free(r: u32, ) -> Weight {
@@ -372,9 +372,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 193_689 nanoseconds.
-        Weight::from_ref_time(170_580_231)
+        Weight::from_parts(170_580_231, 0)
             // Standard Error: 278_566
-            .saturating_add(Weight::from_ref_time(123_420_096).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(123_420_096, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 256]`.
     fn gr_reserve_gas(r: u32, ) -> Weight {
@@ -382,9 +382,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_404 nanoseconds.
-        Weight::from_ref_time(88_583_428)
+        Weight::from_parts(88_583_428, 0)
             // Standard Error: 3_546
-            .saturating_add(Weight::from_ref_time(3_421_193).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_421_193, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 256]`.
     fn gr_unreserve_gas(r: u32, ) -> Weight {
@@ -392,9 +392,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 131_673 nanoseconds.
-        Weight::from_ref_time(139_085_832)
+        Weight::from_parts(139_085_832, 0)
             // Standard Error: 15_674
-            .saturating_add(Weight::from_ref_time(3_646_255).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_646_255, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_system_reserve_gas(r: u32, ) -> Weight {
@@ -402,9 +402,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_127 nanoseconds.
-        Weight::from_ref_time(107_304_676)
+        Weight::from_parts(107_304_676, 0)
             // Standard Error: 280_555
-            .saturating_add(Weight::from_ref_time(183_537_739).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(183_537_739, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_message_id(r: u32, ) -> Weight {
@@ -412,9 +412,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_204 nanoseconds.
-        Weight::from_ref_time(63_855_671)
+        Weight::from_parts(63_855_671, 0)
             // Standard Error: 255_652
-            .saturating_add(Weight::from_ref_time(180_882_229).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_882_229, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_origin(r: u32, ) -> Weight {
@@ -422,9 +422,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_747 nanoseconds.
-        Weight::from_ref_time(62_378_952)
+        Weight::from_parts(62_378_952, 0)
             // Standard Error: 243_378
-            .saturating_add(Weight::from_ref_time(181_354_986).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_354_986, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_program_id(r: u32, ) -> Weight {
@@ -432,9 +432,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_628 nanoseconds.
-        Weight::from_ref_time(62_023_316)
+        Weight::from_parts(62_023_316, 0)
             // Standard Error: 239_172
-            .saturating_add(Weight::from_ref_time(181_312_090).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_312_090, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_source(r: u32, ) -> Weight {
@@ -442,9 +442,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_107 nanoseconds.
-        Weight::from_ref_time(64_448_589)
+        Weight::from_parts(64_448_589, 0)
             // Standard Error: 243_926
-            .saturating_add(Weight::from_ref_time(181_908_539).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_908_539, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_value(r: u32, ) -> Weight {
@@ -452,9 +452,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_063 nanoseconds.
-        Weight::from_ref_time(63_994_362)
+        Weight::from_parts(63_994_362, 0)
             // Standard Error: 222_109
-            .saturating_add(Weight::from_ref_time(180_538_936).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_538_936, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_value_available(r: u32, ) -> Weight {
@@ -462,9 +462,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 79_507 nanoseconds.
-        Weight::from_ref_time(62_253_457)
+        Weight::from_parts(62_253_457, 0)
             // Standard Error: 237_685
-            .saturating_add(Weight::from_ref_time(180_220_624).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_220_624, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_gas_available(r: u32, ) -> Weight {
@@ -472,9 +472,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_164 nanoseconds.
-        Weight::from_ref_time(64_087_928)
+        Weight::from_parts(64_087_928, 0)
             // Standard Error: 254_664
-            .saturating_add(Weight::from_ref_time(180_159_594).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_159_594, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_size(r: u32, ) -> Weight {
@@ -482,9 +482,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_583 nanoseconds.
-        Weight::from_ref_time(67_596_795)
+        Weight::from_parts(67_596_795, 0)
             // Standard Error: 234_491
-            .saturating_add(Weight::from_ref_time(181_034_283).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_034_283, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_read(r: u32, ) -> Weight {
@@ -492,9 +492,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 707_674 nanoseconds.
-        Weight::from_ref_time(799_106_757)
+        Weight::from_parts(799_106_757, 0)
             // Standard Error: 290_054
-            .saturating_add(Weight::from_ref_time(237_370_449).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(237_370_449, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_read_per_kb(n: u32, ) -> Weight {
@@ -502,9 +502,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 952_371 nanoseconds.
-        Weight::from_ref_time(956_495_000)
+        Weight::from_parts(956_495_000, 0)
             // Standard Error: 60_878
-            .saturating_add(Weight::from_ref_time(14_227_144).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(14_227_144, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_block_height(r: u32, ) -> Weight {
@@ -512,9 +512,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_283 nanoseconds.
-        Weight::from_ref_time(67_213_364)
+        Weight::from_parts(67_213_364, 0)
             // Standard Error: 216_089
-            .saturating_add(Weight::from_ref_time(179_717_831).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(179_717_831, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_block_timestamp(r: u32, ) -> Weight {
@@ -522,9 +522,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_151 nanoseconds.
-        Weight::from_ref_time(64_827_395)
+        Weight::from_parts(64_827_395, 0)
             // Standard Error: 240_155
-            .saturating_add(Weight::from_ref_time(180_340_647).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_340_647, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 20]`.
     fn gr_random(n: u32, ) -> Weight {
@@ -532,9 +532,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_607 nanoseconds.
-        Weight::from_ref_time(97_606_147)
+        Weight::from_parts(97_606_147, 0)
             // Standard Error: 253_065
-            .saturating_add(Weight::from_ref_time(234_245_810).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(234_245_810, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_init(r: u32, ) -> Weight {
@@ -542,9 +542,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_345 nanoseconds.
-        Weight::from_ref_time(63_840_792)
+        Weight::from_parts(63_840_792, 0)
             // Standard Error: 226_520
-            .saturating_add(Weight::from_ref_time(187_131_229).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(187_131_229, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_push(r: u32, ) -> Weight {
@@ -552,9 +552,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 3_677_374 nanoseconds.
-        Weight::from_ref_time(3_820_987_062)
+        Weight::from_parts(3_820_987_062, 0)
             // Standard Error: 268_252
-            .saturating_add(Weight::from_ref_time(255_977_920).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(255_977_920, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_send_push_per_kb(n: u32, ) -> Weight {
@@ -562,9 +562,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 515_418 nanoseconds.
-        Weight::from_ref_time(522_188_000)
+        Weight::from_parts(522_188_000, 0)
             // Standard Error: 55_829
-            .saturating_add(Weight::from_ref_time(31_257_326).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(31_257_326, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_commit(r: u32, ) -> Weight {
@@ -572,9 +572,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_956 nanoseconds.
-        Weight::from_ref_time(135_884_682)
+        Weight::from_parts(135_884_682, 0)
             // Standard Error: 312_774
-            .saturating_add(Weight::from_ref_time(353_743_445).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(353_743_445, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_send_commit_per_kb(n: u32, ) -> Weight {
@@ -582,9 +582,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 437_809 nanoseconds.
-        Weight::from_ref_time(441_185_000)
+        Weight::from_parts(441_185_000, 0)
             // Standard Error: 64_589
-            .saturating_add(Weight::from_ref_time(21_143_950).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(21_143_950, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reservation_send_commit(r: u32, ) -> Weight {
@@ -592,9 +592,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 240_166 nanoseconds.
-        Weight::from_ref_time(307_423_566)
+        Weight::from_parts(307_423_566, 0)
             // Standard Error: 263_198
-            .saturating_add(Weight::from_ref_time(365_304_897).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(365_304_897, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reservation_send_commit_per_kb(n: u32, ) -> Weight {
@@ -602,9 +602,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 466_793 nanoseconds.
-        Weight::from_ref_time(479_126_000)
+        Weight::from_parts(479_126_000, 0)
             // Standard Error: 63_386
-            .saturating_add(Weight::from_ref_time(21_350_039).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(21_350_039, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_reply_commit(r: u32, ) -> Weight {
@@ -612,9 +612,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_102 nanoseconds.
-        Weight::from_ref_time(83_399_128)
+        Weight::from_parts(83_399_128, 0)
             // Standard Error: 229_588
-            .saturating_add(Weight::from_ref_time(20_817_771).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(20_817_771, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reply_commit_per_kb(n: u32, ) -> Weight {
@@ -622,9 +622,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 99_001 nanoseconds.
-        Weight::from_ref_time(86_637_798)
+        Weight::from_parts(86_637_798, 0)
             // Standard Error: 923
-            .saturating_add(Weight::from_ref_time(424_190).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(424_190, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reply_push(r: u32, ) -> Weight {
@@ -632,9 +632,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_499 nanoseconds.
-        Weight::from_ref_time(131_462_314)
+        Weight::from_parts(131_462_314, 0)
             // Standard Error: 296_583
-            .saturating_add(Weight::from_ref_time(246_894_431).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(246_894_431, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 8192]`.
     fn gr_reply_push_per_kb(n: u32, ) -> Weight {
@@ -642,9 +642,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 96_357 nanoseconds.
-        Weight::from_ref_time(97_184_000)
+        Weight::from_parts(97_184_000, 0)
             // Standard Error: 2_351
-            .saturating_add(Weight::from_ref_time(640_572).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(640_572, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_reservation_reply_commit(r: u32, ) -> Weight {
@@ -652,9 +652,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 89_493 nanoseconds.
-        Weight::from_ref_time(93_301_112)
+        Weight::from_parts(93_301_112, 0)
             // Standard Error: 231_085
-            .saturating_add(Weight::from_ref_time(9_751_187).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(9_751_187, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reservation_reply_commit_per_kb(n: u32, ) -> Weight {
@@ -662,9 +662,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 102_738 nanoseconds.
-        Weight::from_ref_time(85_959_957)
+        Weight::from_parts(85_959_957, 0)
             // Standard Error: 1_056
-            .saturating_add(Weight::from_ref_time(426_826).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(426_826, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reply_to(r: u32, ) -> Weight {
@@ -672,9 +672,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_593 nanoseconds.
-        Weight::from_ref_time(61_040_651)
+        Weight::from_parts(61_040_651, 0)
             // Standard Error: 231_867
-            .saturating_add(Weight::from_ref_time(183_706_745).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(183_706_745, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_signal_from(r: u32, ) -> Weight {
@@ -682,9 +682,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_324 nanoseconds.
-        Weight::from_ref_time(66_339_260)
+        Weight::from_parts(66_339_260, 0)
             // Standard Error: 254_057
-            .saturating_add(Weight::from_ref_time(181_778_743).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_778_743, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reply_push_input(r: u32, ) -> Weight {
@@ -692,9 +692,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 706_163 nanoseconds.
-        Weight::from_ref_time(746_906_968)
+        Weight::from_parts(746_906_968, 0)
             // Standard Error: 289_363
-            .saturating_add(Weight::from_ref_time(197_735_344).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(197_735_344, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reply_push_input_per_kb(n: u32, ) -> Weight {
@@ -702,9 +702,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 727_470 nanoseconds.
-        Weight::from_ref_time(764_436_591)
+        Weight::from_parts(764_436_591, 0)
             // Standard Error: 1_954
-            .saturating_add(Weight::from_ref_time(155_898).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(155_898, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_push_input(r: u32, ) -> Weight {
@@ -712,9 +712,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_379_140 nanoseconds.
-        Weight::from_ref_time(4_509_467_459)
+        Weight::from_parts(4_509_467_459, 0)
             // Standard Error: 293_145
-            .saturating_add(Weight::from_ref_time(202_192_351).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(202_192_351, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_send_push_input_per_kb(n: u32, ) -> Weight {
@@ -722,9 +722,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_116_085 nanoseconds.
-        Weight::from_ref_time(1_161_687_850)
+        Weight::from_parts(1_161_687_850, 0)
             // Standard Error: 9_577
-            .saturating_add(Weight::from_ref_time(13_711_920).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(13_711_920, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_debug(r: u32, ) -> Weight {
@@ -732,9 +732,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_884 nanoseconds.
-        Weight::from_ref_time(97_414_295)
+        Weight::from_parts(97_414_295, 0)
             // Standard Error: 266_242
-            .saturating_add(Weight::from_ref_time(191_541_864).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(191_541_864, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_debug_per_kb(n: u32, ) -> Weight {
@@ -742,9 +742,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 259_961 nanoseconds.
-        Weight::from_ref_time(261_294_000)
+        Weight::from_parts(261_294_000, 0)
             // Standard Error: 55_450
-            .saturating_add(Weight::from_ref_time(26_992_075).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(26_992_075, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_error(r: u32, ) -> Weight {
@@ -752,9 +752,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 94_153 nanoseconds.
-        Weight::from_ref_time(92_584_315)
+        Weight::from_parts(92_584_315, 0)
             // Standard Error: 263_504
-            .saturating_add(Weight::from_ref_time(235_583_714).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(235_583_714, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_status_code(r: u32, ) -> Weight {
@@ -762,9 +762,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_011 nanoseconds.
-        Weight::from_ref_time(60_532_712)
+        Weight::from_parts(60_532_712, 0)
             // Standard Error: 252_427
-            .saturating_add(Weight::from_ref_time(181_273_142).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_273_142, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_exit(r: u32, ) -> Weight {
@@ -772,9 +772,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 79_956 nanoseconds.
-        Weight::from_ref_time(83_128_273)
+        Weight::from_parts(83_128_273, 0)
             // Standard Error: 233_270
-            .saturating_add(Weight::from_ref_time(24_200_326).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(24_200_326, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_leave(r: u32, ) -> Weight {
@@ -782,9 +782,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_471 nanoseconds.
-        Weight::from_ref_time(84_933_897)
+        Weight::from_parts(84_933_897, 0)
             // Standard Error: 228_044
-            .saturating_add(Weight::from_ref_time(10_863_802).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(10_863_802, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_wait(r: u32, ) -> Weight {
@@ -792,9 +792,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 79_140 nanoseconds.
-        Weight::from_ref_time(82_413_287)
+        Weight::from_parts(82_413_287, 0)
             // Standard Error: 242_017
-            .saturating_add(Weight::from_ref_time(15_558_512).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(15_558_512, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_wait_for(r: u32, ) -> Weight {
@@ -802,9 +802,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 79_597 nanoseconds.
-        Weight::from_ref_time(83_256_853)
+        Weight::from_parts(83_256_853, 0)
             // Standard Error: 251_615
-            .saturating_add(Weight::from_ref_time(14_287_546).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(14_287_546, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_wait_up_to(r: u32, ) -> Weight {
@@ -812,9 +812,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_149 nanoseconds.
-        Weight::from_ref_time(84_067_253)
+        Weight::from_parts(84_067_253, 0)
             // Standard Error: 242_934
-            .saturating_add(Weight::from_ref_time(12_984_046).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(12_984_046, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_wake(r: u32, ) -> Weight {
@@ -822,9 +822,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 134_568 nanoseconds.
-        Weight::from_ref_time(191_754_546)
+        Weight::from_parts(191_754_546, 0)
             // Standard Error: 310_042
-            .saturating_add(Weight::from_ref_time(258_517_274).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(258_517_274, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_create_program_wgas(r: u32, ) -> Weight {
@@ -832,9 +832,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 89_961 nanoseconds.
-        Weight::from_ref_time(135_401_157)
+        Weight::from_parts(135_401_157, 0)
             // Standard Error: 330_013
-            .saturating_add(Weight::from_ref_time(438_218_419).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(438_218_419, 0).saturating_mul(r.into()))
     }
     /// The range of component `p` is `[0, 2048]`.
     /// The range of component `s` is `[1, 2048]`.
@@ -843,11 +843,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 44_618_378 nanoseconds.
-        Weight::from_ref_time(44_975_555_000)
+        Weight::from_parts(44_975_555_000, 0)
             // Standard Error: 259_430
-            .saturating_add(Weight::from_ref_time(7_365_489).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(7_365_489, 0).saturating_mul(p.into()))
             // Standard Error: 259_417
-            .saturating_add(Weight::from_ref_time(155_224_672).saturating_mul(s.into()))
+            .saturating_add(Weight::from_parts(155_224_672, 0).saturating_mul(s.into()))
     }
     /// The range of component `p` is `[0, 512]`.
     fn lazy_pages_signal_read(p: u32, ) -> Weight {
@@ -857,7 +857,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 81_060 nanoseconds.
         Weight::from_parts(116_078_081, 141)
             // Standard Error: 8_097
-            .saturating_add(Weight::from_ref_time(11_697_667).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(11_697_667, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
     }
@@ -869,7 +869,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 82_253 nanoseconds.
         Weight::from_parts(83_487_000, 141)
             // Standard Error: 44_559
-            .saturating_add(Weight::from_ref_time(36_153_847).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(36_153_847, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
     }
@@ -881,7 +881,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 6_059_320 nanoseconds.
         Weight::from_parts(6_026_768_509, 5068941)
             // Standard Error: 74_371
-            .saturating_add(Weight::from_ref_time(37_256_749).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(37_256_749, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads(2048_u64))
     }
     /// The range of component `p` is `[0, 512]`.
@@ -892,7 +892,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 82_117 nanoseconds.
         Weight::from_parts(84_007_000, 949)
             // Standard Error: 37_631
-            .saturating_add(Weight::from_ref_time(45_958_696).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(45_958_696, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(75606).saturating_mul(p.into()))
     }
@@ -904,7 +904,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 93_080 nanoseconds.
         Weight::from_parts(77_592_595, 506)
             // Standard Error: 74_142
-            .saturating_add(Weight::from_ref_time(37_638_856).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(37_638_856, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
     }
@@ -916,7 +916,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 748_265 nanoseconds.
         Weight::from_parts(748_224_476, 506)
             // Standard Error: 324_620
-            .saturating_add(Weight::from_ref_time(46_953_221).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(46_953_221, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
     }
@@ -928,7 +928,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 1_126_554 nanoseconds.
         Weight::from_parts(1_175_012_009, 316941)
             // Standard Error: 204_912
-            .saturating_add(Weight::from_ref_time(43_619_826).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(43_619_826, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads(128_u64))
     }
     /// The range of component `r` is `[50, 500]`.
@@ -937,9 +937,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_248_587 nanoseconds.
-        Weight::from_ref_time(4_247_395_501)
+        Weight::from_parts(4_247_395_501, 0)
             // Standard Error: 11_091
-            .saturating_add(Weight::from_ref_time(3_323_996).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_323_996, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[50, 500]`.
     fn instr_i32load(r: u32, ) -> Weight {
@@ -947,9 +947,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_244_604 nanoseconds.
-        Weight::from_ref_time(4_236_154_065)
+        Weight::from_parts(4_236_154_065, 0)
             // Standard Error: 10_679
-            .saturating_add(Weight::from_ref_time(3_383_238).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_383_238, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[50, 500]`.
     fn instr_i64store(r: u32, ) -> Weight {
@@ -957,9 +957,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 10_566_548 nanoseconds.
-        Weight::from_ref_time(10_110_815_063)
+        Weight::from_parts(10_110_815_063, 0)
             // Standard Error: 164_010
-            .saturating_add(Weight::from_ref_time(15_834_994).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(15_834_994, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[50, 500]`.
     fn instr_i32store(r: u32, ) -> Weight {
@@ -967,9 +967,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 10_594_891 nanoseconds.
-        Weight::from_ref_time(10_824_075_202)
+        Weight::from_parts(10_824_075_202, 0)
             // Standard Error: 246_795
-            .saturating_add(Weight::from_ref_time(8_865_110).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(8_865_110, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_select(r: u32, ) -> Weight {
@@ -977,9 +977,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_984 nanoseconds.
-        Weight::from_ref_time(2_022_000)
+        Weight::from_parts(2_022_000, 0)
             // Standard Error: 8_549
-            .saturating_add(Weight::from_ref_time(3_833_242).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_833_242, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_if(r: u32, ) -> Weight {
@@ -987,9 +987,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_972 nanoseconds.
-        Weight::from_ref_time(2_014_000)
+        Weight::from_parts(2_014_000, 0)
             // Standard Error: 4_696
-            .saturating_add(Weight::from_ref_time(3_071_869).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_071_869, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_br(r: u32, ) -> Weight {
@@ -997,9 +997,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_990 nanoseconds.
-        Weight::from_ref_time(3_141_848)
+        Weight::from_parts(3_141_848, 0)
             // Standard Error: 1_067
-            .saturating_add(Weight::from_ref_time(1_565_212).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_565_212, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_br_if(r: u32, ) -> Weight {
@@ -1007,9 +1007,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_910 nanoseconds.
-        Weight::from_ref_time(1_977_000)
+        Weight::from_parts(1_977_000, 0)
             // Standard Error: 10_190
-            .saturating_add(Weight::from_ref_time(2_916_284).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_916_284, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_br_table(r: u32, ) -> Weight {
@@ -1017,9 +1017,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_055 nanoseconds.
-        Weight::from_ref_time(2_124_000)
+        Weight::from_parts(2_124_000, 0)
             // Standard Error: 9_616
-            .saturating_add(Weight::from_ref_time(5_239_104).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(5_239_104, 0).saturating_mul(r.into()))
     }
     /// The range of component `e` is `[1, 256]`.
     fn instr_br_table_per_entry(e: u32, ) -> Weight {
@@ -1027,9 +1027,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 6_569 nanoseconds.
-        Weight::from_ref_time(5_561_073)
+        Weight::from_parts(5_561_073, 0)
             // Standard Error: 1_593
-            .saturating_add(Weight::from_ref_time(158_847).saturating_mul(e.into()))
+            .saturating_add(Weight::from_parts(158_847, 0).saturating_mul(e.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_call_const(r: u32, ) -> Weight {
@@ -1037,14 +1037,14 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_001 nanoseconds.
-        Weight::from_ref_time(4_351_879)
+        Weight::from_parts(4_351_879, 0)
             // Standard Error: 6_992
-            .saturating_add(Weight::from_ref_time(2_579_629).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_579_629, 0).saturating_mul(r.into()))
     }
     fn instr_i64const(r: u32, ) -> Weight {
-        Weight::from_ref_time(0)
-            .saturating_add(Weight::from_ref_time(2_579_629 -
-            2_411_507).saturating_mul(r.into()))
+        Weight::from_parts(0, 0)
+            .saturating_add(Weight::from_parts(2_579_629 -
+            2_411_507, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_call(r: u32, ) -> Weight {
@@ -1052,9 +1052,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_001 nanoseconds.
-        Weight::from_ref_time(4_619_716)
+        Weight::from_parts(4_619_716, 0)
             // Standard Error: 12_765
-            .saturating_add(Weight::from_ref_time(2_411_507).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_411_507, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_call_indirect(r: u32, ) -> Weight {
@@ -1062,9 +1062,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_321 nanoseconds.
-        Weight::from_ref_time(13_844_527)
+        Weight::from_parts(13_844_527, 0)
             // Standard Error: 28_587
-            .saturating_add(Weight::from_ref_time(10_571_661).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(10_571_661, 0).saturating_mul(r.into()))
     }
     /// The range of component `p` is `[0, 128]`.
     fn instr_call_indirect_per_param(p: u32, ) -> Weight {
@@ -1072,9 +1072,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 12_173 nanoseconds.
-        Weight::from_ref_time(4_877_843)
+        Weight::from_parts(4_877_843, 0)
             // Standard Error: 7_292
-            .saturating_add(Weight::from_ref_time(1_288_806).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_288_806, 0).saturating_mul(p.into()))
     }
     /// The range of component `l` is `[0, 1024]`.
     fn instr_call_per_local(l: u32, ) -> Weight {
@@ -1082,9 +1082,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_997 nanoseconds.
-        Weight::from_ref_time(5_260_743)
+        Weight::from_parts(5_260_743, 0)
             // Standard Error: 13
-            .saturating_add(Weight::from_ref_time(22).saturating_mul(l.into()))
+            .saturating_add(Weight::from_parts(22, 0).saturating_mul(l.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_local_get(r: u32, ) -> Weight {
@@ -1092,9 +1092,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_940 nanoseconds.
-        Weight::from_ref_time(1_830_043)
+        Weight::from_parts(1_830_043, 0)
             // Standard Error: 2_843
-            .saturating_add(Weight::from_ref_time(258_952).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(258_952, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_local_set(r: u32, ) -> Weight {
@@ -1102,9 +1102,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_991 nanoseconds.
-        Weight::from_ref_time(2_027_000)
+        Weight::from_parts(2_027_000, 0)
             // Standard Error: 5_369
-            .saturating_add(Weight::from_ref_time(736_000).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(736_000, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_local_tee(r: u32, ) -> Weight {
@@ -1112,9 +1112,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_000 nanoseconds.
-        Weight::from_ref_time(2_062_000)
+        Weight::from_parts(2_062_000, 0)
             // Standard Error: 4_630
-            .saturating_add(Weight::from_ref_time(719_367).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(719_367, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_global_get(r: u32, ) -> Weight {
@@ -1122,9 +1122,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_741 nanoseconds.
-        Weight::from_ref_time(2_616_782)
+        Weight::from_parts(2_616_782, 0)
             // Standard Error: 6_777
-            .saturating_add(Weight::from_ref_time(731_002).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(731_002, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_global_set(r: u32, ) -> Weight {
@@ -1132,9 +1132,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_795 nanoseconds.
-        Weight::from_ref_time(5_840_000)
+        Weight::from_parts(5_840_000, 0)
             // Standard Error: 8_144
-            .saturating_add(Weight::from_ref_time(1_259_731).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_259_731, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_memory_current(r: u32, ) -> Weight {
@@ -1142,9 +1142,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 6_596 nanoseconds.
-        Weight::from_ref_time(2_374_393)
+        Weight::from_parts(2_374_393, 0)
             // Standard Error: 12_129
-            .saturating_add(Weight::from_ref_time(6_823_668).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(6_823_668, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64clz(r: u32, ) -> Weight {
@@ -1152,9 +1152,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_980 nanoseconds.
-        Weight::from_ref_time(2_045_000)
+        Weight::from_parts(2_045_000, 0)
             // Standard Error: 8_388
-            .saturating_add(Weight::from_ref_time(3_325_416).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_325_416, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32clz(r: u32, ) -> Weight {
@@ -1162,9 +1162,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_950 nanoseconds.
-        Weight::from_ref_time(2_041_000)
+        Weight::from_parts(2_041_000, 0)
             // Standard Error: 7_692
-            .saturating_add(Weight::from_ref_time(3_034_615).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_034_615, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ctz(r: u32, ) -> Weight {
@@ -1172,9 +1172,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_981 nanoseconds.
-        Weight::from_ref_time(2_061_000)
+        Weight::from_parts(2_061_000, 0)
             // Standard Error: 8_251
-            .saturating_add(Weight::from_ref_time(3_019_593).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_019_593, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ctz(r: u32, ) -> Weight {
@@ -1182,9 +1182,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_980 nanoseconds.
-        Weight::from_ref_time(2_039_000)
+        Weight::from_parts(2_039_000, 0)
             // Standard Error: 6_062
-            .saturating_add(Weight::from_ref_time(2_592_066).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_592_066, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64popcnt(r: u32, ) -> Weight {
@@ -1192,9 +1192,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_036 nanoseconds.
-        Weight::from_ref_time(2_085_000)
+        Weight::from_parts(2_085_000, 0)
             // Standard Error: 3_811
-            .saturating_add(Weight::from_ref_time(537_423).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(537_423, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32popcnt(r: u32, ) -> Weight {
@@ -1202,9 +1202,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_987 nanoseconds.
-        Weight::from_ref_time(1_301_383)
+        Weight::from_parts(1_301_383, 0)
             // Standard Error: 3_109
-            .saturating_add(Weight::from_ref_time(381_295).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(381_295, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64eqz(r: u32, ) -> Weight {
@@ -1212,9 +1212,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_999 nanoseconds.
-        Weight::from_ref_time(2_069_000)
+        Weight::from_parts(2_069_000, 0)
             // Standard Error: 11_800
-            .saturating_add(Weight::from_ref_time(1_805_699).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_805_699, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32eqz(r: u32, ) -> Weight {
@@ -1222,9 +1222,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_014 nanoseconds.
-        Weight::from_ref_time(2_070_000)
+        Weight::from_parts(2_070_000, 0)
             // Standard Error: 8_255
-            .saturating_add(Weight::from_ref_time(1_114_949).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_114_949, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64extendsi32(r: u32, ) -> Weight {
@@ -1232,9 +1232,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_900 nanoseconds.
-        Weight::from_ref_time(1_701_470)
+        Weight::from_parts(1_701_470, 0)
             // Standard Error: 2_591
-            .saturating_add(Weight::from_ref_time(312_279).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(312_279, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64extendui32(r: u32, ) -> Weight {
@@ -1242,9 +1242,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_982 nanoseconds.
-        Weight::from_ref_time(2_190_000)
+        Weight::from_parts(2_190_000, 0)
             // Standard Error: 1_685
-            .saturating_add(Weight::from_ref_time(172_493).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(172_493, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32wrapi64(r: u32, ) -> Weight {
@@ -1252,9 +1252,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_041 nanoseconds.
-        Weight::from_ref_time(2_605_622)
+        Weight::from_parts(2_605_622, 0)
             // Standard Error: 1_576
-            .saturating_add(Weight::from_ref_time(159_097).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(159_097, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64eq(r: u32, ) -> Weight {
@@ -1262,9 +1262,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_918 nanoseconds.
-        Weight::from_ref_time(2_021_000)
+        Weight::from_parts(2_021_000, 0)
             // Standard Error: 11_160
-            .saturating_add(Weight::from_ref_time(1_781_573).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_781_573, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32eq(r: u32, ) -> Weight {
@@ -1272,9 +1272,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_990 nanoseconds.
-        Weight::from_ref_time(2_047_000)
+        Weight::from_parts(2_047_000, 0)
             // Standard Error: 6_989
-            .saturating_add(Weight::from_ref_time(1_086_510).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_086_510, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ne(r: u32, ) -> Weight {
@@ -1282,9 +1282,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_991 nanoseconds.
-        Weight::from_ref_time(2_035_000)
+        Weight::from_parts(2_035_000, 0)
             // Standard Error: 9_623
-            .saturating_add(Weight::from_ref_time(1_797_223).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_797_223, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ne(r: u32, ) -> Weight {
@@ -1292,9 +1292,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_957 nanoseconds.
-        Weight::from_ref_time(2_016_000)
+        Weight::from_parts(2_016_000, 0)
             // Standard Error: 7_516
-            .saturating_add(Weight::from_ref_time(1_100_146).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_100_146, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64lts(r: u32, ) -> Weight {
@@ -1302,9 +1302,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_975 nanoseconds.
-        Weight::from_ref_time(2_042_000)
+        Weight::from_parts(2_042_000, 0)
             // Standard Error: 9_617
-            .saturating_add(Weight::from_ref_time(1_798_574).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_798_574, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32lts(r: u32, ) -> Weight {
@@ -1312,9 +1312,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_919 nanoseconds.
-        Weight::from_ref_time(2_044_000)
+        Weight::from_parts(2_044_000, 0)
             // Standard Error: 7_469
-            .saturating_add(Weight::from_ref_time(1_119_079).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_119_079, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ltu(r: u32, ) -> Weight {
@@ -1322,9 +1322,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_983 nanoseconds.
-        Weight::from_ref_time(2_025_000)
+        Weight::from_parts(2_025_000, 0)
             // Standard Error: 11_078
-            .saturating_add(Weight::from_ref_time(1_866_193).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_866_193, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ltu(r: u32, ) -> Weight {
@@ -1332,9 +1332,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_945 nanoseconds.
-        Weight::from_ref_time(2_063_000)
+        Weight::from_parts(2_063_000, 0)
             // Standard Error: 7_762
-            .saturating_add(Weight::from_ref_time(1_098_384).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_098_384, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64gts(r: u32, ) -> Weight {
@@ -1342,9 +1342,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_984 nanoseconds.
-        Weight::from_ref_time(2_013_000)
+        Weight::from_parts(2_013_000, 0)
             // Standard Error: 13_010
-            .saturating_add(Weight::from_ref_time(1_809_632).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_809_632, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32gts(r: u32, ) -> Weight {
@@ -1352,9 +1352,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_936 nanoseconds.
-        Weight::from_ref_time(2_085_000)
+        Weight::from_parts(2_085_000, 0)
             // Standard Error: 7_662
-            .saturating_add(Weight::from_ref_time(1_077_967).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_077_967, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64gtu(r: u32, ) -> Weight {
@@ -1362,9 +1362,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_960 nanoseconds.
-        Weight::from_ref_time(2_013_000)
+        Weight::from_parts(2_013_000, 0)
             // Standard Error: 11_774
-            .saturating_add(Weight::from_ref_time(1_786_196).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_786_196, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32gtu(r: u32, ) -> Weight {
@@ -1372,9 +1372,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_938 nanoseconds.
-        Weight::from_ref_time(1_981_000)
+        Weight::from_parts(1_981_000, 0)
             // Standard Error: 7_698
-            .saturating_add(Weight::from_ref_time(1_068_379).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_068_379, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64les(r: u32, ) -> Weight {
@@ -1382,9 +1382,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_992 nanoseconds.
-        Weight::from_ref_time(2_053_000)
+        Weight::from_parts(2_053_000, 0)
             // Standard Error: 11_716
-            .saturating_add(Weight::from_ref_time(1_786_578).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_786_578, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32les(r: u32, ) -> Weight {
@@ -1392,9 +1392,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_940 nanoseconds.
-        Weight::from_ref_time(2_005_000)
+        Weight::from_parts(2_005_000, 0)
             // Standard Error: 7_815
-            .saturating_add(Weight::from_ref_time(1_090_447).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_090_447, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64leu(r: u32, ) -> Weight {
@@ -1402,9 +1402,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_930 nanoseconds.
-        Weight::from_ref_time(2_037_000)
+        Weight::from_parts(2_037_000, 0)
             // Standard Error: 14_146
-            .saturating_add(Weight::from_ref_time(1_837_345).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_837_345, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32leu(r: u32, ) -> Weight {
@@ -1412,9 +1412,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_953 nanoseconds.
-        Weight::from_ref_time(1_994_000)
+        Weight::from_parts(1_994_000, 0)
             // Standard Error: 7_326
-            .saturating_add(Weight::from_ref_time(1_124_069).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_124_069, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ges(r: u32, ) -> Weight {
@@ -1422,9 +1422,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_990 nanoseconds.
-        Weight::from_ref_time(2_022_000)
+        Weight::from_parts(2_022_000, 0)
             // Standard Error: 11_502
-            .saturating_add(Weight::from_ref_time(1_784_579).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_784_579, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ges(r: u32, ) -> Weight {
@@ -1432,9 +1432,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_955 nanoseconds.
-        Weight::from_ref_time(2_030_000)
+        Weight::from_parts(2_030_000, 0)
             // Standard Error: 7_269
-            .saturating_add(Weight::from_ref_time(1_087_418).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_087_418, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64geu(r: u32, ) -> Weight {
@@ -1442,9 +1442,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_966 nanoseconds.
-        Weight::from_ref_time(2_021_000)
+        Weight::from_parts(2_021_000, 0)
             // Standard Error: 10_931
-            .saturating_add(Weight::from_ref_time(1_779_890).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_779_890, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32geu(r: u32, ) -> Weight {
@@ -1452,9 +1452,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_985 nanoseconds.
-        Weight::from_ref_time(2_057_000)
+        Weight::from_parts(2_057_000, 0)
             // Standard Error: 7_783
-            .saturating_add(Weight::from_ref_time(1_115_230).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_115_230, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64add(r: u32, ) -> Weight {
@@ -1462,9 +1462,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_927 nanoseconds.
-        Weight::from_ref_time(2_053_000)
+        Weight::from_parts(2_053_000, 0)
             // Standard Error: 7_508
-            .saturating_add(Weight::from_ref_time(1_212_190).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_212_190, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32add(r: u32, ) -> Weight {
@@ -1472,9 +1472,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_009 nanoseconds.
-        Weight::from_ref_time(2_075_000)
+        Weight::from_parts(2_075_000, 0)
             // Standard Error: 3_877
-            .saturating_add(Weight::from_ref_time(576_488).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(576_488, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64sub(r: u32, ) -> Weight {
@@ -1482,9 +1482,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_909 nanoseconds.
-        Weight::from_ref_time(1_957_000)
+        Weight::from_parts(1_957_000, 0)
             // Standard Error: 7_060
-            .saturating_add(Weight::from_ref_time(1_174_700).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_174_700, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32sub(r: u32, ) -> Weight {
@@ -1492,9 +1492,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_985 nanoseconds.
-        Weight::from_ref_time(2_041_000)
+        Weight::from_parts(2_041_000, 0)
             // Standard Error: 4_555
-            .saturating_add(Weight::from_ref_time(594_904).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(594_904, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64mul(r: u32, ) -> Weight {
@@ -1502,9 +1502,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_982 nanoseconds.
-        Weight::from_ref_time(2_073_000)
+        Weight::from_parts(2_073_000, 0)
             // Standard Error: 12_025
-            .saturating_add(Weight::from_ref_time(1_724_065).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_724_065, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32mul(r: u32, ) -> Weight {
@@ -1512,9 +1512,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_957 nanoseconds.
-        Weight::from_ref_time(2_007_000)
+        Weight::from_parts(2_007_000, 0)
             // Standard Error: 8_716
-            .saturating_add(Weight::from_ref_time(1_150_408).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_150_408, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64divs(r: u32, ) -> Weight {
@@ -1522,9 +1522,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_884 nanoseconds.
-        Weight::from_ref_time(1_144_446)
+        Weight::from_parts(1_144_446, 0)
             // Standard Error: 10_547
-            .saturating_add(Weight::from_ref_time(2_675_861).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_675_861, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32divs(r: u32, ) -> Weight {
@@ -1532,9 +1532,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_006 nanoseconds.
-        Weight::from_ref_time(69_582)
+        Weight::from_parts(69_582, 0)
             // Standard Error: 11_472
-            .saturating_add(Weight::from_ref_time(2_348_861).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_348_861, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64divu(r: u32, ) -> Weight {
@@ -1542,9 +1542,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_935 nanoseconds.
-        Weight::from_ref_time(1_504_156)
+        Weight::from_parts(1_504_156, 0)
             // Standard Error: 16_606
-            .saturating_add(Weight::from_ref_time(2_805_608).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_805_608, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32divu(r: u32, ) -> Weight {
@@ -1552,9 +1552,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_982 nanoseconds.
-        Weight::from_ref_time(7_507_453)
+        Weight::from_parts(7_507_453, 0)
             // Standard Error: 27_413
-            .saturating_add(Weight::from_ref_time(2_106_829).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_106_829, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64rems(r: u32, ) -> Weight {
@@ -1562,9 +1562,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_957 nanoseconds.
-        Weight::from_ref_time(2_062_000)
+        Weight::from_parts(2_062_000, 0)
             // Standard Error: 22_291
-            .saturating_add(Weight::from_ref_time(9_226_033).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(9_226_033, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32rems(r: u32, ) -> Weight {
@@ -1572,9 +1572,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_952 nanoseconds.
-        Weight::from_ref_time(737_483)
+        Weight::from_parts(737_483, 0)
             // Standard Error: 45_126
-            .saturating_add(Weight::from_ref_time(7_533_584).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(7_533_584, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64remu(r: u32, ) -> Weight {
@@ -1582,9 +1582,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_957 nanoseconds.
-        Weight::from_ref_time(3_376_184)
+        Weight::from_parts(3_376_184, 0)
             // Standard Error: 20_172
-            .saturating_add(Weight::from_ref_time(2_862_201).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_862_201, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32remu(r: u32, ) -> Weight {
@@ -1592,9 +1592,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_982 nanoseconds.
-        Weight::from_ref_time(2_067_000)
+        Weight::from_parts(2_067_000, 0)
             // Standard Error: 5_984
-            .saturating_add(Weight::from_ref_time(2_531_767).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_531_767, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64and(r: u32, ) -> Weight {
@@ -1602,9 +1602,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_968 nanoseconds.
-        Weight::from_ref_time(2_028_000)
+        Weight::from_parts(2_028_000, 0)
             // Standard Error: 8_261
-            .saturating_add(Weight::from_ref_time(1_261_509).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_261_509, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32and(r: u32, ) -> Weight {
@@ -1612,9 +1612,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_029 nanoseconds.
-        Weight::from_ref_time(2_047_000)
+        Weight::from_parts(2_047_000, 0)
             // Standard Error: 4_691
-            .saturating_add(Weight::from_ref_time(613_890).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(613_890, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64or(r: u32, ) -> Weight {
@@ -1622,9 +1622,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_946 nanoseconds.
-        Weight::from_ref_time(2_035_000)
+        Weight::from_parts(2_035_000, 0)
             // Standard Error: 8_090
-            .saturating_add(Weight::from_ref_time(1_206_785).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_206_785, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32or(r: u32, ) -> Weight {
@@ -1632,9 +1632,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_022 nanoseconds.
-        Weight::from_ref_time(2_069_000)
+        Weight::from_parts(2_069_000, 0)
             // Standard Error: 4_558
-            .saturating_add(Weight::from_ref_time(600_340).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(600_340, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64xor(r: u32, ) -> Weight {
@@ -1642,9 +1642,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_031 nanoseconds.
-        Weight::from_ref_time(2_088_000)
+        Weight::from_parts(2_088_000, 0)
             // Standard Error: 7_497
-            .saturating_add(Weight::from_ref_time(1_200_146).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_200_146, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32xor(r: u32, ) -> Weight {
@@ -1652,9 +1652,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_007 nanoseconds.
-        Weight::from_ref_time(2_047_000)
+        Weight::from_parts(2_047_000, 0)
             // Standard Error: 4_583
-            .saturating_add(Weight::from_ref_time(601_809).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(601_809, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64shl(r: u32, ) -> Weight {
@@ -1662,9 +1662,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_968 nanoseconds.
-        Weight::from_ref_time(2_035_000)
+        Weight::from_parts(2_035_000, 0)
             // Standard Error: 7_148
-            .saturating_add(Weight::from_ref_time(1_033_991).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_033_991, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32shl(r: u32, ) -> Weight {
@@ -1672,9 +1672,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_951 nanoseconds.
-        Weight::from_ref_time(2_036_000)
+        Weight::from_parts(2_036_000, 0)
             // Standard Error: 3_798
-            .saturating_add(Weight::from_ref_time(557_173).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(557_173, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64shrs(r: u32, ) -> Weight {
@@ -1682,9 +1682,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_008 nanoseconds.
-        Weight::from_ref_time(2_059_000)
+        Weight::from_parts(2_059_000, 0)
             // Standard Error: 6_814
-            .saturating_add(Weight::from_ref_time(1_071_968).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_071_968, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32shrs(r: u32, ) -> Weight {
@@ -1692,9 +1692,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_988 nanoseconds.
-        Weight::from_ref_time(2_050_000)
+        Weight::from_parts(2_050_000, 0)
             // Standard Error: 3_646
-            .saturating_add(Weight::from_ref_time(552_674).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(552_674, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64shru(r: u32, ) -> Weight {
@@ -1702,9 +1702,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_975 nanoseconds.
-        Weight::from_ref_time(2_007_000)
+        Weight::from_parts(2_007_000, 0)
             // Standard Error: 6_233
-            .saturating_add(Weight::from_ref_time(1_020_688).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_020_688, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32shru(r: u32, ) -> Weight {
@@ -1712,9 +1712,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_921 nanoseconds.
-        Weight::from_ref_time(2_007_000)
+        Weight::from_parts(2_007_000, 0)
             // Standard Error: 3_338
-            .saturating_add(Weight::from_ref_time(524_904).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(524_904, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64rotl(r: u32, ) -> Weight {
@@ -1722,9 +1722,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_035 nanoseconds.
-        Weight::from_ref_time(2_096_000)
+        Weight::from_parts(2_096_000, 0)
             // Standard Error: 6_820
-            .saturating_add(Weight::from_ref_time(989_478).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(989_478, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32rotl(r: u32, ) -> Weight {
@@ -1732,9 +1732,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_917 nanoseconds.
-        Weight::from_ref_time(10_071)
+        Weight::from_parts(10_071, 0)
             // Standard Error: 5_314
-            .saturating_add(Weight::from_ref_time(585_983).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(585_983, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64rotr(r: u32, ) -> Weight {
@@ -1742,9 +1742,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_993 nanoseconds.
-        Weight::from_ref_time(2_062_000)
+        Weight::from_parts(2_062_000, 0)
             // Standard Error: 7_508
-            .saturating_add(Weight::from_ref_time(1_010_373).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_010_373, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32rotr(r: u32, ) -> Weight {
@@ -1752,9 +1752,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_944 nanoseconds.
-        Weight::from_ref_time(1_993_000)
+        Weight::from_parts(1_993_000, 0)
             // Standard Error: 3_741
-            .saturating_add(Weight::from_ref_time(549_410).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(549_410, 0).saturating_mul(r.into()))
     }
 }
 
@@ -1780,9 +1780,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 714 nanoseconds.
-        Weight::from_ref_time(762_000)
+        Weight::from_parts(762_000, 0)
             // Standard Error: 916
-            .saturating_add(Weight::from_ref_time(249_959).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(249_959, 0).saturating_mul(c.into()))
             .saturating_add(RocksDbWeight::get().writes(1_u64))
     }
     /// The range of component `c` is `[0, 512]`.
@@ -1793,7 +1793,7 @@ impl WeightInfo for () {
         // Minimum execution time: 2_591 nanoseconds.
         Weight::from_parts(2_658_000, 2546)
             // Standard Error: 1_587
-            .saturating_add(Weight::from_ref_time(691_791).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(691_791, 0).saturating_mul(c.into()))
             .saturating_add(RocksDbWeight::get().reads(1_u64))
             .saturating_add(Weight::from_proof_size(1024).saturating_mul(c.into()))
     }
@@ -1803,9 +1803,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 47_048 nanoseconds.
-        Weight::from_ref_time(80_532_528)
+        Weight::from_parts(80_532_528, 0)
             // Standard Error: 4_561
-            .saturating_add(Weight::from_ref_time(2_208_073).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(2_208_073, 0).saturating_mul(c.into()))
     }
     fn claim_value() -> Weight {
         // Proof Size summary in bytes:
@@ -1824,7 +1824,7 @@ impl WeightInfo for () {
         // Minimum execution time: 55_252 nanoseconds.
         Weight::from_parts(39_508_166, 3010)
             // Standard Error: 54_990
-            .saturating_add(Weight::from_ref_time(53_653_596).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(53_653_596, 0).saturating_mul(c.into()))
             .saturating_add(RocksDbWeight::get().reads(2_u64))
             .saturating_add(RocksDbWeight::get().writes(4_u64))
     }
@@ -1836,7 +1836,7 @@ impl WeightInfo for () {
         // Minimum execution time: 45_837 nanoseconds.
         Weight::from_parts(67_499_867, 17714)
             // Standard Error: 0
-            .saturating_add(Weight::from_ref_time(2_312).saturating_mul(s.into()))
+            .saturating_add(Weight::from_parts(2_312, 0).saturating_mul(s.into()))
             .saturating_add(RocksDbWeight::get().reads(10_u64))
             .saturating_add(RocksDbWeight::get().writes(8_u64))
     }
@@ -1849,9 +1849,9 @@ impl WeightInfo for () {
         // Minimum execution time: 9_772_476 nanoseconds.
         Weight::from_parts(137_998_681, 13432)
             // Standard Error: 153_459
-            .saturating_add(Weight::from_ref_time(54_040_008).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(54_040_008, 0).saturating_mul(c.into()))
             // Standard Error: 9
-            .saturating_add(Weight::from_ref_time(2_271).saturating_mul(s.into()))
+            .saturating_add(Weight::from_parts(2_271, 0).saturating_mul(s.into()))
             .saturating_add(RocksDbWeight::get().reads(10_u64))
             .saturating_add(RocksDbWeight::get().writes(12_u64))
     }
@@ -1863,7 +1863,7 @@ impl WeightInfo for () {
         // Minimum execution time: 47_594 nanoseconds.
         Weight::from_parts(39_261_875, 14759)
             // Standard Error: 0
-            .saturating_add(Weight::from_ref_time(1_154).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_154, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads(9_u64))
             .saturating_add(RocksDbWeight::get().writes(8_u64))
     }
@@ -1875,7 +1875,7 @@ impl WeightInfo for () {
         // Minimum execution time: 69_752 nanoseconds.
         Weight::from_parts(56_435_092, 30879)
             // Standard Error: 1
-            .saturating_add(Weight::from_ref_time(1_169).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_169, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads(13_u64))
             .saturating_add(RocksDbWeight::get().writes(10_u64))
     }
@@ -1887,7 +1887,7 @@ impl WeightInfo for () {
         // Minimum execution time: 257_221 nanoseconds.
         Weight::from_parts(266_363_888, 40731)
             // Standard Error: 927
-            .saturating_add(Weight::from_ref_time(13_060).saturating_mul(q.into()))
+            .saturating_add(Weight::from_parts(13_060, 0).saturating_mul(q.into()))
             .saturating_add(RocksDbWeight::get().reads(24_u64))
             .saturating_add(RocksDbWeight::get().writes(21_u64))
     }
@@ -1899,7 +1899,7 @@ impl WeightInfo for () {
         // Minimum execution time: 272_686 nanoseconds.
         Weight::from_parts(284_450_996, 40581)
             // Standard Error: 786
-            .saturating_add(Weight::from_ref_time(260).saturating_mul(q.into()))
+            .saturating_add(Weight::from_parts(260, 0).saturating_mul(q.into()))
             .saturating_add(RocksDbWeight::get().reads(24_u64))
             .saturating_add(RocksDbWeight::get().writes(21_u64))
     }
@@ -1911,7 +1911,7 @@ impl WeightInfo for () {
         // Minimum execution time: 40_325 nanoseconds.
         Weight::from_parts(40_776_000, 2973)
             // Standard Error: 26_634
-            .saturating_add(Weight::from_ref_time(51_482_330).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(51_482_330, 0).saturating_mul(c.into()))
             .saturating_add(RocksDbWeight::get().reads(1_u64))
             .saturating_add(RocksDbWeight::get().writes(2_u64))
             .saturating_add(Weight::from_proof_size(2150).saturating_mul(c.into()))
@@ -1922,9 +1922,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_124 nanoseconds.
-        Weight::from_ref_time(56_808_831)
+        Weight::from_parts(56_808_831, 0)
             // Standard Error: 286_293
-            .saturating_add(Weight::from_ref_time(121_779_133).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(121_779_133, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn free(r: u32, ) -> Weight {
@@ -1932,9 +1932,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 193_689 nanoseconds.
-        Weight::from_ref_time(170_580_231)
+        Weight::from_parts(170_580_231, 0)
             // Standard Error: 278_566
-            .saturating_add(Weight::from_ref_time(123_420_096).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(123_420_096, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 256]`.
     fn gr_reserve_gas(r: u32, ) -> Weight {
@@ -1942,9 +1942,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_404 nanoseconds.
-        Weight::from_ref_time(88_583_428)
+        Weight::from_parts(88_583_428, 0)
             // Standard Error: 3_546
-            .saturating_add(Weight::from_ref_time(3_421_193).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_421_193, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 256]`.
     fn gr_unreserve_gas(r: u32, ) -> Weight {
@@ -1952,9 +1952,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 131_673 nanoseconds.
-        Weight::from_ref_time(139_085_832)
+        Weight::from_parts(139_085_832, 0)
             // Standard Error: 15_674
-            .saturating_add(Weight::from_ref_time(3_646_255).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_646_255, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_system_reserve_gas(r: u32, ) -> Weight {
@@ -1962,9 +1962,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_127 nanoseconds.
-        Weight::from_ref_time(107_304_676)
+        Weight::from_parts(107_304_676, 0)
             // Standard Error: 280_555
-            .saturating_add(Weight::from_ref_time(183_537_739).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(183_537_739, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_message_id(r: u32, ) -> Weight {
@@ -1972,9 +1972,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_204 nanoseconds.
-        Weight::from_ref_time(63_855_671)
+        Weight::from_parts(63_855_671, 0)
             // Standard Error: 255_652
-            .saturating_add(Weight::from_ref_time(180_882_229).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_882_229, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_origin(r: u32, ) -> Weight {
@@ -1982,9 +1982,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_747 nanoseconds.
-        Weight::from_ref_time(62_378_952)
+        Weight::from_parts(62_378_952, 0)
             // Standard Error: 243_378
-            .saturating_add(Weight::from_ref_time(181_354_986).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_354_986, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_program_id(r: u32, ) -> Weight {
@@ -1992,9 +1992,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_628 nanoseconds.
-        Weight::from_ref_time(62_023_316)
+        Weight::from_parts(62_023_316, 0)
             // Standard Error: 239_172
-            .saturating_add(Weight::from_ref_time(181_312_090).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_312_090, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_source(r: u32, ) -> Weight {
@@ -2002,9 +2002,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_107 nanoseconds.
-        Weight::from_ref_time(64_448_589)
+        Weight::from_parts(64_448_589, 0)
             // Standard Error: 243_926
-            .saturating_add(Weight::from_ref_time(181_908_539).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_908_539, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_value(r: u32, ) -> Weight {
@@ -2012,9 +2012,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_063 nanoseconds.
-        Weight::from_ref_time(63_994_362)
+        Weight::from_parts(63_994_362, 0)
             // Standard Error: 222_109
-            .saturating_add(Weight::from_ref_time(180_538_936).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_538_936, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_value_available(r: u32, ) -> Weight {
@@ -2022,9 +2022,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 79_507 nanoseconds.
-        Weight::from_ref_time(62_253_457)
+        Weight::from_parts(62_253_457, 0)
             // Standard Error: 237_685
-            .saturating_add(Weight::from_ref_time(180_220_624).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_220_624, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_gas_available(r: u32, ) -> Weight {
@@ -2032,9 +2032,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_164 nanoseconds.
-        Weight::from_ref_time(64_087_928)
+        Weight::from_parts(64_087_928, 0)
             // Standard Error: 254_664
-            .saturating_add(Weight::from_ref_time(180_159_594).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_159_594, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_size(r: u32, ) -> Weight {
@@ -2042,9 +2042,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_583 nanoseconds.
-        Weight::from_ref_time(67_596_795)
+        Weight::from_parts(67_596_795, 0)
             // Standard Error: 234_491
-            .saturating_add(Weight::from_ref_time(181_034_283).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_034_283, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_read(r: u32, ) -> Weight {
@@ -2052,9 +2052,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 707_674 nanoseconds.
-        Weight::from_ref_time(799_106_757)
+        Weight::from_parts(799_106_757, 0)
             // Standard Error: 290_054
-            .saturating_add(Weight::from_ref_time(237_370_449).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(237_370_449, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_read_per_kb(n: u32, ) -> Weight {
@@ -2062,9 +2062,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 952_371 nanoseconds.
-        Weight::from_ref_time(956_495_000)
+        Weight::from_parts(956_495_000, 0)
             // Standard Error: 60_878
-            .saturating_add(Weight::from_ref_time(14_227_144).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(14_227_144, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_block_height(r: u32, ) -> Weight {
@@ -2072,9 +2072,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_283 nanoseconds.
-        Weight::from_ref_time(67_213_364)
+        Weight::from_parts(67_213_364, 0)
             // Standard Error: 216_089
-            .saturating_add(Weight::from_ref_time(179_717_831).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(179_717_831, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_block_timestamp(r: u32, ) -> Weight {
@@ -2082,9 +2082,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_151 nanoseconds.
-        Weight::from_ref_time(64_827_395)
+        Weight::from_parts(64_827_395, 0)
             // Standard Error: 240_155
-            .saturating_add(Weight::from_ref_time(180_340_647).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_340_647, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 20]`.
     fn gr_random(n: u32, ) -> Weight {
@@ -2092,9 +2092,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_607 nanoseconds.
-        Weight::from_ref_time(97_606_147)
+        Weight::from_parts(97_606_147, 0)
             // Standard Error: 253_065
-            .saturating_add(Weight::from_ref_time(234_245_810).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(234_245_810, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_init(r: u32, ) -> Weight {
@@ -2102,9 +2102,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_345 nanoseconds.
-        Weight::from_ref_time(63_840_792)
+        Weight::from_parts(63_840_792, 0)
             // Standard Error: 226_520
-            .saturating_add(Weight::from_ref_time(187_131_229).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(187_131_229, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_push(r: u32, ) -> Weight {
@@ -2112,9 +2112,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 3_677_374 nanoseconds.
-        Weight::from_ref_time(3_820_987_062)
+        Weight::from_parts(3_820_987_062, 0)
             // Standard Error: 268_252
-            .saturating_add(Weight::from_ref_time(255_977_920).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(255_977_920, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_send_push_per_kb(n: u32, ) -> Weight {
@@ -2122,9 +2122,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 515_418 nanoseconds.
-        Weight::from_ref_time(522_188_000)
+        Weight::from_parts(522_188_000, 0)
             // Standard Error: 55_829
-            .saturating_add(Weight::from_ref_time(31_257_326).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(31_257_326, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_commit(r: u32, ) -> Weight {
@@ -2132,9 +2132,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_956 nanoseconds.
-        Weight::from_ref_time(135_884_682)
+        Weight::from_parts(135_884_682, 0)
             // Standard Error: 312_774
-            .saturating_add(Weight::from_ref_time(353_743_445).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(353_743_445, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_send_commit_per_kb(n: u32, ) -> Weight {
@@ -2142,9 +2142,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 437_809 nanoseconds.
-        Weight::from_ref_time(441_185_000)
+        Weight::from_parts(441_185_000, 0)
             // Standard Error: 64_589
-            .saturating_add(Weight::from_ref_time(21_143_950).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(21_143_950, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reservation_send_commit(r: u32, ) -> Weight {
@@ -2152,9 +2152,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 240_166 nanoseconds.
-        Weight::from_ref_time(307_423_566)
+        Weight::from_parts(307_423_566, 0)
             // Standard Error: 263_198
-            .saturating_add(Weight::from_ref_time(365_304_897).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(365_304_897, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reservation_send_commit_per_kb(n: u32, ) -> Weight {
@@ -2162,9 +2162,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 466_793 nanoseconds.
-        Weight::from_ref_time(479_126_000)
+        Weight::from_parts(479_126_000, 0)
             // Standard Error: 63_386
-            .saturating_add(Weight::from_ref_time(21_350_039).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(21_350_039, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_reply_commit(r: u32, ) -> Weight {
@@ -2172,9 +2172,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_102 nanoseconds.
-        Weight::from_ref_time(83_399_128)
+        Weight::from_parts(83_399_128, 0)
             // Standard Error: 229_588
-            .saturating_add(Weight::from_ref_time(20_817_771).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(20_817_771, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reply_commit_per_kb(n: u32, ) -> Weight {
@@ -2182,9 +2182,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 99_001 nanoseconds.
-        Weight::from_ref_time(86_637_798)
+        Weight::from_parts(86_637_798, 0)
             // Standard Error: 923
-            .saturating_add(Weight::from_ref_time(424_190).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(424_190, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reply_push(r: u32, ) -> Weight {
@@ -2192,9 +2192,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_499 nanoseconds.
-        Weight::from_ref_time(131_462_314)
+        Weight::from_parts(131_462_314, 0)
             // Standard Error: 296_583
-            .saturating_add(Weight::from_ref_time(246_894_431).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(246_894_431, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 8192]`.
     fn gr_reply_push_per_kb(n: u32, ) -> Weight {
@@ -2202,9 +2202,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 96_357 nanoseconds.
-        Weight::from_ref_time(97_184_000)
+        Weight::from_parts(97_184_000, 0)
             // Standard Error: 2_351
-            .saturating_add(Weight::from_ref_time(640_572).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(640_572, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_reservation_reply_commit(r: u32, ) -> Weight {
@@ -2212,9 +2212,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 89_493 nanoseconds.
-        Weight::from_ref_time(93_301_112)
+        Weight::from_parts(93_301_112, 0)
             // Standard Error: 231_085
-            .saturating_add(Weight::from_ref_time(9_751_187).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(9_751_187, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reservation_reply_commit_per_kb(n: u32, ) -> Weight {
@@ -2222,9 +2222,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 102_738 nanoseconds.
-        Weight::from_ref_time(85_959_957)
+        Weight::from_parts(85_959_957, 0)
             // Standard Error: 1_056
-            .saturating_add(Weight::from_ref_time(426_826).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(426_826, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reply_to(r: u32, ) -> Weight {
@@ -2232,9 +2232,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_593 nanoseconds.
-        Weight::from_ref_time(61_040_651)
+        Weight::from_parts(61_040_651, 0)
             // Standard Error: 231_867
-            .saturating_add(Weight::from_ref_time(183_706_745).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(183_706_745, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_signal_from(r: u32, ) -> Weight {
@@ -2242,9 +2242,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_324 nanoseconds.
-        Weight::from_ref_time(66_339_260)
+        Weight::from_parts(66_339_260, 0)
             // Standard Error: 254_057
-            .saturating_add(Weight::from_ref_time(181_778_743).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_778_743, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reply_push_input(r: u32, ) -> Weight {
@@ -2252,9 +2252,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 706_163 nanoseconds.
-        Weight::from_ref_time(746_906_968)
+        Weight::from_parts(746_906_968, 0)
             // Standard Error: 289_363
-            .saturating_add(Weight::from_ref_time(197_735_344).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(197_735_344, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reply_push_input_per_kb(n: u32, ) -> Weight {
@@ -2262,9 +2262,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 727_470 nanoseconds.
-        Weight::from_ref_time(764_436_591)
+        Weight::from_parts(764_436_591, 0)
             // Standard Error: 1_954
-            .saturating_add(Weight::from_ref_time(155_898).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(155_898, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_push_input(r: u32, ) -> Weight {
@@ -2272,9 +2272,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_379_140 nanoseconds.
-        Weight::from_ref_time(4_509_467_459)
+        Weight::from_parts(4_509_467_459, 0)
             // Standard Error: 293_145
-            .saturating_add(Weight::from_ref_time(202_192_351).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(202_192_351, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_send_push_input_per_kb(n: u32, ) -> Weight {
@@ -2282,9 +2282,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_116_085 nanoseconds.
-        Weight::from_ref_time(1_161_687_850)
+        Weight::from_parts(1_161_687_850, 0)
             // Standard Error: 9_577
-            .saturating_add(Weight::from_ref_time(13_711_920).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(13_711_920, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_debug(r: u32, ) -> Weight {
@@ -2292,9 +2292,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_884 nanoseconds.
-        Weight::from_ref_time(97_414_295)
+        Weight::from_parts(97_414_295, 0)
             // Standard Error: 266_242
-            .saturating_add(Weight::from_ref_time(191_541_864).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(191_541_864, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_debug_per_kb(n: u32, ) -> Weight {
@@ -2302,9 +2302,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 259_961 nanoseconds.
-        Weight::from_ref_time(261_294_000)
+        Weight::from_parts(261_294_000, 0)
             // Standard Error: 55_450
-            .saturating_add(Weight::from_ref_time(26_992_075).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(26_992_075, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_error(r: u32, ) -> Weight {
@@ -2312,9 +2312,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 94_153 nanoseconds.
-        Weight::from_ref_time(92_584_315)
+        Weight::from_parts(92_584_315, 0)
             // Standard Error: 263_504
-            .saturating_add(Weight::from_ref_time(235_583_714).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(235_583_714, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_status_code(r: u32, ) -> Weight {
@@ -2322,9 +2322,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_011 nanoseconds.
-        Weight::from_ref_time(60_532_712)
+        Weight::from_parts(60_532_712, 0)
             // Standard Error: 252_427
-            .saturating_add(Weight::from_ref_time(181_273_142).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_273_142, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_exit(r: u32, ) -> Weight {
@@ -2332,9 +2332,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 79_956 nanoseconds.
-        Weight::from_ref_time(83_128_273)
+        Weight::from_parts(83_128_273, 0)
             // Standard Error: 233_270
-            .saturating_add(Weight::from_ref_time(24_200_326).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(24_200_326, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_leave(r: u32, ) -> Weight {
@@ -2342,9 +2342,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_471 nanoseconds.
-        Weight::from_ref_time(84_933_897)
+        Weight::from_parts(84_933_897, 0)
             // Standard Error: 228_044
-            .saturating_add(Weight::from_ref_time(10_863_802).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(10_863_802, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_wait(r: u32, ) -> Weight {
@@ -2352,9 +2352,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 79_140 nanoseconds.
-        Weight::from_ref_time(82_413_287)
+        Weight::from_parts(82_413_287, 0)
             // Standard Error: 242_017
-            .saturating_add(Weight::from_ref_time(15_558_512).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(15_558_512, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_wait_for(r: u32, ) -> Weight {
@@ -2362,9 +2362,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 79_597 nanoseconds.
-        Weight::from_ref_time(83_256_853)
+        Weight::from_parts(83_256_853, 0)
             // Standard Error: 251_615
-            .saturating_add(Weight::from_ref_time(14_287_546).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(14_287_546, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_wait_up_to(r: u32, ) -> Weight {
@@ -2372,9 +2372,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_149 nanoseconds.
-        Weight::from_ref_time(84_067_253)
+        Weight::from_parts(84_067_253, 0)
             // Standard Error: 242_934
-            .saturating_add(Weight::from_ref_time(12_984_046).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(12_984_046, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_wake(r: u32, ) -> Weight {
@@ -2382,9 +2382,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 134_568 nanoseconds.
-        Weight::from_ref_time(191_754_546)
+        Weight::from_parts(191_754_546, 0)
             // Standard Error: 310_042
-            .saturating_add(Weight::from_ref_time(258_517_274).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(258_517_274, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_create_program_wgas(r: u32, ) -> Weight {
@@ -2392,9 +2392,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 89_961 nanoseconds.
-        Weight::from_ref_time(135_401_157)
+        Weight::from_parts(135_401_157, 0)
             // Standard Error: 330_013
-            .saturating_add(Weight::from_ref_time(438_218_419).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(438_218_419, 0).saturating_mul(r.into()))
     }
     /// The range of component `p` is `[0, 2048]`.
     /// The range of component `s` is `[1, 2048]`.
@@ -2403,11 +2403,11 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 44_618_378 nanoseconds.
-        Weight::from_ref_time(44_975_555_000)
+        Weight::from_parts(44_975_555_000, 0)
             // Standard Error: 259_430
-            .saturating_add(Weight::from_ref_time(7_365_489).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(7_365_489, 0).saturating_mul(p.into()))
             // Standard Error: 259_417
-            .saturating_add(Weight::from_ref_time(155_224_672).saturating_mul(s.into()))
+            .saturating_add(Weight::from_parts(155_224_672, 0).saturating_mul(s.into()))
     }
     /// The range of component `p` is `[0, 512]`.
     fn lazy_pages_signal_read(p: u32, ) -> Weight {
@@ -2417,7 +2417,7 @@ impl WeightInfo for () {
         // Minimum execution time: 81_060 nanoseconds.
         Weight::from_parts(116_078_081, 141)
             // Standard Error: 8_097
-            .saturating_add(Weight::from_ref_time(11_697_667).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(11_697_667, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
     }
@@ -2429,7 +2429,7 @@ impl WeightInfo for () {
         // Minimum execution time: 82_253 nanoseconds.
         Weight::from_parts(83_487_000, 141)
             // Standard Error: 44_559
-            .saturating_add(Weight::from_ref_time(36_153_847).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(36_153_847, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
     }
@@ -2441,7 +2441,7 @@ impl WeightInfo for () {
         // Minimum execution time: 6_059_320 nanoseconds.
         Weight::from_parts(6_026_768_509, 5068941)
             // Standard Error: 74_371
-            .saturating_add(Weight::from_ref_time(37_256_749).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(37_256_749, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads(2048_u64))
     }
     /// The range of component `p` is `[0, 512]`.
@@ -2452,7 +2452,7 @@ impl WeightInfo for () {
         // Minimum execution time: 82_117 nanoseconds.
         Weight::from_parts(84_007_000, 949)
             // Standard Error: 37_631
-            .saturating_add(Weight::from_ref_time(45_958_696).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(45_958_696, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(75606).saturating_mul(p.into()))
     }
@@ -2464,7 +2464,7 @@ impl WeightInfo for () {
         // Minimum execution time: 93_080 nanoseconds.
         Weight::from_parts(77_592_595, 506)
             // Standard Error: 74_142
-            .saturating_add(Weight::from_ref_time(37_638_856).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(37_638_856, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
     }
@@ -2476,7 +2476,7 @@ impl WeightInfo for () {
         // Minimum execution time: 748_265 nanoseconds.
         Weight::from_parts(748_224_476, 506)
             // Standard Error: 324_620
-            .saturating_add(Weight::from_ref_time(46_953_221).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(46_953_221, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
     }
@@ -2488,7 +2488,7 @@ impl WeightInfo for () {
         // Minimum execution time: 1_126_554 nanoseconds.
         Weight::from_parts(1_175_012_009, 316941)
             // Standard Error: 204_912
-            .saturating_add(Weight::from_ref_time(43_619_826).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(43_619_826, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads(128_u64))
     }
     /// The range of component `r` is `[50, 500]`.
@@ -2497,9 +2497,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_248_587 nanoseconds.
-        Weight::from_ref_time(4_247_395_501)
+        Weight::from_parts(4_247_395_501, 0)
             // Standard Error: 11_091
-            .saturating_add(Weight::from_ref_time(3_323_996).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_323_996, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[50, 500]`.
     fn instr_i32load(r: u32, ) -> Weight {
@@ -2507,9 +2507,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_244_604 nanoseconds.
-        Weight::from_ref_time(4_236_154_065)
+        Weight::from_parts(4_236_154_065, 0)
             // Standard Error: 10_679
-            .saturating_add(Weight::from_ref_time(3_383_238).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_383_238, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[50, 500]`.
     fn instr_i64store(r: u32, ) -> Weight {
@@ -2517,9 +2517,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 10_566_548 nanoseconds.
-        Weight::from_ref_time(10_110_815_063)
+        Weight::from_parts(10_110_815_063, 0)
             // Standard Error: 164_010
-            .saturating_add(Weight::from_ref_time(15_834_994).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(15_834_994, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[50, 500]`.
     fn instr_i32store(r: u32, ) -> Weight {
@@ -2527,9 +2527,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 10_594_891 nanoseconds.
-        Weight::from_ref_time(10_824_075_202)
+        Weight::from_parts(10_824_075_202, 0)
             // Standard Error: 246_795
-            .saturating_add(Weight::from_ref_time(8_865_110).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(8_865_110, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_select(r: u32, ) -> Weight {
@@ -2537,9 +2537,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_984 nanoseconds.
-        Weight::from_ref_time(2_022_000)
+        Weight::from_parts(2_022_000, 0)
             // Standard Error: 8_549
-            .saturating_add(Weight::from_ref_time(3_833_242).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_833_242, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_if(r: u32, ) -> Weight {
@@ -2547,9 +2547,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_972 nanoseconds.
-        Weight::from_ref_time(2_014_000)
+        Weight::from_parts(2_014_000, 0)
             // Standard Error: 4_696
-            .saturating_add(Weight::from_ref_time(3_071_869).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_071_869, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_br(r: u32, ) -> Weight {
@@ -2557,9 +2557,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_990 nanoseconds.
-        Weight::from_ref_time(3_141_848)
+        Weight::from_parts(3_141_848, 0)
             // Standard Error: 1_067
-            .saturating_add(Weight::from_ref_time(1_565_212).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_565_212, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_br_if(r: u32, ) -> Weight {
@@ -2567,9 +2567,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_910 nanoseconds.
-        Weight::from_ref_time(1_977_000)
+        Weight::from_parts(1_977_000, 0)
             // Standard Error: 10_190
-            .saturating_add(Weight::from_ref_time(2_916_284).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_916_284, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_br_table(r: u32, ) -> Weight {
@@ -2577,9 +2577,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_055 nanoseconds.
-        Weight::from_ref_time(2_124_000)
+        Weight::from_parts(2_124_000, 0)
             // Standard Error: 9_616
-            .saturating_add(Weight::from_ref_time(5_239_104).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(5_239_104, 0).saturating_mul(r.into()))
     }
     /// The range of component `e` is `[1, 256]`.
     fn instr_br_table_per_entry(e: u32, ) -> Weight {
@@ -2587,9 +2587,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 6_569 nanoseconds.
-        Weight::from_ref_time(5_561_073)
+        Weight::from_parts(5_561_073, 0)
             // Standard Error: 1_593
-            .saturating_add(Weight::from_ref_time(158_847).saturating_mul(e.into()))
+            .saturating_add(Weight::from_parts(158_847, 0).saturating_mul(e.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_call_const(r: u32, ) -> Weight {
@@ -2597,14 +2597,14 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_001 nanoseconds.
-        Weight::from_ref_time(4_351_879)
+        Weight::from_parts(4_351_879, 0)
             // Standard Error: 6_992
-            .saturating_add(Weight::from_ref_time(2_579_629).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_579_629, 0).saturating_mul(r.into()))
     }
     fn instr_i64const(r: u32, ) -> Weight {
-        Weight::from_ref_time(0)
-            .saturating_add(Weight::from_ref_time(2_579_629 -
-            2_411_507).saturating_mul(r.into()))
+        Weight::from_parts(0, 0)
+            .saturating_add(Weight::from_parts(2_579_629 -
+            2_411_507, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_call(r: u32, ) -> Weight {
@@ -2612,9 +2612,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_001 nanoseconds.
-        Weight::from_ref_time(4_619_716)
+        Weight::from_parts(4_619_716, 0)
             // Standard Error: 12_765
-            .saturating_add(Weight::from_ref_time(2_411_507).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_411_507, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_call_indirect(r: u32, ) -> Weight {
@@ -2622,9 +2622,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_321 nanoseconds.
-        Weight::from_ref_time(13_844_527)
+        Weight::from_parts(13_844_527, 0)
             // Standard Error: 28_587
-            .saturating_add(Weight::from_ref_time(10_571_661).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(10_571_661, 0).saturating_mul(r.into()))
     }
     /// The range of component `p` is `[0, 128]`.
     fn instr_call_indirect_per_param(p: u32, ) -> Weight {
@@ -2632,9 +2632,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 12_173 nanoseconds.
-        Weight::from_ref_time(4_877_843)
+        Weight::from_parts(4_877_843, 0)
             // Standard Error: 7_292
-            .saturating_add(Weight::from_ref_time(1_288_806).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_288_806, 0).saturating_mul(p.into()))
     }
     /// The range of component `l` is `[0, 1024]`.
     fn instr_call_per_local(l: u32, ) -> Weight {
@@ -2642,9 +2642,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_997 nanoseconds.
-        Weight::from_ref_time(5_260_743)
+        Weight::from_parts(5_260_743, 0)
             // Standard Error: 13
-            .saturating_add(Weight::from_ref_time(22).saturating_mul(l.into()))
+            .saturating_add(Weight::from_parts(22, 0).saturating_mul(l.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_local_get(r: u32, ) -> Weight {
@@ -2652,9 +2652,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_940 nanoseconds.
-        Weight::from_ref_time(1_830_043)
+        Weight::from_parts(1_830_043, 0)
             // Standard Error: 2_843
-            .saturating_add(Weight::from_ref_time(258_952).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(258_952, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_local_set(r: u32, ) -> Weight {
@@ -2662,9 +2662,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_991 nanoseconds.
-        Weight::from_ref_time(2_027_000)
+        Weight::from_parts(2_027_000, 0)
             // Standard Error: 5_369
-            .saturating_add(Weight::from_ref_time(736_000).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(736_000, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_local_tee(r: u32, ) -> Weight {
@@ -2672,9 +2672,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_000 nanoseconds.
-        Weight::from_ref_time(2_062_000)
+        Weight::from_parts(2_062_000, 0)
             // Standard Error: 4_630
-            .saturating_add(Weight::from_ref_time(719_367).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(719_367, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_global_get(r: u32, ) -> Weight {
@@ -2682,9 +2682,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_741 nanoseconds.
-        Weight::from_ref_time(2_616_782)
+        Weight::from_parts(2_616_782, 0)
             // Standard Error: 6_777
-            .saturating_add(Weight::from_ref_time(731_002).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(731_002, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_global_set(r: u32, ) -> Weight {
@@ -2692,9 +2692,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_795 nanoseconds.
-        Weight::from_ref_time(5_840_000)
+        Weight::from_parts(5_840_000, 0)
             // Standard Error: 8_144
-            .saturating_add(Weight::from_ref_time(1_259_731).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_259_731, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_memory_current(r: u32, ) -> Weight {
@@ -2702,9 +2702,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 6_596 nanoseconds.
-        Weight::from_ref_time(2_374_393)
+        Weight::from_parts(2_374_393, 0)
             // Standard Error: 12_129
-            .saturating_add(Weight::from_ref_time(6_823_668).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(6_823_668, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64clz(r: u32, ) -> Weight {
@@ -2712,9 +2712,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_980 nanoseconds.
-        Weight::from_ref_time(2_045_000)
+        Weight::from_parts(2_045_000, 0)
             // Standard Error: 8_388
-            .saturating_add(Weight::from_ref_time(3_325_416).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_325_416, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32clz(r: u32, ) -> Weight {
@@ -2722,9 +2722,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_950 nanoseconds.
-        Weight::from_ref_time(2_041_000)
+        Weight::from_parts(2_041_000, 0)
             // Standard Error: 7_692
-            .saturating_add(Weight::from_ref_time(3_034_615).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_034_615, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ctz(r: u32, ) -> Weight {
@@ -2732,9 +2732,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_981 nanoseconds.
-        Weight::from_ref_time(2_061_000)
+        Weight::from_parts(2_061_000, 0)
             // Standard Error: 8_251
-            .saturating_add(Weight::from_ref_time(3_019_593).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_019_593, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ctz(r: u32, ) -> Weight {
@@ -2742,9 +2742,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_980 nanoseconds.
-        Weight::from_ref_time(2_039_000)
+        Weight::from_parts(2_039_000, 0)
             // Standard Error: 6_062
-            .saturating_add(Weight::from_ref_time(2_592_066).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_592_066, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64popcnt(r: u32, ) -> Weight {
@@ -2752,9 +2752,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_036 nanoseconds.
-        Weight::from_ref_time(2_085_000)
+        Weight::from_parts(2_085_000, 0)
             // Standard Error: 3_811
-            .saturating_add(Weight::from_ref_time(537_423).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(537_423, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32popcnt(r: u32, ) -> Weight {
@@ -2762,9 +2762,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_987 nanoseconds.
-        Weight::from_ref_time(1_301_383)
+        Weight::from_parts(1_301_383, 0)
             // Standard Error: 3_109
-            .saturating_add(Weight::from_ref_time(381_295).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(381_295, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64eqz(r: u32, ) -> Weight {
@@ -2772,9 +2772,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_999 nanoseconds.
-        Weight::from_ref_time(2_069_000)
+        Weight::from_parts(2_069_000, 0)
             // Standard Error: 11_800
-            .saturating_add(Weight::from_ref_time(1_805_699).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_805_699, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32eqz(r: u32, ) -> Weight {
@@ -2782,9 +2782,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_014 nanoseconds.
-        Weight::from_ref_time(2_070_000)
+        Weight::from_parts(2_070_000, 0)
             // Standard Error: 8_255
-            .saturating_add(Weight::from_ref_time(1_114_949).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_114_949, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64extendsi32(r: u32, ) -> Weight {
@@ -2792,9 +2792,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_900 nanoseconds.
-        Weight::from_ref_time(1_701_470)
+        Weight::from_parts(1_701_470, 0)
             // Standard Error: 2_591
-            .saturating_add(Weight::from_ref_time(312_279).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(312_279, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64extendui32(r: u32, ) -> Weight {
@@ -2802,9 +2802,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_982 nanoseconds.
-        Weight::from_ref_time(2_190_000)
+        Weight::from_parts(2_190_000, 0)
             // Standard Error: 1_685
-            .saturating_add(Weight::from_ref_time(172_493).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(172_493, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32wrapi64(r: u32, ) -> Weight {
@@ -2812,9 +2812,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_041 nanoseconds.
-        Weight::from_ref_time(2_605_622)
+        Weight::from_parts(2_605_622, 0)
             // Standard Error: 1_576
-            .saturating_add(Weight::from_ref_time(159_097).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(159_097, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64eq(r: u32, ) -> Weight {
@@ -2822,9 +2822,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_918 nanoseconds.
-        Weight::from_ref_time(2_021_000)
+        Weight::from_parts(2_021_000, 0)
             // Standard Error: 11_160
-            .saturating_add(Weight::from_ref_time(1_781_573).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_781_573, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32eq(r: u32, ) -> Weight {
@@ -2832,9 +2832,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_990 nanoseconds.
-        Weight::from_ref_time(2_047_000)
+        Weight::from_parts(2_047_000, 0)
             // Standard Error: 6_989
-            .saturating_add(Weight::from_ref_time(1_086_510).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_086_510, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ne(r: u32, ) -> Weight {
@@ -2842,9 +2842,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_991 nanoseconds.
-        Weight::from_ref_time(2_035_000)
+        Weight::from_parts(2_035_000, 0)
             // Standard Error: 9_623
-            .saturating_add(Weight::from_ref_time(1_797_223).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_797_223, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ne(r: u32, ) -> Weight {
@@ -2852,9 +2852,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_957 nanoseconds.
-        Weight::from_ref_time(2_016_000)
+        Weight::from_parts(2_016_000, 0)
             // Standard Error: 7_516
-            .saturating_add(Weight::from_ref_time(1_100_146).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_100_146, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64lts(r: u32, ) -> Weight {
@@ -2862,9 +2862,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_975 nanoseconds.
-        Weight::from_ref_time(2_042_000)
+        Weight::from_parts(2_042_000, 0)
             // Standard Error: 9_617
-            .saturating_add(Weight::from_ref_time(1_798_574).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_798_574, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32lts(r: u32, ) -> Weight {
@@ -2872,9 +2872,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_919 nanoseconds.
-        Weight::from_ref_time(2_044_000)
+        Weight::from_parts(2_044_000, 0)
             // Standard Error: 7_469
-            .saturating_add(Weight::from_ref_time(1_119_079).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_119_079, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ltu(r: u32, ) -> Weight {
@@ -2882,9 +2882,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_983 nanoseconds.
-        Weight::from_ref_time(2_025_000)
+        Weight::from_parts(2_025_000, 0)
             // Standard Error: 11_078
-            .saturating_add(Weight::from_ref_time(1_866_193).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_866_193, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ltu(r: u32, ) -> Weight {
@@ -2892,9 +2892,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_945 nanoseconds.
-        Weight::from_ref_time(2_063_000)
+        Weight::from_parts(2_063_000, 0)
             // Standard Error: 7_762
-            .saturating_add(Weight::from_ref_time(1_098_384).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_098_384, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64gts(r: u32, ) -> Weight {
@@ -2902,9 +2902,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_984 nanoseconds.
-        Weight::from_ref_time(2_013_000)
+        Weight::from_parts(2_013_000, 0)
             // Standard Error: 13_010
-            .saturating_add(Weight::from_ref_time(1_809_632).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_809_632, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32gts(r: u32, ) -> Weight {
@@ -2912,9 +2912,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_936 nanoseconds.
-        Weight::from_ref_time(2_085_000)
+        Weight::from_parts(2_085_000, 0)
             // Standard Error: 7_662
-            .saturating_add(Weight::from_ref_time(1_077_967).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_077_967, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64gtu(r: u32, ) -> Weight {
@@ -2922,9 +2922,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_960 nanoseconds.
-        Weight::from_ref_time(2_013_000)
+        Weight::from_parts(2_013_000, 0)
             // Standard Error: 11_774
-            .saturating_add(Weight::from_ref_time(1_786_196).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_786_196, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32gtu(r: u32, ) -> Weight {
@@ -2932,9 +2932,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_938 nanoseconds.
-        Weight::from_ref_time(1_981_000)
+        Weight::from_parts(1_981_000, 0)
             // Standard Error: 7_698
-            .saturating_add(Weight::from_ref_time(1_068_379).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_068_379, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64les(r: u32, ) -> Weight {
@@ -2942,9 +2942,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_992 nanoseconds.
-        Weight::from_ref_time(2_053_000)
+        Weight::from_parts(2_053_000, 0)
             // Standard Error: 11_716
-            .saturating_add(Weight::from_ref_time(1_786_578).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_786_578, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32les(r: u32, ) -> Weight {
@@ -2952,9 +2952,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_940 nanoseconds.
-        Weight::from_ref_time(2_005_000)
+        Weight::from_parts(2_005_000, 0)
             // Standard Error: 7_815
-            .saturating_add(Weight::from_ref_time(1_090_447).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_090_447, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64leu(r: u32, ) -> Weight {
@@ -2962,9 +2962,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_930 nanoseconds.
-        Weight::from_ref_time(2_037_000)
+        Weight::from_parts(2_037_000, 0)
             // Standard Error: 14_146
-            .saturating_add(Weight::from_ref_time(1_837_345).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_837_345, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32leu(r: u32, ) -> Weight {
@@ -2972,9 +2972,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_953 nanoseconds.
-        Weight::from_ref_time(1_994_000)
+        Weight::from_parts(1_994_000, 0)
             // Standard Error: 7_326
-            .saturating_add(Weight::from_ref_time(1_124_069).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_124_069, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ges(r: u32, ) -> Weight {
@@ -2982,9 +2982,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_990 nanoseconds.
-        Weight::from_ref_time(2_022_000)
+        Weight::from_parts(2_022_000, 0)
             // Standard Error: 11_502
-            .saturating_add(Weight::from_ref_time(1_784_579).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_784_579, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ges(r: u32, ) -> Weight {
@@ -2992,9 +2992,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_955 nanoseconds.
-        Weight::from_ref_time(2_030_000)
+        Weight::from_parts(2_030_000, 0)
             // Standard Error: 7_269
-            .saturating_add(Weight::from_ref_time(1_087_418).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_087_418, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64geu(r: u32, ) -> Weight {
@@ -3002,9 +3002,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_966 nanoseconds.
-        Weight::from_ref_time(2_021_000)
+        Weight::from_parts(2_021_000, 0)
             // Standard Error: 10_931
-            .saturating_add(Weight::from_ref_time(1_779_890).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_779_890, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32geu(r: u32, ) -> Weight {
@@ -3012,9 +3012,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_985 nanoseconds.
-        Weight::from_ref_time(2_057_000)
+        Weight::from_parts(2_057_000, 0)
             // Standard Error: 7_783
-            .saturating_add(Weight::from_ref_time(1_115_230).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_115_230, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64add(r: u32, ) -> Weight {
@@ -3022,9 +3022,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_927 nanoseconds.
-        Weight::from_ref_time(2_053_000)
+        Weight::from_parts(2_053_000, 0)
             // Standard Error: 7_508
-            .saturating_add(Weight::from_ref_time(1_212_190).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_212_190, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32add(r: u32, ) -> Weight {
@@ -3032,9 +3032,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_009 nanoseconds.
-        Weight::from_ref_time(2_075_000)
+        Weight::from_parts(2_075_000, 0)
             // Standard Error: 3_877
-            .saturating_add(Weight::from_ref_time(576_488).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(576_488, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64sub(r: u32, ) -> Weight {
@@ -3042,9 +3042,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_909 nanoseconds.
-        Weight::from_ref_time(1_957_000)
+        Weight::from_parts(1_957_000, 0)
             // Standard Error: 7_060
-            .saturating_add(Weight::from_ref_time(1_174_700).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_174_700, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32sub(r: u32, ) -> Weight {
@@ -3052,9 +3052,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_985 nanoseconds.
-        Weight::from_ref_time(2_041_000)
+        Weight::from_parts(2_041_000, 0)
             // Standard Error: 4_555
-            .saturating_add(Weight::from_ref_time(594_904).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(594_904, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64mul(r: u32, ) -> Weight {
@@ -3062,9 +3062,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_982 nanoseconds.
-        Weight::from_ref_time(2_073_000)
+        Weight::from_parts(2_073_000, 0)
             // Standard Error: 12_025
-            .saturating_add(Weight::from_ref_time(1_724_065).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_724_065, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32mul(r: u32, ) -> Weight {
@@ -3072,9 +3072,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_957 nanoseconds.
-        Weight::from_ref_time(2_007_000)
+        Weight::from_parts(2_007_000, 0)
             // Standard Error: 8_716
-            .saturating_add(Weight::from_ref_time(1_150_408).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_150_408, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64divs(r: u32, ) -> Weight {
@@ -3082,9 +3082,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_884 nanoseconds.
-        Weight::from_ref_time(1_144_446)
+        Weight::from_parts(1_144_446, 0)
             // Standard Error: 10_547
-            .saturating_add(Weight::from_ref_time(2_675_861).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_675_861, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32divs(r: u32, ) -> Weight {
@@ -3092,9 +3092,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_006 nanoseconds.
-        Weight::from_ref_time(69_582)
+        Weight::from_parts(69_582, 0)
             // Standard Error: 11_472
-            .saturating_add(Weight::from_ref_time(2_348_861).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_348_861, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64divu(r: u32, ) -> Weight {
@@ -3102,9 +3102,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_935 nanoseconds.
-        Weight::from_ref_time(1_504_156)
+        Weight::from_parts(1_504_156, 0)
             // Standard Error: 16_606
-            .saturating_add(Weight::from_ref_time(2_805_608).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_805_608, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32divu(r: u32, ) -> Weight {
@@ -3112,9 +3112,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_982 nanoseconds.
-        Weight::from_ref_time(7_507_453)
+        Weight::from_parts(7_507_453, 0)
             // Standard Error: 27_413
-            .saturating_add(Weight::from_ref_time(2_106_829).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_106_829, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64rems(r: u32, ) -> Weight {
@@ -3122,9 +3122,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_957 nanoseconds.
-        Weight::from_ref_time(2_062_000)
+        Weight::from_parts(2_062_000, 0)
             // Standard Error: 22_291
-            .saturating_add(Weight::from_ref_time(9_226_033).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(9_226_033, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32rems(r: u32, ) -> Weight {
@@ -3132,9 +3132,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_952 nanoseconds.
-        Weight::from_ref_time(737_483)
+        Weight::from_parts(737_483, 0)
             // Standard Error: 45_126
-            .saturating_add(Weight::from_ref_time(7_533_584).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(7_533_584, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64remu(r: u32, ) -> Weight {
@@ -3142,9 +3142,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_957 nanoseconds.
-        Weight::from_ref_time(3_376_184)
+        Weight::from_parts(3_376_184, 0)
             // Standard Error: 20_172
-            .saturating_add(Weight::from_ref_time(2_862_201).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_862_201, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32remu(r: u32, ) -> Weight {
@@ -3152,9 +3152,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_982 nanoseconds.
-        Weight::from_ref_time(2_067_000)
+        Weight::from_parts(2_067_000, 0)
             // Standard Error: 5_984
-            .saturating_add(Weight::from_ref_time(2_531_767).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_531_767, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64and(r: u32, ) -> Weight {
@@ -3162,9 +3162,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_968 nanoseconds.
-        Weight::from_ref_time(2_028_000)
+        Weight::from_parts(2_028_000, 0)
             // Standard Error: 8_261
-            .saturating_add(Weight::from_ref_time(1_261_509).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_261_509, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32and(r: u32, ) -> Weight {
@@ -3172,9 +3172,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_029 nanoseconds.
-        Weight::from_ref_time(2_047_000)
+        Weight::from_parts(2_047_000, 0)
             // Standard Error: 4_691
-            .saturating_add(Weight::from_ref_time(613_890).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(613_890, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64or(r: u32, ) -> Weight {
@@ -3182,9 +3182,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_946 nanoseconds.
-        Weight::from_ref_time(2_035_000)
+        Weight::from_parts(2_035_000, 0)
             // Standard Error: 8_090
-            .saturating_add(Weight::from_ref_time(1_206_785).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_206_785, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32or(r: u32, ) -> Weight {
@@ -3192,9 +3192,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_022 nanoseconds.
-        Weight::from_ref_time(2_069_000)
+        Weight::from_parts(2_069_000, 0)
             // Standard Error: 4_558
-            .saturating_add(Weight::from_ref_time(600_340).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(600_340, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64xor(r: u32, ) -> Weight {
@@ -3202,9 +3202,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_031 nanoseconds.
-        Weight::from_ref_time(2_088_000)
+        Weight::from_parts(2_088_000, 0)
             // Standard Error: 7_497
-            .saturating_add(Weight::from_ref_time(1_200_146).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_200_146, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32xor(r: u32, ) -> Weight {
@@ -3212,9 +3212,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_007 nanoseconds.
-        Weight::from_ref_time(2_047_000)
+        Weight::from_parts(2_047_000, 0)
             // Standard Error: 4_583
-            .saturating_add(Weight::from_ref_time(601_809).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(601_809, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64shl(r: u32, ) -> Weight {
@@ -3222,9 +3222,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_968 nanoseconds.
-        Weight::from_ref_time(2_035_000)
+        Weight::from_parts(2_035_000, 0)
             // Standard Error: 7_148
-            .saturating_add(Weight::from_ref_time(1_033_991).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_033_991, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32shl(r: u32, ) -> Weight {
@@ -3232,9 +3232,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_951 nanoseconds.
-        Weight::from_ref_time(2_036_000)
+        Weight::from_parts(2_036_000, 0)
             // Standard Error: 3_798
-            .saturating_add(Weight::from_ref_time(557_173).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(557_173, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64shrs(r: u32, ) -> Weight {
@@ -3242,9 +3242,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_008 nanoseconds.
-        Weight::from_ref_time(2_059_000)
+        Weight::from_parts(2_059_000, 0)
             // Standard Error: 6_814
-            .saturating_add(Weight::from_ref_time(1_071_968).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_071_968, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32shrs(r: u32, ) -> Weight {
@@ -3252,9 +3252,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_988 nanoseconds.
-        Weight::from_ref_time(2_050_000)
+        Weight::from_parts(2_050_000, 0)
             // Standard Error: 3_646
-            .saturating_add(Weight::from_ref_time(552_674).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(552_674, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64shru(r: u32, ) -> Weight {
@@ -3262,9 +3262,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_975 nanoseconds.
-        Weight::from_ref_time(2_007_000)
+        Weight::from_parts(2_007_000, 0)
             // Standard Error: 6_233
-            .saturating_add(Weight::from_ref_time(1_020_688).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_020_688, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32shru(r: u32, ) -> Weight {
@@ -3272,9 +3272,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_921 nanoseconds.
-        Weight::from_ref_time(2_007_000)
+        Weight::from_parts(2_007_000, 0)
             // Standard Error: 3_338
-            .saturating_add(Weight::from_ref_time(524_904).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(524_904, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64rotl(r: u32, ) -> Weight {
@@ -3282,9 +3282,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_035 nanoseconds.
-        Weight::from_ref_time(2_096_000)
+        Weight::from_parts(2_096_000, 0)
             // Standard Error: 6_820
-            .saturating_add(Weight::from_ref_time(989_478).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(989_478, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32rotl(r: u32, ) -> Weight {
@@ -3292,9 +3292,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_917 nanoseconds.
-        Weight::from_ref_time(10_071)
+        Weight::from_parts(10_071, 0)
             // Standard Error: 5_314
-            .saturating_add(Weight::from_ref_time(585_983).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(585_983, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64rotr(r: u32, ) -> Weight {
@@ -3302,9 +3302,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_993 nanoseconds.
-        Weight::from_ref_time(2_062_000)
+        Weight::from_parts(2_062_000, 0)
             // Standard Error: 7_508
-            .saturating_add(Weight::from_ref_time(1_010_373).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_010_373, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32rotr(r: u32, ) -> Weight {
@@ -3312,8 +3312,8 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_944 nanoseconds.
-        Weight::from_ref_time(1_993_000)
+        Weight::from_parts(1_993_000, 0)
             // Standard Error: 3_741
-            .saturating_add(Weight::from_ref_time(549_410).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(549_410, 0).saturating_mul(r.into()))
     }
 }

--- a/pallets/gear/src/weights.rs
+++ b/pallets/gear/src/weights.rs
@@ -232,7 +232,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             // Standard Error: 1_587
             .saturating_add(Weight::from_parts(691_791, 0).saturating_mul(c.into()))
             .saturating_add(T::DbWeight::get().reads(1_u64))
-            .saturating_add(Weight::from_proof_size(1024).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(0, 1024).saturating_mul(c.into()))
     }
     /// The range of component `c` is `[0, 512]`.
     fn instantiate_module_per_kb(c: u32, ) -> Weight {
@@ -351,7 +351,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             .saturating_add(Weight::from_parts(51_482_330, 0).saturating_mul(c.into()))
             .saturating_add(T::DbWeight::get().reads(1_u64))
             .saturating_add(T::DbWeight::get().writes(2_u64))
-            .saturating_add(Weight::from_proof_size(2150).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(0, 2150).saturating_mul(c.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn alloc(r: u32, ) -> Weight {
@@ -856,7 +856,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             // Standard Error: 8_097
             .saturating_add(Weight::from_parts(11_697_667, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9900).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 512]`.
     fn lazy_pages_signal_write(p: u32, ) -> Weight {
@@ -868,7 +868,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             // Standard Error: 44_559
             .saturating_add(Weight::from_parts(36_153_847, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9900).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 512]`.
     fn lazy_pages_signal_write_after_read(p: u32, ) -> Weight {
@@ -891,7 +891,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             // Standard Error: 37_631
             .saturating_add(Weight::from_parts(45_958_696, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(75606).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 75606).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 32]`.
     fn lazy_pages_host_func_read(p: u32, ) -> Weight {
@@ -903,7 +903,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             // Standard Error: 74_142
             .saturating_add(Weight::from_parts(37_638_856, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9883).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 32]`.
     fn lazy_pages_host_func_write(p: u32, ) -> Weight {
@@ -915,7 +915,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             // Standard Error: 324_620
             .saturating_add(Weight::from_parts(46_953_221, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9883).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 32]`.
     fn lazy_pages_host_func_write_after_read(p: u32, ) -> Weight {
@@ -1792,7 +1792,7 @@ impl WeightInfo for () {
             // Standard Error: 1_587
             .saturating_add(Weight::from_parts(691_791, 0).saturating_mul(c.into()))
             .saturating_add(RocksDbWeight::get().reads(1_u64))
-            .saturating_add(Weight::from_proof_size(1024).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(0, 1024).saturating_mul(c.into()))
     }
     /// The range of component `c` is `[0, 512]`.
     fn instantiate_module_per_kb(c: u32, ) -> Weight {
@@ -1911,7 +1911,7 @@ impl WeightInfo for () {
             .saturating_add(Weight::from_parts(51_482_330, 0).saturating_mul(c.into()))
             .saturating_add(RocksDbWeight::get().reads(1_u64))
             .saturating_add(RocksDbWeight::get().writes(2_u64))
-            .saturating_add(Weight::from_proof_size(2150).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(0, 2150).saturating_mul(c.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn alloc(r: u32, ) -> Weight {
@@ -2416,7 +2416,7 @@ impl WeightInfo for () {
             // Standard Error: 8_097
             .saturating_add(Weight::from_parts(11_697_667, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9900).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 512]`.
     fn lazy_pages_signal_write(p: u32, ) -> Weight {
@@ -2428,7 +2428,7 @@ impl WeightInfo for () {
             // Standard Error: 44_559
             .saturating_add(Weight::from_parts(36_153_847, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9900).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 512]`.
     fn lazy_pages_signal_write_after_read(p: u32, ) -> Weight {
@@ -2451,7 +2451,7 @@ impl WeightInfo for () {
             // Standard Error: 37_631
             .saturating_add(Weight::from_parts(45_958_696, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(75606).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 75606).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 32]`.
     fn lazy_pages_host_func_read(p: u32, ) -> Weight {
@@ -2463,7 +2463,7 @@ impl WeightInfo for () {
             // Standard Error: 74_142
             .saturating_add(Weight::from_parts(37_638_856, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9883).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 32]`.
     fn lazy_pages_host_func_write(p: u32, ) -> Weight {
@@ -2475,7 +2475,7 @@ impl WeightInfo for () {
             // Standard Error: 324_620
             .saturating_add(Weight::from_parts(46_953_221, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9883).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 32]`.
     fn lazy_pages_host_func_write_after_read(p: u32, ) -> Weight {

--- a/pallets/payment/src/lib.rs
+++ b/pallets/payment/src/lib.rs
@@ -163,11 +163,12 @@ where
             let multiplier = TransactionPayment::<T>::next_fee_multiplier();
             if multiplier > Multiplier::saturating_from_integer(1) {
                 let mut info: DispatchInfo = *info;
-                info.weight = Weight::from_ref_time(
+                info.weight = Weight::from_parts(
                     multiplier
                         .reciprocal() // take inverse
                         .unwrap_or_else(Multiplier::max_value)
                         .saturating_mul_int(info.weight.ref_time()),
+                    0,
                 );
                 Cow::Owned(info)
             } else {
@@ -239,11 +240,12 @@ impl<T: Config> Pallet<T> {
                 <Extrinsic as ExtractCall<CallOf<T>>>::extract_call(&unchecked_extrinsic);
             // If call is exempted from weight multiplication pre-divide it with the fee multiplier
             let adjusted_weight = if !T::ExtraFeeCallFilter::contains(&call) {
-                Weight::from_ref_time(
+                Weight::from_parts(
                     TransactionPayment::<T>::next_fee_multiplier()
                         .reciprocal()
                         .unwrap_or_else(Multiplier::max_value)
                         .saturating_mul_int(weight.ref_time()),
+                    0,
                 )
             } else {
                 weight
@@ -292,11 +294,12 @@ impl<T: Config> Pallet<T> {
             let call: CallOf<T> =
                 <Extrinsic as ExtractCall<CallOf<T>>>::extract_call(&unchecked_extrinsic);
             let adjusted_weight = if !T::ExtraFeeCallFilter::contains(&call) {
-                Weight::from_ref_time(
+                Weight::from_parts(
                     TransactionPayment::<T>::next_fee_multiplier()
                         .reciprocal()
                         .unwrap_or_else(Multiplier::max_value)
                         .saturating_mul_int(weight.ref_time()),
+                    0,
                 )
             } else {
                 weight

--- a/pallets/payment/src/lib.rs
+++ b/pallets/payment/src/lib.rs
@@ -17,8 +17,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-// (issue #2531)
-#![allow(deprecated)]
 
 use common::{storage::*, ExtractCall};
 use frame_support::{

--- a/pallets/payment/src/tests.rs
+++ b/pallets/payment/src/tests.rs
@@ -134,7 +134,7 @@ fn fee_rounding_error_bounded_by_multiplier() {
             // not charging for tx len to make rounding error more significant
             let len = 0;
 
-            let rounding_error = WeightToFeeFor::<Test>::weight_to_fee(&Weight::from_ref_time(mul));
+            let rounding_error = WeightToFeeFor::<Test>::weight_to_fee(&Weight::from_parts(mul, 0));
 
             for w in weights {
                 let alice_initial_balance = Balances::free_balance(ALICE);
@@ -173,9 +173,9 @@ fn fee_rounding_error_bounded_by_multiplier() {
             });
 
         let weights = vec![
-            Weight::from_ref_time(1_000),
-            Weight::from_ref_time(100_000),
-            Weight::from_ref_time(10_000_000),
+            Weight::from_parts(1_000, 0),
+            Weight::from_parts(100_000, 0),
+            Weight::from_parts(10_000_000, 0),
         ];
 
         // MQ is empty => multiplier is 1. No rounding error expected
@@ -221,9 +221,9 @@ fn mq_size_affecting_fee_works() {
             });
 
         let len = 100usize;
-        let fee_length = LengthToFeeFor::<Test>::weight_to_fee(&Weight::from_ref_time(len as u64));
+        let fee_length = LengthToFeeFor::<Test>::weight_to_fee(&Weight::from_parts(len as u64, 0));
 
-        let weight = Weight::from_ref_time(1_000);
+        let weight = Weight::from_parts(1_000, 0);
 
         let pre = CustomChargeTransactionPayment::<Test>::from(0)
             .pre_dispatch(&ALICE, call, &info_from_weight(weight), len)
@@ -311,9 +311,9 @@ fn mq_size_not_affecting_fee_works() {
             });
 
         let len = 100usize;
-        let fee_length = LengthToFeeFor::<Test>::weight_to_fee(&Weight::from_ref_time(len as u64));
+        let fee_length = LengthToFeeFor::<Test>::weight_to_fee(&Weight::from_parts(len as u64, 0));
 
-        let weight = Weight::from_ref_time(1_000);
+        let weight = Weight::from_parts(1_000, 0);
 
         let pre = CustomChargeTransactionPayment::<Test>::from(0)
             .pre_dispatch(&ALICE, call, &info_from_weight(weight), len)
@@ -361,7 +361,7 @@ fn mq_size_not_affecting_fee_works() {
             .pre_dispatch(&ALICE, call, &info_from_weight(weight), len)
             .unwrap();
 
-        let rounding_error = WeightToFeeFor::<Test>::weight_to_fee(&Weight::from_ref_time(16));
+        let rounding_error = WeightToFeeFor::<Test>::weight_to_fee(&Weight::from_parts(16, 0));
         // Now we may have some rounding error somewhere at the least significant digits
         assert_approx_eq!(
             Balances::free_balance(ALICE),
@@ -420,7 +420,7 @@ fn query_info_and_fee_details_work() {
     new_test_ext().execute_with(|| {
         // Empty Message queue => extra fee is not applied
         let fee_affecting_weight = WeightToFeeFor::<Test>::weight_to_fee(&info_affecting_mq.weight);
-        let fee_affecting_length = LengthToFeeFor::<Test>::weight_to_fee(&Weight::from_ref_time(len_affecting_mq.into()));
+        let fee_affecting_length = LengthToFeeFor::<Test>::weight_to_fee(&Weight::from_parts(len_affecting_mq.into(), 0));
         assert_eq!(
             GearPayment::query_info(xt_affecting_mq.clone(), len_affecting_mq),
             RuntimeDispatchInfo {
@@ -433,7 +433,7 @@ fn query_info_and_fee_details_work() {
         );
 
         let fee_weight = WeightToFeeFor::<Test>::weight_to_fee(&info_not_affecting_mq.weight);
-        let fee_length = LengthToFeeFor::<Test>::weight_to_fee(&Weight::from_ref_time(len_not_affecting_mq.into()));
+        let fee_length = LengthToFeeFor::<Test>::weight_to_fee(&Weight::from_parts(len_not_affecting_mq.into(), 0));
         assert_eq!(
             GearPayment::query_info(xt_not_affecting_mq.clone(), len_not_affecting_mq),
             RuntimeDispatchInfo {
@@ -504,7 +504,7 @@ fn query_info_and_fee_details_work() {
 
         // Extra fee not applicable => fee should be exactly what it was for empty MQ
         // However, we must account for the rounding error in this case
-        let rounding_error = WeightToFeeFor::<Test>::weight_to_fee(&Weight::from_ref_time(16));
+        let rounding_error = WeightToFeeFor::<Test>::weight_to_fee(&Weight::from_parts(16, 0));
         assert_eq!(
             GearPayment::query_info(xt_not_affecting_mq.clone(), len_not_affecting_mq),
             RuntimeDispatchInfo {

--- a/pallets/staking-rewards/src/weights.rs
+++ b/pallets/staking-rewards/src/weights.rs
@@ -42,7 +42,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Weights borrowed from `vara_runtime::weights::pallet_balances::SubstrateWeight::transfer()`
 	// Added another DB write for depositing an event
 	fn refill() -> Weight {
-		Weight::from_ref_time(55_241_000_u64)
+		Weight::from_parts(55_241_000_u64, 0)
             .saturating_add(T::DbWeight::get().reads(1_u64))
             .saturating_add(T::DbWeight::get().writes(2_u64))
 	}
@@ -50,14 +50,14 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn force_refill() -> Weight {
 		// Same as `vara_runtime::weights::pallet_balances::SubstrateWeight::force_transfer()`
 		// except for an additional DB write for depositing event
-		Weight::from_ref_time(54_529_000_u64)
+		Weight::from_parts(54_529_000_u64, 0)
             .saturating_add(T::DbWeight::get().reads(2_u64))
             .saturating_add(T::DbWeight::get().writes(3_u64))
 	}
 
 	fn withdraw() -> Weight {
 		// Same as `force_refill()`
-		Weight::from_ref_time(54_529_000_u64)
+		Weight::from_parts(54_529_000_u64, 0)
             .saturating_add(T::DbWeight::get().reads(2_u64))
             .saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -66,19 +66,19 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 // For backwards compatibility and tests
 impl WeightInfo for () {
 	fn refill() -> Weight {
-		Weight::from_ref_time(55_241_000_u64)
+		Weight::from_parts(55_241_000_u64, 0)
             .saturating_add(RocksDbWeight::get().reads(1_u64))
             .saturating_add(RocksDbWeight::get().writes(2_u64))
 	}
 
 	fn force_refill() -> Weight {
-		Weight::from_ref_time(54_529_000_u64)
+		Weight::from_parts(54_529_000_u64, 0)
             .saturating_add(RocksDbWeight::get().reads(2_u64))
             .saturating_add(RocksDbWeight::get().writes(3_u64))
 	}
 
 	fn withdraw() -> Weight {
-		Weight::from_ref_time(54_529_000_u64)
+		Weight::from_parts(54_529_000_u64, 0)
             .saturating_add(RocksDbWeight::get().reads(2_u64))
             .saturating_add(RocksDbWeight::get().writes(3_u64))
 	}

--- a/pallets/staking-rewards/src/weights.rs
+++ b/pallets/staking-rewards/src/weights.rs
@@ -22,8 +22,6 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(unused_parens)]
 #![allow(unused_imports)]
-
-// (issue #2531)
 #![allow(deprecated)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};

--- a/pallets/staking-rewards/src/weights.rs
+++ b/pallets/staking-rewards/src/weights.rs
@@ -22,7 +22,6 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(unused_parens)]
 #![allow(unused_imports)]
-#![allow(deprecated)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
 use sp_std::marker::PhantomData;

--- a/runtime/gear/src/weights/frame_system.rs
+++ b/runtime/gear/src/weights/frame_system.rs
@@ -54,9 +54,9 @@ impl<T: frame_system::Config> frame_system::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_195 nanoseconds.
-        Weight::from_ref_time(1_173_301)
+        Weight::from_parts(1_173_301, 0)
             // Standard Error: 0
-            .saturating_add(Weight::from_ref_time(458).saturating_mul(b.into()))
+            .saturating_add(Weight::from_parts(458, 0).saturating_mul(b.into()))
     }
     /// The range of component `b` is `[0, 1310720]`.
     fn remark_with_event(b: u32, ) -> Weight {
@@ -64,9 +64,9 @@ impl<T: frame_system::Config> frame_system::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_020 nanoseconds.
-        Weight::from_ref_time(5_078_000)
+        Weight::from_parts(5_078_000, 0)
             // Standard Error: 0
-            .saturating_add(Weight::from_ref_time(1_740).saturating_mul(b.into()))
+            .saturating_add(Weight::from_parts(1_740, 0).saturating_mul(b.into()))
     }
     fn set_heap_pages() -> Weight {
         // Proof Size summary in bytes:
@@ -83,9 +83,9 @@ impl<T: frame_system::Config> frame_system::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_180 nanoseconds.
-        Weight::from_ref_time(1_217_000)
+        Weight::from_parts(1_217_000, 0)
             // Standard Error: 851
-            .saturating_add(Weight::from_ref_time(559_307).saturating_mul(i.into()))
+            .saturating_add(Weight::from_parts(559_307, 0).saturating_mul(i.into()))
             .saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
     }
     /// The range of component `i` is `[0, 1000]`.
@@ -94,9 +94,9 @@ impl<T: frame_system::Config> frame_system::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_219 nanoseconds.
-        Weight::from_ref_time(1_249_000)
+        Weight::from_parts(1_249_000, 0)
             // Standard Error: 759
-            .saturating_add(Weight::from_ref_time(461_946).saturating_mul(i.into()))
+            .saturating_add(Weight::from_parts(461_946, 0).saturating_mul(i.into()))
             .saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
     }
     /// The range of component `p` is `[0, 1000]`.
@@ -107,7 +107,7 @@ impl<T: frame_system::Config> frame_system::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 2_503 nanoseconds.
         Weight::from_parts(2_658_000, 64)
             // Standard Error: 1_232
-            .saturating_add(Weight::from_ref_time(1_025_157).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_025_157, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(70).saturating_mul(p.into()))
     }
@@ -121,9 +121,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_195 nanoseconds.
-        Weight::from_ref_time(1_173_301)
+        Weight::from_parts(1_173_301, 0)
             // Standard Error: 0
-            .saturating_add(Weight::from_ref_time(458).saturating_mul(b.into()))
+            .saturating_add(Weight::from_parts(458, 0).saturating_mul(b.into()))
     }
     /// The range of component `b` is `[0, 1310720]`.
     fn remark_with_event(b: u32, ) -> Weight {
@@ -131,9 +131,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_020 nanoseconds.
-        Weight::from_ref_time(5_078_000)
+        Weight::from_parts(5_078_000, 0)
             // Standard Error: 0
-            .saturating_add(Weight::from_ref_time(1_740).saturating_mul(b.into()))
+            .saturating_add(Weight::from_parts(1_740, 0).saturating_mul(b.into()))
     }
     fn set_heap_pages() -> Weight {
         // Proof Size summary in bytes:
@@ -150,9 +150,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_180 nanoseconds.
-        Weight::from_ref_time(1_217_000)
+        Weight::from_parts(1_217_000, 0)
             // Standard Error: 851
-            .saturating_add(Weight::from_ref_time(559_307).saturating_mul(i.into()))
+            .saturating_add(Weight::from_parts(559_307, 0).saturating_mul(i.into()))
             .saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(i.into())))
     }
     /// The range of component `i` is `[0, 1000]`.
@@ -161,9 +161,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_219 nanoseconds.
-        Weight::from_ref_time(1_249_000)
+        Weight::from_parts(1_249_000, 0)
             // Standard Error: 759
-            .saturating_add(Weight::from_ref_time(461_946).saturating_mul(i.into()))
+            .saturating_add(Weight::from_parts(461_946, 0).saturating_mul(i.into()))
             .saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(i.into())))
     }
     /// The range of component `p` is `[0, 1000]`.
@@ -174,7 +174,7 @@ impl WeightInfo for () {
         // Minimum execution time: 2_503 nanoseconds.
         Weight::from_parts(2_658_000, 64)
             // Standard Error: 1_232
-            .saturating_add(Weight::from_ref_time(1_025_157).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_025_157, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(70).saturating_mul(p.into()))
     }

--- a/runtime/gear/src/weights/frame_system.rs
+++ b/runtime/gear/src/weights/frame_system.rs
@@ -109,7 +109,7 @@ impl<T: frame_system::Config> frame_system::WeightInfo for SubstrateWeight<T> {
             // Standard Error: 1_232
             .saturating_add(Weight::from_parts(1_025_157, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(70).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 70).saturating_mul(p.into()))
     }
 }
 
@@ -176,6 +176,6 @@ impl WeightInfo for () {
             // Standard Error: 1_232
             .saturating_add(Weight::from_parts(1_025_157, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(70).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 70).saturating_mul(p.into()))
     }
 }

--- a/runtime/gear/src/weights/mod.rs
+++ b/runtime/gear/src/weights/mod.rs
@@ -18,8 +18,6 @@
 
 //! A list of the different weight modules for our runtime.
 
-#![allow(deprecated)]
-
 pub mod frame_system;
 pub mod pallet_balances;
 pub mod pallet_gear;

--- a/runtime/gear/src/weights/mod.rs
+++ b/runtime/gear/src/weights/mod.rs
@@ -18,7 +18,6 @@
 
 //! A list of the different weight modules for our runtime.
 
-// (issue #2531)
 #![allow(deprecated)]
 
 pub mod frame_system;

--- a/runtime/gear/src/weights/pallet_gear.rs
+++ b/runtime/gear/src/weights/pallet_gear.rs
@@ -232,7 +232,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
             // Standard Error: 1_587
             .saturating_add(Weight::from_parts(691_791, 0).saturating_mul(c.into()))
             .saturating_add(T::DbWeight::get().reads(1_u64))
-            .saturating_add(Weight::from_proof_size(1024).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(0, 1024).saturating_mul(c.into()))
     }
     /// The range of component `c` is `[0, 512]`.
     fn instantiate_module_per_kb(c: u32, ) -> Weight {
@@ -351,7 +351,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
             .saturating_add(Weight::from_parts(51_482_330, 0).saturating_mul(c.into()))
             .saturating_add(T::DbWeight::get().reads(1_u64))
             .saturating_add(T::DbWeight::get().writes(2_u64))
-            .saturating_add(Weight::from_proof_size(2150).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(0, 2150).saturating_mul(c.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn alloc(r: u32, ) -> Weight {
@@ -856,7 +856,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
             // Standard Error: 8_097
             .saturating_add(Weight::from_parts(11_697_667, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9900).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 512]`.
     fn lazy_pages_signal_write(p: u32, ) -> Weight {
@@ -868,7 +868,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
             // Standard Error: 44_559
             .saturating_add(Weight::from_parts(36_153_847, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9900).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 512]`.
     fn lazy_pages_signal_write_after_read(p: u32, ) -> Weight {
@@ -891,7 +891,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
             // Standard Error: 37_631
             .saturating_add(Weight::from_parts(45_958_696, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(75606).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 75606).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 32]`.
     fn lazy_pages_host_func_read(p: u32, ) -> Weight {
@@ -903,7 +903,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
             // Standard Error: 74_142
             .saturating_add(Weight::from_parts(37_638_856, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9883).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 32]`.
     fn lazy_pages_host_func_write(p: u32, ) -> Weight {
@@ -915,7 +915,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
             // Standard Error: 324_620
             .saturating_add(Weight::from_parts(46_953_221, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9883).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 32]`.
     fn lazy_pages_host_func_write_after_read(p: u32, ) -> Weight {
@@ -1792,7 +1792,7 @@ impl WeightInfo for () {
             // Standard Error: 1_587
             .saturating_add(Weight::from_parts(691_791, 0).saturating_mul(c.into()))
             .saturating_add(RocksDbWeight::get().reads(1_u64))
-            .saturating_add(Weight::from_proof_size(1024).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(0, 1024).saturating_mul(c.into()))
     }
     /// The range of component `c` is `[0, 512]`.
     fn instantiate_module_per_kb(c: u32, ) -> Weight {
@@ -1911,7 +1911,7 @@ impl WeightInfo for () {
             .saturating_add(Weight::from_parts(51_482_330, 0).saturating_mul(c.into()))
             .saturating_add(RocksDbWeight::get().reads(1_u64))
             .saturating_add(RocksDbWeight::get().writes(2_u64))
-            .saturating_add(Weight::from_proof_size(2150).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(0, 2150).saturating_mul(c.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn alloc(r: u32, ) -> Weight {
@@ -2416,7 +2416,7 @@ impl WeightInfo for () {
             // Standard Error: 8_097
             .saturating_add(Weight::from_parts(11_697_667, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9900).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 512]`.
     fn lazy_pages_signal_write(p: u32, ) -> Weight {
@@ -2428,7 +2428,7 @@ impl WeightInfo for () {
             // Standard Error: 44_559
             .saturating_add(Weight::from_parts(36_153_847, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9900).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 512]`.
     fn lazy_pages_signal_write_after_read(p: u32, ) -> Weight {
@@ -2451,7 +2451,7 @@ impl WeightInfo for () {
             // Standard Error: 37_631
             .saturating_add(Weight::from_parts(45_958_696, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(75606).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 75606).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 32]`.
     fn lazy_pages_host_func_read(p: u32, ) -> Weight {
@@ -2463,7 +2463,7 @@ impl WeightInfo for () {
             // Standard Error: 74_142
             .saturating_add(Weight::from_parts(37_638_856, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9883).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 32]`.
     fn lazy_pages_host_func_write(p: u32, ) -> Weight {
@@ -2475,7 +2475,7 @@ impl WeightInfo for () {
             // Standard Error: 324_620
             .saturating_add(Weight::from_parts(46_953_221, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9883).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 32]`.
     fn lazy_pages_host_func_write_after_read(p: u32, ) -> Weight {

--- a/runtime/gear/src/weights/pallet_gear.rs
+++ b/runtime/gear/src/weights/pallet_gear.rs
@@ -217,9 +217,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 714 nanoseconds.
-        Weight::from_ref_time(762_000)
+        Weight::from_parts(762_000, 0)
             // Standard Error: 916
-            .saturating_add(Weight::from_ref_time(249_959).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(249_959, 0).saturating_mul(c.into()))
             .saturating_add(T::DbWeight::get().writes(1_u64))
     }
     /// The range of component `c` is `[0, 512]`.
@@ -230,7 +230,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 2_591 nanoseconds.
         Weight::from_parts(2_658_000, 2546)
             // Standard Error: 1_587
-            .saturating_add(Weight::from_ref_time(691_791).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(691_791, 0).saturating_mul(c.into()))
             .saturating_add(T::DbWeight::get().reads(1_u64))
             .saturating_add(Weight::from_proof_size(1024).saturating_mul(c.into()))
     }
@@ -240,9 +240,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 47_048 nanoseconds.
-        Weight::from_ref_time(80_532_528)
+        Weight::from_parts(80_532_528, 0)
             // Standard Error: 4_561
-            .saturating_add(Weight::from_ref_time(2_208_073).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(2_208_073, 0).saturating_mul(c.into()))
     }
     fn claim_value() -> Weight {
         // Proof Size summary in bytes:
@@ -261,7 +261,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 55_252 nanoseconds.
         Weight::from_parts(39_508_166, 3010)
             // Standard Error: 54_990
-            .saturating_add(Weight::from_ref_time(53_653_596).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(53_653_596, 0).saturating_mul(c.into()))
             .saturating_add(T::DbWeight::get().reads(2_u64))
             .saturating_add(T::DbWeight::get().writes(4_u64))
     }
@@ -273,7 +273,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 45_837 nanoseconds.
         Weight::from_parts(67_499_867, 17714)
             // Standard Error: 0
-            .saturating_add(Weight::from_ref_time(2_312).saturating_mul(s.into()))
+            .saturating_add(Weight::from_parts(2_312, 0).saturating_mul(s.into()))
             .saturating_add(T::DbWeight::get().reads(10_u64))
             .saturating_add(T::DbWeight::get().writes(8_u64))
     }
@@ -286,9 +286,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 9_772_476 nanoseconds.
         Weight::from_parts(137_998_681, 13432)
             // Standard Error: 153_459
-            .saturating_add(Weight::from_ref_time(54_040_008).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(54_040_008, 0).saturating_mul(c.into()))
             // Standard Error: 9
-            .saturating_add(Weight::from_ref_time(2_271).saturating_mul(s.into()))
+            .saturating_add(Weight::from_parts(2_271, 0).saturating_mul(s.into()))
             .saturating_add(T::DbWeight::get().reads(10_u64))
             .saturating_add(T::DbWeight::get().writes(12_u64))
     }
@@ -300,7 +300,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 47_594 nanoseconds.
         Weight::from_parts(39_261_875, 14759)
             // Standard Error: 0
-            .saturating_add(Weight::from_ref_time(1_154).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_154, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads(9_u64))
             .saturating_add(T::DbWeight::get().writes(8_u64))
     }
@@ -312,7 +312,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 69_752 nanoseconds.
         Weight::from_parts(56_435_092, 30879)
             // Standard Error: 1
-            .saturating_add(Weight::from_ref_time(1_169).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_169, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads(13_u64))
             .saturating_add(T::DbWeight::get().writes(10_u64))
     }
@@ -324,7 +324,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 257_221 nanoseconds.
         Weight::from_parts(266_363_888, 40731)
             // Standard Error: 927
-            .saturating_add(Weight::from_ref_time(13_060).saturating_mul(q.into()))
+            .saturating_add(Weight::from_parts(13_060, 0).saturating_mul(q.into()))
             .saturating_add(T::DbWeight::get().reads(24_u64))
             .saturating_add(T::DbWeight::get().writes(21_u64))
     }
@@ -336,7 +336,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 272_686 nanoseconds.
         Weight::from_parts(284_450_996, 40581)
             // Standard Error: 786
-            .saturating_add(Weight::from_ref_time(260).saturating_mul(q.into()))
+            .saturating_add(Weight::from_parts(260, 0).saturating_mul(q.into()))
             .saturating_add(T::DbWeight::get().reads(24_u64))
             .saturating_add(T::DbWeight::get().writes(21_u64))
     }
@@ -348,7 +348,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 40_325 nanoseconds.
         Weight::from_parts(40_776_000, 2973)
             // Standard Error: 26_634
-            .saturating_add(Weight::from_ref_time(51_482_330).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(51_482_330, 0).saturating_mul(c.into()))
             .saturating_add(T::DbWeight::get().reads(1_u64))
             .saturating_add(T::DbWeight::get().writes(2_u64))
             .saturating_add(Weight::from_proof_size(2150).saturating_mul(c.into()))
@@ -359,9 +359,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_124 nanoseconds.
-        Weight::from_ref_time(56_808_831)
+        Weight::from_parts(56_808_831, 0)
             // Standard Error: 286_293
-            .saturating_add(Weight::from_ref_time(121_779_133).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(121_779_133, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn free(r: u32, ) -> Weight {
@@ -369,9 +369,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 193_689 nanoseconds.
-        Weight::from_ref_time(170_580_231)
+        Weight::from_parts(170_580_231, 0)
             // Standard Error: 278_566
-            .saturating_add(Weight::from_ref_time(123_420_096).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(123_420_096, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 256]`.
     fn gr_reserve_gas(r: u32, ) -> Weight {
@@ -379,9 +379,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_404 nanoseconds.
-        Weight::from_ref_time(88_583_428)
+        Weight::from_parts(88_583_428, 0)
             // Standard Error: 3_546
-            .saturating_add(Weight::from_ref_time(3_421_193).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_421_193, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 256]`.
     fn gr_unreserve_gas(r: u32, ) -> Weight {
@@ -389,9 +389,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 131_673 nanoseconds.
-        Weight::from_ref_time(139_085_832)
+        Weight::from_parts(139_085_832, 0)
             // Standard Error: 15_674
-            .saturating_add(Weight::from_ref_time(3_646_255).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_646_255, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_system_reserve_gas(r: u32, ) -> Weight {
@@ -399,9 +399,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_127 nanoseconds.
-        Weight::from_ref_time(107_304_676)
+        Weight::from_parts(107_304_676, 0)
             // Standard Error: 280_555
-            .saturating_add(Weight::from_ref_time(183_537_739).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(183_537_739, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_message_id(r: u32, ) -> Weight {
@@ -409,9 +409,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_204 nanoseconds.
-        Weight::from_ref_time(63_855_671)
+        Weight::from_parts(63_855_671, 0)
             // Standard Error: 255_652
-            .saturating_add(Weight::from_ref_time(180_882_229).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_882_229, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_origin(r: u32, ) -> Weight {
@@ -419,9 +419,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_747 nanoseconds.
-        Weight::from_ref_time(62_378_952)
+        Weight::from_parts(62_378_952, 0)
             // Standard Error: 243_378
-            .saturating_add(Weight::from_ref_time(181_354_986).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_354_986, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_program_id(r: u32, ) -> Weight {
@@ -429,9 +429,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_628 nanoseconds.
-        Weight::from_ref_time(62_023_316)
+        Weight::from_parts(62_023_316, 0)
             // Standard Error: 239_172
-            .saturating_add(Weight::from_ref_time(181_312_090).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_312_090, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_source(r: u32, ) -> Weight {
@@ -439,9 +439,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_107 nanoseconds.
-        Weight::from_ref_time(64_448_589)
+        Weight::from_parts(64_448_589, 0)
             // Standard Error: 243_926
-            .saturating_add(Weight::from_ref_time(181_908_539).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_908_539, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_value(r: u32, ) -> Weight {
@@ -449,9 +449,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_063 nanoseconds.
-        Weight::from_ref_time(63_994_362)
+        Weight::from_parts(63_994_362, 0)
             // Standard Error: 222_109
-            .saturating_add(Weight::from_ref_time(180_538_936).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_538_936, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_value_available(r: u32, ) -> Weight {
@@ -459,9 +459,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 79_507 nanoseconds.
-        Weight::from_ref_time(62_253_457)
+        Weight::from_parts(62_253_457, 0)
             // Standard Error: 237_685
-            .saturating_add(Weight::from_ref_time(180_220_624).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_220_624, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_gas_available(r: u32, ) -> Weight {
@@ -469,9 +469,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_164 nanoseconds.
-        Weight::from_ref_time(64_087_928)
+        Weight::from_parts(64_087_928, 0)
             // Standard Error: 254_664
-            .saturating_add(Weight::from_ref_time(180_159_594).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_159_594, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_size(r: u32, ) -> Weight {
@@ -479,9 +479,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_583 nanoseconds.
-        Weight::from_ref_time(67_596_795)
+        Weight::from_parts(67_596_795, 0)
             // Standard Error: 234_491
-            .saturating_add(Weight::from_ref_time(181_034_283).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_034_283, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_read(r: u32, ) -> Weight {
@@ -489,9 +489,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 707_674 nanoseconds.
-        Weight::from_ref_time(799_106_757)
+        Weight::from_parts(799_106_757, 0)
             // Standard Error: 290_054
-            .saturating_add(Weight::from_ref_time(237_370_449).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(237_370_449, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_read_per_kb(n: u32, ) -> Weight {
@@ -499,9 +499,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 952_371 nanoseconds.
-        Weight::from_ref_time(956_495_000)
+        Weight::from_parts(956_495_000, 0)
             // Standard Error: 60_878
-            .saturating_add(Weight::from_ref_time(14_227_144).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(14_227_144, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_block_height(r: u32, ) -> Weight {
@@ -509,9 +509,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_283 nanoseconds.
-        Weight::from_ref_time(67_213_364)
+        Weight::from_parts(67_213_364, 0)
             // Standard Error: 216_089
-            .saturating_add(Weight::from_ref_time(179_717_831).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(179_717_831, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_block_timestamp(r: u32, ) -> Weight {
@@ -519,9 +519,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_151 nanoseconds.
-        Weight::from_ref_time(64_827_395)
+        Weight::from_parts(64_827_395, 0)
             // Standard Error: 240_155
-            .saturating_add(Weight::from_ref_time(180_340_647).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_340_647, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 20]`.
     fn gr_random(n: u32, ) -> Weight {
@@ -529,9 +529,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_607 nanoseconds.
-        Weight::from_ref_time(97_606_147)
+        Weight::from_parts(97_606_147, 0)
             // Standard Error: 253_065
-            .saturating_add(Weight::from_ref_time(234_245_810).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(234_245_810, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_init(r: u32, ) -> Weight {
@@ -539,9 +539,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_345 nanoseconds.
-        Weight::from_ref_time(63_840_792)
+        Weight::from_parts(63_840_792, 0)
             // Standard Error: 226_520
-            .saturating_add(Weight::from_ref_time(187_131_229).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(187_131_229, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_push(r: u32, ) -> Weight {
@@ -549,9 +549,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 3_677_374 nanoseconds.
-        Weight::from_ref_time(3_820_987_062)
+        Weight::from_parts(3_820_987_062, 0)
             // Standard Error: 268_252
-            .saturating_add(Weight::from_ref_time(255_977_920).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(255_977_920, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_send_push_per_kb(n: u32, ) -> Weight {
@@ -559,9 +559,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 515_418 nanoseconds.
-        Weight::from_ref_time(522_188_000)
+        Weight::from_parts(522_188_000, 0)
             // Standard Error: 55_829
-            .saturating_add(Weight::from_ref_time(31_257_326).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(31_257_326, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_commit(r: u32, ) -> Weight {
@@ -569,9 +569,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_956 nanoseconds.
-        Weight::from_ref_time(135_884_682)
+        Weight::from_parts(135_884_682, 0)
             // Standard Error: 312_774
-            .saturating_add(Weight::from_ref_time(353_743_445).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(353_743_445, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_send_commit_per_kb(n: u32, ) -> Weight {
@@ -579,9 +579,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 437_809 nanoseconds.
-        Weight::from_ref_time(441_185_000)
+        Weight::from_parts(441_185_000, 0)
             // Standard Error: 64_589
-            .saturating_add(Weight::from_ref_time(21_143_950).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(21_143_950, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reservation_send_commit(r: u32, ) -> Weight {
@@ -589,9 +589,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 240_166 nanoseconds.
-        Weight::from_ref_time(307_423_566)
+        Weight::from_parts(307_423_566, 0)
             // Standard Error: 263_198
-            .saturating_add(Weight::from_ref_time(365_304_897).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(365_304_897, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reservation_send_commit_per_kb(n: u32, ) -> Weight {
@@ -599,9 +599,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 466_793 nanoseconds.
-        Weight::from_ref_time(479_126_000)
+        Weight::from_parts(479_126_000, 0)
             // Standard Error: 63_386
-            .saturating_add(Weight::from_ref_time(21_350_039).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(21_350_039, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_reply_commit(r: u32, ) -> Weight {
@@ -609,9 +609,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_102 nanoseconds.
-        Weight::from_ref_time(83_399_128)
+        Weight::from_parts(83_399_128, 0)
             // Standard Error: 229_588
-            .saturating_add(Weight::from_ref_time(20_817_771).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(20_817_771, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reply_commit_per_kb(n: u32, ) -> Weight {
@@ -619,9 +619,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 99_001 nanoseconds.
-        Weight::from_ref_time(86_637_798)
+        Weight::from_parts(86_637_798, 0)
             // Standard Error: 923
-            .saturating_add(Weight::from_ref_time(424_190).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(424_190, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reply_push(r: u32, ) -> Weight {
@@ -629,9 +629,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_499 nanoseconds.
-        Weight::from_ref_time(131_462_314)
+        Weight::from_parts(131_462_314, 0)
             // Standard Error: 296_583
-            .saturating_add(Weight::from_ref_time(246_894_431).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(246_894_431, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 8192]`.
     fn gr_reply_push_per_kb(n: u32, ) -> Weight {
@@ -639,9 +639,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 96_357 nanoseconds.
-        Weight::from_ref_time(97_184_000)
+        Weight::from_parts(97_184_000, 0)
             // Standard Error: 2_351
-            .saturating_add(Weight::from_ref_time(640_572).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(640_572, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_reservation_reply_commit(r: u32, ) -> Weight {
@@ -649,9 +649,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 89_493 nanoseconds.
-        Weight::from_ref_time(93_301_112)
+        Weight::from_parts(93_301_112, 0)
             // Standard Error: 231_085
-            .saturating_add(Weight::from_ref_time(9_751_187).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(9_751_187, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reservation_reply_commit_per_kb(n: u32, ) -> Weight {
@@ -659,9 +659,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 102_738 nanoseconds.
-        Weight::from_ref_time(85_959_957)
+        Weight::from_parts(85_959_957, 0)
             // Standard Error: 1_056
-            .saturating_add(Weight::from_ref_time(426_826).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(426_826, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reply_to(r: u32, ) -> Weight {
@@ -669,9 +669,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_593 nanoseconds.
-        Weight::from_ref_time(61_040_651)
+        Weight::from_parts(61_040_651, 0)
             // Standard Error: 231_867
-            .saturating_add(Weight::from_ref_time(183_706_745).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(183_706_745, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_signal_from(r: u32, ) -> Weight {
@@ -679,9 +679,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_324 nanoseconds.
-        Weight::from_ref_time(66_339_260)
+        Weight::from_parts(66_339_260, 0)
             // Standard Error: 254_057
-            .saturating_add(Weight::from_ref_time(181_778_743).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_778_743, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reply_push_input(r: u32, ) -> Weight {
@@ -689,9 +689,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 706_163 nanoseconds.
-        Weight::from_ref_time(746_906_968)
+        Weight::from_parts(746_906_968, 0)
             // Standard Error: 289_363
-            .saturating_add(Weight::from_ref_time(197_735_344).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(197_735_344, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reply_push_input_per_kb(n: u32, ) -> Weight {
@@ -699,9 +699,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 727_470 nanoseconds.
-        Weight::from_ref_time(764_436_591)
+        Weight::from_parts(764_436_591, 0)
             // Standard Error: 1_954
-            .saturating_add(Weight::from_ref_time(155_898).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(155_898, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_push_input(r: u32, ) -> Weight {
@@ -709,9 +709,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_379_140 nanoseconds.
-        Weight::from_ref_time(4_509_467_459)
+        Weight::from_parts(4_509_467_459, 0)
             // Standard Error: 293_145
-            .saturating_add(Weight::from_ref_time(202_192_351).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(202_192_351, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_send_push_input_per_kb(n: u32, ) -> Weight {
@@ -719,9 +719,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_116_085 nanoseconds.
-        Weight::from_ref_time(1_161_687_850)
+        Weight::from_parts(1_161_687_850, 0)
             // Standard Error: 9_577
-            .saturating_add(Weight::from_ref_time(13_711_920).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(13_711_920, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_debug(r: u32, ) -> Weight {
@@ -729,9 +729,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_884 nanoseconds.
-        Weight::from_ref_time(97_414_295)
+        Weight::from_parts(97_414_295, 0)
             // Standard Error: 266_242
-            .saturating_add(Weight::from_ref_time(191_541_864).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(191_541_864, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_debug_per_kb(n: u32, ) -> Weight {
@@ -739,9 +739,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 259_961 nanoseconds.
-        Weight::from_ref_time(261_294_000)
+        Weight::from_parts(261_294_000, 0)
             // Standard Error: 55_450
-            .saturating_add(Weight::from_ref_time(26_992_075).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(26_992_075, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_error(r: u32, ) -> Weight {
@@ -749,9 +749,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 94_153 nanoseconds.
-        Weight::from_ref_time(92_584_315)
+        Weight::from_parts(92_584_315, 0)
             // Standard Error: 263_504
-            .saturating_add(Weight::from_ref_time(235_583_714).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(235_583_714, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_status_code(r: u32, ) -> Weight {
@@ -759,9 +759,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_011 nanoseconds.
-        Weight::from_ref_time(60_532_712)
+        Weight::from_parts(60_532_712, 0)
             // Standard Error: 252_427
-            .saturating_add(Weight::from_ref_time(181_273_142).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_273_142, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_exit(r: u32, ) -> Weight {
@@ -769,9 +769,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 79_956 nanoseconds.
-        Weight::from_ref_time(83_128_273)
+        Weight::from_parts(83_128_273, 0)
             // Standard Error: 233_270
-            .saturating_add(Weight::from_ref_time(24_200_326).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(24_200_326, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_leave(r: u32, ) -> Weight {
@@ -779,9 +779,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_471 nanoseconds.
-        Weight::from_ref_time(84_933_897)
+        Weight::from_parts(84_933_897, 0)
             // Standard Error: 228_044
-            .saturating_add(Weight::from_ref_time(10_863_802).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(10_863_802, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_wait(r: u32, ) -> Weight {
@@ -789,9 +789,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 79_140 nanoseconds.
-        Weight::from_ref_time(82_413_287)
+        Weight::from_parts(82_413_287, 0)
             // Standard Error: 242_017
-            .saturating_add(Weight::from_ref_time(15_558_512).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(15_558_512, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_wait_for(r: u32, ) -> Weight {
@@ -799,9 +799,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 79_597 nanoseconds.
-        Weight::from_ref_time(83_256_853)
+        Weight::from_parts(83_256_853, 0)
             // Standard Error: 251_615
-            .saturating_add(Weight::from_ref_time(14_287_546).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(14_287_546, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_wait_up_to(r: u32, ) -> Weight {
@@ -809,9 +809,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_149 nanoseconds.
-        Weight::from_ref_time(84_067_253)
+        Weight::from_parts(84_067_253, 0)
             // Standard Error: 242_934
-            .saturating_add(Weight::from_ref_time(12_984_046).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(12_984_046, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_wake(r: u32, ) -> Weight {
@@ -819,9 +819,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 134_568 nanoseconds.
-        Weight::from_ref_time(191_754_546)
+        Weight::from_parts(191_754_546, 0)
             // Standard Error: 310_042
-            .saturating_add(Weight::from_ref_time(258_517_274).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(258_517_274, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_create_program_wgas(r: u32, ) -> Weight {
@@ -829,9 +829,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 89_961 nanoseconds.
-        Weight::from_ref_time(135_401_157)
+        Weight::from_parts(135_401_157, 0)
             // Standard Error: 330_013
-            .saturating_add(Weight::from_ref_time(438_218_419).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(438_218_419, 0).saturating_mul(r.into()))
     }
     /// The range of component `p` is `[0, 2048]`.
     /// The range of component `s` is `[1, 2048]`.
@@ -840,11 +840,11 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 44_618_378 nanoseconds.
-        Weight::from_ref_time(44_975_555_000)
+        Weight::from_parts(44_975_555_000, 0)
             // Standard Error: 259_430
-            .saturating_add(Weight::from_ref_time(7_365_489).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(7_365_489, 0).saturating_mul(p.into()))
             // Standard Error: 259_417
-            .saturating_add(Weight::from_ref_time(155_224_672).saturating_mul(s.into()))
+            .saturating_add(Weight::from_parts(155_224_672, 0).saturating_mul(s.into()))
     }
     /// The range of component `p` is `[0, 512]`.
     fn lazy_pages_signal_read(p: u32, ) -> Weight {
@@ -854,7 +854,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 81_060 nanoseconds.
         Weight::from_parts(116_078_081, 141)
             // Standard Error: 8_097
-            .saturating_add(Weight::from_ref_time(11_697_667).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(11_697_667, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
     }
@@ -866,7 +866,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 82_253 nanoseconds.
         Weight::from_parts(83_487_000, 141)
             // Standard Error: 44_559
-            .saturating_add(Weight::from_ref_time(36_153_847).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(36_153_847, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
     }
@@ -878,7 +878,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 6_059_320 nanoseconds.
         Weight::from_parts(6_026_768_509, 5068941)
             // Standard Error: 74_371
-            .saturating_add(Weight::from_ref_time(37_256_749).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(37_256_749, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads(2048_u64))
     }
     /// The range of component `p` is `[0, 512]`.
@@ -889,7 +889,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 82_117 nanoseconds.
         Weight::from_parts(84_007_000, 949)
             // Standard Error: 37_631
-            .saturating_add(Weight::from_ref_time(45_958_696).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(45_958_696, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(75606).saturating_mul(p.into()))
     }
@@ -901,7 +901,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 93_080 nanoseconds.
         Weight::from_parts(77_592_595, 506)
             // Standard Error: 74_142
-            .saturating_add(Weight::from_ref_time(37_638_856).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(37_638_856, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
     }
@@ -913,7 +913,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 748_265 nanoseconds.
         Weight::from_parts(748_224_476, 506)
             // Standard Error: 324_620
-            .saturating_add(Weight::from_ref_time(46_953_221).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(46_953_221, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
     }
@@ -925,7 +925,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 1_126_554 nanoseconds.
         Weight::from_parts(1_175_012_009, 316941)
             // Standard Error: 204_912
-            .saturating_add(Weight::from_ref_time(43_619_826).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(43_619_826, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads(128_u64))
     }
     /// The range of component `r` is `[50, 500]`.
@@ -934,9 +934,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_248_587 nanoseconds.
-        Weight::from_ref_time(4_247_395_501)
+        Weight::from_parts(4_247_395_501, 0)
             // Standard Error: 11_091
-            .saturating_add(Weight::from_ref_time(3_323_996).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_323_996, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[50, 500]`.
     fn instr_i32load(r: u32, ) -> Weight {
@@ -944,9 +944,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_244_604 nanoseconds.
-        Weight::from_ref_time(4_236_154_065)
+        Weight::from_parts(4_236_154_065, 0)
             // Standard Error: 10_679
-            .saturating_add(Weight::from_ref_time(3_383_238).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_383_238, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[50, 500]`.
     fn instr_i64store(r: u32, ) -> Weight {
@@ -954,9 +954,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 10_566_548 nanoseconds.
-        Weight::from_ref_time(10_110_815_063)
+        Weight::from_parts(10_110_815_063, 0)
             // Standard Error: 164_010
-            .saturating_add(Weight::from_ref_time(15_834_994).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(15_834_994, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[50, 500]`.
     fn instr_i32store(r: u32, ) -> Weight {
@@ -964,9 +964,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 10_594_891 nanoseconds.
-        Weight::from_ref_time(10_824_075_202)
+        Weight::from_parts(10_824_075_202, 0)
             // Standard Error: 246_795
-            .saturating_add(Weight::from_ref_time(8_865_110).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(8_865_110, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_select(r: u32, ) -> Weight {
@@ -974,9 +974,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_984 nanoseconds.
-        Weight::from_ref_time(2_022_000)
+        Weight::from_parts(2_022_000, 0)
             // Standard Error: 8_549
-            .saturating_add(Weight::from_ref_time(3_833_242).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_833_242, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_if(r: u32, ) -> Weight {
@@ -984,9 +984,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_972 nanoseconds.
-        Weight::from_ref_time(2_014_000)
+        Weight::from_parts(2_014_000, 0)
             // Standard Error: 4_696
-            .saturating_add(Weight::from_ref_time(3_071_869).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_071_869, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_br(r: u32, ) -> Weight {
@@ -994,9 +994,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_990 nanoseconds.
-        Weight::from_ref_time(3_141_848)
+        Weight::from_parts(3_141_848, 0)
             // Standard Error: 1_067
-            .saturating_add(Weight::from_ref_time(1_565_212).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_565_212, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_br_if(r: u32, ) -> Weight {
@@ -1004,9 +1004,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_910 nanoseconds.
-        Weight::from_ref_time(1_977_000)
+        Weight::from_parts(1_977_000, 0)
             // Standard Error: 10_190
-            .saturating_add(Weight::from_ref_time(2_916_284).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_916_284, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_br_table(r: u32, ) -> Weight {
@@ -1014,9 +1014,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_055 nanoseconds.
-        Weight::from_ref_time(2_124_000)
+        Weight::from_parts(2_124_000, 0)
             // Standard Error: 9_616
-            .saturating_add(Weight::from_ref_time(5_239_104).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(5_239_104, 0).saturating_mul(r.into()))
     }
     /// The range of component `e` is `[1, 256]`.
     fn instr_br_table_per_entry(e: u32, ) -> Weight {
@@ -1024,9 +1024,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 6_569 nanoseconds.
-        Weight::from_ref_time(5_561_073)
+        Weight::from_parts(5_561_073, 0)
             // Standard Error: 1_593
-            .saturating_add(Weight::from_ref_time(158_847).saturating_mul(e.into()))
+            .saturating_add(Weight::from_parts(158_847, 0).saturating_mul(e.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_call_const(r: u32, ) -> Weight {
@@ -1034,14 +1034,14 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_001 nanoseconds.
-        Weight::from_ref_time(4_351_879)
+        Weight::from_parts(4_351_879, 0)
             // Standard Error: 6_992
-            .saturating_add(Weight::from_ref_time(2_579_629).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_579_629, 0).saturating_mul(r.into()))
     }
     fn instr_i64const(r: u32, ) -> Weight {
-        Weight::from_ref_time(0)
-            .saturating_add(Weight::from_ref_time(2_579_629 -
-            2_411_507).saturating_mul(r.into()))
+        Weight::from_parts(0, 0)
+            .saturating_add(Weight::from_parts(2_579_629 -
+            2_411_507, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_call(r: u32, ) -> Weight {
@@ -1049,9 +1049,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_001 nanoseconds.
-        Weight::from_ref_time(4_619_716)
+        Weight::from_parts(4_619_716, 0)
             // Standard Error: 12_765
-            .saturating_add(Weight::from_ref_time(2_411_507).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_411_507, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_call_indirect(r: u32, ) -> Weight {
@@ -1059,9 +1059,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_321 nanoseconds.
-        Weight::from_ref_time(13_844_527)
+        Weight::from_parts(13_844_527, 0)
             // Standard Error: 28_587
-            .saturating_add(Weight::from_ref_time(10_571_661).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(10_571_661, 0).saturating_mul(r.into()))
     }
     /// The range of component `p` is `[0, 128]`.
     fn instr_call_indirect_per_param(p: u32, ) -> Weight {
@@ -1069,9 +1069,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 12_173 nanoseconds.
-        Weight::from_ref_time(4_877_843)
+        Weight::from_parts(4_877_843, 0)
             // Standard Error: 7_292
-            .saturating_add(Weight::from_ref_time(1_288_806).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_288_806, 0).saturating_mul(p.into()))
     }
     /// The range of component `l` is `[0, 1024]`.
     fn instr_call_per_local(l: u32, ) -> Weight {
@@ -1079,9 +1079,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_997 nanoseconds.
-        Weight::from_ref_time(5_260_743)
+        Weight::from_parts(5_260_743, 0)
             // Standard Error: 13
-            .saturating_add(Weight::from_ref_time(22).saturating_mul(l.into()))
+            .saturating_add(Weight::from_parts(22, 0).saturating_mul(l.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_local_get(r: u32, ) -> Weight {
@@ -1089,9 +1089,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_940 nanoseconds.
-        Weight::from_ref_time(1_830_043)
+        Weight::from_parts(1_830_043, 0)
             // Standard Error: 2_843
-            .saturating_add(Weight::from_ref_time(258_952).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(258_952, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_local_set(r: u32, ) -> Weight {
@@ -1099,9 +1099,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_991 nanoseconds.
-        Weight::from_ref_time(2_027_000)
+        Weight::from_parts(2_027_000, 0)
             // Standard Error: 5_369
-            .saturating_add(Weight::from_ref_time(736_000).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(736_000, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_local_tee(r: u32, ) -> Weight {
@@ -1109,9 +1109,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_000 nanoseconds.
-        Weight::from_ref_time(2_062_000)
+        Weight::from_parts(2_062_000, 0)
             // Standard Error: 4_630
-            .saturating_add(Weight::from_ref_time(719_367).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(719_367, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_global_get(r: u32, ) -> Weight {
@@ -1119,9 +1119,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_741 nanoseconds.
-        Weight::from_ref_time(2_616_782)
+        Weight::from_parts(2_616_782, 0)
             // Standard Error: 6_777
-            .saturating_add(Weight::from_ref_time(731_002).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(731_002, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_global_set(r: u32, ) -> Weight {
@@ -1129,9 +1129,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_795 nanoseconds.
-        Weight::from_ref_time(5_840_000)
+        Weight::from_parts(5_840_000, 0)
             // Standard Error: 8_144
-            .saturating_add(Weight::from_ref_time(1_259_731).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_259_731, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_memory_current(r: u32, ) -> Weight {
@@ -1139,9 +1139,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 6_596 nanoseconds.
-        Weight::from_ref_time(2_374_393)
+        Weight::from_parts(2_374_393, 0)
             // Standard Error: 12_129
-            .saturating_add(Weight::from_ref_time(6_823_668).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(6_823_668, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64clz(r: u32, ) -> Weight {
@@ -1149,9 +1149,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_980 nanoseconds.
-        Weight::from_ref_time(2_045_000)
+        Weight::from_parts(2_045_000, 0)
             // Standard Error: 8_388
-            .saturating_add(Weight::from_ref_time(3_325_416).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_325_416, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32clz(r: u32, ) -> Weight {
@@ -1159,9 +1159,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_950 nanoseconds.
-        Weight::from_ref_time(2_041_000)
+        Weight::from_parts(2_041_000, 0)
             // Standard Error: 7_692
-            .saturating_add(Weight::from_ref_time(3_034_615).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_034_615, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ctz(r: u32, ) -> Weight {
@@ -1169,9 +1169,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_981 nanoseconds.
-        Weight::from_ref_time(2_061_000)
+        Weight::from_parts(2_061_000, 0)
             // Standard Error: 8_251
-            .saturating_add(Weight::from_ref_time(3_019_593).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_019_593, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ctz(r: u32, ) -> Weight {
@@ -1179,9 +1179,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_980 nanoseconds.
-        Weight::from_ref_time(2_039_000)
+        Weight::from_parts(2_039_000, 0)
             // Standard Error: 6_062
-            .saturating_add(Weight::from_ref_time(2_592_066).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_592_066, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64popcnt(r: u32, ) -> Weight {
@@ -1189,9 +1189,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_036 nanoseconds.
-        Weight::from_ref_time(2_085_000)
+        Weight::from_parts(2_085_000, 0)
             // Standard Error: 3_811
-            .saturating_add(Weight::from_ref_time(537_423).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(537_423, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32popcnt(r: u32, ) -> Weight {
@@ -1199,9 +1199,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_987 nanoseconds.
-        Weight::from_ref_time(1_301_383)
+        Weight::from_parts(1_301_383, 0)
             // Standard Error: 3_109
-            .saturating_add(Weight::from_ref_time(381_295).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(381_295, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64eqz(r: u32, ) -> Weight {
@@ -1209,9 +1209,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_999 nanoseconds.
-        Weight::from_ref_time(2_069_000)
+        Weight::from_parts(2_069_000, 0)
             // Standard Error: 11_800
-            .saturating_add(Weight::from_ref_time(1_805_699).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_805_699, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32eqz(r: u32, ) -> Weight {
@@ -1219,9 +1219,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_014 nanoseconds.
-        Weight::from_ref_time(2_070_000)
+        Weight::from_parts(2_070_000, 0)
             // Standard Error: 8_255
-            .saturating_add(Weight::from_ref_time(1_114_949).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_114_949, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64extendsi32(r: u32, ) -> Weight {
@@ -1229,9 +1229,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_900 nanoseconds.
-        Weight::from_ref_time(1_701_470)
+        Weight::from_parts(1_701_470, 0)
             // Standard Error: 2_591
-            .saturating_add(Weight::from_ref_time(312_279).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(312_279, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64extendui32(r: u32, ) -> Weight {
@@ -1239,9 +1239,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_982 nanoseconds.
-        Weight::from_ref_time(2_190_000)
+        Weight::from_parts(2_190_000, 0)
             // Standard Error: 1_685
-            .saturating_add(Weight::from_ref_time(172_493).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(172_493, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32wrapi64(r: u32, ) -> Weight {
@@ -1249,9 +1249,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_041 nanoseconds.
-        Weight::from_ref_time(2_605_622)
+        Weight::from_parts(2_605_622, 0)
             // Standard Error: 1_576
-            .saturating_add(Weight::from_ref_time(159_097).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(159_097, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64eq(r: u32, ) -> Weight {
@@ -1259,9 +1259,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_918 nanoseconds.
-        Weight::from_ref_time(2_021_000)
+        Weight::from_parts(2_021_000, 0)
             // Standard Error: 11_160
-            .saturating_add(Weight::from_ref_time(1_781_573).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_781_573, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32eq(r: u32, ) -> Weight {
@@ -1269,9 +1269,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_990 nanoseconds.
-        Weight::from_ref_time(2_047_000)
+        Weight::from_parts(2_047_000, 0)
             // Standard Error: 6_989
-            .saturating_add(Weight::from_ref_time(1_086_510).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_086_510, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ne(r: u32, ) -> Weight {
@@ -1279,9 +1279,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_991 nanoseconds.
-        Weight::from_ref_time(2_035_000)
+        Weight::from_parts(2_035_000, 0)
             // Standard Error: 9_623
-            .saturating_add(Weight::from_ref_time(1_797_223).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_797_223, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ne(r: u32, ) -> Weight {
@@ -1289,9 +1289,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_957 nanoseconds.
-        Weight::from_ref_time(2_016_000)
+        Weight::from_parts(2_016_000, 0)
             // Standard Error: 7_516
-            .saturating_add(Weight::from_ref_time(1_100_146).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_100_146, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64lts(r: u32, ) -> Weight {
@@ -1299,9 +1299,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_975 nanoseconds.
-        Weight::from_ref_time(2_042_000)
+        Weight::from_parts(2_042_000, 0)
             // Standard Error: 9_617
-            .saturating_add(Weight::from_ref_time(1_798_574).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_798_574, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32lts(r: u32, ) -> Weight {
@@ -1309,9 +1309,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_919 nanoseconds.
-        Weight::from_ref_time(2_044_000)
+        Weight::from_parts(2_044_000, 0)
             // Standard Error: 7_469
-            .saturating_add(Weight::from_ref_time(1_119_079).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_119_079, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ltu(r: u32, ) -> Weight {
@@ -1319,9 +1319,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_983 nanoseconds.
-        Weight::from_ref_time(2_025_000)
+        Weight::from_parts(2_025_000, 0)
             // Standard Error: 11_078
-            .saturating_add(Weight::from_ref_time(1_866_193).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_866_193, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ltu(r: u32, ) -> Weight {
@@ -1329,9 +1329,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_945 nanoseconds.
-        Weight::from_ref_time(2_063_000)
+        Weight::from_parts(2_063_000, 0)
             // Standard Error: 7_762
-            .saturating_add(Weight::from_ref_time(1_098_384).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_098_384, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64gts(r: u32, ) -> Weight {
@@ -1339,9 +1339,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_984 nanoseconds.
-        Weight::from_ref_time(2_013_000)
+        Weight::from_parts(2_013_000, 0)
             // Standard Error: 13_010
-            .saturating_add(Weight::from_ref_time(1_809_632).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_809_632, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32gts(r: u32, ) -> Weight {
@@ -1349,9 +1349,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_936 nanoseconds.
-        Weight::from_ref_time(2_085_000)
+        Weight::from_parts(2_085_000, 0)
             // Standard Error: 7_662
-            .saturating_add(Weight::from_ref_time(1_077_967).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_077_967, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64gtu(r: u32, ) -> Weight {
@@ -1359,9 +1359,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_960 nanoseconds.
-        Weight::from_ref_time(2_013_000)
+        Weight::from_parts(2_013_000, 0)
             // Standard Error: 11_774
-            .saturating_add(Weight::from_ref_time(1_786_196).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_786_196, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32gtu(r: u32, ) -> Weight {
@@ -1369,9 +1369,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_938 nanoseconds.
-        Weight::from_ref_time(1_981_000)
+        Weight::from_parts(1_981_000, 0)
             // Standard Error: 7_698
-            .saturating_add(Weight::from_ref_time(1_068_379).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_068_379, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64les(r: u32, ) -> Weight {
@@ -1379,9 +1379,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_992 nanoseconds.
-        Weight::from_ref_time(2_053_000)
+        Weight::from_parts(2_053_000, 0)
             // Standard Error: 11_716
-            .saturating_add(Weight::from_ref_time(1_786_578).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_786_578, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32les(r: u32, ) -> Weight {
@@ -1389,9 +1389,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_940 nanoseconds.
-        Weight::from_ref_time(2_005_000)
+        Weight::from_parts(2_005_000, 0)
             // Standard Error: 7_815
-            .saturating_add(Weight::from_ref_time(1_090_447).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_090_447, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64leu(r: u32, ) -> Weight {
@@ -1399,9 +1399,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_930 nanoseconds.
-        Weight::from_ref_time(2_037_000)
+        Weight::from_parts(2_037_000, 0)
             // Standard Error: 14_146
-            .saturating_add(Weight::from_ref_time(1_837_345).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_837_345, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32leu(r: u32, ) -> Weight {
@@ -1409,9 +1409,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_953 nanoseconds.
-        Weight::from_ref_time(1_994_000)
+        Weight::from_parts(1_994_000, 0)
             // Standard Error: 7_326
-            .saturating_add(Weight::from_ref_time(1_124_069).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_124_069, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ges(r: u32, ) -> Weight {
@@ -1419,9 +1419,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_990 nanoseconds.
-        Weight::from_ref_time(2_022_000)
+        Weight::from_parts(2_022_000, 0)
             // Standard Error: 11_502
-            .saturating_add(Weight::from_ref_time(1_784_579).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_784_579, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ges(r: u32, ) -> Weight {
@@ -1429,9 +1429,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_955 nanoseconds.
-        Weight::from_ref_time(2_030_000)
+        Weight::from_parts(2_030_000, 0)
             // Standard Error: 7_269
-            .saturating_add(Weight::from_ref_time(1_087_418).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_087_418, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64geu(r: u32, ) -> Weight {
@@ -1439,9 +1439,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_966 nanoseconds.
-        Weight::from_ref_time(2_021_000)
+        Weight::from_parts(2_021_000, 0)
             // Standard Error: 10_931
-            .saturating_add(Weight::from_ref_time(1_779_890).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_779_890, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32geu(r: u32, ) -> Weight {
@@ -1449,9 +1449,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_985 nanoseconds.
-        Weight::from_ref_time(2_057_000)
+        Weight::from_parts(2_057_000, 0)
             // Standard Error: 7_783
-            .saturating_add(Weight::from_ref_time(1_115_230).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_115_230, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64add(r: u32, ) -> Weight {
@@ -1459,9 +1459,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_927 nanoseconds.
-        Weight::from_ref_time(2_053_000)
+        Weight::from_parts(2_053_000, 0)
             // Standard Error: 7_508
-            .saturating_add(Weight::from_ref_time(1_212_190).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_212_190, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32add(r: u32, ) -> Weight {
@@ -1469,9 +1469,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_009 nanoseconds.
-        Weight::from_ref_time(2_075_000)
+        Weight::from_parts(2_075_000, 0)
             // Standard Error: 3_877
-            .saturating_add(Weight::from_ref_time(576_488).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(576_488, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64sub(r: u32, ) -> Weight {
@@ -1479,9 +1479,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_909 nanoseconds.
-        Weight::from_ref_time(1_957_000)
+        Weight::from_parts(1_957_000, 0)
             // Standard Error: 7_060
-            .saturating_add(Weight::from_ref_time(1_174_700).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_174_700, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32sub(r: u32, ) -> Weight {
@@ -1489,9 +1489,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_985 nanoseconds.
-        Weight::from_ref_time(2_041_000)
+        Weight::from_parts(2_041_000, 0)
             // Standard Error: 4_555
-            .saturating_add(Weight::from_ref_time(594_904).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(594_904, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64mul(r: u32, ) -> Weight {
@@ -1499,9 +1499,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_982 nanoseconds.
-        Weight::from_ref_time(2_073_000)
+        Weight::from_parts(2_073_000, 0)
             // Standard Error: 12_025
-            .saturating_add(Weight::from_ref_time(1_724_065).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_724_065, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32mul(r: u32, ) -> Weight {
@@ -1509,9 +1509,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_957 nanoseconds.
-        Weight::from_ref_time(2_007_000)
+        Weight::from_parts(2_007_000, 0)
             // Standard Error: 8_716
-            .saturating_add(Weight::from_ref_time(1_150_408).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_150_408, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64divs(r: u32, ) -> Weight {
@@ -1519,9 +1519,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_884 nanoseconds.
-        Weight::from_ref_time(1_144_446)
+        Weight::from_parts(1_144_446, 0)
             // Standard Error: 10_547
-            .saturating_add(Weight::from_ref_time(2_675_861).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_675_861, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32divs(r: u32, ) -> Weight {
@@ -1529,9 +1529,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_006 nanoseconds.
-        Weight::from_ref_time(69_582)
+        Weight::from_parts(69_582, 0)
             // Standard Error: 11_472
-            .saturating_add(Weight::from_ref_time(2_348_861).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_348_861, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64divu(r: u32, ) -> Weight {
@@ -1539,9 +1539,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_935 nanoseconds.
-        Weight::from_ref_time(1_504_156)
+        Weight::from_parts(1_504_156, 0)
             // Standard Error: 16_606
-            .saturating_add(Weight::from_ref_time(2_805_608).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_805_608, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32divu(r: u32, ) -> Weight {
@@ -1549,9 +1549,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_982 nanoseconds.
-        Weight::from_ref_time(7_507_453)
+        Weight::from_parts(7_507_453, 0)
             // Standard Error: 27_413
-            .saturating_add(Weight::from_ref_time(2_106_829).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_106_829, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64rems(r: u32, ) -> Weight {
@@ -1559,9 +1559,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_957 nanoseconds.
-        Weight::from_ref_time(2_062_000)
+        Weight::from_parts(2_062_000, 0)
             // Standard Error: 22_291
-            .saturating_add(Weight::from_ref_time(9_226_033).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(9_226_033, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32rems(r: u32, ) -> Weight {
@@ -1569,9 +1569,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_952 nanoseconds.
-        Weight::from_ref_time(737_483)
+        Weight::from_parts(737_483, 0)
             // Standard Error: 45_126
-            .saturating_add(Weight::from_ref_time(7_533_584).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(7_533_584, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64remu(r: u32, ) -> Weight {
@@ -1579,9 +1579,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_957 nanoseconds.
-        Weight::from_ref_time(3_376_184)
+        Weight::from_parts(3_376_184, 0)
             // Standard Error: 20_172
-            .saturating_add(Weight::from_ref_time(2_862_201).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_862_201, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32remu(r: u32, ) -> Weight {
@@ -1589,9 +1589,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_982 nanoseconds.
-        Weight::from_ref_time(2_067_000)
+        Weight::from_parts(2_067_000, 0)
             // Standard Error: 5_984
-            .saturating_add(Weight::from_ref_time(2_531_767).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_531_767, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64and(r: u32, ) -> Weight {
@@ -1599,9 +1599,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_968 nanoseconds.
-        Weight::from_ref_time(2_028_000)
+        Weight::from_parts(2_028_000, 0)
             // Standard Error: 8_261
-            .saturating_add(Weight::from_ref_time(1_261_509).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_261_509, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32and(r: u32, ) -> Weight {
@@ -1609,9 +1609,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_029 nanoseconds.
-        Weight::from_ref_time(2_047_000)
+        Weight::from_parts(2_047_000, 0)
             // Standard Error: 4_691
-            .saturating_add(Weight::from_ref_time(613_890).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(613_890, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64or(r: u32, ) -> Weight {
@@ -1619,9 +1619,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_946 nanoseconds.
-        Weight::from_ref_time(2_035_000)
+        Weight::from_parts(2_035_000, 0)
             // Standard Error: 8_090
-            .saturating_add(Weight::from_ref_time(1_206_785).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_206_785, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32or(r: u32, ) -> Weight {
@@ -1629,9 +1629,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_022 nanoseconds.
-        Weight::from_ref_time(2_069_000)
+        Weight::from_parts(2_069_000, 0)
             // Standard Error: 4_558
-            .saturating_add(Weight::from_ref_time(600_340).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(600_340, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64xor(r: u32, ) -> Weight {
@@ -1639,9 +1639,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_031 nanoseconds.
-        Weight::from_ref_time(2_088_000)
+        Weight::from_parts(2_088_000, 0)
             // Standard Error: 7_497
-            .saturating_add(Weight::from_ref_time(1_200_146).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_200_146, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32xor(r: u32, ) -> Weight {
@@ -1649,9 +1649,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_007 nanoseconds.
-        Weight::from_ref_time(2_047_000)
+        Weight::from_parts(2_047_000, 0)
             // Standard Error: 4_583
-            .saturating_add(Weight::from_ref_time(601_809).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(601_809, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64shl(r: u32, ) -> Weight {
@@ -1659,9 +1659,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_968 nanoseconds.
-        Weight::from_ref_time(2_035_000)
+        Weight::from_parts(2_035_000, 0)
             // Standard Error: 7_148
-            .saturating_add(Weight::from_ref_time(1_033_991).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_033_991, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32shl(r: u32, ) -> Weight {
@@ -1669,9 +1669,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_951 nanoseconds.
-        Weight::from_ref_time(2_036_000)
+        Weight::from_parts(2_036_000, 0)
             // Standard Error: 3_798
-            .saturating_add(Weight::from_ref_time(557_173).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(557_173, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64shrs(r: u32, ) -> Weight {
@@ -1679,9 +1679,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_008 nanoseconds.
-        Weight::from_ref_time(2_059_000)
+        Weight::from_parts(2_059_000, 0)
             // Standard Error: 6_814
-            .saturating_add(Weight::from_ref_time(1_071_968).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_071_968, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32shrs(r: u32, ) -> Weight {
@@ -1689,9 +1689,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_988 nanoseconds.
-        Weight::from_ref_time(2_050_000)
+        Weight::from_parts(2_050_000, 0)
             // Standard Error: 3_646
-            .saturating_add(Weight::from_ref_time(552_674).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(552_674, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64shru(r: u32, ) -> Weight {
@@ -1699,9 +1699,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_975 nanoseconds.
-        Weight::from_ref_time(2_007_000)
+        Weight::from_parts(2_007_000, 0)
             // Standard Error: 6_233
-            .saturating_add(Weight::from_ref_time(1_020_688).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_020_688, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32shru(r: u32, ) -> Weight {
@@ -1709,9 +1709,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_921 nanoseconds.
-        Weight::from_ref_time(2_007_000)
+        Weight::from_parts(2_007_000, 0)
             // Standard Error: 3_338
-            .saturating_add(Weight::from_ref_time(524_904).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(524_904, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64rotl(r: u32, ) -> Weight {
@@ -1719,9 +1719,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_035 nanoseconds.
-        Weight::from_ref_time(2_096_000)
+        Weight::from_parts(2_096_000, 0)
             // Standard Error: 6_820
-            .saturating_add(Weight::from_ref_time(989_478).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(989_478, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32rotl(r: u32, ) -> Weight {
@@ -1729,9 +1729,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_917 nanoseconds.
-        Weight::from_ref_time(10_071)
+        Weight::from_parts(10_071, 0)
             // Standard Error: 5_314
-            .saturating_add(Weight::from_ref_time(585_983).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(585_983, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64rotr(r: u32, ) -> Weight {
@@ -1739,9 +1739,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_993 nanoseconds.
-        Weight::from_ref_time(2_062_000)
+        Weight::from_parts(2_062_000, 0)
             // Standard Error: 7_508
-            .saturating_add(Weight::from_ref_time(1_010_373).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_010_373, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32rotr(r: u32, ) -> Weight {
@@ -1749,9 +1749,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_944 nanoseconds.
-        Weight::from_ref_time(1_993_000)
+        Weight::from_parts(1_993_000, 0)
             // Standard Error: 3_741
-            .saturating_add(Weight::from_ref_time(549_410).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(549_410, 0).saturating_mul(r.into()))
     }
 }
 
@@ -1777,9 +1777,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 714 nanoseconds.
-        Weight::from_ref_time(762_000)
+        Weight::from_parts(762_000, 0)
             // Standard Error: 916
-            .saturating_add(Weight::from_ref_time(249_959).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(249_959, 0).saturating_mul(c.into()))
             .saturating_add(RocksDbWeight::get().writes(1_u64))
     }
     /// The range of component `c` is `[0, 512]`.
@@ -1790,7 +1790,7 @@ impl WeightInfo for () {
         // Minimum execution time: 2_591 nanoseconds.
         Weight::from_parts(2_658_000, 2546)
             // Standard Error: 1_587
-            .saturating_add(Weight::from_ref_time(691_791).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(691_791, 0).saturating_mul(c.into()))
             .saturating_add(RocksDbWeight::get().reads(1_u64))
             .saturating_add(Weight::from_proof_size(1024).saturating_mul(c.into()))
     }
@@ -1800,9 +1800,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 47_048 nanoseconds.
-        Weight::from_ref_time(80_532_528)
+        Weight::from_parts(80_532_528, 0)
             // Standard Error: 4_561
-            .saturating_add(Weight::from_ref_time(2_208_073).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(2_208_073, 0).saturating_mul(c.into()))
     }
     fn claim_value() -> Weight {
         // Proof Size summary in bytes:
@@ -1821,7 +1821,7 @@ impl WeightInfo for () {
         // Minimum execution time: 55_252 nanoseconds.
         Weight::from_parts(39_508_166, 3010)
             // Standard Error: 54_990
-            .saturating_add(Weight::from_ref_time(53_653_596).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(53_653_596, 0).saturating_mul(c.into()))
             .saturating_add(RocksDbWeight::get().reads(2_u64))
             .saturating_add(RocksDbWeight::get().writes(4_u64))
     }
@@ -1833,7 +1833,7 @@ impl WeightInfo for () {
         // Minimum execution time: 45_837 nanoseconds.
         Weight::from_parts(67_499_867, 17714)
             // Standard Error: 0
-            .saturating_add(Weight::from_ref_time(2_312).saturating_mul(s.into()))
+            .saturating_add(Weight::from_parts(2_312, 0).saturating_mul(s.into()))
             .saturating_add(RocksDbWeight::get().reads(10_u64))
             .saturating_add(RocksDbWeight::get().writes(8_u64))
     }
@@ -1846,9 +1846,9 @@ impl WeightInfo for () {
         // Minimum execution time: 9_772_476 nanoseconds.
         Weight::from_parts(137_998_681, 13432)
             // Standard Error: 153_459
-            .saturating_add(Weight::from_ref_time(54_040_008).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(54_040_008, 0).saturating_mul(c.into()))
             // Standard Error: 9
-            .saturating_add(Weight::from_ref_time(2_271).saturating_mul(s.into()))
+            .saturating_add(Weight::from_parts(2_271, 0).saturating_mul(s.into()))
             .saturating_add(RocksDbWeight::get().reads(10_u64))
             .saturating_add(RocksDbWeight::get().writes(12_u64))
     }
@@ -1860,7 +1860,7 @@ impl WeightInfo for () {
         // Minimum execution time: 47_594 nanoseconds.
         Weight::from_parts(39_261_875, 14759)
             // Standard Error: 0
-            .saturating_add(Weight::from_ref_time(1_154).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_154, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads(9_u64))
             .saturating_add(RocksDbWeight::get().writes(8_u64))
     }
@@ -1872,7 +1872,7 @@ impl WeightInfo for () {
         // Minimum execution time: 69_752 nanoseconds.
         Weight::from_parts(56_435_092, 30879)
             // Standard Error: 1
-            .saturating_add(Weight::from_ref_time(1_169).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_169, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads(13_u64))
             .saturating_add(RocksDbWeight::get().writes(10_u64))
     }
@@ -1884,7 +1884,7 @@ impl WeightInfo for () {
         // Minimum execution time: 257_221 nanoseconds.
         Weight::from_parts(266_363_888, 40731)
             // Standard Error: 927
-            .saturating_add(Weight::from_ref_time(13_060).saturating_mul(q.into()))
+            .saturating_add(Weight::from_parts(13_060, 0).saturating_mul(q.into()))
             .saturating_add(RocksDbWeight::get().reads(24_u64))
             .saturating_add(RocksDbWeight::get().writes(21_u64))
     }
@@ -1896,7 +1896,7 @@ impl WeightInfo for () {
         // Minimum execution time: 272_686 nanoseconds.
         Weight::from_parts(284_450_996, 40581)
             // Standard Error: 786
-            .saturating_add(Weight::from_ref_time(260).saturating_mul(q.into()))
+            .saturating_add(Weight::from_parts(260, 0).saturating_mul(q.into()))
             .saturating_add(RocksDbWeight::get().reads(24_u64))
             .saturating_add(RocksDbWeight::get().writes(21_u64))
     }
@@ -1908,7 +1908,7 @@ impl WeightInfo for () {
         // Minimum execution time: 40_325 nanoseconds.
         Weight::from_parts(40_776_000, 2973)
             // Standard Error: 26_634
-            .saturating_add(Weight::from_ref_time(51_482_330).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(51_482_330, 0).saturating_mul(c.into()))
             .saturating_add(RocksDbWeight::get().reads(1_u64))
             .saturating_add(RocksDbWeight::get().writes(2_u64))
             .saturating_add(Weight::from_proof_size(2150).saturating_mul(c.into()))
@@ -1919,9 +1919,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_124 nanoseconds.
-        Weight::from_ref_time(56_808_831)
+        Weight::from_parts(56_808_831, 0)
             // Standard Error: 286_293
-            .saturating_add(Weight::from_ref_time(121_779_133).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(121_779_133, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn free(r: u32, ) -> Weight {
@@ -1929,9 +1929,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 193_689 nanoseconds.
-        Weight::from_ref_time(170_580_231)
+        Weight::from_parts(170_580_231, 0)
             // Standard Error: 278_566
-            .saturating_add(Weight::from_ref_time(123_420_096).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(123_420_096, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 256]`.
     fn gr_reserve_gas(r: u32, ) -> Weight {
@@ -1939,9 +1939,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_404 nanoseconds.
-        Weight::from_ref_time(88_583_428)
+        Weight::from_parts(88_583_428, 0)
             // Standard Error: 3_546
-            .saturating_add(Weight::from_ref_time(3_421_193).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_421_193, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 256]`.
     fn gr_unreserve_gas(r: u32, ) -> Weight {
@@ -1949,9 +1949,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 131_673 nanoseconds.
-        Weight::from_ref_time(139_085_832)
+        Weight::from_parts(139_085_832, 0)
             // Standard Error: 15_674
-            .saturating_add(Weight::from_ref_time(3_646_255).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_646_255, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_system_reserve_gas(r: u32, ) -> Weight {
@@ -1959,9 +1959,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_127 nanoseconds.
-        Weight::from_ref_time(107_304_676)
+        Weight::from_parts(107_304_676, 0)
             // Standard Error: 280_555
-            .saturating_add(Weight::from_ref_time(183_537_739).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(183_537_739, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_message_id(r: u32, ) -> Weight {
@@ -1969,9 +1969,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_204 nanoseconds.
-        Weight::from_ref_time(63_855_671)
+        Weight::from_parts(63_855_671, 0)
             // Standard Error: 255_652
-            .saturating_add(Weight::from_ref_time(180_882_229).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_882_229, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_origin(r: u32, ) -> Weight {
@@ -1979,9 +1979,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_747 nanoseconds.
-        Weight::from_ref_time(62_378_952)
+        Weight::from_parts(62_378_952, 0)
             // Standard Error: 243_378
-            .saturating_add(Weight::from_ref_time(181_354_986).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_354_986, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_program_id(r: u32, ) -> Weight {
@@ -1989,9 +1989,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_628 nanoseconds.
-        Weight::from_ref_time(62_023_316)
+        Weight::from_parts(62_023_316, 0)
             // Standard Error: 239_172
-            .saturating_add(Weight::from_ref_time(181_312_090).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_312_090, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_source(r: u32, ) -> Weight {
@@ -1999,9 +1999,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_107 nanoseconds.
-        Weight::from_ref_time(64_448_589)
+        Weight::from_parts(64_448_589, 0)
             // Standard Error: 243_926
-            .saturating_add(Weight::from_ref_time(181_908_539).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_908_539, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_value(r: u32, ) -> Weight {
@@ -2009,9 +2009,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_063 nanoseconds.
-        Weight::from_ref_time(63_994_362)
+        Weight::from_parts(63_994_362, 0)
             // Standard Error: 222_109
-            .saturating_add(Weight::from_ref_time(180_538_936).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_538_936, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_value_available(r: u32, ) -> Weight {
@@ -2019,9 +2019,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 79_507 nanoseconds.
-        Weight::from_ref_time(62_253_457)
+        Weight::from_parts(62_253_457, 0)
             // Standard Error: 237_685
-            .saturating_add(Weight::from_ref_time(180_220_624).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_220_624, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_gas_available(r: u32, ) -> Weight {
@@ -2029,9 +2029,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_164 nanoseconds.
-        Weight::from_ref_time(64_087_928)
+        Weight::from_parts(64_087_928, 0)
             // Standard Error: 254_664
-            .saturating_add(Weight::from_ref_time(180_159_594).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_159_594, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_size(r: u32, ) -> Weight {
@@ -2039,9 +2039,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_583 nanoseconds.
-        Weight::from_ref_time(67_596_795)
+        Weight::from_parts(67_596_795, 0)
             // Standard Error: 234_491
-            .saturating_add(Weight::from_ref_time(181_034_283).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_034_283, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_read(r: u32, ) -> Weight {
@@ -2049,9 +2049,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 707_674 nanoseconds.
-        Weight::from_ref_time(799_106_757)
+        Weight::from_parts(799_106_757, 0)
             // Standard Error: 290_054
-            .saturating_add(Weight::from_ref_time(237_370_449).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(237_370_449, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_read_per_kb(n: u32, ) -> Weight {
@@ -2059,9 +2059,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 952_371 nanoseconds.
-        Weight::from_ref_time(956_495_000)
+        Weight::from_parts(956_495_000, 0)
             // Standard Error: 60_878
-            .saturating_add(Weight::from_ref_time(14_227_144).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(14_227_144, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_block_height(r: u32, ) -> Weight {
@@ -2069,9 +2069,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_283 nanoseconds.
-        Weight::from_ref_time(67_213_364)
+        Weight::from_parts(67_213_364, 0)
             // Standard Error: 216_089
-            .saturating_add(Weight::from_ref_time(179_717_831).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(179_717_831, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_block_timestamp(r: u32, ) -> Weight {
@@ -2079,9 +2079,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_151 nanoseconds.
-        Weight::from_ref_time(64_827_395)
+        Weight::from_parts(64_827_395, 0)
             // Standard Error: 240_155
-            .saturating_add(Weight::from_ref_time(180_340_647).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_340_647, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 20]`.
     fn gr_random(n: u32, ) -> Weight {
@@ -2089,9 +2089,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_607 nanoseconds.
-        Weight::from_ref_time(97_606_147)
+        Weight::from_parts(97_606_147, 0)
             // Standard Error: 253_065
-            .saturating_add(Weight::from_ref_time(234_245_810).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(234_245_810, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_init(r: u32, ) -> Weight {
@@ -2099,9 +2099,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_345 nanoseconds.
-        Weight::from_ref_time(63_840_792)
+        Weight::from_parts(63_840_792, 0)
             // Standard Error: 226_520
-            .saturating_add(Weight::from_ref_time(187_131_229).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(187_131_229, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_push(r: u32, ) -> Weight {
@@ -2109,9 +2109,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 3_677_374 nanoseconds.
-        Weight::from_ref_time(3_820_987_062)
+        Weight::from_parts(3_820_987_062, 0)
             // Standard Error: 268_252
-            .saturating_add(Weight::from_ref_time(255_977_920).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(255_977_920, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_send_push_per_kb(n: u32, ) -> Weight {
@@ -2119,9 +2119,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 515_418 nanoseconds.
-        Weight::from_ref_time(522_188_000)
+        Weight::from_parts(522_188_000, 0)
             // Standard Error: 55_829
-            .saturating_add(Weight::from_ref_time(31_257_326).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(31_257_326, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_commit(r: u32, ) -> Weight {
@@ -2129,9 +2129,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_956 nanoseconds.
-        Weight::from_ref_time(135_884_682)
+        Weight::from_parts(135_884_682, 0)
             // Standard Error: 312_774
-            .saturating_add(Weight::from_ref_time(353_743_445).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(353_743_445, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_send_commit_per_kb(n: u32, ) -> Weight {
@@ -2139,9 +2139,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 437_809 nanoseconds.
-        Weight::from_ref_time(441_185_000)
+        Weight::from_parts(441_185_000, 0)
             // Standard Error: 64_589
-            .saturating_add(Weight::from_ref_time(21_143_950).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(21_143_950, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reservation_send_commit(r: u32, ) -> Weight {
@@ -2149,9 +2149,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 240_166 nanoseconds.
-        Weight::from_ref_time(307_423_566)
+        Weight::from_parts(307_423_566, 0)
             // Standard Error: 263_198
-            .saturating_add(Weight::from_ref_time(365_304_897).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(365_304_897, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reservation_send_commit_per_kb(n: u32, ) -> Weight {
@@ -2159,9 +2159,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 466_793 nanoseconds.
-        Weight::from_ref_time(479_126_000)
+        Weight::from_parts(479_126_000, 0)
             // Standard Error: 63_386
-            .saturating_add(Weight::from_ref_time(21_350_039).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(21_350_039, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_reply_commit(r: u32, ) -> Weight {
@@ -2169,9 +2169,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_102 nanoseconds.
-        Weight::from_ref_time(83_399_128)
+        Weight::from_parts(83_399_128, 0)
             // Standard Error: 229_588
-            .saturating_add(Weight::from_ref_time(20_817_771).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(20_817_771, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reply_commit_per_kb(n: u32, ) -> Weight {
@@ -2179,9 +2179,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 99_001 nanoseconds.
-        Weight::from_ref_time(86_637_798)
+        Weight::from_parts(86_637_798, 0)
             // Standard Error: 923
-            .saturating_add(Weight::from_ref_time(424_190).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(424_190, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reply_push(r: u32, ) -> Weight {
@@ -2189,9 +2189,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_499 nanoseconds.
-        Weight::from_ref_time(131_462_314)
+        Weight::from_parts(131_462_314, 0)
             // Standard Error: 296_583
-            .saturating_add(Weight::from_ref_time(246_894_431).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(246_894_431, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 8192]`.
     fn gr_reply_push_per_kb(n: u32, ) -> Weight {
@@ -2199,9 +2199,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 96_357 nanoseconds.
-        Weight::from_ref_time(97_184_000)
+        Weight::from_parts(97_184_000, 0)
             // Standard Error: 2_351
-            .saturating_add(Weight::from_ref_time(640_572).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(640_572, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_reservation_reply_commit(r: u32, ) -> Weight {
@@ -2209,9 +2209,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 89_493 nanoseconds.
-        Weight::from_ref_time(93_301_112)
+        Weight::from_parts(93_301_112, 0)
             // Standard Error: 231_085
-            .saturating_add(Weight::from_ref_time(9_751_187).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(9_751_187, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reservation_reply_commit_per_kb(n: u32, ) -> Weight {
@@ -2219,9 +2219,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 102_738 nanoseconds.
-        Weight::from_ref_time(85_959_957)
+        Weight::from_parts(85_959_957, 0)
             // Standard Error: 1_056
-            .saturating_add(Weight::from_ref_time(426_826).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(426_826, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reply_to(r: u32, ) -> Weight {
@@ -2229,9 +2229,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_593 nanoseconds.
-        Weight::from_ref_time(61_040_651)
+        Weight::from_parts(61_040_651, 0)
             // Standard Error: 231_867
-            .saturating_add(Weight::from_ref_time(183_706_745).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(183_706_745, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_signal_from(r: u32, ) -> Weight {
@@ -2239,9 +2239,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_324 nanoseconds.
-        Weight::from_ref_time(66_339_260)
+        Weight::from_parts(66_339_260, 0)
             // Standard Error: 254_057
-            .saturating_add(Weight::from_ref_time(181_778_743).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_778_743, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reply_push_input(r: u32, ) -> Weight {
@@ -2249,9 +2249,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 706_163 nanoseconds.
-        Weight::from_ref_time(746_906_968)
+        Weight::from_parts(746_906_968, 0)
             // Standard Error: 289_363
-            .saturating_add(Weight::from_ref_time(197_735_344).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(197_735_344, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reply_push_input_per_kb(n: u32, ) -> Weight {
@@ -2259,9 +2259,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 727_470 nanoseconds.
-        Weight::from_ref_time(764_436_591)
+        Weight::from_parts(764_436_591, 0)
             // Standard Error: 1_954
-            .saturating_add(Weight::from_ref_time(155_898).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(155_898, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_push_input(r: u32, ) -> Weight {
@@ -2269,9 +2269,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_379_140 nanoseconds.
-        Weight::from_ref_time(4_509_467_459)
+        Weight::from_parts(4_509_467_459, 0)
             // Standard Error: 293_145
-            .saturating_add(Weight::from_ref_time(202_192_351).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(202_192_351, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_send_push_input_per_kb(n: u32, ) -> Weight {
@@ -2279,9 +2279,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_116_085 nanoseconds.
-        Weight::from_ref_time(1_161_687_850)
+        Weight::from_parts(1_161_687_850, 0)
             // Standard Error: 9_577
-            .saturating_add(Weight::from_ref_time(13_711_920).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(13_711_920, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_debug(r: u32, ) -> Weight {
@@ -2289,9 +2289,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_884 nanoseconds.
-        Weight::from_ref_time(97_414_295)
+        Weight::from_parts(97_414_295, 0)
             // Standard Error: 266_242
-            .saturating_add(Weight::from_ref_time(191_541_864).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(191_541_864, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_debug_per_kb(n: u32, ) -> Weight {
@@ -2299,9 +2299,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 259_961 nanoseconds.
-        Weight::from_ref_time(261_294_000)
+        Weight::from_parts(261_294_000, 0)
             // Standard Error: 55_450
-            .saturating_add(Weight::from_ref_time(26_992_075).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(26_992_075, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_error(r: u32, ) -> Weight {
@@ -2309,9 +2309,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 94_153 nanoseconds.
-        Weight::from_ref_time(92_584_315)
+        Weight::from_parts(92_584_315, 0)
             // Standard Error: 263_504
-            .saturating_add(Weight::from_ref_time(235_583_714).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(235_583_714, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_status_code(r: u32, ) -> Weight {
@@ -2319,9 +2319,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_011 nanoseconds.
-        Weight::from_ref_time(60_532_712)
+        Weight::from_parts(60_532_712, 0)
             // Standard Error: 252_427
-            .saturating_add(Weight::from_ref_time(181_273_142).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(181_273_142, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_exit(r: u32, ) -> Weight {
@@ -2329,9 +2329,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 79_956 nanoseconds.
-        Weight::from_ref_time(83_128_273)
+        Weight::from_parts(83_128_273, 0)
             // Standard Error: 233_270
-            .saturating_add(Weight::from_ref_time(24_200_326).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(24_200_326, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_leave(r: u32, ) -> Weight {
@@ -2339,9 +2339,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_471 nanoseconds.
-        Weight::from_ref_time(84_933_897)
+        Weight::from_parts(84_933_897, 0)
             // Standard Error: 228_044
-            .saturating_add(Weight::from_ref_time(10_863_802).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(10_863_802, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_wait(r: u32, ) -> Weight {
@@ -2349,9 +2349,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 79_140 nanoseconds.
-        Weight::from_ref_time(82_413_287)
+        Weight::from_parts(82_413_287, 0)
             // Standard Error: 242_017
-            .saturating_add(Weight::from_ref_time(15_558_512).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(15_558_512, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_wait_for(r: u32, ) -> Weight {
@@ -2359,9 +2359,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 79_597 nanoseconds.
-        Weight::from_ref_time(83_256_853)
+        Weight::from_parts(83_256_853, 0)
             // Standard Error: 251_615
-            .saturating_add(Weight::from_ref_time(14_287_546).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(14_287_546, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_wait_up_to(r: u32, ) -> Weight {
@@ -2369,9 +2369,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_149 nanoseconds.
-        Weight::from_ref_time(84_067_253)
+        Weight::from_parts(84_067_253, 0)
             // Standard Error: 242_934
-            .saturating_add(Weight::from_ref_time(12_984_046).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(12_984_046, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_wake(r: u32, ) -> Weight {
@@ -2379,9 +2379,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 134_568 nanoseconds.
-        Weight::from_ref_time(191_754_546)
+        Weight::from_parts(191_754_546, 0)
             // Standard Error: 310_042
-            .saturating_add(Weight::from_ref_time(258_517_274).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(258_517_274, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_create_program_wgas(r: u32, ) -> Weight {
@@ -2389,9 +2389,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 89_961 nanoseconds.
-        Weight::from_ref_time(135_401_157)
+        Weight::from_parts(135_401_157, 0)
             // Standard Error: 330_013
-            .saturating_add(Weight::from_ref_time(438_218_419).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(438_218_419, 0).saturating_mul(r.into()))
     }
     /// The range of component `p` is `[0, 2048]`.
     /// The range of component `s` is `[1, 2048]`.
@@ -2400,11 +2400,11 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 44_618_378 nanoseconds.
-        Weight::from_ref_time(44_975_555_000)
+        Weight::from_parts(44_975_555_000, 0)
             // Standard Error: 259_430
-            .saturating_add(Weight::from_ref_time(7_365_489).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(7_365_489, 0).saturating_mul(p.into()))
             // Standard Error: 259_417
-            .saturating_add(Weight::from_ref_time(155_224_672).saturating_mul(s.into()))
+            .saturating_add(Weight::from_parts(155_224_672, 0).saturating_mul(s.into()))
     }
     /// The range of component `p` is `[0, 512]`.
     fn lazy_pages_signal_read(p: u32, ) -> Weight {
@@ -2414,7 +2414,7 @@ impl WeightInfo for () {
         // Minimum execution time: 81_060 nanoseconds.
         Weight::from_parts(116_078_081, 141)
             // Standard Error: 8_097
-            .saturating_add(Weight::from_ref_time(11_697_667).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(11_697_667, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
     }
@@ -2426,7 +2426,7 @@ impl WeightInfo for () {
         // Minimum execution time: 82_253 nanoseconds.
         Weight::from_parts(83_487_000, 141)
             // Standard Error: 44_559
-            .saturating_add(Weight::from_ref_time(36_153_847).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(36_153_847, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
     }
@@ -2438,7 +2438,7 @@ impl WeightInfo for () {
         // Minimum execution time: 6_059_320 nanoseconds.
         Weight::from_parts(6_026_768_509, 5068941)
             // Standard Error: 74_371
-            .saturating_add(Weight::from_ref_time(37_256_749).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(37_256_749, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads(2048_u64))
     }
     /// The range of component `p` is `[0, 512]`.
@@ -2449,7 +2449,7 @@ impl WeightInfo for () {
         // Minimum execution time: 82_117 nanoseconds.
         Weight::from_parts(84_007_000, 949)
             // Standard Error: 37_631
-            .saturating_add(Weight::from_ref_time(45_958_696).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(45_958_696, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(75606).saturating_mul(p.into()))
     }
@@ -2461,7 +2461,7 @@ impl WeightInfo for () {
         // Minimum execution time: 93_080 nanoseconds.
         Weight::from_parts(77_592_595, 506)
             // Standard Error: 74_142
-            .saturating_add(Weight::from_ref_time(37_638_856).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(37_638_856, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
     }
@@ -2473,7 +2473,7 @@ impl WeightInfo for () {
         // Minimum execution time: 748_265 nanoseconds.
         Weight::from_parts(748_224_476, 506)
             // Standard Error: 324_620
-            .saturating_add(Weight::from_ref_time(46_953_221).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(46_953_221, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
     }
@@ -2485,7 +2485,7 @@ impl WeightInfo for () {
         // Minimum execution time: 1_126_554 nanoseconds.
         Weight::from_parts(1_175_012_009, 316941)
             // Standard Error: 204_912
-            .saturating_add(Weight::from_ref_time(43_619_826).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(43_619_826, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads(128_u64))
     }
     /// The range of component `r` is `[50, 500]`.
@@ -2494,9 +2494,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_248_587 nanoseconds.
-        Weight::from_ref_time(4_247_395_501)
+        Weight::from_parts(4_247_395_501, 0)
             // Standard Error: 11_091
-            .saturating_add(Weight::from_ref_time(3_323_996).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_323_996, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[50, 500]`.
     fn instr_i32load(r: u32, ) -> Weight {
@@ -2504,9 +2504,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_244_604 nanoseconds.
-        Weight::from_ref_time(4_236_154_065)
+        Weight::from_parts(4_236_154_065, 0)
             // Standard Error: 10_679
-            .saturating_add(Weight::from_ref_time(3_383_238).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_383_238, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[50, 500]`.
     fn instr_i64store(r: u32, ) -> Weight {
@@ -2514,9 +2514,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 10_566_548 nanoseconds.
-        Weight::from_ref_time(10_110_815_063)
+        Weight::from_parts(10_110_815_063, 0)
             // Standard Error: 164_010
-            .saturating_add(Weight::from_ref_time(15_834_994).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(15_834_994, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[50, 500]`.
     fn instr_i32store(r: u32, ) -> Weight {
@@ -2524,9 +2524,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 10_594_891 nanoseconds.
-        Weight::from_ref_time(10_824_075_202)
+        Weight::from_parts(10_824_075_202, 0)
             // Standard Error: 246_795
-            .saturating_add(Weight::from_ref_time(8_865_110).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(8_865_110, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_select(r: u32, ) -> Weight {
@@ -2534,9 +2534,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_984 nanoseconds.
-        Weight::from_ref_time(2_022_000)
+        Weight::from_parts(2_022_000, 0)
             // Standard Error: 8_549
-            .saturating_add(Weight::from_ref_time(3_833_242).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_833_242, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_if(r: u32, ) -> Weight {
@@ -2544,9 +2544,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_972 nanoseconds.
-        Weight::from_ref_time(2_014_000)
+        Weight::from_parts(2_014_000, 0)
             // Standard Error: 4_696
-            .saturating_add(Weight::from_ref_time(3_071_869).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_071_869, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_br(r: u32, ) -> Weight {
@@ -2554,9 +2554,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_990 nanoseconds.
-        Weight::from_ref_time(3_141_848)
+        Weight::from_parts(3_141_848, 0)
             // Standard Error: 1_067
-            .saturating_add(Weight::from_ref_time(1_565_212).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_565_212, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_br_if(r: u32, ) -> Weight {
@@ -2564,9 +2564,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_910 nanoseconds.
-        Weight::from_ref_time(1_977_000)
+        Weight::from_parts(1_977_000, 0)
             // Standard Error: 10_190
-            .saturating_add(Weight::from_ref_time(2_916_284).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_916_284, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_br_table(r: u32, ) -> Weight {
@@ -2574,9 +2574,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_055 nanoseconds.
-        Weight::from_ref_time(2_124_000)
+        Weight::from_parts(2_124_000, 0)
             // Standard Error: 9_616
-            .saturating_add(Weight::from_ref_time(5_239_104).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(5_239_104, 0).saturating_mul(r.into()))
     }
     /// The range of component `e` is `[1, 256]`.
     fn instr_br_table_per_entry(e: u32, ) -> Weight {
@@ -2584,9 +2584,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 6_569 nanoseconds.
-        Weight::from_ref_time(5_561_073)
+        Weight::from_parts(5_561_073, 0)
             // Standard Error: 1_593
-            .saturating_add(Weight::from_ref_time(158_847).saturating_mul(e.into()))
+            .saturating_add(Weight::from_parts(158_847, 0).saturating_mul(e.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_call_const(r: u32, ) -> Weight {
@@ -2594,14 +2594,14 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_001 nanoseconds.
-        Weight::from_ref_time(4_351_879)
+        Weight::from_parts(4_351_879, 0)
             // Standard Error: 6_992
-            .saturating_add(Weight::from_ref_time(2_579_629).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_579_629, 0).saturating_mul(r.into()))
     }
     fn instr_i64const(r: u32, ) -> Weight {
-        Weight::from_ref_time(0)
-            .saturating_add(Weight::from_ref_time(2_579_629 -
-            2_411_507).saturating_mul(r.into()))
+        Weight::from_parts(0, 0)
+            .saturating_add(Weight::from_parts(2_579_629 -
+            2_411_507, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_call(r: u32, ) -> Weight {
@@ -2609,9 +2609,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_001 nanoseconds.
-        Weight::from_ref_time(4_619_716)
+        Weight::from_parts(4_619_716, 0)
             // Standard Error: 12_765
-            .saturating_add(Weight::from_ref_time(2_411_507).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_411_507, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_call_indirect(r: u32, ) -> Weight {
@@ -2619,9 +2619,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_321 nanoseconds.
-        Weight::from_ref_time(13_844_527)
+        Weight::from_parts(13_844_527, 0)
             // Standard Error: 28_587
-            .saturating_add(Weight::from_ref_time(10_571_661).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(10_571_661, 0).saturating_mul(r.into()))
     }
     /// The range of component `p` is `[0, 128]`.
     fn instr_call_indirect_per_param(p: u32, ) -> Weight {
@@ -2629,9 +2629,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 12_173 nanoseconds.
-        Weight::from_ref_time(4_877_843)
+        Weight::from_parts(4_877_843, 0)
             // Standard Error: 7_292
-            .saturating_add(Weight::from_ref_time(1_288_806).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_288_806, 0).saturating_mul(p.into()))
     }
     /// The range of component `l` is `[0, 1024]`.
     fn instr_call_per_local(l: u32, ) -> Weight {
@@ -2639,9 +2639,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_997 nanoseconds.
-        Weight::from_ref_time(5_260_743)
+        Weight::from_parts(5_260_743, 0)
             // Standard Error: 13
-            .saturating_add(Weight::from_ref_time(22).saturating_mul(l.into()))
+            .saturating_add(Weight::from_parts(22, 0).saturating_mul(l.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_local_get(r: u32, ) -> Weight {
@@ -2649,9 +2649,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_940 nanoseconds.
-        Weight::from_ref_time(1_830_043)
+        Weight::from_parts(1_830_043, 0)
             // Standard Error: 2_843
-            .saturating_add(Weight::from_ref_time(258_952).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(258_952, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_local_set(r: u32, ) -> Weight {
@@ -2659,9 +2659,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_991 nanoseconds.
-        Weight::from_ref_time(2_027_000)
+        Weight::from_parts(2_027_000, 0)
             // Standard Error: 5_369
-            .saturating_add(Weight::from_ref_time(736_000).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(736_000, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_local_tee(r: u32, ) -> Weight {
@@ -2669,9 +2669,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_000 nanoseconds.
-        Weight::from_ref_time(2_062_000)
+        Weight::from_parts(2_062_000, 0)
             // Standard Error: 4_630
-            .saturating_add(Weight::from_ref_time(719_367).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(719_367, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_global_get(r: u32, ) -> Weight {
@@ -2679,9 +2679,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_741 nanoseconds.
-        Weight::from_ref_time(2_616_782)
+        Weight::from_parts(2_616_782, 0)
             // Standard Error: 6_777
-            .saturating_add(Weight::from_ref_time(731_002).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(731_002, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_global_set(r: u32, ) -> Weight {
@@ -2689,9 +2689,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_795 nanoseconds.
-        Weight::from_ref_time(5_840_000)
+        Weight::from_parts(5_840_000, 0)
             // Standard Error: 8_144
-            .saturating_add(Weight::from_ref_time(1_259_731).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_259_731, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_memory_current(r: u32, ) -> Weight {
@@ -2699,9 +2699,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 6_596 nanoseconds.
-        Weight::from_ref_time(2_374_393)
+        Weight::from_parts(2_374_393, 0)
             // Standard Error: 12_129
-            .saturating_add(Weight::from_ref_time(6_823_668).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(6_823_668, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64clz(r: u32, ) -> Weight {
@@ -2709,9 +2709,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_980 nanoseconds.
-        Weight::from_ref_time(2_045_000)
+        Weight::from_parts(2_045_000, 0)
             // Standard Error: 8_388
-            .saturating_add(Weight::from_ref_time(3_325_416).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_325_416, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32clz(r: u32, ) -> Weight {
@@ -2719,9 +2719,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_950 nanoseconds.
-        Weight::from_ref_time(2_041_000)
+        Weight::from_parts(2_041_000, 0)
             // Standard Error: 7_692
-            .saturating_add(Weight::from_ref_time(3_034_615).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_034_615, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ctz(r: u32, ) -> Weight {
@@ -2729,9 +2729,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_981 nanoseconds.
-        Weight::from_ref_time(2_061_000)
+        Weight::from_parts(2_061_000, 0)
             // Standard Error: 8_251
-            .saturating_add(Weight::from_ref_time(3_019_593).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_019_593, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ctz(r: u32, ) -> Weight {
@@ -2739,9 +2739,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_980 nanoseconds.
-        Weight::from_ref_time(2_039_000)
+        Weight::from_parts(2_039_000, 0)
             // Standard Error: 6_062
-            .saturating_add(Weight::from_ref_time(2_592_066).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_592_066, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64popcnt(r: u32, ) -> Weight {
@@ -2749,9 +2749,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_036 nanoseconds.
-        Weight::from_ref_time(2_085_000)
+        Weight::from_parts(2_085_000, 0)
             // Standard Error: 3_811
-            .saturating_add(Weight::from_ref_time(537_423).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(537_423, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32popcnt(r: u32, ) -> Weight {
@@ -2759,9 +2759,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_987 nanoseconds.
-        Weight::from_ref_time(1_301_383)
+        Weight::from_parts(1_301_383, 0)
             // Standard Error: 3_109
-            .saturating_add(Weight::from_ref_time(381_295).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(381_295, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64eqz(r: u32, ) -> Weight {
@@ -2769,9 +2769,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_999 nanoseconds.
-        Weight::from_ref_time(2_069_000)
+        Weight::from_parts(2_069_000, 0)
             // Standard Error: 11_800
-            .saturating_add(Weight::from_ref_time(1_805_699).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_805_699, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32eqz(r: u32, ) -> Weight {
@@ -2779,9 +2779,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_014 nanoseconds.
-        Weight::from_ref_time(2_070_000)
+        Weight::from_parts(2_070_000, 0)
             // Standard Error: 8_255
-            .saturating_add(Weight::from_ref_time(1_114_949).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_114_949, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64extendsi32(r: u32, ) -> Weight {
@@ -2789,9 +2789,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_900 nanoseconds.
-        Weight::from_ref_time(1_701_470)
+        Weight::from_parts(1_701_470, 0)
             // Standard Error: 2_591
-            .saturating_add(Weight::from_ref_time(312_279).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(312_279, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64extendui32(r: u32, ) -> Weight {
@@ -2799,9 +2799,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_982 nanoseconds.
-        Weight::from_ref_time(2_190_000)
+        Weight::from_parts(2_190_000, 0)
             // Standard Error: 1_685
-            .saturating_add(Weight::from_ref_time(172_493).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(172_493, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32wrapi64(r: u32, ) -> Weight {
@@ -2809,9 +2809,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_041 nanoseconds.
-        Weight::from_ref_time(2_605_622)
+        Weight::from_parts(2_605_622, 0)
             // Standard Error: 1_576
-            .saturating_add(Weight::from_ref_time(159_097).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(159_097, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64eq(r: u32, ) -> Weight {
@@ -2819,9 +2819,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_918 nanoseconds.
-        Weight::from_ref_time(2_021_000)
+        Weight::from_parts(2_021_000, 0)
             // Standard Error: 11_160
-            .saturating_add(Weight::from_ref_time(1_781_573).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_781_573, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32eq(r: u32, ) -> Weight {
@@ -2829,9 +2829,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_990 nanoseconds.
-        Weight::from_ref_time(2_047_000)
+        Weight::from_parts(2_047_000, 0)
             // Standard Error: 6_989
-            .saturating_add(Weight::from_ref_time(1_086_510).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_086_510, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ne(r: u32, ) -> Weight {
@@ -2839,9 +2839,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_991 nanoseconds.
-        Weight::from_ref_time(2_035_000)
+        Weight::from_parts(2_035_000, 0)
             // Standard Error: 9_623
-            .saturating_add(Weight::from_ref_time(1_797_223).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_797_223, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ne(r: u32, ) -> Weight {
@@ -2849,9 +2849,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_957 nanoseconds.
-        Weight::from_ref_time(2_016_000)
+        Weight::from_parts(2_016_000, 0)
             // Standard Error: 7_516
-            .saturating_add(Weight::from_ref_time(1_100_146).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_100_146, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64lts(r: u32, ) -> Weight {
@@ -2859,9 +2859,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_975 nanoseconds.
-        Weight::from_ref_time(2_042_000)
+        Weight::from_parts(2_042_000, 0)
             // Standard Error: 9_617
-            .saturating_add(Weight::from_ref_time(1_798_574).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_798_574, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32lts(r: u32, ) -> Weight {
@@ -2869,9 +2869,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_919 nanoseconds.
-        Weight::from_ref_time(2_044_000)
+        Weight::from_parts(2_044_000, 0)
             // Standard Error: 7_469
-            .saturating_add(Weight::from_ref_time(1_119_079).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_119_079, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ltu(r: u32, ) -> Weight {
@@ -2879,9 +2879,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_983 nanoseconds.
-        Weight::from_ref_time(2_025_000)
+        Weight::from_parts(2_025_000, 0)
             // Standard Error: 11_078
-            .saturating_add(Weight::from_ref_time(1_866_193).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_866_193, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ltu(r: u32, ) -> Weight {
@@ -2889,9 +2889,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_945 nanoseconds.
-        Weight::from_ref_time(2_063_000)
+        Weight::from_parts(2_063_000, 0)
             // Standard Error: 7_762
-            .saturating_add(Weight::from_ref_time(1_098_384).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_098_384, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64gts(r: u32, ) -> Weight {
@@ -2899,9 +2899,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_984 nanoseconds.
-        Weight::from_ref_time(2_013_000)
+        Weight::from_parts(2_013_000, 0)
             // Standard Error: 13_010
-            .saturating_add(Weight::from_ref_time(1_809_632).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_809_632, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32gts(r: u32, ) -> Weight {
@@ -2909,9 +2909,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_936 nanoseconds.
-        Weight::from_ref_time(2_085_000)
+        Weight::from_parts(2_085_000, 0)
             // Standard Error: 7_662
-            .saturating_add(Weight::from_ref_time(1_077_967).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_077_967, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64gtu(r: u32, ) -> Weight {
@@ -2919,9 +2919,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_960 nanoseconds.
-        Weight::from_ref_time(2_013_000)
+        Weight::from_parts(2_013_000, 0)
             // Standard Error: 11_774
-            .saturating_add(Weight::from_ref_time(1_786_196).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_786_196, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32gtu(r: u32, ) -> Weight {
@@ -2929,9 +2929,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_938 nanoseconds.
-        Weight::from_ref_time(1_981_000)
+        Weight::from_parts(1_981_000, 0)
             // Standard Error: 7_698
-            .saturating_add(Weight::from_ref_time(1_068_379).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_068_379, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64les(r: u32, ) -> Weight {
@@ -2939,9 +2939,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_992 nanoseconds.
-        Weight::from_ref_time(2_053_000)
+        Weight::from_parts(2_053_000, 0)
             // Standard Error: 11_716
-            .saturating_add(Weight::from_ref_time(1_786_578).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_786_578, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32les(r: u32, ) -> Weight {
@@ -2949,9 +2949,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_940 nanoseconds.
-        Weight::from_ref_time(2_005_000)
+        Weight::from_parts(2_005_000, 0)
             // Standard Error: 7_815
-            .saturating_add(Weight::from_ref_time(1_090_447).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_090_447, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64leu(r: u32, ) -> Weight {
@@ -2959,9 +2959,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_930 nanoseconds.
-        Weight::from_ref_time(2_037_000)
+        Weight::from_parts(2_037_000, 0)
             // Standard Error: 14_146
-            .saturating_add(Weight::from_ref_time(1_837_345).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_837_345, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32leu(r: u32, ) -> Weight {
@@ -2969,9 +2969,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_953 nanoseconds.
-        Weight::from_ref_time(1_994_000)
+        Weight::from_parts(1_994_000, 0)
             // Standard Error: 7_326
-            .saturating_add(Weight::from_ref_time(1_124_069).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_124_069, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ges(r: u32, ) -> Weight {
@@ -2979,9 +2979,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_990 nanoseconds.
-        Weight::from_ref_time(2_022_000)
+        Weight::from_parts(2_022_000, 0)
             // Standard Error: 11_502
-            .saturating_add(Weight::from_ref_time(1_784_579).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_784_579, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ges(r: u32, ) -> Weight {
@@ -2989,9 +2989,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_955 nanoseconds.
-        Weight::from_ref_time(2_030_000)
+        Weight::from_parts(2_030_000, 0)
             // Standard Error: 7_269
-            .saturating_add(Weight::from_ref_time(1_087_418).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_087_418, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64geu(r: u32, ) -> Weight {
@@ -2999,9 +2999,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_966 nanoseconds.
-        Weight::from_ref_time(2_021_000)
+        Weight::from_parts(2_021_000, 0)
             // Standard Error: 10_931
-            .saturating_add(Weight::from_ref_time(1_779_890).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_779_890, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32geu(r: u32, ) -> Weight {
@@ -3009,9 +3009,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_985 nanoseconds.
-        Weight::from_ref_time(2_057_000)
+        Weight::from_parts(2_057_000, 0)
             // Standard Error: 7_783
-            .saturating_add(Weight::from_ref_time(1_115_230).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_115_230, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64add(r: u32, ) -> Weight {
@@ -3019,9 +3019,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_927 nanoseconds.
-        Weight::from_ref_time(2_053_000)
+        Weight::from_parts(2_053_000, 0)
             // Standard Error: 7_508
-            .saturating_add(Weight::from_ref_time(1_212_190).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_212_190, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32add(r: u32, ) -> Weight {
@@ -3029,9 +3029,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_009 nanoseconds.
-        Weight::from_ref_time(2_075_000)
+        Weight::from_parts(2_075_000, 0)
             // Standard Error: 3_877
-            .saturating_add(Weight::from_ref_time(576_488).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(576_488, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64sub(r: u32, ) -> Weight {
@@ -3039,9 +3039,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_909 nanoseconds.
-        Weight::from_ref_time(1_957_000)
+        Weight::from_parts(1_957_000, 0)
             // Standard Error: 7_060
-            .saturating_add(Weight::from_ref_time(1_174_700).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_174_700, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32sub(r: u32, ) -> Weight {
@@ -3049,9 +3049,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_985 nanoseconds.
-        Weight::from_ref_time(2_041_000)
+        Weight::from_parts(2_041_000, 0)
             // Standard Error: 4_555
-            .saturating_add(Weight::from_ref_time(594_904).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(594_904, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64mul(r: u32, ) -> Weight {
@@ -3059,9 +3059,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_982 nanoseconds.
-        Weight::from_ref_time(2_073_000)
+        Weight::from_parts(2_073_000, 0)
             // Standard Error: 12_025
-            .saturating_add(Weight::from_ref_time(1_724_065).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_724_065, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32mul(r: u32, ) -> Weight {
@@ -3069,9 +3069,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_957 nanoseconds.
-        Weight::from_ref_time(2_007_000)
+        Weight::from_parts(2_007_000, 0)
             // Standard Error: 8_716
-            .saturating_add(Weight::from_ref_time(1_150_408).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_150_408, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64divs(r: u32, ) -> Weight {
@@ -3079,9 +3079,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_884 nanoseconds.
-        Weight::from_ref_time(1_144_446)
+        Weight::from_parts(1_144_446, 0)
             // Standard Error: 10_547
-            .saturating_add(Weight::from_ref_time(2_675_861).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_675_861, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32divs(r: u32, ) -> Weight {
@@ -3089,9 +3089,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_006 nanoseconds.
-        Weight::from_ref_time(69_582)
+        Weight::from_parts(69_582, 0)
             // Standard Error: 11_472
-            .saturating_add(Weight::from_ref_time(2_348_861).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_348_861, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64divu(r: u32, ) -> Weight {
@@ -3099,9 +3099,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_935 nanoseconds.
-        Weight::from_ref_time(1_504_156)
+        Weight::from_parts(1_504_156, 0)
             // Standard Error: 16_606
-            .saturating_add(Weight::from_ref_time(2_805_608).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_805_608, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32divu(r: u32, ) -> Weight {
@@ -3109,9 +3109,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_982 nanoseconds.
-        Weight::from_ref_time(7_507_453)
+        Weight::from_parts(7_507_453, 0)
             // Standard Error: 27_413
-            .saturating_add(Weight::from_ref_time(2_106_829).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_106_829, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64rems(r: u32, ) -> Weight {
@@ -3119,9 +3119,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_957 nanoseconds.
-        Weight::from_ref_time(2_062_000)
+        Weight::from_parts(2_062_000, 0)
             // Standard Error: 22_291
-            .saturating_add(Weight::from_ref_time(9_226_033).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(9_226_033, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32rems(r: u32, ) -> Weight {
@@ -3129,9 +3129,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_952 nanoseconds.
-        Weight::from_ref_time(737_483)
+        Weight::from_parts(737_483, 0)
             // Standard Error: 45_126
-            .saturating_add(Weight::from_ref_time(7_533_584).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(7_533_584, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64remu(r: u32, ) -> Weight {
@@ -3139,9 +3139,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_957 nanoseconds.
-        Weight::from_ref_time(3_376_184)
+        Weight::from_parts(3_376_184, 0)
             // Standard Error: 20_172
-            .saturating_add(Weight::from_ref_time(2_862_201).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_862_201, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32remu(r: u32, ) -> Weight {
@@ -3149,9 +3149,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_982 nanoseconds.
-        Weight::from_ref_time(2_067_000)
+        Weight::from_parts(2_067_000, 0)
             // Standard Error: 5_984
-            .saturating_add(Weight::from_ref_time(2_531_767).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_531_767, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64and(r: u32, ) -> Weight {
@@ -3159,9 +3159,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_968 nanoseconds.
-        Weight::from_ref_time(2_028_000)
+        Weight::from_parts(2_028_000, 0)
             // Standard Error: 8_261
-            .saturating_add(Weight::from_ref_time(1_261_509).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_261_509, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32and(r: u32, ) -> Weight {
@@ -3169,9 +3169,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_029 nanoseconds.
-        Weight::from_ref_time(2_047_000)
+        Weight::from_parts(2_047_000, 0)
             // Standard Error: 4_691
-            .saturating_add(Weight::from_ref_time(613_890).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(613_890, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64or(r: u32, ) -> Weight {
@@ -3179,9 +3179,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_946 nanoseconds.
-        Weight::from_ref_time(2_035_000)
+        Weight::from_parts(2_035_000, 0)
             // Standard Error: 8_090
-            .saturating_add(Weight::from_ref_time(1_206_785).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_206_785, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32or(r: u32, ) -> Weight {
@@ -3189,9 +3189,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_022 nanoseconds.
-        Weight::from_ref_time(2_069_000)
+        Weight::from_parts(2_069_000, 0)
             // Standard Error: 4_558
-            .saturating_add(Weight::from_ref_time(600_340).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(600_340, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64xor(r: u32, ) -> Weight {
@@ -3199,9 +3199,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_031 nanoseconds.
-        Weight::from_ref_time(2_088_000)
+        Weight::from_parts(2_088_000, 0)
             // Standard Error: 7_497
-            .saturating_add(Weight::from_ref_time(1_200_146).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_200_146, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32xor(r: u32, ) -> Weight {
@@ -3209,9 +3209,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_007 nanoseconds.
-        Weight::from_ref_time(2_047_000)
+        Weight::from_parts(2_047_000, 0)
             // Standard Error: 4_583
-            .saturating_add(Weight::from_ref_time(601_809).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(601_809, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64shl(r: u32, ) -> Weight {
@@ -3219,9 +3219,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_968 nanoseconds.
-        Weight::from_ref_time(2_035_000)
+        Weight::from_parts(2_035_000, 0)
             // Standard Error: 7_148
-            .saturating_add(Weight::from_ref_time(1_033_991).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_033_991, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32shl(r: u32, ) -> Weight {
@@ -3229,9 +3229,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_951 nanoseconds.
-        Weight::from_ref_time(2_036_000)
+        Weight::from_parts(2_036_000, 0)
             // Standard Error: 3_798
-            .saturating_add(Weight::from_ref_time(557_173).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(557_173, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64shrs(r: u32, ) -> Weight {
@@ -3239,9 +3239,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_008 nanoseconds.
-        Weight::from_ref_time(2_059_000)
+        Weight::from_parts(2_059_000, 0)
             // Standard Error: 6_814
-            .saturating_add(Weight::from_ref_time(1_071_968).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_071_968, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32shrs(r: u32, ) -> Weight {
@@ -3249,9 +3249,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_988 nanoseconds.
-        Weight::from_ref_time(2_050_000)
+        Weight::from_parts(2_050_000, 0)
             // Standard Error: 3_646
-            .saturating_add(Weight::from_ref_time(552_674).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(552_674, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64shru(r: u32, ) -> Weight {
@@ -3259,9 +3259,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_975 nanoseconds.
-        Weight::from_ref_time(2_007_000)
+        Weight::from_parts(2_007_000, 0)
             // Standard Error: 6_233
-            .saturating_add(Weight::from_ref_time(1_020_688).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_020_688, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32shru(r: u32, ) -> Weight {
@@ -3269,9 +3269,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_921 nanoseconds.
-        Weight::from_ref_time(2_007_000)
+        Weight::from_parts(2_007_000, 0)
             // Standard Error: 3_338
-            .saturating_add(Weight::from_ref_time(524_904).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(524_904, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64rotl(r: u32, ) -> Weight {
@@ -3279,9 +3279,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_035 nanoseconds.
-        Weight::from_ref_time(2_096_000)
+        Weight::from_parts(2_096_000, 0)
             // Standard Error: 6_820
-            .saturating_add(Weight::from_ref_time(989_478).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(989_478, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32rotl(r: u32, ) -> Weight {
@@ -3289,9 +3289,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_917 nanoseconds.
-        Weight::from_ref_time(10_071)
+        Weight::from_parts(10_071, 0)
             // Standard Error: 5_314
-            .saturating_add(Weight::from_ref_time(585_983).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(585_983, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64rotr(r: u32, ) -> Weight {
@@ -3299,9 +3299,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_993 nanoseconds.
-        Weight::from_ref_time(2_062_000)
+        Weight::from_parts(2_062_000, 0)
             // Standard Error: 7_508
-            .saturating_add(Weight::from_ref_time(1_010_373).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_010_373, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32rotr(r: u32, ) -> Weight {
@@ -3309,8 +3309,8 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_944 nanoseconds.
-        Weight::from_ref_time(1_993_000)
+        Weight::from_parts(1_993_000, 0)
             // Standard Error: 3_741
-            .saturating_add(Weight::from_ref_time(549_410).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(549_410, 0).saturating_mul(r.into()))
     }
 }

--- a/runtime/gear/src/weights/pallet_timestamp.rs
+++ b/runtime/gear/src/weights/pallet_timestamp.rs
@@ -58,7 +58,7 @@ impl<T: frame_system::Config> pallet_timestamp::WeightInfo for SubstrateWeight<T
         //  Measured:  `57`
         //  Estimated: `0`
         // Minimum execution time: 2_962 nanoseconds.
-        Weight::from_ref_time(3_076_000)
+        Weight::from_parts(3_076_000, 0)
     }
 }
 
@@ -78,6 +78,6 @@ impl WeightInfo for () {
         //  Measured:  `57`
         //  Estimated: `0`
         // Minimum execution time: 2_962 nanoseconds.
-        Weight::from_ref_time(3_076_000)
+        Weight::from_parts(3_076_000, 0)
     }
 }

--- a/runtime/gear/src/weights/pallet_utility.rs
+++ b/runtime/gear/src/weights/pallet_utility.rs
@@ -53,16 +53,16 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for SubstrateWeight<T> 
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_429 nanoseconds.
-        Weight::from_ref_time(19_656_250)
+        Weight::from_parts(19_656_250, 0)
             // Standard Error: 3_394
-            .saturating_add(Weight::from_ref_time(3_077_516).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(3_077_516, 0).saturating_mul(c.into()))
     }
     fn as_derivative() -> Weight {
         // Proof Size summary in bytes:
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 3_044 nanoseconds.
-        Weight::from_ref_time(3_237_000)
+        Weight::from_parts(3_237_000, 0)
     }
     /// The range of component `c` is `[0, 1000]`.
     fn batch_all(c: u32, ) -> Weight {
@@ -70,16 +70,16 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for SubstrateWeight<T> 
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_303 nanoseconds.
-        Weight::from_ref_time(15_139_208)
+        Weight::from_parts(15_139_208, 0)
             // Standard Error: 2_904
-            .saturating_add(Weight::from_ref_time(3_228_469).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(3_228_469, 0).saturating_mul(c.into()))
     }
     fn dispatch_as() -> Weight {
         // Proof Size summary in bytes:
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_788 nanoseconds.
-        Weight::from_ref_time(5_939_000)
+        Weight::from_parts(5_939_000, 0)
     }
     /// The range of component `c` is `[0, 1000]`.
     fn force_batch(c: u32, ) -> Weight {
@@ -87,9 +87,9 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for SubstrateWeight<T> 
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_330 nanoseconds.
-        Weight::from_ref_time(13_164_914)
+        Weight::from_parts(13_164_914, 0)
             // Standard Error: 3_271
-            .saturating_add(Weight::from_ref_time(3_100_254).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(3_100_254, 0).saturating_mul(c.into()))
     }
 }
 
@@ -101,16 +101,16 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_429 nanoseconds.
-        Weight::from_ref_time(19_656_250)
+        Weight::from_parts(19_656_250, 0)
             // Standard Error: 3_394
-            .saturating_add(Weight::from_ref_time(3_077_516).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(3_077_516, 0).saturating_mul(c.into()))
     }
     fn as_derivative() -> Weight {
         // Proof Size summary in bytes:
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 3_044 nanoseconds.
-        Weight::from_ref_time(3_237_000)
+        Weight::from_parts(3_237_000, 0)
     }
     /// The range of component `c` is `[0, 1000]`.
     fn batch_all(c: u32, ) -> Weight {
@@ -118,16 +118,16 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_303 nanoseconds.
-        Weight::from_ref_time(15_139_208)
+        Weight::from_parts(15_139_208, 0)
             // Standard Error: 2_904
-            .saturating_add(Weight::from_ref_time(3_228_469).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(3_228_469, 0).saturating_mul(c.into()))
     }
     fn dispatch_as() -> Weight {
         // Proof Size summary in bytes:
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_788 nanoseconds.
-        Weight::from_ref_time(5_939_000)
+        Weight::from_parts(5_939_000, 0)
     }
     /// The range of component `c` is `[0, 1000]`.
     fn force_batch(c: u32, ) -> Weight {
@@ -135,8 +135,8 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_330 nanoseconds.
-        Weight::from_ref_time(13_164_914)
+        Weight::from_parts(13_164_914, 0)
             // Standard Error: 3_271
-            .saturating_add(Weight::from_ref_time(3_100_254).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(3_100_254, 0).saturating_mul(c.into()))
     }
 }

--- a/runtime/vara/src/weights/frame_system.rs
+++ b/runtime/vara/src/weights/frame_system.rs
@@ -109,7 +109,7 @@ impl<T: frame_system::Config> frame_system::WeightInfo for SubstrateWeight<T> {
             // Standard Error: 1_176
             .saturating_add(Weight::from_parts(1_039_360, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(70).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 70).saturating_mul(p.into()))
     }
 }
 
@@ -176,6 +176,6 @@ impl WeightInfo for () {
             // Standard Error: 1_176
             .saturating_add(Weight::from_parts(1_039_360, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(70).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 70).saturating_mul(p.into()))
     }
 }

--- a/runtime/vara/src/weights/frame_system.rs
+++ b/runtime/vara/src/weights/frame_system.rs
@@ -54,9 +54,9 @@ impl<T: frame_system::Config> frame_system::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_200 nanoseconds.
-        Weight::from_ref_time(928_589)
+        Weight::from_parts(928_589, 0)
             // Standard Error: 0
-            .saturating_add(Weight::from_ref_time(457).saturating_mul(b.into()))
+            .saturating_add(Weight::from_parts(457, 0).saturating_mul(b.into()))
     }
     /// The range of component `b` is `[0, 1310720]`.
     fn remark_with_event(b: u32, ) -> Weight {
@@ -64,9 +64,9 @@ impl<T: frame_system::Config> frame_system::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_020 nanoseconds.
-        Weight::from_ref_time(5_353_000)
+        Weight::from_parts(5_353_000, 0)
             // Standard Error: 0
-            .saturating_add(Weight::from_ref_time(1_741).saturating_mul(b.into()))
+            .saturating_add(Weight::from_parts(1_741, 0).saturating_mul(b.into()))
     }
     fn set_heap_pages() -> Weight {
         // Proof Size summary in bytes:
@@ -83,9 +83,9 @@ impl<T: frame_system::Config> frame_system::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_167 nanoseconds.
-        Weight::from_ref_time(1_218_000)
+        Weight::from_parts(1_218_000, 0)
             // Standard Error: 820
-            .saturating_add(Weight::from_ref_time(561_217).saturating_mul(i.into()))
+            .saturating_add(Weight::from_parts(561_217, 0).saturating_mul(i.into()))
             .saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
     }
     /// The range of component `i` is `[0, 1000]`.
@@ -94,9 +94,9 @@ impl<T: frame_system::Config> frame_system::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_211 nanoseconds.
-        Weight::from_ref_time(1_304_000)
+        Weight::from_parts(1_304_000, 0)
             // Standard Error: 751
-            .saturating_add(Weight::from_ref_time(463_602).saturating_mul(i.into()))
+            .saturating_add(Weight::from_parts(463_602, 0).saturating_mul(i.into()))
             .saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
     }
     /// The range of component `p` is `[0, 1000]`.
@@ -107,7 +107,7 @@ impl<T: frame_system::Config> frame_system::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 2_655 nanoseconds.
         Weight::from_parts(2_802_000, 80)
             // Standard Error: 1_176
-            .saturating_add(Weight::from_ref_time(1_039_360).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_039_360, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(70).saturating_mul(p.into()))
     }
@@ -121,9 +121,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_200 nanoseconds.
-        Weight::from_ref_time(928_589)
+        Weight::from_parts(928_589, 0)
             // Standard Error: 0
-            .saturating_add(Weight::from_ref_time(457).saturating_mul(b.into()))
+            .saturating_add(Weight::from_parts(457, 0).saturating_mul(b.into()))
     }
     /// The range of component `b` is `[0, 1310720]`.
     fn remark_with_event(b: u32, ) -> Weight {
@@ -131,9 +131,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_020 nanoseconds.
-        Weight::from_ref_time(5_353_000)
+        Weight::from_parts(5_353_000, 0)
             // Standard Error: 0
-            .saturating_add(Weight::from_ref_time(1_741).saturating_mul(b.into()))
+            .saturating_add(Weight::from_parts(1_741, 0).saturating_mul(b.into()))
     }
     fn set_heap_pages() -> Weight {
         // Proof Size summary in bytes:
@@ -150,9 +150,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_167 nanoseconds.
-        Weight::from_ref_time(1_218_000)
+        Weight::from_parts(1_218_000, 0)
             // Standard Error: 820
-            .saturating_add(Weight::from_ref_time(561_217).saturating_mul(i.into()))
+            .saturating_add(Weight::from_parts(561_217, 0).saturating_mul(i.into()))
             .saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(i.into())))
     }
     /// The range of component `i` is `[0, 1000]`.
@@ -161,9 +161,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_211 nanoseconds.
-        Weight::from_ref_time(1_304_000)
+        Weight::from_parts(1_304_000, 0)
             // Standard Error: 751
-            .saturating_add(Weight::from_ref_time(463_602).saturating_mul(i.into()))
+            .saturating_add(Weight::from_parts(463_602, 0).saturating_mul(i.into()))
             .saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(i.into())))
     }
     /// The range of component `p` is `[0, 1000]`.
@@ -174,7 +174,7 @@ impl WeightInfo for () {
         // Minimum execution time: 2_655 nanoseconds.
         Weight::from_parts(2_802_000, 80)
             // Standard Error: 1_176
-            .saturating_add(Weight::from_ref_time(1_039_360).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_039_360, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(70).saturating_mul(p.into()))
     }

--- a/runtime/vara/src/weights/mod.rs
+++ b/runtime/vara/src/weights/mod.rs
@@ -18,8 +18,6 @@
 
 //! A list of the different weight modules for our runtime.
 
-#![allow(deprecated)]
-
 pub mod frame_system;
 pub mod pallet_balances;
 pub mod pallet_gear;

--- a/runtime/vara/src/weights/mod.rs
+++ b/runtime/vara/src/weights/mod.rs
@@ -18,7 +18,6 @@
 
 //! A list of the different weight modules for our runtime.
 
-// (issue #2531)
 #![allow(deprecated)]
 
 pub mod frame_system;

--- a/runtime/vara/src/weights/pallet_gear.rs
+++ b/runtime/vara/src/weights/pallet_gear.rs
@@ -232,7 +232,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
             // Standard Error: 2_641
             .saturating_add(Weight::from_parts(696_372, 0).saturating_mul(c.into()))
             .saturating_add(T::DbWeight::get().reads(1_u64))
-            .saturating_add(Weight::from_proof_size(1024).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(0, 1024).saturating_mul(c.into()))
     }
     /// The range of component `c` is `[0, 512]`.
     fn instantiate_module_per_kb(c: u32, ) -> Weight {
@@ -351,7 +351,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
             .saturating_add(Weight::from_parts(51_043_357, 0).saturating_mul(c.into()))
             .saturating_add(T::DbWeight::get().reads(1_u64))
             .saturating_add(T::DbWeight::get().writes(2_u64))
-            .saturating_add(Weight::from_proof_size(2150).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(0, 2150).saturating_mul(c.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn alloc(r: u32, ) -> Weight {
@@ -856,7 +856,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
             // Standard Error: 7_125
             .saturating_add(Weight::from_parts(11_656_827, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9900).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 512]`.
     fn lazy_pages_signal_write(p: u32, ) -> Weight {
@@ -868,7 +868,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
             // Standard Error: 36_484
             .saturating_add(Weight::from_parts(34_711_742, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9900).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 512]`.
     fn lazy_pages_signal_write_after_read(p: u32, ) -> Weight {
@@ -891,7 +891,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
             // Standard Error: 33_523
             .saturating_add(Weight::from_parts(43_951_462, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(75606).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 75606).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 32]`.
     fn lazy_pages_host_func_read(p: u32, ) -> Weight {
@@ -903,7 +903,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
             // Standard Error: 59_825
             .saturating_add(Weight::from_parts(35_208_171, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9883).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 32]`.
     fn lazy_pages_host_func_write(p: u32, ) -> Weight {
@@ -915,7 +915,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
             // Standard Error: 182_196
             .saturating_add(Weight::from_parts(42_500_948, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9883).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 32]`.
     fn lazy_pages_host_func_write_after_read(p: u32, ) -> Weight {
@@ -1792,7 +1792,7 @@ impl WeightInfo for () {
             // Standard Error: 2_641
             .saturating_add(Weight::from_parts(696_372, 0).saturating_mul(c.into()))
             .saturating_add(RocksDbWeight::get().reads(1_u64))
-            .saturating_add(Weight::from_proof_size(1024).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(0, 1024).saturating_mul(c.into()))
     }
     /// The range of component `c` is `[0, 512]`.
     fn instantiate_module_per_kb(c: u32, ) -> Weight {
@@ -1911,7 +1911,7 @@ impl WeightInfo for () {
             .saturating_add(Weight::from_parts(51_043_357, 0).saturating_mul(c.into()))
             .saturating_add(RocksDbWeight::get().reads(1_u64))
             .saturating_add(RocksDbWeight::get().writes(2_u64))
-            .saturating_add(Weight::from_proof_size(2150).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(0, 2150).saturating_mul(c.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn alloc(r: u32, ) -> Weight {
@@ -2416,7 +2416,7 @@ impl WeightInfo for () {
             // Standard Error: 7_125
             .saturating_add(Weight::from_parts(11_656_827, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9900).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 512]`.
     fn lazy_pages_signal_write(p: u32, ) -> Weight {
@@ -2428,7 +2428,7 @@ impl WeightInfo for () {
             // Standard Error: 36_484
             .saturating_add(Weight::from_parts(34_711_742, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9900).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 512]`.
     fn lazy_pages_signal_write_after_read(p: u32, ) -> Weight {
@@ -2451,7 +2451,7 @@ impl WeightInfo for () {
             // Standard Error: 33_523
             .saturating_add(Weight::from_parts(43_951_462, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(75606).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 75606).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 32]`.
     fn lazy_pages_host_func_read(p: u32, ) -> Weight {
@@ -2463,7 +2463,7 @@ impl WeightInfo for () {
             // Standard Error: 59_825
             .saturating_add(Weight::from_parts(35_208_171, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9883).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 32]`.
     fn lazy_pages_host_func_write(p: u32, ) -> Weight {
@@ -2475,7 +2475,7 @@ impl WeightInfo for () {
             // Standard Error: 182_196
             .saturating_add(Weight::from_parts(42_500_948, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
-            .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(0, 9883).saturating_mul(p.into()))
     }
     /// The range of component `p` is `[0, 32]`.
     fn lazy_pages_host_func_write_after_read(p: u32, ) -> Weight {

--- a/runtime/vara/src/weights/pallet_gear.rs
+++ b/runtime/vara/src/weights/pallet_gear.rs
@@ -217,9 +217,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 761 nanoseconds.
-        Weight::from_ref_time(794_000)
+        Weight::from_parts(794_000, 0)
             // Standard Error: 960
-            .saturating_add(Weight::from_ref_time(212_224).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(212_224, 0).saturating_mul(c.into()))
             .saturating_add(T::DbWeight::get().writes(1_u64))
     }
     /// The range of component `c` is `[0, 512]`.
@@ -230,7 +230,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 3_067 nanoseconds.
         Weight::from_parts(3_132_000, 2617)
             // Standard Error: 2_641
-            .saturating_add(Weight::from_ref_time(696_372).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(696_372, 0).saturating_mul(c.into()))
             .saturating_add(T::DbWeight::get().reads(1_u64))
             .saturating_add(Weight::from_proof_size(1024).saturating_mul(c.into()))
     }
@@ -240,9 +240,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 48_163 nanoseconds.
-        Weight::from_ref_time(102_637_811)
+        Weight::from_parts(102_637_811, 0)
             // Standard Error: 7_418
-            .saturating_add(Weight::from_ref_time(2_284_334).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(2_284_334, 0).saturating_mul(c.into()))
     }
     fn claim_value() -> Weight {
         // Proof Size summary in bytes:
@@ -261,7 +261,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 57_788 nanoseconds.
         Weight::from_parts(31_642_282, 3290)
             // Standard Error: 47_873
-            .saturating_add(Weight::from_ref_time(53_067_634).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(53_067_634, 0).saturating_mul(c.into()))
             .saturating_add(T::DbWeight::get().reads(2_u64))
             .saturating_add(T::DbWeight::get().writes(4_u64))
     }
@@ -273,7 +273,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 47_046 nanoseconds.
         Weight::from_parts(65_865_510, 18282)
             // Standard Error: 0
-            .saturating_add(Weight::from_ref_time(2_272).saturating_mul(s.into()))
+            .saturating_add(Weight::from_parts(2_272, 0).saturating_mul(s.into()))
             .saturating_add(T::DbWeight::get().reads(10_u64))
             .saturating_add(T::DbWeight::get().writes(8_u64))
     }
@@ -286,9 +286,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 9_629_458 nanoseconds.
         Weight::from_parts(128_023_124, 14142)
             // Standard Error: 164_368
-            .saturating_add(Weight::from_ref_time(54_589_020).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(54_589_020, 0).saturating_mul(c.into()))
             // Standard Error: 9
-            .saturating_add(Weight::from_ref_time(2_268).saturating_mul(s.into()))
+            .saturating_add(Weight::from_parts(2_268, 0).saturating_mul(s.into()))
             .saturating_add(T::DbWeight::get().reads(10_u64))
             .saturating_add(T::DbWeight::get().writes(12_u64))
     }
@@ -300,7 +300,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 48_557 nanoseconds.
         Weight::from_parts(28_383_814, 14765)
             // Standard Error: 1
-            .saturating_add(Weight::from_ref_time(1_134).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_134, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads(9_u64))
             .saturating_add(T::DbWeight::get().writes(8_u64))
     }
@@ -312,7 +312,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 72_760 nanoseconds.
         Weight::from_parts(61_055_469, 31447)
             // Standard Error: 1
-            .saturating_add(Weight::from_ref_time(1_145).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_145, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads(13_u64))
             .saturating_add(T::DbWeight::get().writes(10_u64))
     }
@@ -324,7 +324,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 278_465 nanoseconds.
         Weight::from_parts(289_144_814, 49130)
             // Standard Error: 930
-            .saturating_add(Weight::from_ref_time(3_745).saturating_mul(q.into()))
+            .saturating_add(Weight::from_parts(3_745, 0).saturating_mul(q.into()))
             .saturating_add(T::DbWeight::get().reads(26_u64))
             .saturating_add(T::DbWeight::get().writes(22_u64))
     }
@@ -336,7 +336,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 289_940 nanoseconds.
         Weight::from_parts(301_064_878, 49018)
             // Standard Error: 1_069
-            .saturating_add(Weight::from_ref_time(4_413).saturating_mul(q.into()))
+            .saturating_add(Weight::from_parts(4_413, 0).saturating_mul(q.into()))
             .saturating_add(T::DbWeight::get().reads(26_u64))
             .saturating_add(T::DbWeight::get().writes(22_u64))
     }
@@ -348,7 +348,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 41_220 nanoseconds.
         Weight::from_parts(41_558_000, 2973)
             // Standard Error: 43_154
-            .saturating_add(Weight::from_ref_time(51_043_357).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(51_043_357, 0).saturating_mul(c.into()))
             .saturating_add(T::DbWeight::get().reads(1_u64))
             .saturating_add(T::DbWeight::get().writes(2_u64))
             .saturating_add(Weight::from_proof_size(2150).saturating_mul(c.into()))
@@ -359,9 +359,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_620 nanoseconds.
-        Weight::from_ref_time(85_723_324)
+        Weight::from_parts(85_723_324, 0)
             // Standard Error: 302_409
-            .saturating_add(Weight::from_ref_time(129_670_159).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(129_670_159, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn free(r: u32, ) -> Weight {
@@ -369,9 +369,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 198_883 nanoseconds.
-        Weight::from_ref_time(180_549_249)
+        Weight::from_parts(180_549_249, 0)
             // Standard Error: 279_283
-            .saturating_add(Weight::from_ref_time(127_604_915).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(127_604_915, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 256]`.
     fn gr_reserve_gas(r: u32, ) -> Weight {
@@ -379,9 +379,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 84_282 nanoseconds.
-        Weight::from_ref_time(85_230_381)
+        Weight::from_parts(85_230_381, 0)
             // Standard Error: 9_033
-            .saturating_add(Weight::from_ref_time(3_509_899).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_509_899, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 256]`.
     fn gr_unreserve_gas(r: u32, ) -> Weight {
@@ -389,9 +389,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 131_615 nanoseconds.
-        Weight::from_ref_time(168_307_579)
+        Weight::from_parts(168_307_579, 0)
             // Standard Error: 20_410
-            .saturating_add(Weight::from_ref_time(3_513_779).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_513_779, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_system_reserve_gas(r: u32, ) -> Weight {
@@ -399,9 +399,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_244 nanoseconds.
-        Weight::from_ref_time(133_381_524)
+        Weight::from_parts(133_381_524, 0)
             // Standard Error: 364_215
-            .saturating_add(Weight::from_ref_time(175_263_065).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(175_263_065, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_message_id(r: u32, ) -> Weight {
@@ -409,9 +409,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_871 nanoseconds.
-        Weight::from_ref_time(83_728_178)
+        Weight::from_parts(83_728_178, 0)
             // Standard Error: 237_530
-            .saturating_add(Weight::from_ref_time(175_396_894).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(175_396_894, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_origin(r: u32, ) -> Weight {
@@ -419,9 +419,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_344 nanoseconds.
-        Weight::from_ref_time(80_814_311)
+        Weight::from_parts(80_814_311, 0)
             // Standard Error: 242_865
-            .saturating_add(Weight::from_ref_time(176_183_080).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(176_183_080, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_program_id(r: u32, ) -> Weight {
@@ -429,9 +429,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_550 nanoseconds.
-        Weight::from_ref_time(86_713_676)
+        Weight::from_parts(86_713_676, 0)
             // Standard Error: 238_659
-            .saturating_add(Weight::from_ref_time(174_365_605).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(174_365_605, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_source(r: u32, ) -> Weight {
@@ -439,9 +439,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_212 nanoseconds.
-        Weight::from_ref_time(81_118_155)
+        Weight::from_parts(81_118_155, 0)
             // Standard Error: 247_291
-            .saturating_add(Weight::from_ref_time(175_847_363).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(175_847_363, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_value(r: u32, ) -> Weight {
@@ -449,9 +449,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_148 nanoseconds.
-        Weight::from_ref_time(83_939_496)
+        Weight::from_parts(83_939_496, 0)
             // Standard Error: 280_041
-            .saturating_add(Weight::from_ref_time(175_400_021).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(175_400_021, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_value_available(r: u32, ) -> Weight {
@@ -459,9 +459,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_682 nanoseconds.
-        Weight::from_ref_time(85_424_687)
+        Weight::from_parts(85_424_687, 0)
             // Standard Error: 255_412
-            .saturating_add(Weight::from_ref_time(174_010_282).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(174_010_282, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_gas_available(r: u32, ) -> Weight {
@@ -469,9 +469,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_825 nanoseconds.
-        Weight::from_ref_time(86_478_699)
+        Weight::from_parts(86_478_699, 0)
             // Standard Error: 252_429
-            .saturating_add(Weight::from_ref_time(177_432_143).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(177_432_143, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_size(r: u32, ) -> Weight {
@@ -479,9 +479,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_170 nanoseconds.
-        Weight::from_ref_time(84_210_822)
+        Weight::from_parts(84_210_822, 0)
             // Standard Error: 251_283
-            .saturating_add(Weight::from_ref_time(180_568_190).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_568_190, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_read(r: u32, ) -> Weight {
@@ -489,9 +489,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 557_635 nanoseconds.
-        Weight::from_ref_time(634_644_194)
+        Weight::from_parts(634_644_194, 0)
             // Standard Error: 400_411
-            .saturating_add(Weight::from_ref_time(239_352_408).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(239_352_408, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_read_per_kb(n: u32, ) -> Weight {
@@ -499,9 +499,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 828_353 nanoseconds.
-        Weight::from_ref_time(837_715_000)
+        Weight::from_parts(837_715_000, 0)
             // Standard Error: 60_739
-            .saturating_add(Weight::from_ref_time(14_146_957).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(14_146_957, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_block_height(r: u32, ) -> Weight {
@@ -509,9 +509,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_842 nanoseconds.
-        Weight::from_ref_time(78_011_099)
+        Weight::from_parts(78_011_099, 0)
             // Standard Error: 304_537
-            .saturating_add(Weight::from_ref_time(174_648_210).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(174_648_210, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_block_timestamp(r: u32, ) -> Weight {
@@ -519,9 +519,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_383 nanoseconds.
-        Weight::from_ref_time(85_071_672)
+        Weight::from_parts(85_071_672, 0)
             // Standard Error: 277_230
-            .saturating_add(Weight::from_ref_time(175_739_698).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(175_739_698, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 20]`.
     fn gr_random(n: u32, ) -> Weight {
@@ -529,9 +529,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_759 nanoseconds.
-        Weight::from_ref_time(97_315_812)
+        Weight::from_parts(97_315_812, 0)
             // Standard Error: 238_252
-            .saturating_add(Weight::from_ref_time(238_074_206).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(238_074_206, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_init(r: u32, ) -> Weight {
@@ -539,9 +539,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 84_613 nanoseconds.
-        Weight::from_ref_time(73_884_051)
+        Weight::from_parts(73_884_051, 0)
             // Standard Error: 231_926
-            .saturating_add(Weight::from_ref_time(188_042_953).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(188_042_953, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_push(r: u32, ) -> Weight {
@@ -549,9 +549,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 3_706_952 nanoseconds.
-        Weight::from_ref_time(3_841_642_964)
+        Weight::from_parts(3_841_642_964, 0)
             // Standard Error: 288_960
-            .saturating_add(Weight::from_ref_time(247_877_210).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(247_877_210, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_send_push_per_kb(n: u32, ) -> Weight {
@@ -559,9 +559,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 520_139 nanoseconds.
-        Weight::from_ref_time(523_195_000)
+        Weight::from_parts(523_195_000, 0)
             // Standard Error: 61_816
-            .saturating_add(Weight::from_ref_time(29_665_714).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(29_665_714, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_commit(r: u32, ) -> Weight {
@@ -569,9 +569,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 84_478 nanoseconds.
-        Weight::from_ref_time(131_497_693)
+        Weight::from_parts(131_497_693, 0)
             // Standard Error: 299_463
-            .saturating_add(Weight::from_ref_time(352_624_503).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(352_624_503, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_send_commit_per_kb(n: u32, ) -> Weight {
@@ -579,9 +579,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 437_137 nanoseconds.
-        Weight::from_ref_time(440_652_000)
+        Weight::from_parts(440_652_000, 0)
             // Standard Error: 59_951
-            .saturating_add(Weight::from_ref_time(21_224_751).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(21_224_751, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reservation_send_commit(r: u32, ) -> Weight {
@@ -589,9 +589,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 242_701 nanoseconds.
-        Weight::from_ref_time(305_043_647)
+        Weight::from_parts(305_043_647, 0)
             // Standard Error: 244_718
-            .saturating_add(Weight::from_ref_time(369_921_323).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(369_921_323, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reservation_send_commit_per_kb(n: u32, ) -> Weight {
@@ -599,9 +599,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 471_909 nanoseconds.
-        Weight::from_ref_time(481_316_000)
+        Weight::from_parts(481_316_000, 0)
             // Standard Error: 51_289
-            .saturating_add(Weight::from_ref_time(21_001_799).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(21_001_799, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_reply_commit(r: u32, ) -> Weight {
@@ -609,9 +609,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_287 nanoseconds.
-        Weight::from_ref_time(84_806_134)
+        Weight::from_parts(84_806_134, 0)
             // Standard Error: 250_891
-            .saturating_add(Weight::from_ref_time(17_607_365).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(17_607_365, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reply_commit_per_kb(n: u32, ) -> Weight {
@@ -619,9 +619,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 100_681 nanoseconds.
-        Weight::from_ref_time(86_530_601)
+        Weight::from_parts(86_530_601, 0)
             // Standard Error: 774
-            .saturating_add(Weight::from_ref_time(423_018).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(423_018, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reply_push(r: u32, ) -> Weight {
@@ -629,9 +629,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_835 nanoseconds.
-        Weight::from_ref_time(137_479_664)
+        Weight::from_parts(137_479_664, 0)
             // Standard Error: 331_995
-            .saturating_add(Weight::from_ref_time(243_721_746).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(243_721_746, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 8192]`.
     fn gr_reply_push_per_kb(n: u32, ) -> Weight {
@@ -639,9 +639,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 97_910 nanoseconds.
-        Weight::from_ref_time(99_515_000)
+        Weight::from_parts(99_515_000, 0)
             // Standard Error: 2_501
-            .saturating_add(Weight::from_ref_time(605_467).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(605_467, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_reservation_reply_commit(r: u32, ) -> Weight {
@@ -649,9 +649,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 88_365 nanoseconds.
-        Weight::from_ref_time(91_586_508)
+        Weight::from_parts(91_586_508, 0)
             // Standard Error: 253_416
-            .saturating_add(Weight::from_ref_time(11_330_891).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(11_330_891, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reservation_reply_commit_per_kb(n: u32, ) -> Weight {
@@ -659,9 +659,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 101_342 nanoseconds.
-        Weight::from_ref_time(86_985_218)
+        Weight::from_parts(86_985_218, 0)
             // Standard Error: 729
-            .saturating_add(Weight::from_ref_time(420_626).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(420_626, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reply_to(r: u32, ) -> Weight {
@@ -669,9 +669,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_176 nanoseconds.
-        Weight::from_ref_time(85_895_984)
+        Weight::from_parts(85_895_984, 0)
             // Standard Error: 315_843
-            .saturating_add(Weight::from_ref_time(175_959_029).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(175_959_029, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_signal_from(r: u32, ) -> Weight {
@@ -679,9 +679,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 84_180 nanoseconds.
-        Weight::from_ref_time(87_329_873)
+        Weight::from_parts(87_329_873, 0)
             // Standard Error: 255_146
-            .saturating_add(Weight::from_ref_time(175_210_834).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(175_210_834, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reply_push_input(r: u32, ) -> Weight {
@@ -689,9 +689,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 553_563 nanoseconds.
-        Weight::from_ref_time(609_509_128)
+        Weight::from_parts(609_509_128, 0)
             // Standard Error: 401_197
-            .saturating_add(Weight::from_ref_time(187_924_542).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(187_924_542, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reply_push_input_per_kb(n: u32, ) -> Weight {
@@ -699,9 +699,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 574_867 nanoseconds.
-        Weight::from_ref_time(587_172_863)
+        Weight::from_parts(587_172_863, 0)
             // Standard Error: 954
-            .saturating_add(Weight::from_ref_time(121_260).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(121_260, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_push_input(r: u32, ) -> Weight {
@@ -709,9 +709,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_153_438 nanoseconds.
-        Weight::from_ref_time(4_303_178_639)
+        Weight::from_parts(4_303_178_639, 0)
             // Standard Error: 265_183
-            .saturating_add(Weight::from_ref_time(192_266_698).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(192_266_698, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_send_push_input_per_kb(n: u32, ) -> Weight {
@@ -719,9 +719,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 939_474 nanoseconds.
-        Weight::from_ref_time(836_256_075)
+        Weight::from_parts(836_256_075, 0)
             // Standard Error: 10_783
-            .saturating_add(Weight::from_ref_time(12_584_153).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(12_584_153, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_debug(r: u32, ) -> Weight {
@@ -729,9 +729,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_912 nanoseconds.
-        Weight::from_ref_time(107_702_879)
+        Weight::from_parts(107_702_879, 0)
             // Standard Error: 316_515
-            .saturating_add(Weight::from_ref_time(187_518_617).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(187_518_617, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_debug_per_kb(n: u32, ) -> Weight {
@@ -739,9 +739,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 260_251 nanoseconds.
-        Weight::from_ref_time(265_607_000)
+        Weight::from_parts(265_607_000, 0)
             // Standard Error: 47_176
-            .saturating_add(Weight::from_ref_time(25_735_678).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(25_735_678, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_error(r: u32, ) -> Weight {
@@ -749,9 +749,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 96_526 nanoseconds.
-        Weight::from_ref_time(103_383_863)
+        Weight::from_parts(103_383_863, 0)
             // Standard Error: 281_743
-            .saturating_add(Weight::from_ref_time(229_630_385).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(229_630_385, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_status_code(r: u32, ) -> Weight {
@@ -759,9 +759,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_646 nanoseconds.
-        Weight::from_ref_time(77_387_247)
+        Weight::from_parts(77_387_247, 0)
             // Standard Error: 240_622
-            .saturating_add(Weight::from_ref_time(177_210_179).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(177_210_179, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_exit(r: u32, ) -> Weight {
@@ -769,9 +769,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_732 nanoseconds.
-        Weight::from_ref_time(86_746_559)
+        Weight::from_parts(86_746_559, 0)
             // Standard Error: 276_411
-            .saturating_add(Weight::from_ref_time(24_364_740).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(24_364_740, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_leave(r: u32, ) -> Weight {
@@ -779,9 +779,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_768 nanoseconds.
-        Weight::from_ref_time(86_254_018)
+        Weight::from_parts(86_254_018, 0)
             // Standard Error: 270_944
-            .saturating_add(Weight::from_ref_time(13_674_081).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(13_674_081, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_wait(r: u32, ) -> Weight {
@@ -789,9 +789,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_973 nanoseconds.
-        Weight::from_ref_time(86_357_653)
+        Weight::from_parts(86_357_653, 0)
             // Standard Error: 275_003
-            .saturating_add(Weight::from_ref_time(14_931_046).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(14_931_046, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_wait_for(r: u32, ) -> Weight {
@@ -799,9 +799,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_826 nanoseconds.
-        Weight::from_ref_time(86_467_016)
+        Weight::from_parts(86_467_016, 0)
             // Standard Error: 264_613
-            .saturating_add(Weight::from_ref_time(14_260_583).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(14_260_583, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_wait_up_to(r: u32, ) -> Weight {
@@ -809,9 +809,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_605 nanoseconds.
-        Weight::from_ref_time(86_532_340)
+        Weight::from_parts(86_532_340, 0)
             // Standard Error: 278_759
-            .saturating_add(Weight::from_ref_time(14_028_659).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(14_028_659, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_wake(r: u32, ) -> Weight {
@@ -819,9 +819,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 132_543 nanoseconds.
-        Weight::from_ref_time(192_378_038)
+        Weight::from_parts(192_378_038, 0)
             // Standard Error: 249_057
-            .saturating_add(Weight::from_ref_time(254_777_085).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(254_777_085, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_create_program_wgas(r: u32, ) -> Weight {
@@ -829,9 +829,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 92_114 nanoseconds.
-        Weight::from_ref_time(156_606_434)
+        Weight::from_parts(156_606_434, 0)
             // Standard Error: 295_787
-            .saturating_add(Weight::from_ref_time(425_470_652).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(425_470_652, 0).saturating_mul(r.into()))
     }
     /// The range of component `p` is `[0, 2048]`.
     /// The range of component `s` is `[1, 2048]`.
@@ -840,11 +840,11 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 43_256_334 nanoseconds.
-        Weight::from_ref_time(43_465_935_000)
+        Weight::from_parts(43_465_935_000, 0)
             // Standard Error: 263_063
-            .saturating_add(Weight::from_ref_time(7_902_649).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(7_902_649, 0).saturating_mul(p.into()))
             // Standard Error: 263_050
-            .saturating_add(Weight::from_ref_time(152_656_694).saturating_mul(s.into()))
+            .saturating_add(Weight::from_parts(152_656_694, 0).saturating_mul(s.into()))
     }
     /// The range of component `p` is `[0, 512]`.
     fn lazy_pages_signal_read(p: u32, ) -> Weight {
@@ -854,7 +854,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 81_807 nanoseconds.
         Weight::from_parts(121_821_266, 141)
             // Standard Error: 7_125
-            .saturating_add(Weight::from_ref_time(11_656_827).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(11_656_827, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
     }
@@ -866,7 +866,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 83_262 nanoseconds.
         Weight::from_parts(84_399_000, 141)
             // Standard Error: 36_484
-            .saturating_add(Weight::from_ref_time(34_711_742).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(34_711_742, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
     }
@@ -878,7 +878,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 6_028_492 nanoseconds.
         Weight::from_parts(5_810_695_816, 5068941)
             // Standard Error: 54_356
-            .saturating_add(Weight::from_ref_time(36_889_507).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(36_889_507, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads(2048_u64))
     }
     /// The range of component `p` is `[0, 512]`.
@@ -889,7 +889,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 84_317 nanoseconds.
         Weight::from_parts(85_299_000, 949)
             // Standard Error: 33_523
-            .saturating_add(Weight::from_ref_time(43_951_462).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(43_951_462, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(75606).saturating_mul(p.into()))
     }
@@ -901,7 +901,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 95_734 nanoseconds.
         Weight::from_parts(99_957_245, 506)
             // Standard Error: 59_825
-            .saturating_add(Weight::from_ref_time(35_208_171).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(35_208_171, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
     }
@@ -913,7 +913,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 586_697 nanoseconds.
         Weight::from_parts(579_394_810, 506)
             // Standard Error: 182_196
-            .saturating_add(Weight::from_ref_time(42_500_948).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(42_500_948, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
     }
@@ -925,7 +925,7 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         // Minimum execution time: 983_916 nanoseconds.
         Weight::from_parts(1_010_515_733, 316941)
             // Standard Error: 143_944
-            .saturating_add(Weight::from_ref_time(42_508_767).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(42_508_767, 0).saturating_mul(p.into()))
             .saturating_add(T::DbWeight::get().reads(128_u64))
     }
     /// The range of component `r` is `[50, 500]`.
@@ -934,9 +934,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_226_275 nanoseconds.
-        Weight::from_ref_time(4_225_648_608)
+        Weight::from_parts(4_225_648_608, 0)
             // Standard Error: 10_161
-            .saturating_add(Weight::from_ref_time(3_355_980).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_355_980, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[50, 500]`.
     fn instr_i32load(r: u32, ) -> Weight {
@@ -944,9 +944,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_228_938 nanoseconds.
-        Weight::from_ref_time(4_228_073_783)
+        Weight::from_parts(4_228_073_783, 0)
             // Standard Error: 10_035
-            .saturating_add(Weight::from_ref_time(3_370_264).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_370_264, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[50, 500]`.
     fn instr_i64store(r: u32, ) -> Weight {
@@ -954,9 +954,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 9_719_113 nanoseconds.
-        Weight::from_ref_time(9_865_862_677)
+        Weight::from_parts(9_865_862_677, 0)
             // Standard Error: 186_470
-            .saturating_add(Weight::from_ref_time(16_510_034).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(16_510_034, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[50, 500]`.
     fn instr_i32store(r: u32, ) -> Weight {
@@ -964,9 +964,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 9_539_429 nanoseconds.
-        Weight::from_ref_time(8_971_089_150)
+        Weight::from_parts(8_971_089_150, 0)
             // Standard Error: 149_624
-            .saturating_add(Weight::from_ref_time(16_140_559).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(16_140_559, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_select(r: u32, ) -> Weight {
@@ -974,9 +974,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_017 nanoseconds.
-        Weight::from_ref_time(2_162_000)
+        Weight::from_parts(2_162_000, 0)
             // Standard Error: 8_150
-            .saturating_add(Weight::from_ref_time(3_810_640).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_810_640, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_if(r: u32, ) -> Weight {
@@ -984,9 +984,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_005 nanoseconds.
-        Weight::from_ref_time(2_091_000)
+        Weight::from_parts(2_091_000, 0)
             // Standard Error: 7_804
-            .saturating_add(Weight::from_ref_time(3_085_440).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_085_440, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_br(r: u32, ) -> Weight {
@@ -994,9 +994,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_948 nanoseconds.
-        Weight::from_ref_time(3_039_323)
+        Weight::from_parts(3_039_323, 0)
             // Standard Error: 916
-            .saturating_add(Weight::from_ref_time(1_573_630).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_573_630, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_br_if(r: u32, ) -> Weight {
@@ -1004,9 +1004,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_945 nanoseconds.
-        Weight::from_ref_time(2_017_000)
+        Weight::from_parts(2_017_000, 0)
             // Standard Error: 9_300
-            .saturating_add(Weight::from_ref_time(2_940_862).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_940_862, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_br_table(r: u32, ) -> Weight {
@@ -1014,9 +1014,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_039 nanoseconds.
-        Weight::from_ref_time(7_505_360)
+        Weight::from_parts(7_505_360, 0)
             // Standard Error: 27_099
-            .saturating_add(Weight::from_ref_time(4_937_410).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(4_937_410, 0).saturating_mul(r.into()))
     }
     /// The range of component `e` is `[1, 256]`.
     fn instr_br_table_per_entry(e: u32, ) -> Weight {
@@ -1024,9 +1024,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 6_690 nanoseconds.
-        Weight::from_ref_time(4_745_487)
+        Weight::from_parts(4_745_487, 0)
             // Standard Error: 1_598
-            .saturating_add(Weight::from_ref_time(190_014).saturating_mul(e.into()))
+            .saturating_add(Weight::from_parts(190_014, 0).saturating_mul(e.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_call_const(r: u32, ) -> Weight {
@@ -1034,14 +1034,14 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_128 nanoseconds.
-        Weight::from_ref_time(5_580_087)
+        Weight::from_parts(5_580_087, 0)
             // Standard Error: 8_909
-            .saturating_add(Weight::from_ref_time(2_581_842).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_581_842, 0).saturating_mul(r.into()))
     }
     fn instr_i64const(r: u32, ) -> Weight {
-        Weight::from_ref_time(0)
-            .saturating_add(Weight::from_ref_time(2_581_842 -
-            2_429_530).saturating_mul(r.into()))
+        Weight::from_parts(0, 0)
+            .saturating_add(Weight::from_parts(2_581_842 -
+            2_429_530, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_call(r: u32, ) -> Weight {
@@ -1049,9 +1049,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_108 nanoseconds.
-        Weight::from_ref_time(5_054_933)
+        Weight::from_parts(5_054_933, 0)
             // Standard Error: 12_863
-            .saturating_add(Weight::from_ref_time(2_429_530).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_429_530, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_call_indirect(r: u32, ) -> Weight {
@@ -1059,9 +1059,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_370 nanoseconds.
-        Weight::from_ref_time(18_616_562)
+        Weight::from_parts(18_616_562, 0)
             // Standard Error: 29_254
-            .saturating_add(Weight::from_ref_time(10_375_535).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(10_375_535, 0).saturating_mul(r.into()))
     }
     /// The range of component `p` is `[0, 128]`.
     fn instr_call_indirect_per_param(p: u32, ) -> Weight {
@@ -1069,9 +1069,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 12_168 nanoseconds.
-        Weight::from_ref_time(3_775_924)
+        Weight::from_parts(3_775_924, 0)
             // Standard Error: 6_558
-            .saturating_add(Weight::from_ref_time(1_321_364).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_321_364, 0).saturating_mul(p.into()))
     }
     /// The range of component `l` is `[0, 1024]`.
     fn instr_call_per_local(l: u32, ) -> Weight {
@@ -1079,9 +1079,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_006 nanoseconds.
-        Weight::from_ref_time(5_256_467)
+        Weight::from_parts(5_256_467, 0)
             // Standard Error: 12
-            .saturating_add(Weight::from_ref_time(57).saturating_mul(l.into()))
+            .saturating_add(Weight::from_parts(57, 0).saturating_mul(l.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_local_get(r: u32, ) -> Weight {
@@ -1089,9 +1089,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_019 nanoseconds.
-        Weight::from_ref_time(1_408_120)
+        Weight::from_parts(1_408_120, 0)
             // Standard Error: 3_519
-            .saturating_add(Weight::from_ref_time(298_892).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(298_892, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_local_set(r: u32, ) -> Weight {
@@ -1099,9 +1099,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_058 nanoseconds.
-        Weight::from_ref_time(2_092_000)
+        Weight::from_parts(2_092_000, 0)
             // Standard Error: 7_004
-            .saturating_add(Weight::from_ref_time(892_803).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(892_803, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_local_tee(r: u32, ) -> Weight {
@@ -1109,9 +1109,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_976 nanoseconds.
-        Weight::from_ref_time(2_078_000)
+        Weight::from_parts(2_078_000, 0)
             // Standard Error: 6_769
-            .saturating_add(Weight::from_ref_time(930_108).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(930_108, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_global_get(r: u32, ) -> Weight {
@@ -1119,9 +1119,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_803 nanoseconds.
-        Weight::from_ref_time(1_190_711)
+        Weight::from_parts(1_190_711, 0)
             // Standard Error: 9_230
-            .saturating_add(Weight::from_ref_time(936_198).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(936_198, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_global_set(r: u32, ) -> Weight {
@@ -1129,9 +1129,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_683 nanoseconds.
-        Weight::from_ref_time(5_732_000)
+        Weight::from_parts(5_732_000, 0)
             // Standard Error: 8_615
-            .saturating_add(Weight::from_ref_time(1_560_589).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_560_589, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_memory_current(r: u32, ) -> Weight {
@@ -1139,9 +1139,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 6_114 nanoseconds.
-        Weight::from_ref_time(2_722_110)
+        Weight::from_parts(2_722_110, 0)
             // Standard Error: 11_589
-            .saturating_add(Weight::from_ref_time(7_043_740).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(7_043_740, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64clz(r: u32, ) -> Weight {
@@ -1149,9 +1149,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_052 nanoseconds.
-        Weight::from_ref_time(2_116_000)
+        Weight::from_parts(2_116_000, 0)
             // Standard Error: 6_212
-            .saturating_add(Weight::from_ref_time(3_598_868).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_598_868, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32clz(r: u32, ) -> Weight {
@@ -1159,9 +1159,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_998 nanoseconds.
-        Weight::from_ref_time(2_072_000)
+        Weight::from_parts(2_072_000, 0)
             // Standard Error: 5_918
-            .saturating_add(Weight::from_ref_time(3_311_778).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_311_778, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ctz(r: u32, ) -> Weight {
@@ -1169,9 +1169,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_050 nanoseconds.
-        Weight::from_ref_time(2_099_000)
+        Weight::from_parts(2_099_000, 0)
             // Standard Error: 5_716
-            .saturating_add(Weight::from_ref_time(3_268_202).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_268_202, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ctz(r: u32, ) -> Weight {
@@ -1179,9 +1179,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_011 nanoseconds.
-        Weight::from_ref_time(2_050_000)
+        Weight::from_parts(2_050_000, 0)
             // Standard Error: 5_135
-            .saturating_add(Weight::from_ref_time(2_811_963).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_811_963, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64popcnt(r: u32, ) -> Weight {
@@ -1189,9 +1189,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_009 nanoseconds.
-        Weight::from_ref_time(2_124_000)
+        Weight::from_parts(2_124_000, 0)
             // Standard Error: 3_335
-            .saturating_add(Weight::from_ref_time(599_710).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(599_710, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32popcnt(r: u32, ) -> Weight {
@@ -1199,9 +1199,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_989 nanoseconds.
-        Weight::from_ref_time(1_302_632)
+        Weight::from_parts(1_302_632, 0)
             // Standard Error: 3_398
-            .saturating_add(Weight::from_ref_time(415_577).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(415_577, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64eqz(r: u32, ) -> Weight {
@@ -1209,9 +1209,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_982 nanoseconds.
-        Weight::from_ref_time(2_046_000)
+        Weight::from_parts(2_046_000, 0)
             // Standard Error: 12_618
-            .saturating_add(Weight::from_ref_time(1_899_867).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_899_867, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32eqz(r: u32, ) -> Weight {
@@ -1219,9 +1219,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_965 nanoseconds.
-        Weight::from_ref_time(2_013_000)
+        Weight::from_parts(2_013_000, 0)
             // Standard Error: 8_787
-            .saturating_add(Weight::from_ref_time(1_153_841).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_153_841, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64extendsi32(r: u32, ) -> Weight {
@@ -1229,9 +1229,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_995 nanoseconds.
-        Weight::from_ref_time(1_453_796)
+        Weight::from_parts(1_453_796, 0)
             // Standard Error: 3_114
-            .saturating_add(Weight::from_ref_time(327_471).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(327_471, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64extendui32(r: u32, ) -> Weight {
@@ -1239,9 +1239,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_999 nanoseconds.
-        Weight::from_ref_time(2_357_081)
+        Weight::from_parts(2_357_081, 0)
             // Standard Error: 2_303
-            .saturating_add(Weight::from_ref_time(189_759).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(189_759, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32wrapi64(r: u32, ) -> Weight {
@@ -1249,9 +1249,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_943 nanoseconds.
-        Weight::from_ref_time(2_328_805)
+        Weight::from_parts(2_328_805, 0)
             // Standard Error: 1_980
-            .saturating_add(Weight::from_ref_time(196_714).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(196_714, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64eq(r: u32, ) -> Weight {
@@ -1259,9 +1259,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_016 nanoseconds.
-        Weight::from_ref_time(2_044_000)
+        Weight::from_parts(2_044_000, 0)
             // Standard Error: 12_976
-            .saturating_add(Weight::from_ref_time(1_999_087).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_999_087, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32eq(r: u32, ) -> Weight {
@@ -1269,9 +1269,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_010 nanoseconds.
-        Weight::from_ref_time(2_050_000)
+        Weight::from_parts(2_050_000, 0)
             // Standard Error: 8_186
-            .saturating_add(Weight::from_ref_time(1_216_597).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_216_597, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ne(r: u32, ) -> Weight {
@@ -1279,9 +1279,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_018 nanoseconds.
-        Weight::from_ref_time(2_085_000)
+        Weight::from_parts(2_085_000, 0)
             // Standard Error: 11_416
-            .saturating_add(Weight::from_ref_time(1_983_732).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_983_732, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ne(r: u32, ) -> Weight {
@@ -1289,9 +1289,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_976 nanoseconds.
-        Weight::from_ref_time(2_051_000)
+        Weight::from_parts(2_051_000, 0)
             // Standard Error: 8_062
-            .saturating_add(Weight::from_ref_time(1_242_110).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_242_110, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64lts(r: u32, ) -> Weight {
@@ -1299,9 +1299,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_998 nanoseconds.
-        Weight::from_ref_time(2_044_000)
+        Weight::from_parts(2_044_000, 0)
             // Standard Error: 10_495
-            .saturating_add(Weight::from_ref_time(1_932_653).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_932_653, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32lts(r: u32, ) -> Weight {
@@ -1309,9 +1309,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_043 nanoseconds.
-        Weight::from_ref_time(2_081_000)
+        Weight::from_parts(2_081_000, 0)
             // Standard Error: 7_512
-            .saturating_add(Weight::from_ref_time(1_186_900).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_186_900, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ltu(r: u32, ) -> Weight {
@@ -1319,9 +1319,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_026 nanoseconds.
-        Weight::from_ref_time(2_083_000)
+        Weight::from_parts(2_083_000, 0)
             // Standard Error: 10_425
-            .saturating_add(Weight::from_ref_time(1_898_222).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_898_222, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ltu(r: u32, ) -> Weight {
@@ -1329,9 +1329,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_010 nanoseconds.
-        Weight::from_ref_time(2_117_000)
+        Weight::from_parts(2_117_000, 0)
             // Standard Error: 6_972
-            .saturating_add(Weight::from_ref_time(1_160_775).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_160_775, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64gts(r: u32, ) -> Weight {
@@ -1339,9 +1339,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_990 nanoseconds.
-        Weight::from_ref_time(2_047_000)
+        Weight::from_parts(2_047_000, 0)
             // Standard Error: 12_802
-            .saturating_add(Weight::from_ref_time(1_934_073).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_934_073, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32gts(r: u32, ) -> Weight {
@@ -1349,9 +1349,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_994 nanoseconds.
-        Weight::from_ref_time(2_051_000)
+        Weight::from_parts(2_051_000, 0)
             // Standard Error: 8_950
-            .saturating_add(Weight::from_ref_time(1_150_032).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_150_032, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64gtu(r: u32, ) -> Weight {
@@ -1359,9 +1359,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_033 nanoseconds.
-        Weight::from_ref_time(2_064_000)
+        Weight::from_parts(2_064_000, 0)
             // Standard Error: 10_982
-            .saturating_add(Weight::from_ref_time(1_860_562).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_860_562, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32gtu(r: u32, ) -> Weight {
@@ -1369,9 +1369,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_952 nanoseconds.
-        Weight::from_ref_time(2_017_000)
+        Weight::from_parts(2_017_000, 0)
             // Standard Error: 7_830
-            .saturating_add(Weight::from_ref_time(1_142_371).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_142_371, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64les(r: u32, ) -> Weight {
@@ -1379,9 +1379,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_967 nanoseconds.
-        Weight::from_ref_time(2_043_000)
+        Weight::from_parts(2_043_000, 0)
             // Standard Error: 13_663
-            .saturating_add(Weight::from_ref_time(1_916_603).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_916_603, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32les(r: u32, ) -> Weight {
@@ -1389,9 +1389,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_997 nanoseconds.
-        Weight::from_ref_time(2_106_000)
+        Weight::from_parts(2_106_000, 0)
             // Standard Error: 8_319
-            .saturating_add(Weight::from_ref_time(1_134_347).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_134_347, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64leu(r: u32, ) -> Weight {
@@ -1399,9 +1399,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_023 nanoseconds.
-        Weight::from_ref_time(2_081_000)
+        Weight::from_parts(2_081_000, 0)
             // Standard Error: 11_442
-            .saturating_add(Weight::from_ref_time(1_911_437).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_911_437, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32leu(r: u32, ) -> Weight {
@@ -1409,9 +1409,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_057 nanoseconds.
-        Weight::from_ref_time(2_094_000)
+        Weight::from_parts(2_094_000, 0)
             // Standard Error: 9_220
-            .saturating_add(Weight::from_ref_time(1_180_260).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_180_260, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ges(r: u32, ) -> Weight {
@@ -1419,9 +1419,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_975 nanoseconds.
-        Weight::from_ref_time(2_048_000)
+        Weight::from_parts(2_048_000, 0)
             // Standard Error: 12_117
-            .saturating_add(Weight::from_ref_time(1_976_120).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_976_120, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ges(r: u32, ) -> Weight {
@@ -1429,9 +1429,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_928 nanoseconds.
-        Weight::from_ref_time(2_011_000)
+        Weight::from_parts(2_011_000, 0)
             // Standard Error: 6_776
-            .saturating_add(Weight::from_ref_time(1_194_751).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_194_751, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64geu(r: u32, ) -> Weight {
@@ -1439,9 +1439,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_004 nanoseconds.
-        Weight::from_ref_time(2_045_000)
+        Weight::from_parts(2_045_000, 0)
             // Standard Error: 10_428
-            .saturating_add(Weight::from_ref_time(1_856_349).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_856_349, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32geu(r: u32, ) -> Weight {
@@ -1449,9 +1449,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_992 nanoseconds.
-        Weight::from_ref_time(2_064_000)
+        Weight::from_parts(2_064_000, 0)
             // Standard Error: 7_849
-            .saturating_add(Weight::from_ref_time(1_153_509).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_153_509, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64add(r: u32, ) -> Weight {
@@ -1459,9 +1459,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_956 nanoseconds.
-        Weight::from_ref_time(2_030_000)
+        Weight::from_parts(2_030_000, 0)
             // Standard Error: 8_433
-            .saturating_add(Weight::from_ref_time(1_268_864).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_268_864, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32add(r: u32, ) -> Weight {
@@ -1469,9 +1469,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_947 nanoseconds.
-        Weight::from_ref_time(2_018_000)
+        Weight::from_parts(2_018_000, 0)
             // Standard Error: 4_547
-            .saturating_add(Weight::from_ref_time(645_032).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(645_032, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64sub(r: u32, ) -> Weight {
@@ -1479,9 +1479,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_032 nanoseconds.
-        Weight::from_ref_time(2_064_000)
+        Weight::from_parts(2_064_000, 0)
             // Standard Error: 8_005
-            .saturating_add(Weight::from_ref_time(1_289_651).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_289_651, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32sub(r: u32, ) -> Weight {
@@ -1489,9 +1489,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_986 nanoseconds.
-        Weight::from_ref_time(2_028_000)
+        Weight::from_parts(2_028_000, 0)
             // Standard Error: 5_600
-            .saturating_add(Weight::from_ref_time(678_797).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(678_797, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64mul(r: u32, ) -> Weight {
@@ -1499,9 +1499,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_994 nanoseconds.
-        Weight::from_ref_time(2_039_000)
+        Weight::from_parts(2_039_000, 0)
             // Standard Error: 10_526
-            .saturating_add(Weight::from_ref_time(1_973_986).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_973_986, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32mul(r: u32, ) -> Weight {
@@ -1509,9 +1509,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_984 nanoseconds.
-        Weight::from_ref_time(2_043_000)
+        Weight::from_parts(2_043_000, 0)
             // Standard Error: 7_034
-            .saturating_add(Weight::from_ref_time(1_215_647).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_215_647, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64divs(r: u32, ) -> Weight {
@@ -1519,9 +1519,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_988 nanoseconds.
-        Weight::from_ref_time(2_050_000)
+        Weight::from_parts(2_050_000, 0)
             // Standard Error: 7_212
-            .saturating_add(Weight::from_ref_time(2_771_771).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_771_771, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32divs(r: u32, ) -> Weight {
@@ -1529,9 +1529,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_981 nanoseconds.
-        Weight::from_ref_time(2_076_000)
+        Weight::from_parts(2_076_000, 0)
             // Standard Error: 7_088
-            .saturating_add(Weight::from_ref_time(2_419_686).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_419_686, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64divu(r: u32, ) -> Weight {
@@ -1539,9 +1539,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_036 nanoseconds.
-        Weight::from_ref_time(2_083_000)
+        Weight::from_parts(2_083_000, 0)
             // Standard Error: 9_570
-            .saturating_add(Weight::from_ref_time(2_981_619).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_981_619, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32divu(r: u32, ) -> Weight {
@@ -1549,9 +1549,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_027 nanoseconds.
-        Weight::from_ref_time(191_713)
+        Weight::from_parts(191_713, 0)
             // Standard Error: 16_475
-            .saturating_add(Weight::from_ref_time(2_611_675).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_611_675, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64rems(r: u32, ) -> Weight {
@@ -1559,9 +1559,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_028 nanoseconds.
-        Weight::from_ref_time(2_100_000)
+        Weight::from_parts(2_100_000, 0)
             // Standard Error: 13_977
-            .saturating_add(Weight::from_ref_time(9_909_370).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(9_909_370, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32rems(r: u32, ) -> Weight {
@@ -1569,9 +1569,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_980 nanoseconds.
-        Weight::from_ref_time(2_054_000)
+        Weight::from_parts(2_054_000, 0)
             // Standard Error: 26_367
-            .saturating_add(Weight::from_ref_time(7_874_905).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(7_874_905, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64remu(r: u32, ) -> Weight {
@@ -1579,9 +1579,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_997 nanoseconds.
-        Weight::from_ref_time(2_043_000)
+        Weight::from_parts(2_043_000, 0)
             // Standard Error: 9_661
-            .saturating_add(Weight::from_ref_time(3_029_452).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_029_452, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32remu(r: u32, ) -> Weight {
@@ -1589,9 +1589,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_040 nanoseconds.
-        Weight::from_ref_time(2_145_000)
+        Weight::from_parts(2_145_000, 0)
             // Standard Error: 12_480
-            .saturating_add(Weight::from_ref_time(2_537_714).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_537_714, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64and(r: u32, ) -> Weight {
@@ -1599,9 +1599,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_991 nanoseconds.
-        Weight::from_ref_time(2_043_000)
+        Weight::from_parts(2_043_000, 0)
             // Standard Error: 8_986
-            .saturating_add(Weight::from_ref_time(1_297_956).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_297_956, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32and(r: u32, ) -> Weight {
@@ -1609,9 +1609,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_917 nanoseconds.
-        Weight::from_ref_time(1_991_000)
+        Weight::from_parts(1_991_000, 0)
             // Standard Error: 4_526
-            .saturating_add(Weight::from_ref_time(662_435).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(662_435, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64or(r: u32, ) -> Weight {
@@ -1619,9 +1619,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_021 nanoseconds.
-        Weight::from_ref_time(2_069_000)
+        Weight::from_parts(2_069_000, 0)
             // Standard Error: 8_324
-            .saturating_add(Weight::from_ref_time(1_327_872).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_327_872, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32or(r: u32, ) -> Weight {
@@ -1629,9 +1629,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_026 nanoseconds.
-        Weight::from_ref_time(2_070_000)
+        Weight::from_parts(2_070_000, 0)
             // Standard Error: 4_898
-            .saturating_add(Weight::from_ref_time(684_578).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(684_578, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64xor(r: u32, ) -> Weight {
@@ -1639,9 +1639,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_989 nanoseconds.
-        Weight::from_ref_time(2_057_000)
+        Weight::from_parts(2_057_000, 0)
             // Standard Error: 9_116
-            .saturating_add(Weight::from_ref_time(1_341_076).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_341_076, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32xor(r: u32, ) -> Weight {
@@ -1649,9 +1649,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_960 nanoseconds.
-        Weight::from_ref_time(2_004_000)
+        Weight::from_parts(2_004_000, 0)
             // Standard Error: 5_064
-            .saturating_add(Weight::from_ref_time(664_619).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(664_619, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64shl(r: u32, ) -> Weight {
@@ -1659,9 +1659,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_024 nanoseconds.
-        Weight::from_ref_time(2_072_000)
+        Weight::from_parts(2_072_000, 0)
             // Standard Error: 7_079
-            .saturating_add(Weight::from_ref_time(1_109_813).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_109_813, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32shl(r: u32, ) -> Weight {
@@ -1669,9 +1669,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_022 nanoseconds.
-        Weight::from_ref_time(2_110_000)
+        Weight::from_parts(2_110_000, 0)
             // Standard Error: 4_499
-            .saturating_add(Weight::from_ref_time(596_565).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(596_565, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64shrs(r: u32, ) -> Weight {
@@ -1679,9 +1679,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_945 nanoseconds.
-        Weight::from_ref_time(2_043_000)
+        Weight::from_parts(2_043_000, 0)
             // Standard Error: 7_388
-            .saturating_add(Weight::from_ref_time(1_102_019).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_102_019, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32shrs(r: u32, ) -> Weight {
@@ -1689,9 +1689,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_053 nanoseconds.
-        Weight::from_ref_time(2_103_000)
+        Weight::from_parts(2_103_000, 0)
             // Standard Error: 4_340
-            .saturating_add(Weight::from_ref_time(589_998).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(589_998, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64shru(r: u32, ) -> Weight {
@@ -1699,9 +1699,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_017 nanoseconds.
-        Weight::from_ref_time(2_099_000)
+        Weight::from_parts(2_099_000, 0)
             // Standard Error: 7_859
-            .saturating_add(Weight::from_ref_time(1_089_304).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_089_304, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32shru(r: u32, ) -> Weight {
@@ -1709,9 +1709,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_034 nanoseconds.
-        Weight::from_ref_time(2_083_000)
+        Weight::from_parts(2_083_000, 0)
             // Standard Error: 4_304
-            .saturating_add(Weight::from_ref_time(598_598).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(598_598, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64rotl(r: u32, ) -> Weight {
@@ -1719,9 +1719,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_023 nanoseconds.
-        Weight::from_ref_time(2_097_000)
+        Weight::from_parts(2_097_000, 0)
             // Standard Error: 7_539
-            .saturating_add(Weight::from_ref_time(1_121_707).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_121_707, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32rotl(r: u32, ) -> Weight {
@@ -1729,9 +1729,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_063 nanoseconds.
-        Weight::from_ref_time(2_117_000)
+        Weight::from_parts(2_117_000, 0)
             // Standard Error: 4_365
-            .saturating_add(Weight::from_ref_time(566_368).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(566_368, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64rotr(r: u32, ) -> Weight {
@@ -1739,9 +1739,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_995 nanoseconds.
-        Weight::from_ref_time(2_062_000)
+        Weight::from_parts(2_062_000, 0)
             // Standard Error: 8_936
-            .saturating_add(Weight::from_ref_time(1_092_338).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_092_338, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32rotr(r: u32, ) -> Weight {
@@ -1749,9 +1749,9 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_039 nanoseconds.
-        Weight::from_ref_time(2_094_000)
+        Weight::from_parts(2_094_000, 0)
             // Standard Error: 4_196
-            .saturating_add(Weight::from_ref_time(603_336).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(603_336, 0).saturating_mul(r.into()))
     }
 }
 
@@ -1777,9 +1777,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 761 nanoseconds.
-        Weight::from_ref_time(794_000)
+        Weight::from_parts(794_000, 0)
             // Standard Error: 960
-            .saturating_add(Weight::from_ref_time(212_224).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(212_224, 0).saturating_mul(c.into()))
             .saturating_add(RocksDbWeight::get().writes(1_u64))
     }
     /// The range of component `c` is `[0, 512]`.
@@ -1790,7 +1790,7 @@ impl WeightInfo for () {
         // Minimum execution time: 3_067 nanoseconds.
         Weight::from_parts(3_132_000, 2617)
             // Standard Error: 2_641
-            .saturating_add(Weight::from_ref_time(696_372).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(696_372, 0).saturating_mul(c.into()))
             .saturating_add(RocksDbWeight::get().reads(1_u64))
             .saturating_add(Weight::from_proof_size(1024).saturating_mul(c.into()))
     }
@@ -1800,9 +1800,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 48_163 nanoseconds.
-        Weight::from_ref_time(102_637_811)
+        Weight::from_parts(102_637_811, 0)
             // Standard Error: 7_418
-            .saturating_add(Weight::from_ref_time(2_284_334).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(2_284_334, 0).saturating_mul(c.into()))
     }
     fn claim_value() -> Weight {
         // Proof Size summary in bytes:
@@ -1821,7 +1821,7 @@ impl WeightInfo for () {
         // Minimum execution time: 57_788 nanoseconds.
         Weight::from_parts(31_642_282, 3290)
             // Standard Error: 47_873
-            .saturating_add(Weight::from_ref_time(53_067_634).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(53_067_634, 0).saturating_mul(c.into()))
             .saturating_add(RocksDbWeight::get().reads(2_u64))
             .saturating_add(RocksDbWeight::get().writes(4_u64))
     }
@@ -1833,7 +1833,7 @@ impl WeightInfo for () {
         // Minimum execution time: 47_046 nanoseconds.
         Weight::from_parts(65_865_510, 18282)
             // Standard Error: 0
-            .saturating_add(Weight::from_ref_time(2_272).saturating_mul(s.into()))
+            .saturating_add(Weight::from_parts(2_272, 0).saturating_mul(s.into()))
             .saturating_add(RocksDbWeight::get().reads(10_u64))
             .saturating_add(RocksDbWeight::get().writes(8_u64))
     }
@@ -1846,9 +1846,9 @@ impl WeightInfo for () {
         // Minimum execution time: 9_629_458 nanoseconds.
         Weight::from_parts(128_023_124, 14142)
             // Standard Error: 164_368
-            .saturating_add(Weight::from_ref_time(54_589_020).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(54_589_020, 0).saturating_mul(c.into()))
             // Standard Error: 9
-            .saturating_add(Weight::from_ref_time(2_268).saturating_mul(s.into()))
+            .saturating_add(Weight::from_parts(2_268, 0).saturating_mul(s.into()))
             .saturating_add(RocksDbWeight::get().reads(10_u64))
             .saturating_add(RocksDbWeight::get().writes(12_u64))
     }
@@ -1860,7 +1860,7 @@ impl WeightInfo for () {
         // Minimum execution time: 48_557 nanoseconds.
         Weight::from_parts(28_383_814, 14765)
             // Standard Error: 1
-            .saturating_add(Weight::from_ref_time(1_134).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_134, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads(9_u64))
             .saturating_add(RocksDbWeight::get().writes(8_u64))
     }
@@ -1872,7 +1872,7 @@ impl WeightInfo for () {
         // Minimum execution time: 72_760 nanoseconds.
         Weight::from_parts(61_055_469, 31447)
             // Standard Error: 1
-            .saturating_add(Weight::from_ref_time(1_145).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_145, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads(13_u64))
             .saturating_add(RocksDbWeight::get().writes(10_u64))
     }
@@ -1884,7 +1884,7 @@ impl WeightInfo for () {
         // Minimum execution time: 278_465 nanoseconds.
         Weight::from_parts(289_144_814, 49130)
             // Standard Error: 930
-            .saturating_add(Weight::from_ref_time(3_745).saturating_mul(q.into()))
+            .saturating_add(Weight::from_parts(3_745, 0).saturating_mul(q.into()))
             .saturating_add(RocksDbWeight::get().reads(26_u64))
             .saturating_add(RocksDbWeight::get().writes(22_u64))
     }
@@ -1896,7 +1896,7 @@ impl WeightInfo for () {
         // Minimum execution time: 289_940 nanoseconds.
         Weight::from_parts(301_064_878, 49018)
             // Standard Error: 1_069
-            .saturating_add(Weight::from_ref_time(4_413).saturating_mul(q.into()))
+            .saturating_add(Weight::from_parts(4_413, 0).saturating_mul(q.into()))
             .saturating_add(RocksDbWeight::get().reads(26_u64))
             .saturating_add(RocksDbWeight::get().writes(22_u64))
     }
@@ -1908,7 +1908,7 @@ impl WeightInfo for () {
         // Minimum execution time: 41_220 nanoseconds.
         Weight::from_parts(41_558_000, 2973)
             // Standard Error: 43_154
-            .saturating_add(Weight::from_ref_time(51_043_357).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(51_043_357, 0).saturating_mul(c.into()))
             .saturating_add(RocksDbWeight::get().reads(1_u64))
             .saturating_add(RocksDbWeight::get().writes(2_u64))
             .saturating_add(Weight::from_proof_size(2150).saturating_mul(c.into()))
@@ -1919,9 +1919,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_620 nanoseconds.
-        Weight::from_ref_time(85_723_324)
+        Weight::from_parts(85_723_324, 0)
             // Standard Error: 302_409
-            .saturating_add(Weight::from_ref_time(129_670_159).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(129_670_159, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn free(r: u32, ) -> Weight {
@@ -1929,9 +1929,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 198_883 nanoseconds.
-        Weight::from_ref_time(180_549_249)
+        Weight::from_parts(180_549_249, 0)
             // Standard Error: 279_283
-            .saturating_add(Weight::from_ref_time(127_604_915).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(127_604_915, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 256]`.
     fn gr_reserve_gas(r: u32, ) -> Weight {
@@ -1939,9 +1939,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 84_282 nanoseconds.
-        Weight::from_ref_time(85_230_381)
+        Weight::from_parts(85_230_381, 0)
             // Standard Error: 9_033
-            .saturating_add(Weight::from_ref_time(3_509_899).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_509_899, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 256]`.
     fn gr_unreserve_gas(r: u32, ) -> Weight {
@@ -1949,9 +1949,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 131_615 nanoseconds.
-        Weight::from_ref_time(168_307_579)
+        Weight::from_parts(168_307_579, 0)
             // Standard Error: 20_410
-            .saturating_add(Weight::from_ref_time(3_513_779).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_513_779, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_system_reserve_gas(r: u32, ) -> Weight {
@@ -1959,9 +1959,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_244 nanoseconds.
-        Weight::from_ref_time(133_381_524)
+        Weight::from_parts(133_381_524, 0)
             // Standard Error: 364_215
-            .saturating_add(Weight::from_ref_time(175_263_065).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(175_263_065, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_message_id(r: u32, ) -> Weight {
@@ -1969,9 +1969,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 80_871 nanoseconds.
-        Weight::from_ref_time(83_728_178)
+        Weight::from_parts(83_728_178, 0)
             // Standard Error: 237_530
-            .saturating_add(Weight::from_ref_time(175_396_894).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(175_396_894, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_origin(r: u32, ) -> Weight {
@@ -1979,9 +1979,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_344 nanoseconds.
-        Weight::from_ref_time(80_814_311)
+        Weight::from_parts(80_814_311, 0)
             // Standard Error: 242_865
-            .saturating_add(Weight::from_ref_time(176_183_080).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(176_183_080, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_program_id(r: u32, ) -> Weight {
@@ -1989,9 +1989,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_550 nanoseconds.
-        Weight::from_ref_time(86_713_676)
+        Weight::from_parts(86_713_676, 0)
             // Standard Error: 238_659
-            .saturating_add(Weight::from_ref_time(174_365_605).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(174_365_605, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_source(r: u32, ) -> Weight {
@@ -1999,9 +1999,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_212 nanoseconds.
-        Weight::from_ref_time(81_118_155)
+        Weight::from_parts(81_118_155, 0)
             // Standard Error: 247_291
-            .saturating_add(Weight::from_ref_time(175_847_363).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(175_847_363, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_value(r: u32, ) -> Weight {
@@ -2009,9 +2009,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_148 nanoseconds.
-        Weight::from_ref_time(83_939_496)
+        Weight::from_parts(83_939_496, 0)
             // Standard Error: 280_041
-            .saturating_add(Weight::from_ref_time(175_400_021).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(175_400_021, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_value_available(r: u32, ) -> Weight {
@@ -2019,9 +2019,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_682 nanoseconds.
-        Weight::from_ref_time(85_424_687)
+        Weight::from_parts(85_424_687, 0)
             // Standard Error: 255_412
-            .saturating_add(Weight::from_ref_time(174_010_282).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(174_010_282, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_gas_available(r: u32, ) -> Weight {
@@ -2029,9 +2029,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_825 nanoseconds.
-        Weight::from_ref_time(86_478_699)
+        Weight::from_parts(86_478_699, 0)
             // Standard Error: 252_429
-            .saturating_add(Weight::from_ref_time(177_432_143).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(177_432_143, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_size(r: u32, ) -> Weight {
@@ -2039,9 +2039,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_170 nanoseconds.
-        Weight::from_ref_time(84_210_822)
+        Weight::from_parts(84_210_822, 0)
             // Standard Error: 251_283
-            .saturating_add(Weight::from_ref_time(180_568_190).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(180_568_190, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_read(r: u32, ) -> Weight {
@@ -2049,9 +2049,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 557_635 nanoseconds.
-        Weight::from_ref_time(634_644_194)
+        Weight::from_parts(634_644_194, 0)
             // Standard Error: 400_411
-            .saturating_add(Weight::from_ref_time(239_352_408).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(239_352_408, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_read_per_kb(n: u32, ) -> Weight {
@@ -2059,9 +2059,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 828_353 nanoseconds.
-        Weight::from_ref_time(837_715_000)
+        Weight::from_parts(837_715_000, 0)
             // Standard Error: 60_739
-            .saturating_add(Weight::from_ref_time(14_146_957).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(14_146_957, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_block_height(r: u32, ) -> Weight {
@@ -2069,9 +2069,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_842 nanoseconds.
-        Weight::from_ref_time(78_011_099)
+        Weight::from_parts(78_011_099, 0)
             // Standard Error: 304_537
-            .saturating_add(Weight::from_ref_time(174_648_210).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(174_648_210, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_block_timestamp(r: u32, ) -> Weight {
@@ -2079,9 +2079,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_383 nanoseconds.
-        Weight::from_ref_time(85_071_672)
+        Weight::from_parts(85_071_672, 0)
             // Standard Error: 277_230
-            .saturating_add(Weight::from_ref_time(175_739_698).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(175_739_698, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 20]`.
     fn gr_random(n: u32, ) -> Weight {
@@ -2089,9 +2089,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_759 nanoseconds.
-        Weight::from_ref_time(97_315_812)
+        Weight::from_parts(97_315_812, 0)
             // Standard Error: 238_252
-            .saturating_add(Weight::from_ref_time(238_074_206).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(238_074_206, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_init(r: u32, ) -> Weight {
@@ -2099,9 +2099,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 84_613 nanoseconds.
-        Weight::from_ref_time(73_884_051)
+        Weight::from_parts(73_884_051, 0)
             // Standard Error: 231_926
-            .saturating_add(Weight::from_ref_time(188_042_953).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(188_042_953, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_push(r: u32, ) -> Weight {
@@ -2109,9 +2109,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 3_706_952 nanoseconds.
-        Weight::from_ref_time(3_841_642_964)
+        Weight::from_parts(3_841_642_964, 0)
             // Standard Error: 288_960
-            .saturating_add(Weight::from_ref_time(247_877_210).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(247_877_210, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_send_push_per_kb(n: u32, ) -> Weight {
@@ -2119,9 +2119,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 520_139 nanoseconds.
-        Weight::from_ref_time(523_195_000)
+        Weight::from_parts(523_195_000, 0)
             // Standard Error: 61_816
-            .saturating_add(Weight::from_ref_time(29_665_714).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(29_665_714, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_commit(r: u32, ) -> Weight {
@@ -2129,9 +2129,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 84_478 nanoseconds.
-        Weight::from_ref_time(131_497_693)
+        Weight::from_parts(131_497_693, 0)
             // Standard Error: 299_463
-            .saturating_add(Weight::from_ref_time(352_624_503).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(352_624_503, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_send_commit_per_kb(n: u32, ) -> Weight {
@@ -2139,9 +2139,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 437_137 nanoseconds.
-        Weight::from_ref_time(440_652_000)
+        Weight::from_parts(440_652_000, 0)
             // Standard Error: 59_951
-            .saturating_add(Weight::from_ref_time(21_224_751).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(21_224_751, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reservation_send_commit(r: u32, ) -> Weight {
@@ -2149,9 +2149,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 242_701 nanoseconds.
-        Weight::from_ref_time(305_043_647)
+        Weight::from_parts(305_043_647, 0)
             // Standard Error: 244_718
-            .saturating_add(Weight::from_ref_time(369_921_323).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(369_921_323, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reservation_send_commit_per_kb(n: u32, ) -> Weight {
@@ -2159,9 +2159,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 471_909 nanoseconds.
-        Weight::from_ref_time(481_316_000)
+        Weight::from_parts(481_316_000, 0)
             // Standard Error: 51_289
-            .saturating_add(Weight::from_ref_time(21_001_799).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(21_001_799, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_reply_commit(r: u32, ) -> Weight {
@@ -2169,9 +2169,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_287 nanoseconds.
-        Weight::from_ref_time(84_806_134)
+        Weight::from_parts(84_806_134, 0)
             // Standard Error: 250_891
-            .saturating_add(Weight::from_ref_time(17_607_365).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(17_607_365, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reply_commit_per_kb(n: u32, ) -> Weight {
@@ -2179,9 +2179,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 100_681 nanoseconds.
-        Weight::from_ref_time(86_530_601)
+        Weight::from_parts(86_530_601, 0)
             // Standard Error: 774
-            .saturating_add(Weight::from_ref_time(423_018).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(423_018, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reply_push(r: u32, ) -> Weight {
@@ -2189,9 +2189,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_835 nanoseconds.
-        Weight::from_ref_time(137_479_664)
+        Weight::from_parts(137_479_664, 0)
             // Standard Error: 331_995
-            .saturating_add(Weight::from_ref_time(243_721_746).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(243_721_746, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 8192]`.
     fn gr_reply_push_per_kb(n: u32, ) -> Weight {
@@ -2199,9 +2199,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 97_910 nanoseconds.
-        Weight::from_ref_time(99_515_000)
+        Weight::from_parts(99_515_000, 0)
             // Standard Error: 2_501
-            .saturating_add(Weight::from_ref_time(605_467).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(605_467, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_reservation_reply_commit(r: u32, ) -> Weight {
@@ -2209,9 +2209,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 88_365 nanoseconds.
-        Weight::from_ref_time(91_586_508)
+        Weight::from_parts(91_586_508, 0)
             // Standard Error: 253_416
-            .saturating_add(Weight::from_ref_time(11_330_891).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(11_330_891, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reservation_reply_commit_per_kb(n: u32, ) -> Weight {
@@ -2219,9 +2219,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 101_342 nanoseconds.
-        Weight::from_ref_time(86_985_218)
+        Weight::from_parts(86_985_218, 0)
             // Standard Error: 729
-            .saturating_add(Weight::from_ref_time(420_626).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(420_626, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reply_to(r: u32, ) -> Weight {
@@ -2229,9 +2229,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_176 nanoseconds.
-        Weight::from_ref_time(85_895_984)
+        Weight::from_parts(85_895_984, 0)
             // Standard Error: 315_843
-            .saturating_add(Weight::from_ref_time(175_959_029).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(175_959_029, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_signal_from(r: u32, ) -> Weight {
@@ -2239,9 +2239,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 84_180 nanoseconds.
-        Weight::from_ref_time(87_329_873)
+        Weight::from_parts(87_329_873, 0)
             // Standard Error: 255_146
-            .saturating_add(Weight::from_ref_time(175_210_834).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(175_210_834, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_reply_push_input(r: u32, ) -> Weight {
@@ -2249,9 +2249,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 553_563 nanoseconds.
-        Weight::from_ref_time(609_509_128)
+        Weight::from_parts(609_509_128, 0)
             // Standard Error: 401_197
-            .saturating_add(Weight::from_ref_time(187_924_542).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(187_924_542, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_reply_push_input_per_kb(n: u32, ) -> Weight {
@@ -2259,9 +2259,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 574_867 nanoseconds.
-        Weight::from_ref_time(587_172_863)
+        Weight::from_parts(587_172_863, 0)
             // Standard Error: 954
-            .saturating_add(Weight::from_ref_time(121_260).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(121_260, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_send_push_input(r: u32, ) -> Weight {
@@ -2269,9 +2269,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_153_438 nanoseconds.
-        Weight::from_ref_time(4_303_178_639)
+        Weight::from_parts(4_303_178_639, 0)
             // Standard Error: 265_183
-            .saturating_add(Weight::from_ref_time(192_266_698).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(192_266_698, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_send_push_input_per_kb(n: u32, ) -> Weight {
@@ -2279,9 +2279,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 939_474 nanoseconds.
-        Weight::from_ref_time(836_256_075)
+        Weight::from_parts(836_256_075, 0)
             // Standard Error: 10_783
-            .saturating_add(Weight::from_ref_time(12_584_153).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(12_584_153, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_debug(r: u32, ) -> Weight {
@@ -2289,9 +2289,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 81_912 nanoseconds.
-        Weight::from_ref_time(107_702_879)
+        Weight::from_parts(107_702_879, 0)
             // Standard Error: 316_515
-            .saturating_add(Weight::from_ref_time(187_518_617).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(187_518_617, 0).saturating_mul(r.into()))
     }
     /// The range of component `n` is `[0, 2048]`.
     fn gr_debug_per_kb(n: u32, ) -> Weight {
@@ -2299,9 +2299,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 260_251 nanoseconds.
-        Weight::from_ref_time(265_607_000)
+        Weight::from_parts(265_607_000, 0)
             // Standard Error: 47_176
-            .saturating_add(Weight::from_ref_time(25_735_678).saturating_mul(n.into()))
+            .saturating_add(Weight::from_parts(25_735_678, 0).saturating_mul(n.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_error(r: u32, ) -> Weight {
@@ -2309,9 +2309,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 96_526 nanoseconds.
-        Weight::from_ref_time(103_383_863)
+        Weight::from_parts(103_383_863, 0)
             // Standard Error: 281_743
-            .saturating_add(Weight::from_ref_time(229_630_385).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(229_630_385, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_status_code(r: u32, ) -> Weight {
@@ -2319,9 +2319,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 83_646 nanoseconds.
-        Weight::from_ref_time(77_387_247)
+        Weight::from_parts(77_387_247, 0)
             // Standard Error: 240_622
-            .saturating_add(Weight::from_ref_time(177_210_179).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(177_210_179, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_exit(r: u32, ) -> Weight {
@@ -2329,9 +2329,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_732 nanoseconds.
-        Weight::from_ref_time(86_746_559)
+        Weight::from_parts(86_746_559, 0)
             // Standard Error: 276_411
-            .saturating_add(Weight::from_ref_time(24_364_740).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(24_364_740, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_leave(r: u32, ) -> Weight {
@@ -2339,9 +2339,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_768 nanoseconds.
-        Weight::from_ref_time(86_254_018)
+        Weight::from_parts(86_254_018, 0)
             // Standard Error: 270_944
-            .saturating_add(Weight::from_ref_time(13_674_081).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(13_674_081, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_wait(r: u32, ) -> Weight {
@@ -2349,9 +2349,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_973 nanoseconds.
-        Weight::from_ref_time(86_357_653)
+        Weight::from_parts(86_357_653, 0)
             // Standard Error: 275_003
-            .saturating_add(Weight::from_ref_time(14_931_046).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(14_931_046, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_wait_for(r: u32, ) -> Weight {
@@ -2359,9 +2359,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_826 nanoseconds.
-        Weight::from_ref_time(86_467_016)
+        Weight::from_parts(86_467_016, 0)
             // Standard Error: 264_613
-            .saturating_add(Weight::from_ref_time(14_260_583).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(14_260_583, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 1]`.
     fn gr_wait_up_to(r: u32, ) -> Weight {
@@ -2369,9 +2369,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 82_605 nanoseconds.
-        Weight::from_ref_time(86_532_340)
+        Weight::from_parts(86_532_340, 0)
             // Standard Error: 278_759
-            .saturating_add(Weight::from_ref_time(14_028_659).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(14_028_659, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_wake(r: u32, ) -> Weight {
@@ -2379,9 +2379,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 132_543 nanoseconds.
-        Weight::from_ref_time(192_378_038)
+        Weight::from_parts(192_378_038, 0)
             // Standard Error: 249_057
-            .saturating_add(Weight::from_ref_time(254_777_085).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(254_777_085, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 20]`.
     fn gr_create_program_wgas(r: u32, ) -> Weight {
@@ -2389,9 +2389,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 92_114 nanoseconds.
-        Weight::from_ref_time(156_606_434)
+        Weight::from_parts(156_606_434, 0)
             // Standard Error: 295_787
-            .saturating_add(Weight::from_ref_time(425_470_652).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(425_470_652, 0).saturating_mul(r.into()))
     }
     /// The range of component `p` is `[0, 2048]`.
     /// The range of component `s` is `[1, 2048]`.
@@ -2400,11 +2400,11 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 43_256_334 nanoseconds.
-        Weight::from_ref_time(43_465_935_000)
+        Weight::from_parts(43_465_935_000, 0)
             // Standard Error: 263_063
-            .saturating_add(Weight::from_ref_time(7_902_649).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(7_902_649, 0).saturating_mul(p.into()))
             // Standard Error: 263_050
-            .saturating_add(Weight::from_ref_time(152_656_694).saturating_mul(s.into()))
+            .saturating_add(Weight::from_parts(152_656_694, 0).saturating_mul(s.into()))
     }
     /// The range of component `p` is `[0, 512]`.
     fn lazy_pages_signal_read(p: u32, ) -> Weight {
@@ -2414,7 +2414,7 @@ impl WeightInfo for () {
         // Minimum execution time: 81_807 nanoseconds.
         Weight::from_parts(121_821_266, 141)
             // Standard Error: 7_125
-            .saturating_add(Weight::from_ref_time(11_656_827).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(11_656_827, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
     }
@@ -2426,7 +2426,7 @@ impl WeightInfo for () {
         // Minimum execution time: 83_262 nanoseconds.
         Weight::from_parts(84_399_000, 141)
             // Standard Error: 36_484
-            .saturating_add(Weight::from_ref_time(34_711_742).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(34_711_742, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9900).saturating_mul(p.into()))
     }
@@ -2438,7 +2438,7 @@ impl WeightInfo for () {
         // Minimum execution time: 6_028_492 nanoseconds.
         Weight::from_parts(5_810_695_816, 5068941)
             // Standard Error: 54_356
-            .saturating_add(Weight::from_ref_time(36_889_507).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(36_889_507, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads(2048_u64))
     }
     /// The range of component `p` is `[0, 512]`.
@@ -2449,7 +2449,7 @@ impl WeightInfo for () {
         // Minimum execution time: 84_317 nanoseconds.
         Weight::from_parts(85_299_000, 949)
             // Standard Error: 33_523
-            .saturating_add(Weight::from_ref_time(43_951_462).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(43_951_462, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(75606).saturating_mul(p.into()))
     }
@@ -2461,7 +2461,7 @@ impl WeightInfo for () {
         // Minimum execution time: 95_734 nanoseconds.
         Weight::from_parts(99_957_245, 506)
             // Standard Error: 59_825
-            .saturating_add(Weight::from_ref_time(35_208_171).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(35_208_171, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
     }
@@ -2473,7 +2473,7 @@ impl WeightInfo for () {
         // Minimum execution time: 586_697 nanoseconds.
         Weight::from_parts(579_394_810, 506)
             // Standard Error: 182_196
-            .saturating_add(Weight::from_ref_time(42_500_948).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(42_500_948, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(p.into())))
             .saturating_add(Weight::from_proof_size(9883).saturating_mul(p.into()))
     }
@@ -2485,7 +2485,7 @@ impl WeightInfo for () {
         // Minimum execution time: 983_916 nanoseconds.
         Weight::from_parts(1_010_515_733, 316941)
             // Standard Error: 143_944
-            .saturating_add(Weight::from_ref_time(42_508_767).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(42_508_767, 0).saturating_mul(p.into()))
             .saturating_add(RocksDbWeight::get().reads(128_u64))
     }
     /// The range of component `r` is `[50, 500]`.
@@ -2494,9 +2494,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_226_275 nanoseconds.
-        Weight::from_ref_time(4_225_648_608)
+        Weight::from_parts(4_225_648_608, 0)
             // Standard Error: 10_161
-            .saturating_add(Weight::from_ref_time(3_355_980).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_355_980, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[50, 500]`.
     fn instr_i32load(r: u32, ) -> Weight {
@@ -2504,9 +2504,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_228_938 nanoseconds.
-        Weight::from_ref_time(4_228_073_783)
+        Weight::from_parts(4_228_073_783, 0)
             // Standard Error: 10_035
-            .saturating_add(Weight::from_ref_time(3_370_264).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_370_264, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[50, 500]`.
     fn instr_i64store(r: u32, ) -> Weight {
@@ -2514,9 +2514,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 9_719_113 nanoseconds.
-        Weight::from_ref_time(9_865_862_677)
+        Weight::from_parts(9_865_862_677, 0)
             // Standard Error: 186_470
-            .saturating_add(Weight::from_ref_time(16_510_034).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(16_510_034, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[50, 500]`.
     fn instr_i32store(r: u32, ) -> Weight {
@@ -2524,9 +2524,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 9_539_429 nanoseconds.
-        Weight::from_ref_time(8_971_089_150)
+        Weight::from_parts(8_971_089_150, 0)
             // Standard Error: 149_624
-            .saturating_add(Weight::from_ref_time(16_140_559).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(16_140_559, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_select(r: u32, ) -> Weight {
@@ -2534,9 +2534,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_017 nanoseconds.
-        Weight::from_ref_time(2_162_000)
+        Weight::from_parts(2_162_000, 0)
             // Standard Error: 8_150
-            .saturating_add(Weight::from_ref_time(3_810_640).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_810_640, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_if(r: u32, ) -> Weight {
@@ -2544,9 +2544,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_005 nanoseconds.
-        Weight::from_ref_time(2_091_000)
+        Weight::from_parts(2_091_000, 0)
             // Standard Error: 7_804
-            .saturating_add(Weight::from_ref_time(3_085_440).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_085_440, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_br(r: u32, ) -> Weight {
@@ -2554,9 +2554,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_948 nanoseconds.
-        Weight::from_ref_time(3_039_323)
+        Weight::from_parts(3_039_323, 0)
             // Standard Error: 916
-            .saturating_add(Weight::from_ref_time(1_573_630).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_573_630, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_br_if(r: u32, ) -> Weight {
@@ -2564,9 +2564,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_945 nanoseconds.
-        Weight::from_ref_time(2_017_000)
+        Weight::from_parts(2_017_000, 0)
             // Standard Error: 9_300
-            .saturating_add(Weight::from_ref_time(2_940_862).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_940_862, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_br_table(r: u32, ) -> Weight {
@@ -2574,9 +2574,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_039 nanoseconds.
-        Weight::from_ref_time(7_505_360)
+        Weight::from_parts(7_505_360, 0)
             // Standard Error: 27_099
-            .saturating_add(Weight::from_ref_time(4_937_410).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(4_937_410, 0).saturating_mul(r.into()))
     }
     /// The range of component `e` is `[1, 256]`.
     fn instr_br_table_per_entry(e: u32, ) -> Weight {
@@ -2584,9 +2584,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 6_690 nanoseconds.
-        Weight::from_ref_time(4_745_487)
+        Weight::from_parts(4_745_487, 0)
             // Standard Error: 1_598
-            .saturating_add(Weight::from_ref_time(190_014).saturating_mul(e.into()))
+            .saturating_add(Weight::from_parts(190_014, 0).saturating_mul(e.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_call_const(r: u32, ) -> Weight {
@@ -2594,14 +2594,14 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_128 nanoseconds.
-        Weight::from_ref_time(5_580_087)
+        Weight::from_parts(5_580_087, 0)
             // Standard Error: 8_909
-            .saturating_add(Weight::from_ref_time(2_581_842).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_581_842, 0).saturating_mul(r.into()))
     }
     fn instr_i64const(r: u32, ) -> Weight {
-        Weight::from_ref_time(0)
-            .saturating_add(Weight::from_ref_time(2_581_842 -
-            2_429_530).saturating_mul(r.into()))
+        Weight::from_parts(0, 0)
+            .saturating_add(Weight::from_parts(2_581_842 -
+            2_429_530, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_call(r: u32, ) -> Weight {
@@ -2609,9 +2609,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_108 nanoseconds.
-        Weight::from_ref_time(5_054_933)
+        Weight::from_parts(5_054_933, 0)
             // Standard Error: 12_863
-            .saturating_add(Weight::from_ref_time(2_429_530).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_429_530, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_call_indirect(r: u32, ) -> Weight {
@@ -2619,9 +2619,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_370 nanoseconds.
-        Weight::from_ref_time(18_616_562)
+        Weight::from_parts(18_616_562, 0)
             // Standard Error: 29_254
-            .saturating_add(Weight::from_ref_time(10_375_535).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(10_375_535, 0).saturating_mul(r.into()))
     }
     /// The range of component `p` is `[0, 128]`.
     fn instr_call_indirect_per_param(p: u32, ) -> Weight {
@@ -2629,9 +2629,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 12_168 nanoseconds.
-        Weight::from_ref_time(3_775_924)
+        Weight::from_parts(3_775_924, 0)
             // Standard Error: 6_558
-            .saturating_add(Weight::from_ref_time(1_321_364).saturating_mul(p.into()))
+            .saturating_add(Weight::from_parts(1_321_364, 0).saturating_mul(p.into()))
     }
     /// The range of component `l` is `[0, 1024]`.
     fn instr_call_per_local(l: u32, ) -> Weight {
@@ -2639,9 +2639,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_006 nanoseconds.
-        Weight::from_ref_time(5_256_467)
+        Weight::from_parts(5_256_467, 0)
             // Standard Error: 12
-            .saturating_add(Weight::from_ref_time(57).saturating_mul(l.into()))
+            .saturating_add(Weight::from_parts(57, 0).saturating_mul(l.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_local_get(r: u32, ) -> Weight {
@@ -2649,9 +2649,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_019 nanoseconds.
-        Weight::from_ref_time(1_408_120)
+        Weight::from_parts(1_408_120, 0)
             // Standard Error: 3_519
-            .saturating_add(Weight::from_ref_time(298_892).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(298_892, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_local_set(r: u32, ) -> Weight {
@@ -2659,9 +2659,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_058 nanoseconds.
-        Weight::from_ref_time(2_092_000)
+        Weight::from_parts(2_092_000, 0)
             // Standard Error: 7_004
-            .saturating_add(Weight::from_ref_time(892_803).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(892_803, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_local_tee(r: u32, ) -> Weight {
@@ -2669,9 +2669,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_976 nanoseconds.
-        Weight::from_ref_time(2_078_000)
+        Weight::from_parts(2_078_000, 0)
             // Standard Error: 6_769
-            .saturating_add(Weight::from_ref_time(930_108).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(930_108, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_global_get(r: u32, ) -> Weight {
@@ -2679,9 +2679,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_803 nanoseconds.
-        Weight::from_ref_time(1_190_711)
+        Weight::from_parts(1_190_711, 0)
             // Standard Error: 9_230
-            .saturating_add(Weight::from_ref_time(936_198).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(936_198, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_global_set(r: u32, ) -> Weight {
@@ -2689,9 +2689,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_683 nanoseconds.
-        Weight::from_ref_time(5_732_000)
+        Weight::from_parts(5_732_000, 0)
             // Standard Error: 8_615
-            .saturating_add(Weight::from_ref_time(1_560_589).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_560_589, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_memory_current(r: u32, ) -> Weight {
@@ -2699,9 +2699,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 6_114 nanoseconds.
-        Weight::from_ref_time(2_722_110)
+        Weight::from_parts(2_722_110, 0)
             // Standard Error: 11_589
-            .saturating_add(Weight::from_ref_time(7_043_740).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(7_043_740, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64clz(r: u32, ) -> Weight {
@@ -2709,9 +2709,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_052 nanoseconds.
-        Weight::from_ref_time(2_116_000)
+        Weight::from_parts(2_116_000, 0)
             // Standard Error: 6_212
-            .saturating_add(Weight::from_ref_time(3_598_868).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_598_868, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32clz(r: u32, ) -> Weight {
@@ -2719,9 +2719,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_998 nanoseconds.
-        Weight::from_ref_time(2_072_000)
+        Weight::from_parts(2_072_000, 0)
             // Standard Error: 5_918
-            .saturating_add(Weight::from_ref_time(3_311_778).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_311_778, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ctz(r: u32, ) -> Weight {
@@ -2729,9 +2729,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_050 nanoseconds.
-        Weight::from_ref_time(2_099_000)
+        Weight::from_parts(2_099_000, 0)
             // Standard Error: 5_716
-            .saturating_add(Weight::from_ref_time(3_268_202).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_268_202, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ctz(r: u32, ) -> Weight {
@@ -2739,9 +2739,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_011 nanoseconds.
-        Weight::from_ref_time(2_050_000)
+        Weight::from_parts(2_050_000, 0)
             // Standard Error: 5_135
-            .saturating_add(Weight::from_ref_time(2_811_963).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_811_963, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64popcnt(r: u32, ) -> Weight {
@@ -2749,9 +2749,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_009 nanoseconds.
-        Weight::from_ref_time(2_124_000)
+        Weight::from_parts(2_124_000, 0)
             // Standard Error: 3_335
-            .saturating_add(Weight::from_ref_time(599_710).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(599_710, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32popcnt(r: u32, ) -> Weight {
@@ -2759,9 +2759,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_989 nanoseconds.
-        Weight::from_ref_time(1_302_632)
+        Weight::from_parts(1_302_632, 0)
             // Standard Error: 3_398
-            .saturating_add(Weight::from_ref_time(415_577).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(415_577, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64eqz(r: u32, ) -> Weight {
@@ -2769,9 +2769,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_982 nanoseconds.
-        Weight::from_ref_time(2_046_000)
+        Weight::from_parts(2_046_000, 0)
             // Standard Error: 12_618
-            .saturating_add(Weight::from_ref_time(1_899_867).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_899_867, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32eqz(r: u32, ) -> Weight {
@@ -2779,9 +2779,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_965 nanoseconds.
-        Weight::from_ref_time(2_013_000)
+        Weight::from_parts(2_013_000, 0)
             // Standard Error: 8_787
-            .saturating_add(Weight::from_ref_time(1_153_841).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_153_841, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64extendsi32(r: u32, ) -> Weight {
@@ -2789,9 +2789,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_995 nanoseconds.
-        Weight::from_ref_time(1_453_796)
+        Weight::from_parts(1_453_796, 0)
             // Standard Error: 3_114
-            .saturating_add(Weight::from_ref_time(327_471).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(327_471, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64extendui32(r: u32, ) -> Weight {
@@ -2799,9 +2799,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_999 nanoseconds.
-        Weight::from_ref_time(2_357_081)
+        Weight::from_parts(2_357_081, 0)
             // Standard Error: 2_303
-            .saturating_add(Weight::from_ref_time(189_759).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(189_759, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32wrapi64(r: u32, ) -> Weight {
@@ -2809,9 +2809,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_943 nanoseconds.
-        Weight::from_ref_time(2_328_805)
+        Weight::from_parts(2_328_805, 0)
             // Standard Error: 1_980
-            .saturating_add(Weight::from_ref_time(196_714).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(196_714, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64eq(r: u32, ) -> Weight {
@@ -2819,9 +2819,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_016 nanoseconds.
-        Weight::from_ref_time(2_044_000)
+        Weight::from_parts(2_044_000, 0)
             // Standard Error: 12_976
-            .saturating_add(Weight::from_ref_time(1_999_087).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_999_087, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32eq(r: u32, ) -> Weight {
@@ -2829,9 +2829,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_010 nanoseconds.
-        Weight::from_ref_time(2_050_000)
+        Weight::from_parts(2_050_000, 0)
             // Standard Error: 8_186
-            .saturating_add(Weight::from_ref_time(1_216_597).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_216_597, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ne(r: u32, ) -> Weight {
@@ -2839,9 +2839,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_018 nanoseconds.
-        Weight::from_ref_time(2_085_000)
+        Weight::from_parts(2_085_000, 0)
             // Standard Error: 11_416
-            .saturating_add(Weight::from_ref_time(1_983_732).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_983_732, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ne(r: u32, ) -> Weight {
@@ -2849,9 +2849,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_976 nanoseconds.
-        Weight::from_ref_time(2_051_000)
+        Weight::from_parts(2_051_000, 0)
             // Standard Error: 8_062
-            .saturating_add(Weight::from_ref_time(1_242_110).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_242_110, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64lts(r: u32, ) -> Weight {
@@ -2859,9 +2859,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_998 nanoseconds.
-        Weight::from_ref_time(2_044_000)
+        Weight::from_parts(2_044_000, 0)
             // Standard Error: 10_495
-            .saturating_add(Weight::from_ref_time(1_932_653).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_932_653, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32lts(r: u32, ) -> Weight {
@@ -2869,9 +2869,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_043 nanoseconds.
-        Weight::from_ref_time(2_081_000)
+        Weight::from_parts(2_081_000, 0)
             // Standard Error: 7_512
-            .saturating_add(Weight::from_ref_time(1_186_900).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_186_900, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ltu(r: u32, ) -> Weight {
@@ -2879,9 +2879,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_026 nanoseconds.
-        Weight::from_ref_time(2_083_000)
+        Weight::from_parts(2_083_000, 0)
             // Standard Error: 10_425
-            .saturating_add(Weight::from_ref_time(1_898_222).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_898_222, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ltu(r: u32, ) -> Weight {
@@ -2889,9 +2889,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_010 nanoseconds.
-        Weight::from_ref_time(2_117_000)
+        Weight::from_parts(2_117_000, 0)
             // Standard Error: 6_972
-            .saturating_add(Weight::from_ref_time(1_160_775).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_160_775, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64gts(r: u32, ) -> Weight {
@@ -2899,9 +2899,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_990 nanoseconds.
-        Weight::from_ref_time(2_047_000)
+        Weight::from_parts(2_047_000, 0)
             // Standard Error: 12_802
-            .saturating_add(Weight::from_ref_time(1_934_073).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_934_073, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32gts(r: u32, ) -> Weight {
@@ -2909,9 +2909,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_994 nanoseconds.
-        Weight::from_ref_time(2_051_000)
+        Weight::from_parts(2_051_000, 0)
             // Standard Error: 8_950
-            .saturating_add(Weight::from_ref_time(1_150_032).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_150_032, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64gtu(r: u32, ) -> Weight {
@@ -2919,9 +2919,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_033 nanoseconds.
-        Weight::from_ref_time(2_064_000)
+        Weight::from_parts(2_064_000, 0)
             // Standard Error: 10_982
-            .saturating_add(Weight::from_ref_time(1_860_562).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_860_562, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32gtu(r: u32, ) -> Weight {
@@ -2929,9 +2929,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_952 nanoseconds.
-        Weight::from_ref_time(2_017_000)
+        Weight::from_parts(2_017_000, 0)
             // Standard Error: 7_830
-            .saturating_add(Weight::from_ref_time(1_142_371).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_142_371, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64les(r: u32, ) -> Weight {
@@ -2939,9 +2939,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_967 nanoseconds.
-        Weight::from_ref_time(2_043_000)
+        Weight::from_parts(2_043_000, 0)
             // Standard Error: 13_663
-            .saturating_add(Weight::from_ref_time(1_916_603).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_916_603, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32les(r: u32, ) -> Weight {
@@ -2949,9 +2949,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_997 nanoseconds.
-        Weight::from_ref_time(2_106_000)
+        Weight::from_parts(2_106_000, 0)
             // Standard Error: 8_319
-            .saturating_add(Weight::from_ref_time(1_134_347).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_134_347, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64leu(r: u32, ) -> Weight {
@@ -2959,9 +2959,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_023 nanoseconds.
-        Weight::from_ref_time(2_081_000)
+        Weight::from_parts(2_081_000, 0)
             // Standard Error: 11_442
-            .saturating_add(Weight::from_ref_time(1_911_437).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_911_437, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32leu(r: u32, ) -> Weight {
@@ -2969,9 +2969,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_057 nanoseconds.
-        Weight::from_ref_time(2_094_000)
+        Weight::from_parts(2_094_000, 0)
             // Standard Error: 9_220
-            .saturating_add(Weight::from_ref_time(1_180_260).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_180_260, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64ges(r: u32, ) -> Weight {
@@ -2979,9 +2979,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_975 nanoseconds.
-        Weight::from_ref_time(2_048_000)
+        Weight::from_parts(2_048_000, 0)
             // Standard Error: 12_117
-            .saturating_add(Weight::from_ref_time(1_976_120).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_976_120, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32ges(r: u32, ) -> Weight {
@@ -2989,9 +2989,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_928 nanoseconds.
-        Weight::from_ref_time(2_011_000)
+        Weight::from_parts(2_011_000, 0)
             // Standard Error: 6_776
-            .saturating_add(Weight::from_ref_time(1_194_751).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_194_751, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64geu(r: u32, ) -> Weight {
@@ -2999,9 +2999,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_004 nanoseconds.
-        Weight::from_ref_time(2_045_000)
+        Weight::from_parts(2_045_000, 0)
             // Standard Error: 10_428
-            .saturating_add(Weight::from_ref_time(1_856_349).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_856_349, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32geu(r: u32, ) -> Weight {
@@ -3009,9 +3009,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_992 nanoseconds.
-        Weight::from_ref_time(2_064_000)
+        Weight::from_parts(2_064_000, 0)
             // Standard Error: 7_849
-            .saturating_add(Weight::from_ref_time(1_153_509).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_153_509, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64add(r: u32, ) -> Weight {
@@ -3019,9 +3019,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_956 nanoseconds.
-        Weight::from_ref_time(2_030_000)
+        Weight::from_parts(2_030_000, 0)
             // Standard Error: 8_433
-            .saturating_add(Weight::from_ref_time(1_268_864).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_268_864, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32add(r: u32, ) -> Weight {
@@ -3029,9 +3029,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_947 nanoseconds.
-        Weight::from_ref_time(2_018_000)
+        Weight::from_parts(2_018_000, 0)
             // Standard Error: 4_547
-            .saturating_add(Weight::from_ref_time(645_032).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(645_032, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64sub(r: u32, ) -> Weight {
@@ -3039,9 +3039,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_032 nanoseconds.
-        Weight::from_ref_time(2_064_000)
+        Weight::from_parts(2_064_000, 0)
             // Standard Error: 8_005
-            .saturating_add(Weight::from_ref_time(1_289_651).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_289_651, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32sub(r: u32, ) -> Weight {
@@ -3049,9 +3049,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_986 nanoseconds.
-        Weight::from_ref_time(2_028_000)
+        Weight::from_parts(2_028_000, 0)
             // Standard Error: 5_600
-            .saturating_add(Weight::from_ref_time(678_797).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(678_797, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64mul(r: u32, ) -> Weight {
@@ -3059,9 +3059,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_994 nanoseconds.
-        Weight::from_ref_time(2_039_000)
+        Weight::from_parts(2_039_000, 0)
             // Standard Error: 10_526
-            .saturating_add(Weight::from_ref_time(1_973_986).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_973_986, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32mul(r: u32, ) -> Weight {
@@ -3069,9 +3069,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_984 nanoseconds.
-        Weight::from_ref_time(2_043_000)
+        Weight::from_parts(2_043_000, 0)
             // Standard Error: 7_034
-            .saturating_add(Weight::from_ref_time(1_215_647).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_215_647, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64divs(r: u32, ) -> Weight {
@@ -3079,9 +3079,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_988 nanoseconds.
-        Weight::from_ref_time(2_050_000)
+        Weight::from_parts(2_050_000, 0)
             // Standard Error: 7_212
-            .saturating_add(Weight::from_ref_time(2_771_771).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_771_771, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32divs(r: u32, ) -> Weight {
@@ -3089,9 +3089,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_981 nanoseconds.
-        Weight::from_ref_time(2_076_000)
+        Weight::from_parts(2_076_000, 0)
             // Standard Error: 7_088
-            .saturating_add(Weight::from_ref_time(2_419_686).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_419_686, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64divu(r: u32, ) -> Weight {
@@ -3099,9 +3099,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_036 nanoseconds.
-        Weight::from_ref_time(2_083_000)
+        Weight::from_parts(2_083_000, 0)
             // Standard Error: 9_570
-            .saturating_add(Weight::from_ref_time(2_981_619).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_981_619, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32divu(r: u32, ) -> Weight {
@@ -3109,9 +3109,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_027 nanoseconds.
-        Weight::from_ref_time(191_713)
+        Weight::from_parts(191_713, 0)
             // Standard Error: 16_475
-            .saturating_add(Weight::from_ref_time(2_611_675).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_611_675, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64rems(r: u32, ) -> Weight {
@@ -3119,9 +3119,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_028 nanoseconds.
-        Weight::from_ref_time(2_100_000)
+        Weight::from_parts(2_100_000, 0)
             // Standard Error: 13_977
-            .saturating_add(Weight::from_ref_time(9_909_370).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(9_909_370, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32rems(r: u32, ) -> Weight {
@@ -3129,9 +3129,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_980 nanoseconds.
-        Weight::from_ref_time(2_054_000)
+        Weight::from_parts(2_054_000, 0)
             // Standard Error: 26_367
-            .saturating_add(Weight::from_ref_time(7_874_905).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(7_874_905, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64remu(r: u32, ) -> Weight {
@@ -3139,9 +3139,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_997 nanoseconds.
-        Weight::from_ref_time(2_043_000)
+        Weight::from_parts(2_043_000, 0)
             // Standard Error: 9_661
-            .saturating_add(Weight::from_ref_time(3_029_452).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(3_029_452, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32remu(r: u32, ) -> Weight {
@@ -3149,9 +3149,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_040 nanoseconds.
-        Weight::from_ref_time(2_145_000)
+        Weight::from_parts(2_145_000, 0)
             // Standard Error: 12_480
-            .saturating_add(Weight::from_ref_time(2_537_714).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(2_537_714, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64and(r: u32, ) -> Weight {
@@ -3159,9 +3159,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_991 nanoseconds.
-        Weight::from_ref_time(2_043_000)
+        Weight::from_parts(2_043_000, 0)
             // Standard Error: 8_986
-            .saturating_add(Weight::from_ref_time(1_297_956).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_297_956, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32and(r: u32, ) -> Weight {
@@ -3169,9 +3169,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_917 nanoseconds.
-        Weight::from_ref_time(1_991_000)
+        Weight::from_parts(1_991_000, 0)
             // Standard Error: 4_526
-            .saturating_add(Weight::from_ref_time(662_435).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(662_435, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64or(r: u32, ) -> Weight {
@@ -3179,9 +3179,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_021 nanoseconds.
-        Weight::from_ref_time(2_069_000)
+        Weight::from_parts(2_069_000, 0)
             // Standard Error: 8_324
-            .saturating_add(Weight::from_ref_time(1_327_872).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_327_872, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32or(r: u32, ) -> Weight {
@@ -3189,9 +3189,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_026 nanoseconds.
-        Weight::from_ref_time(2_070_000)
+        Weight::from_parts(2_070_000, 0)
             // Standard Error: 4_898
-            .saturating_add(Weight::from_ref_time(684_578).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(684_578, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64xor(r: u32, ) -> Weight {
@@ -3199,9 +3199,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_989 nanoseconds.
-        Weight::from_ref_time(2_057_000)
+        Weight::from_parts(2_057_000, 0)
             // Standard Error: 9_116
-            .saturating_add(Weight::from_ref_time(1_341_076).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_341_076, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32xor(r: u32, ) -> Weight {
@@ -3209,9 +3209,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_960 nanoseconds.
-        Weight::from_ref_time(2_004_000)
+        Weight::from_parts(2_004_000, 0)
             // Standard Error: 5_064
-            .saturating_add(Weight::from_ref_time(664_619).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(664_619, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64shl(r: u32, ) -> Weight {
@@ -3219,9 +3219,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_024 nanoseconds.
-        Weight::from_ref_time(2_072_000)
+        Weight::from_parts(2_072_000, 0)
             // Standard Error: 7_079
-            .saturating_add(Weight::from_ref_time(1_109_813).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_109_813, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32shl(r: u32, ) -> Weight {
@@ -3229,9 +3229,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_022 nanoseconds.
-        Weight::from_ref_time(2_110_000)
+        Weight::from_parts(2_110_000, 0)
             // Standard Error: 4_499
-            .saturating_add(Weight::from_ref_time(596_565).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(596_565, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64shrs(r: u32, ) -> Weight {
@@ -3239,9 +3239,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_945 nanoseconds.
-        Weight::from_ref_time(2_043_000)
+        Weight::from_parts(2_043_000, 0)
             // Standard Error: 7_388
-            .saturating_add(Weight::from_ref_time(1_102_019).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_102_019, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32shrs(r: u32, ) -> Weight {
@@ -3249,9 +3249,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_053 nanoseconds.
-        Weight::from_ref_time(2_103_000)
+        Weight::from_parts(2_103_000, 0)
             // Standard Error: 4_340
-            .saturating_add(Weight::from_ref_time(589_998).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(589_998, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64shru(r: u32, ) -> Weight {
@@ -3259,9 +3259,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_017 nanoseconds.
-        Weight::from_ref_time(2_099_000)
+        Weight::from_parts(2_099_000, 0)
             // Standard Error: 7_859
-            .saturating_add(Weight::from_ref_time(1_089_304).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_089_304, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32shru(r: u32, ) -> Weight {
@@ -3269,9 +3269,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_034 nanoseconds.
-        Weight::from_ref_time(2_083_000)
+        Weight::from_parts(2_083_000, 0)
             // Standard Error: 4_304
-            .saturating_add(Weight::from_ref_time(598_598).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(598_598, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64rotl(r: u32, ) -> Weight {
@@ -3279,9 +3279,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_023 nanoseconds.
-        Weight::from_ref_time(2_097_000)
+        Weight::from_parts(2_097_000, 0)
             // Standard Error: 7_539
-            .saturating_add(Weight::from_ref_time(1_121_707).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_121_707, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32rotl(r: u32, ) -> Weight {
@@ -3289,9 +3289,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_063 nanoseconds.
-        Weight::from_ref_time(2_117_000)
+        Weight::from_parts(2_117_000, 0)
             // Standard Error: 4_365
-            .saturating_add(Weight::from_ref_time(566_368).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(566_368, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i64rotr(r: u32, ) -> Weight {
@@ -3299,9 +3299,9 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 1_995 nanoseconds.
-        Weight::from_ref_time(2_062_000)
+        Weight::from_parts(2_062_000, 0)
             // Standard Error: 8_936
-            .saturating_add(Weight::from_ref_time(1_092_338).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(1_092_338, 0).saturating_mul(r.into()))
     }
     /// The range of component `r` is `[0, 50]`.
     fn instr_i32rotr(r: u32, ) -> Weight {
@@ -3309,8 +3309,8 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 2_039 nanoseconds.
-        Weight::from_ref_time(2_094_000)
+        Weight::from_parts(2_094_000, 0)
             // Standard Error: 4_196
-            .saturating_add(Weight::from_ref_time(603_336).saturating_mul(r.into()))
+            .saturating_add(Weight::from_parts(603_336, 0).saturating_mul(r.into()))
     }
 }

--- a/runtime/vara/src/weights/pallet_timestamp.rs
+++ b/runtime/vara/src/weights/pallet_timestamp.rs
@@ -58,7 +58,7 @@ impl<T: frame_system::Config> pallet_timestamp::WeightInfo for SubstrateWeight<T
         //  Measured:  `57`
         //  Estimated: `0`
         // Minimum execution time: 3_004 nanoseconds.
-        Weight::from_ref_time(3_137_000)
+        Weight::from_parts(3_137_000, 0)
     }
 }
 
@@ -78,6 +78,6 @@ impl WeightInfo for () {
         //  Measured:  `57`
         //  Estimated: `0`
         // Minimum execution time: 3_004 nanoseconds.
-        Weight::from_ref_time(3_137_000)
+        Weight::from_parts(3_137_000, 0)
     }
 }

--- a/runtime/vara/src/weights/pallet_utility.rs
+++ b/runtime/vara/src/weights/pallet_utility.rs
@@ -53,16 +53,16 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for SubstrateWeight<T> 
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_508 nanoseconds.
-        Weight::from_ref_time(2_271_659)
+        Weight::from_parts(2_271_659, 0)
             // Standard Error: 1_314
-            .saturating_add(Weight::from_ref_time(3_222_732).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(3_222_732, 0).saturating_mul(c.into()))
     }
     fn as_derivative() -> Weight {
         // Proof Size summary in bytes:
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 3_042 nanoseconds.
-        Weight::from_ref_time(3_282_000)
+        Weight::from_parts(3_282_000, 0)
     }
     /// The range of component `c` is `[0, 1000]`.
     fn batch_all(c: u32, ) -> Weight {
@@ -70,16 +70,16 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for SubstrateWeight<T> 
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_315 nanoseconds.
-        Weight::from_ref_time(10_555_108)
+        Weight::from_parts(10_555_108, 0)
             // Standard Error: 1_769
-            .saturating_add(Weight::from_ref_time(3_337_953).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(3_337_953, 0).saturating_mul(c.into()))
     }
     fn dispatch_as() -> Weight {
         // Proof Size summary in bytes:
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_724 nanoseconds.
-        Weight::from_ref_time(6_016_000)
+        Weight::from_parts(6_016_000, 0)
     }
     /// The range of component `c` is `[0, 1000]`.
     fn force_batch(c: u32, ) -> Weight {
@@ -87,9 +87,9 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for SubstrateWeight<T> 
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_374 nanoseconds.
-        Weight::from_ref_time(6_505_404)
+        Weight::from_parts(6_505_404, 0)
             // Standard Error: 1_364
-            .saturating_add(Weight::from_ref_time(3_226_066).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(3_226_066, 0).saturating_mul(c.into()))
     }
 }
 
@@ -101,16 +101,16 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_508 nanoseconds.
-        Weight::from_ref_time(2_271_659)
+        Weight::from_parts(2_271_659, 0)
             // Standard Error: 1_314
-            .saturating_add(Weight::from_ref_time(3_222_732).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(3_222_732, 0).saturating_mul(c.into()))
     }
     fn as_derivative() -> Weight {
         // Proof Size summary in bytes:
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 3_042 nanoseconds.
-        Weight::from_ref_time(3_282_000)
+        Weight::from_parts(3_282_000, 0)
     }
     /// The range of component `c` is `[0, 1000]`.
     fn batch_all(c: u32, ) -> Weight {
@@ -118,16 +118,16 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_315 nanoseconds.
-        Weight::from_ref_time(10_555_108)
+        Weight::from_parts(10_555_108, 0)
             // Standard Error: 1_769
-            .saturating_add(Weight::from_ref_time(3_337_953).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(3_337_953, 0).saturating_mul(c.into()))
     }
     fn dispatch_as() -> Weight {
         // Proof Size summary in bytes:
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 5_724 nanoseconds.
-        Weight::from_ref_time(6_016_000)
+        Weight::from_parts(6_016_000, 0)
     }
     /// The range of component `c` is `[0, 1000]`.
     fn force_batch(c: u32, ) -> Weight {
@@ -135,8 +135,8 @@ impl WeightInfo for () {
         //  Measured:  `0`
         //  Estimated: `0`
         // Minimum execution time: 4_374 nanoseconds.
-        Weight::from_ref_time(6_505_404)
+        Weight::from_parts(6_505_404, 0)
             // Standard Error: 1_364
-            .saturating_add(Weight::from_ref_time(3_226_066).saturating_mul(c.into()))
+            .saturating_add(Weight::from_parts(3_226_066, 0).saturating_mul(c.into()))
     }
 }


### PR DESCRIPTION
Resolves #2531

Changes:
- `Weight::from_ref_time(ref_time)` -> `Weight::from_parts(ref_time, 0)` 
- `Weight::from_proof_size(proof_size)` -> `Weight::from_parts(0, proof_size)`
- removed `#![allow(deprecated)]`

@reviewer-or-team
