### PR TITLE
style: Ignore `clippy::items_after_test_module` lint

### DIFF
--- a/lazy-pages/src/lib.rs
+++ b/lazy-pages/src/lib.rs
@@ -26,6 +26,8 @@
 //! Note: currently we restrict twice write signal from same page during one execution.
 //! It's not necessary behavior, but more simple and safe.
 
+#![allow(clippy::items_after_test_module)]
+
 use common::{LazyPagesExecutionContext, LazyPagesRuntimeContext};
 use gear_backend_common::lazy_pages::{GlobalsAccessConfig, Status};
 use pages::{PageNumber, WasmPageNumber};

--- a/node/authorship/src/lib.rs
+++ b/node/authorship/src/lib.rs
@@ -21,6 +21,8 @@
 // The block proposer explicitly pushes the `pallet_gear::run`
 // extrinsic at the end of each block.
 
+#![allow(clippy::items_after_test_module)]
+
 mod authorship;
 mod block_builder;
 

--- a/pallets/staking-rewards/src/lib.rs
+++ b/pallets/staking-rewards/src/lib.rs
@@ -38,6 +38,7 @@
 //!
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::items_after_test_module)]
 
 pub mod extension;
 mod inflation;

--- a/utils/wasm-gen/src/lib.rs
+++ b/utils/wasm-gen/src/lib.rs
@@ -16,6 +16,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::items_after_test_module)]
+
 use std::{collections::BTreeMap, iter::Cycle, ops::RangeInclusive};
 
 use arbitrary::Unstructured;

--- a/utils/wasm-instrument/src/lib.rs
+++ b/utils/wasm-instrument/src/lib.rs
@@ -17,6 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::items_after_test_module)]
 
 extern crate alloc;
 


### PR DESCRIPTION
This is clippy bug: https://github.com/rust-lang/rust-clippy/issues/10713