### PR TITLE
ci(gcli): add retries for tests

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -238,7 +238,7 @@ jobs:
         run: ./scripts/gear.sh test gear --exclude gclient --exclude gcli --features pallet-gear-debug/lazy-pages --release --locked
 
       - name: "Test: `gcli`"
-        run: ./scripts/gear.sh test gcli --release --locked
+        run: ./scripts/gear.sh test gcli --release --locked --retries 3
 
       - name: "Test: JS metadata"
         run: ./scripts/gear.sh test js


### PR DESCRIPTION
ref #2322

exuection failed by network or temp env is acceptable for command line tools tbh...bcz those are uncertain stuffs, testing if all commands still work after updating is the goal for testing them in CI, so go retrying the failed tests first but not hack or force them to pass

@gear-tech/dev 
