### PR TITLE
fix(node): slow down grandpa finality.

### DIFF
--- a/examples/binaries/reserve-gas/src/lib.rs
+++ b/examples/binaries/reserve-gas/src/lib.rs
@@ -91,7 +91,7 @@ extern "C" fn init() {
 
             unsafe {
                 RESERVATION_ID = Some(
-                    ReservationId::reserve(RESERVATION_AMOUNT, 5)
+                    ReservationId::reserve(RESERVATION_AMOUNT, 15)
                         .expect("reservation across executions"),
                 )
             };

--- a/gclient/tests/upload.rs
+++ b/gclient/tests/upload.rs
@@ -115,7 +115,7 @@ async fn alloc_zero_pages() -> anyhow::Result<()> {
         .await?
         .with("//Bob")?;
     let codes = vec![wat::parse_str(wat_code).unwrap()];
-    upload_programs_and_check(&api, codes, Some(Duration::from_secs(5))).await
+    upload_programs_and_check(&api, codes, Some(Duration::from_secs(15))).await
 }
 
 #[tokio::test]

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -547,8 +547,8 @@ where
     };
 
     let config = sc_consensus_grandpa::Config {
-        // FIXME #1578 make this available through chainspec
-        gossip_duration: std::time::Duration::from_millis(333),
+        // FIXME substrate#1578 make this available through chainspec
+        gossip_duration: std::time::Duration::from_millis(1000),
         justification_period: 512,
         name: Some(name),
         observer_enabled: false,

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -8307,7 +8307,7 @@ fn gas_reservation_works() {
 
         let gas_reserved = GasPrice::gas_price(spent_gas);
         let reservation_amount = GasPrice::gas_price(RESERVATION_AMOUNT);
-        let reservation_holding = 5 * GasPrice::gas_price(CostsPerBlockOf::<Test>::reservation());
+        let reservation_holding = 15 * GasPrice::gas_price(CostsPerBlockOf::<Test>::reservation());
 
         assert_eq!(
             Balances::free_balance(USER_1),


### PR DESCRIPTION
Resolves # .

Slower grandpa finality to reduce CPU usage.

@gear-tech/dev 
