### PR TITLE
Use `validator_set` pallet to manage authorities.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3947,6 +3947,7 @@ dependencies = [
  "sp-std 5.0.0",
  "sp-transaction-pool",
  "sp-version",
+ "substrate-validator-set",
  "substrate-wasm-builder",
 ]
 
@@ -11593,6 +11594,26 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-state-machine",
+]
+
+[[package]]
+name = "substrate-validator-set"
+version = "0.9.41"
+source = "git+https://github.com/gear-tech/substrate-validator-set.git?branch=gear-polkadot-v0.9.41-sign-ext#7c6b4bfde1a68f1f9b61ca85e62b28fd56ff34bd"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-session",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std 5.0.0",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12670,6 +12670,7 @@ dependencies = [
  "sp-transaction-pool",
  "sp-version",
  "static_assertions",
+ "substrate-validator-set",
  "substrate-wasm-builder",
  "wat",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11599,7 +11599,7 @@ dependencies = [
 [[package]]
 name = "substrate-validator-set"
 version = "0.9.41"
-source = "git+https://github.com/gear-tech/substrate-validator-set.git?branch=gear-polkadot-v0.9.41-sign-ext#7c6b4bfde1a68f1f9b61ca85e62b28fd56ff34bd"
+source = "git+https://github.com/gear-tech/substrate-validator-set.git?branch=gear-polkadot-v0.9.41-sign-ext#82ac0b50baab4b195a949665d0dd694e38bdb0f4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13258,7 +13258,7 @@ dependencies = [
 [[package]]
 name = "wasmi-validation"
 version = "0.5.0"
-source = "git+https://github.com/gear-tech/wasmi?branch=v0.13.2-sign-ext#d230c9bba8e763d03b390038750cee07ee937416"
+source = "git+https://github.com/gear-tech/wasmi?branch=v0.13.2-sign-ext#3a0b1022377919e62aadf4d78b762abd1c3e9a04"
 dependencies = [
  "parity-wasm 0.45.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,6 +202,8 @@ vara-runtime = { path = "runtime/vara" }
 wasm-smith = { version = "0.11.4", git = "https://github.com/gear-tech/wasm-tools.git", branch = "gear-stable" }
 wasm-instrument = { version = "0.2.1", git = "https://github.com/gear-tech/wasm-instrument.git", branch = "gear-stable", default-features = false }
 
+validator-set = { package = 'substrate-validator-set', git = 'https://github.com/gear-tech/substrate-validator-set.git', branch = 'gear-polkadot-v0.9.41-sign-ext', default-features = false }
+
 # Substrate deps
 frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.41-sign-ext", default-features = false }
 frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.41-sign-ext" }

--- a/node/service/src/chain_spec/gear.rs
+++ b/node/service/src/chain_spec/gear.rs
@@ -19,7 +19,7 @@
 use crate::chain_spec::{get_account_id_from_seed, get_from_seed, AccountId, Extensions};
 use gear_runtime::{
     BabeConfig, BalancesConfig, GenesisConfig, GrandpaConfig, SessionConfig, SessionKeys,
-    SudoConfig, SystemConfig, WASM_BINARY,
+    SudoConfig, SystemConfig, ValidatorSetConfig, WASM_BINARY,
 };
 use hex_literal::hex;
 use sc_service::ChainType;
@@ -241,6 +241,12 @@ fn testnet_genesis(
                 .cloned()
                 .map(|k| (k, 1 << 60))
                 .collect(),
+        },
+        validator_set: ValidatorSetConfig {
+            initial_validators: initial_authorities
+                .iter()
+                .map(|x| x.0.clone())
+                .collect::<Vec<_>>(),
         },
         babe: BabeConfig {
             authorities: Default::default(),

--- a/node/service/src/chain_spec/vara.rs
+++ b/node/service/src/chain_spec/vara.rs
@@ -30,7 +30,8 @@ use sp_runtime::{Perbill, Perquintill};
 use vara_runtime::{
     constants::currency::UNITS as TOKEN, AuthorityDiscoveryConfig, BabeConfig, BalancesConfig,
     GenesisConfig, GrandpaConfig, ImOnlineConfig, SessionConfig, SessionKeys, StakerStatus,
-    StakingConfig, StakingRewardsConfig, SudoConfig, SystemConfig, VestingConfig, WASM_BINARY,
+    StakingConfig, StakingRewardsConfig, SudoConfig, SystemConfig, ValidatorSetConfig,
+    VestingConfig, WASM_BINARY,
 };
 
 // The URL for the telemetry server.
@@ -572,6 +573,12 @@ fn testnet_genesis(
                 .map(|k: &AccountId| (k.clone(), ENDOWMENT))
                 .chain(initial_authorities.iter().map(|x| (x.0.clone(), STASH)))
                 .collect(),
+        },
+        validator_set: ValidatorSetConfig {
+            initial_validators: initial_authorities
+                .iter()
+                .map(|x| x.0.clone())
+                .collect::<Vec<_>>(),
         },
         babe: BabeConfig {
             authorities: Default::default(),

--- a/node/testing/src/genesis.rs
+++ b/node/testing/src/genesis.rs
@@ -30,7 +30,7 @@ use sp_runtime::{Perbill, Perquintill};
 use vara_runtime::{
     constants::currency::*, AccountId, BabeConfig, BalancesConfig, GenesisConfig, GrandpaConfig,
     SessionConfig, StakerStatus, StakingConfig, StakingRewardsConfig, SudoConfig, SystemConfig,
-    BABE_GENESIS_EPOCH_CONFIG, WASM_BINARY,
+    ValidatorSetConfig, BABE_GENESIS_EPOCH_CONFIG, WASM_BINARY,
 };
 
 fn wasm_binary() -> &'static [u8] {
@@ -70,6 +70,9 @@ pub fn config_endowed(code: Option<&[u8]>, extra_endowed: Vec<AccountId>) -> Gen
                 .unwrap_or_else(|| wasm_binary().to_vec()),
         },
         balances: BalancesConfig { balances: endowed },
+        validator_set: ValidatorSetConfig {
+            initial_validators: vec![],
+        },
         babe: BabeConfig {
             authorities: vec![],
             epoch_config: Some(BABE_GENESIS_EPOCH_CONFIG),

--- a/runtime/gear/Cargo.toml
+++ b/runtime/gear/Cargo.toml
@@ -150,6 +150,7 @@ try-runtime = [
 	"pallet-timestamp/try-runtime",
 	"pallet-transaction-payment/try-runtime",
 	"pallet-utility/try-runtime",
+	"validator-set/try-runtime",
 ]
 debug-mode = ["pallet-gear-debug", "pallet-gear-program/debug-mode"]
 lazy-pages = [

--- a/runtime/gear/Cargo.toml
+++ b/runtime/gear/Cargo.toml
@@ -16,6 +16,8 @@ log.workspace = true
 parity-scale-codec.workspace = true
 scale-info = { workspace = true, features = ["derive"] }
 
+validator-set.workspace = true
+
 # Substrate deps
 frame-support.workspace = true
 frame-system.workspace = true
@@ -89,6 +91,7 @@ std = [
 	"pallet-gear-payment/std",
 	"pallet-gear-rpc-runtime-api/std",
 	"runtime-primitives/std",
+	"validator-set/std",
 	"pallet-grandpa/std",
 	"pallet-session/std",
 	"pallet-sudo/std",

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -41,7 +41,10 @@ pub use frame_support::{
     },
     StorageValue,
 };
-use frame_system::limits::{BlockLength, BlockWeights};
+use frame_system::{
+    limits::{BlockLength, BlockWeights},
+    EnsureRoot,
+};
 pub use pallet_gear::manager::{ExtManager, HandleKind};
 pub use pallet_gear_payment::CustomChargeTransactionPayment;
 use pallet_grandpa::{
@@ -100,7 +103,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 130,
+    spec_version: 140,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,
@@ -263,6 +266,16 @@ impl pallet_transaction_payment::Config for Runtime {
     type FeeMultiplierUpdate = pallet_gear_payment::GearFeeMultiplier<Runtime, QueueLengthStep>;
 }
 
+parameter_types! {
+    pub const MinAuthorities: u32 = 1;
+}
+
+impl validator_set::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type AddRemoveOrigin = EnsureRoot<AccountId>;
+    type MinAuthorities = MinAuthorities;
+}
+
 impl_opaque_keys! {
     pub struct SessionKeys {
         pub babe: Babe,
@@ -273,10 +286,10 @@ impl_opaque_keys! {
 impl pallet_session::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type ValidatorId = <Self as frame_system::Config>::AccountId;
-    type ValidatorIdOf = ();
+    type ValidatorIdOf = validator_set::ValidatorOf<Self>;
     type ShouldEndSession = Babe;
     type NextSessionRotation = Babe;
-    type SessionManager = ();
+    type SessionManager = ValidatorSet;
     type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
     type Keys = SessionKeys;
     type WeightInfo = pallet_session::weights::SubstrateWeight<Runtime>;
@@ -411,6 +424,7 @@ construct_runtime!(
         TransactionPayment: pallet_transaction_payment = 6,
         Session: pallet_session = 7,
         Utility: pallet_utility = 8,
+        ValidatorSet: validator_set = 98,
         Sudo: pallet_sudo = 99,
 
         // Gear pallets
@@ -442,6 +456,7 @@ construct_runtime!(
         TransactionPayment: pallet_transaction_payment = 6,
         Session: pallet_session = 7,
         Utility: pallet_utility = 8,
+        ValidatorSet: validator_set = 98,
         Sudo: pallet_sudo = 99,
 
         // Gear pallets

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -105,7 +105,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 140,
+    spec_version: 130,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,
@@ -288,10 +288,15 @@ impl_opaque_keys! {
 impl pallet_session::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type ValidatorId = <Self as frame_system::Config>::AccountId;
-    type ValidatorIdOf = validator_set::ValidatorOf<Self>;
+    // Uncomment for live network upgrade.
+    // type ValidatorIdOf = validator_set::ValidatorOf<Self>;
+    type ValidatorIdOf = ();
     type ShouldEndSession = Babe;
     type NextSessionRotation = Babe;
-    type SessionManager = ValidatorSet;
+    // Uncomment for live network upgrade.  Won't work in genesis cuz pallet id > pallet_session id.
+    // Empty validator set for session 0 in genesis block.
+    // type SessionManager = ValidatorSet;
+    type SessionManager = ();
     type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
     type Keys = SessionKeys;
     type WeightInfo = pallet_session::weights::SubstrateWeight<Runtime>;

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -288,15 +288,10 @@ impl_opaque_keys! {
 impl pallet_session::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type ValidatorId = <Self as frame_system::Config>::AccountId;
-    // Uncomment for live network upgrade.
-    // type ValidatorIdOf = validator_set::ValidatorOf<Self>;
-    type ValidatorIdOf = ();
+    type ValidatorIdOf = validator_set::ValidatorOf<Self>;
     type ShouldEndSession = Babe;
     type NextSessionRotation = Babe;
-    // Uncomment for live network upgrade.  Won't work in genesis cuz pallet id > pallet_session id.
-    // Empty validator set for session 0 in genesis block.
-    // type SessionManager = ValidatorSet;
-    type SessionManager = ();
+    type SessionManager = ValidatorSet;
     type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
     type Keys = SessionKeys;
     type WeightInfo = pallet_session::weights::SubstrateWeight<Runtime>;

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -90,6 +90,8 @@ pub mod constants;
 
 pub use constants::{currency::*, time::*};
 
+mod migrations;
+
 // Weights used in the runtime.
 mod weights;
 
@@ -498,6 +500,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
+    migrations::Migrations,
 >;
 
 #[cfg(test)]

--- a/runtime/gear/src/migrations.rs
+++ b/runtime/gear/src/migrations.rs
@@ -1,0 +1,17 @@
+use crate::*;
+
+use frame_support::traits::OnRuntimeUpgrade;
+
+pub struct SessionValidatorSetMigration;
+
+impl OnRuntimeUpgrade for SessionValidatorSetMigration {
+    fn on_runtime_upgrade() -> Weight {
+        let current_validators = Session::validators();
+        validator_set::Validators::<Runtime>::mutate(|v| *v = current_validators.clone());
+        validator_set::ApprovedValidators::<Runtime>::mutate(|v| *v = current_validators);
+
+        RuntimeBlockWeights::get().max_block
+    }
+}
+
+pub type Migrations = (SessionValidatorSetMigration,);

--- a/runtime/vara/Cargo.toml
+++ b/runtime/vara/Cargo.toml
@@ -90,6 +90,9 @@ pallet-gear-rpc-runtime-api.workspace = true
 runtime-primitives.workspace = true
 pallet-airdrop.workspace = true
 
+# Authority add/remove
+validator-set.workspace = true
+
 [dev-dependencies]
 sp-io.workspace = true
 sp-keyring.workspace = true
@@ -165,6 +168,7 @@ std = [
 	"sp-version/std",
 	"substrate-wasm-builder",
 	"pallet-airdrop/std",
+	"validator-set/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/runtime/vara/Cargo.toml
+++ b/runtime/vara/Cargo.toml
@@ -229,6 +229,7 @@ try-runtime = [
 	"pallet-whitelist/try-runtime",
 	"pallet-airdrop/try-runtime",
 	"pallet-bags-list/try-runtime",
+	"validator-set/try-runtime",
 ]
 debug-mode = ["pallet-gear-debug", "pallet-gear-program/debug-mode"]
 lazy-pages = [

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -351,15 +351,10 @@ impl_opaque_keys! {
 impl pallet_session::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type ValidatorId = <Self as frame_system::Config>::AccountId;
-    // Uncomment for live network upgrade.
-    // type ValidatorIdOf = validator_set::ValidatorOf<Self>;
-    type ValidatorIdOf = pallet_staking::StashOf<Self>;
+    type ValidatorIdOf = validator_set::ValidatorOf<Self>;
     type ShouldEndSession = Babe;
     type NextSessionRotation = Babe;
-    // Uncomment for live network upgrade.  Won't work in genesis cuz pallet id > pallet_session id.
-    // Empty validator set for session 0 in genesis block.
-    // type SessionManager = ValidatorSet;
-    type SessionManager = pallet_session_historical::NoteHistoricalRoot<Self, Staking>;
+    type SessionManager = ValidatorSet;
     type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
     type Keys = SessionKeys;
     type WeightInfo = pallet_session::weights::SubstrateWeight<Runtime>;

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -112,6 +112,8 @@ use governance::pallet_custom_origins;
 mod extensions;
 pub use extensions::DisableValueTransfers;
 
+mod migrations;
+
 pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("vara"),
     impl_name: create_runtime_str!("vara"),
@@ -858,6 +860,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
+    migrations::Migrations,
 >;
 
 #[cfg(test)]

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -327,6 +327,16 @@ impl pallet_transaction_payment::Config for Runtime {
     type FeeMultiplierUpdate = pallet_gear_payment::GearFeeMultiplier<Runtime, QueueLengthStep>;
 }
 
+parameter_types! {
+    pub const MinAuthorities: u32 = 1;
+}
+
+impl validator_set::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type AddRemoveOrigin = EnsureRoot<AccountId>;
+    type MinAuthorities = MinAuthorities;
+}
+
 impl_opaque_keys! {
     pub struct SessionKeys {
         pub babe: Babe,
@@ -339,10 +349,10 @@ impl_opaque_keys! {
 impl pallet_session::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type ValidatorId = <Self as frame_system::Config>::AccountId;
-    type ValidatorIdOf = pallet_staking::StashOf<Self>;
+    type ValidatorIdOf = validator_set::ValidatorOf<Self>;
     type ShouldEndSession = Babe;
     type NextSessionRotation = Babe;
-    type SessionManager = pallet_session_historical::NoteHistoricalRoot<Self, Staking>;
+    type SessionManager = ValidatorSet;
     type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
     type Keys = SessionKeys;
     type WeightInfo = pallet_session::weights::SubstrateWeight<Runtime>;
@@ -739,7 +749,10 @@ construct_runtime!(
         Origins: pallet_custom_origins = 20,
         Whitelist: pallet_whitelist = 21,
 
+        // TODO: Remove in stage 2
+        ValidatorSet: validator_set = 98,
         Sudo: pallet_sudo = 99,
+
         Scheduler: pallet_scheduler = 22,
         Preimage: pallet_preimage = 23,
         Identity: pallet_identity = 24,
@@ -791,7 +804,10 @@ construct_runtime!(
         Origins: pallet_custom_origins = 20,
         Whitelist: pallet_whitelist = 21,
 
+        // TODO: Remove in stage 2
+        ValidatorSet: validator_set = 98,
         Sudo: pallet_sudo = 99,
+
         Scheduler: pallet_scheduler = 22,
         Preimage: pallet_preimage = 23,
         Identity: pallet_identity = 24,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -351,10 +351,15 @@ impl_opaque_keys! {
 impl pallet_session::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type ValidatorId = <Self as frame_system::Config>::AccountId;
-    type ValidatorIdOf = validator_set::ValidatorOf<Self>;
+    // Uncomment for live network upgrade.
+    // type ValidatorIdOf = validator_set::ValidatorOf<Self>;
+    type ValidatorIdOf = pallet_staking::StashOf<Self>;
     type ShouldEndSession = Babe;
     type NextSessionRotation = Babe;
-    type SessionManager = ValidatorSet;
+    // Uncomment for live network upgrade.  Won't work in genesis cuz pallet id > pallet_session id.
+    // Empty validator set for session 0 in genesis block.
+    // type SessionManager = ValidatorSet;
+    type SessionManager = pallet_session_historical::NoteHistoricalRoot<Self, Staking>;
     type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
     type Keys = SessionKeys;
     type WeightInfo = pallet_session::weights::SubstrateWeight<Runtime>;

--- a/runtime/vara/src/migrations.rs
+++ b/runtime/vara/src/migrations.rs
@@ -1,0 +1,17 @@
+use crate::*;
+
+use frame_support::traits::OnRuntimeUpgrade;
+
+pub struct SessionValidatorSetMigration;
+
+impl OnRuntimeUpgrade for SessionValidatorSetMigration {
+    fn on_runtime_upgrade() -> Weight {
+        let current_validators = Session::validators();
+        validator_set::Validators::<Runtime>::mutate(|v| *v = current_validators.clone());
+        validator_set::ApprovedValidators::<Runtime>::mutate(|v| *v = current_validators);
+
+        RuntimeBlockWeights::get().max_block
+    }
+}
+
+pub type Migrations = (SessionValidatorSetMigration,);


### PR DESCRIPTION
Adds the ability to add/remove validators to `pallet_session`.


~~Cannot be used with new network because pallet id comes after pallet_session. So no `local` and `dev` etc.
Session can't be initialized -`Empty validator set for session 0 in genesis block.`~~

fixed in https://github.com/gear-tech/substrate-validator-set/commit/fc0fbd5bb8b3af40fe078b26097fe7f1186f7daf (Fallback to Session if empty validators list)

@reviewer-or-team
