### PR TITLE
chore(examples): Introduce feature for building examples with debug gstd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6964,6 +6964,7 @@ dependencies = [
  "gear-runtime-interface",
  "gear-wasm-instrument",
  "gmeta",
+ "gstd",
  "gsys",
  "hex",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6964,7 +6964,6 @@ dependencies = [
  "gear-runtime-interface",
  "gear-wasm-instrument",
  "gmeta",
- "gstd",
  "gsys",
  "hex",
  "log",

--- a/examples/binaries/async-custom-entry/Cargo.toml
+++ b/examples/binaries/async-custom-entry/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -19,5 +19,6 @@ gtest.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = ["codec/std"]
 default = ["std"]

--- a/examples/binaries/async-signal-entry/Cargo.toml
+++ b/examples/binaries/async-signal-entry/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -19,5 +19,6 @@ gtest.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = ["codec/std"]
 default = ["std"]

--- a/examples/binaries/async-tester/Cargo.toml
+++ b/examples/binaries/async-tester/Cargo.toml
@@ -7,12 +7,13 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
 
 [features]
+debug = ["gstd/debug"]
 std = []
 default = ["std"]

--- a/examples/binaries/backend-error/Cargo.toml
+++ b/examples/binaries/backend-error/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
+gstd.workspace = true
 gsys.workspace = true
-gstd = { workspace = true, features = ["debug"] }
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -16,5 +16,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = []
 default = ["std"]

--- a/examples/binaries/btree/Cargo.toml
+++ b/examples/binaries/btree/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -19,5 +19,6 @@ gtest.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = ["codec/std"]
 default = ["std"]

--- a/examples/binaries/calc-hash/in-one-block/Cargo.toml
+++ b/examples/binaries/calc-hash/in-one-block/Cargo.toml
@@ -7,15 +7,14 @@ license = "GPL-3.0"
 workspace = "../../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
-
-# encoding
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"]}
+gstd.workspace = true
 shared = { path = "..", package = "demo-calc-hash" }
 
 [build-dependencies]
 gear-wasm-builder = { path = "../../../../utils/wasm-builder" }
 
 [features]
+debug = ["gstd/debug"]
 std = []
 default = [ "std" ]

--- a/examples/binaries/calc-hash/over-blocks/Cargo.toml
+++ b/examples/binaries/calc-hash/over-blocks/Cargo.toml
@@ -7,15 +7,14 @@ license = "GPL-3.0"
 workspace = "../../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
-
-# encoding
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"]}
+gstd.workspace = true
 shared = { path = "../", package = "demo-calc-hash" }
 
 [build-dependencies]
 gear-wasm-builder = { path = "../../../../utils/wasm-builder" }
 
 [features]
+debug = ["gstd/debug"]
 std = []
 default = ["std"]

--- a/examples/binaries/compose/Cargo.toml
+++ b/examples/binaries/compose/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
+gstd.workspace = true
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
 [build-dependencies]
@@ -16,5 +16,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = []
 default = ["std"]

--- a/examples/binaries/contract-template/Cargo.toml
+++ b/examples/binaries/contract-template/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
+gstd.workspace = true
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 rand = { version = "0.8.5", default-features = false, features = ["std_rng"] }
 
@@ -17,5 +17,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = []
 default = ["std"]

--- a/examples/binaries/delayed-sender/Cargo.toml
+++ b/examples/binaries/delayed-sender/Cargo.toml
@@ -7,11 +7,12 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
 
 [features]
+debug = ["gstd/debug"]
 std = [ ]
 default = ["std"]

--- a/examples/binaries/distributor/Cargo.toml
+++ b/examples/binaries/distributor/Cargo.toml
@@ -7,17 +7,19 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
 
 [dev-dependencies]
+gstd = { workspace = true, features = ["debug"] }
 gtest.workspace = true
 
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = ["codec/std"]
 default = ["std"]

--- a/examples/binaries/distributor/src/lib.rs
+++ b/examples/binaries/distributor/src/lib.rs
@@ -34,7 +34,7 @@ pub use code::WASM_BINARY_OPT as WASM_BINARY;
 #[derive(Encode, Debug, Decode, PartialEq, Eq)]
 pub enum Request {
     Receive(u64),
-    Join(u64),
+    Join(ActorId),
     Report,
 }
 
@@ -169,7 +169,7 @@ mod wasm {
             Reply::Success
         }
 
-        async fn handle_join(program_id: u64) -> Reply {
+        async fn handle_join(program_id: ActorId) -> Reply {
             let mut nodes = Self::nodes().lock().await;
             debug!("Inserting into nodes");
             nodes.as_mut().insert(Program::new(program_id));
@@ -285,14 +285,14 @@ mod tests {
         let program_3 = Program::current_with_id(system, program_3_id);
         let _res = program_3.send_bytes(from, b"init");
 
-        let res = program_1.send(from, Request::Join(program_2_id));
+        let res = program_1.send(from, Request::Join(program_2_id.into()));
         let log = Log::builder()
             .source(program_1.id())
             .dest(from)
             .payload(Reply::Success);
         assert!(res.contains(&log));
 
-        let res = program_1.send(from, Request::Join(program_3_id));
+        let res = program_1.send(from, Request::Join(program_3_id.into()));
         let log = Log::builder()
             .source(program_1.id())
             .dest(from)
@@ -343,7 +343,7 @@ mod tests {
         let program_4 = Program::current_with_id(&system, program_4_id);
         let _res = program_4.send_bytes(from, b"init");
 
-        IntoIterator::into_iter([Request::Receive(11), Request::Join(program_4_id)])
+        IntoIterator::into_iter([Request::Receive(11), Request::Join(program_4_id.into())])
             .map(|request| program_1.send(from, request))
             .zip(IntoIterator::into_iter([Reply::Success, Reply::Success]))
             .for_each(|(result, reply)| {

--- a/examples/binaries/exit-handle-sender/Cargo.toml
+++ b/examples/binaries/exit-handle-sender/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -16,5 +16,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = []
 default = ["std"]

--- a/examples/binaries/exit-handle/Cargo.toml
+++ b/examples/binaries/exit-handle/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -15,5 +15,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = []
 default = ["std"]

--- a/examples/binaries/exit-init/Cargo.toml
+++ b/examples/binaries/exit-init/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 gcore.workspace = true
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -16,5 +16,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = []
 default = ["std"]

--- a/examples/binaries/gasless-wasting/Cargo.toml
+++ b/examples/binaries/gasless-wasting/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -16,5 +16,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = ["codec/std"]
 default = ["std"]

--- a/examples/binaries/init-fail-sender/Cargo.toml
+++ b/examples/binaries/init-fail-sender/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -15,5 +15,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = []
 default = ["std"]

--- a/examples/binaries/init-wait-reply-exit/Cargo.toml
+++ b/examples/binaries/init-wait-reply-exit/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -15,5 +15,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = []
 default = ["std"]

--- a/examples/binaries/init-wait/Cargo.toml
+++ b/examples/binaries/init-wait/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -15,5 +15,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = []
 default = ["std"]

--- a/examples/binaries/init-with-value/Cargo.toml
+++ b/examples/binaries/init-with-value/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 hex-literal = "*"
 
 [build-dependencies]
@@ -17,5 +17,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = []
 default = ["std"]

--- a/examples/binaries/init-with-value/src/lib.rs
+++ b/examples/binaries/init-with-value/src/lib.rs
@@ -25,8 +25,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};
-#[cfg(not(feature = "std"))]
-use gstd::prelude::*;
+use gstd::{prelude::*, ActorId};
 
 #[cfg(feature = "std")]
 mod code {
@@ -42,7 +41,7 @@ pub const GAS_LIMIT: u64 = 200_000_001;
 pub enum SendMessage {
     Init { value: u128 },
     InitWithoutGas { value: u128 },
-    Handle { destination: u64, value: u128 },
+    Handle { destination: ActorId, value: u128 },
 }
 
 #[cfg(not(feature = "std"))]

--- a/examples/binaries/meta/Cargo.toml
+++ b/examples/binaries/meta/Cargo.toml
@@ -7,13 +7,14 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
+scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
 
 [features]
+debug = ["gstd/debug"]
 std = ["codec/std"]
 default = ["std"]

--- a/examples/binaries/mul-by-const/Cargo.toml
+++ b/examples/binaries/mul-by-const/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
+gstd.workspace = true
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
 [build-dependencies]
@@ -16,5 +16,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = []
 default = ["std"]

--- a/examples/binaries/ncompose/Cargo.toml
+++ b/examples/binaries/ncompose/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
+gstd.workspace = true
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
 [build-dependencies]
@@ -16,5 +16,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = []
 default = ["std"]

--- a/examples/binaries/new-meta/Cargo.toml
+++ b/examples/binaries/new-meta/Cargo.toml
@@ -7,12 +7,12 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-demo-meta-io = { path = "io" }
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false }
+demo-meta-io = { path = "io" }
 demo-meta-state-v1 = { path = "state-v1", default-features = false, optional = true }
 demo-meta-state-v2 = { path = "state-v2", default-features = false, optional = true }
 demo-meta-state-v3 = { path = "state-v3", default-features = false, optional = true }
+gstd.workspace = true
 
 [build-dependencies]
 demo-meta-io = { path = "io" }
@@ -22,6 +22,7 @@ gear-wasm-builder.workspace = true
 gtest.workspace = true
 
 [features]
+debug = ["gstd/debug"]
 default = ["std"]
 std = [
     "demo-meta-state-v1/std",

--- a/examples/binaries/node/Cargo.toml
+++ b/examples/binaries/node/Cargo.toml
@@ -7,17 +7,19 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
 
 [dev-dependencies]
+gstd = { workspace = true, features = ["debug"] }
 gtest.workspace = true
 
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = ["codec/std"]
 default = ["std"]

--- a/examples/binaries/node/src/lib.rs
+++ b/examples/binaries/node/src/lib.rs
@@ -44,7 +44,7 @@ pub enum Request {
     IsReady,
     Begin(Operation),
     Commit,
-    Add(u64),
+    Add(ActorId),
 }
 
 #[derive(Encode, Debug, Decode, PartialEq, Eq)]
@@ -236,7 +236,7 @@ fn process(request: Request) -> Reply {
             }
         }
         Request::Add(sub_node) => {
-            state().sub_nodes.insert(sub_node.into());
+            state().sub_nodes.insert(sub_node);
             Reply::Success
         }
     }
@@ -367,14 +367,14 @@ mod tests {
         let program_3 = Program::current_with_id(&system, program_3_id);
         let _res = program_3.send(from, Initialization { status: 9 });
 
-        let res = program_1.send(from, Request::Add(program_2_id));
+        let res = program_1.send(from, Request::Add(program_2_id.into()));
         let log = Log::builder()
             .source(program_1.id())
             .dest(from)
             .payload(Reply::Success);
         assert!(res.contains(&log));
 
-        let res = program_1.send(from, Request::Add(program_3_id));
+        let res = program_1.send(from, Request::Add(program_3_id.into()));
         let log = Log::builder()
             .source(program_1.id())
             .dest(from)

--- a/examples/binaries/out-of-memory/Cargo.toml
+++ b/examples/binaries/out-of-memory/Cargo.toml
@@ -7,11 +7,12 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
 
 [features]
+debug = ["gstd/debug"]
 std = []
 default = ["std"]

--- a/examples/binaries/program-factory/Cargo.toml
+++ b/examples/binaries/program-factory/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 hex-literal = "*"
 
 [build-dependencies]
@@ -20,5 +20,6 @@ gtest.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = ["codec/std"]
 default = ["std"]

--- a/examples/binaries/proxy-relay/Cargo.toml
+++ b/examples/binaries/proxy-relay/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 
 [build-dependencies]
@@ -17,5 +17,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = ["codec/std", "scale-info/std"]
 default = ["std"]

--- a/examples/binaries/proxy-reservation-with-gas/Cargo.toml
+++ b/examples/binaries/proxy-reservation-with-gas/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 
 [build-dependencies]
@@ -17,5 +17,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = ["codec/std", "scale-info/std"]
 default = ["std"]

--- a/examples/binaries/proxy-with-gas/Cargo.toml
+++ b/examples/binaries/proxy-with-gas/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 
 [build-dependencies]
@@ -17,5 +17,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = ["codec/std", "scale-info/std"]
 default = ["std"]

--- a/examples/binaries/reserve-gas/Cargo.toml
+++ b/examples/binaries/reserve-gas/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -19,5 +19,6 @@ gtest.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = ["codec/std"]
 default = ["std"]

--- a/examples/binaries/send-from-reservation/Cargo.toml
+++ b/examples/binaries/send-from-reservation/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -19,5 +19,6 @@ gtest.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = ["codec/std"]
 default = ["std"]

--- a/examples/binaries/signal-entry/Cargo.toml
+++ b/examples/binaries/signal-entry/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -19,5 +19,6 @@ gtest.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = ["codec/std"]
 default = ["std"]

--- a/examples/binaries/syscall-error/Cargo.toml
+++ b/examples/binaries/syscall-error/Cargo.toml
@@ -7,9 +7,9 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
-gsys.workspace = true
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
+gsys.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -20,5 +20,6 @@ gtest.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = ["codec/std"]
 default = ["std"]

--- a/examples/binaries/unchecked-mul/Cargo.toml
+++ b/examples/binaries/unchecked-mul/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -15,5 +15,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = []
 default = ["std"]

--- a/examples/binaries/wait-timeout/Cargo.toml
+++ b/examples/binaries/wait-timeout/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 
 [build-dependencies]
@@ -19,5 +19,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = ["codec/std"]
 default = ["std"]

--- a/examples/binaries/wait_wake/Cargo.toml
+++ b/examples/binaries/wait_wake/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -19,5 +19,6 @@ gtest.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = ["codec/std"]
 default = ["std"]

--- a/examples/binaries/waiter/Cargo.toml
+++ b/examples/binaries/waiter/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -18,5 +18,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = ["codec/std"]
 default = ["std"]

--- a/examples/binaries/waiting-proxy/Cargo.toml
+++ b/examples/binaries/waiting-proxy/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd = { workspace = true, features = ["debug"] }
+gstd.workspace = true
 
 [build-dependencies]
 gear-wasm-builder.workspace = true
@@ -15,5 +15,6 @@ gear-wasm-builder.workspace = true
 [lib]
 
 [features]
+debug = ["gstd/debug"]
 std = []
 default = ["std"]

--- a/gclient/Cargo.toml
+++ b/gclient/Cargo.toml
@@ -28,7 +28,6 @@ wat.workspace = true
 env_logger.workspace = true
 hex-literal.workspace = true
 log.workspace = true
-gstd.workspace = true
 demo-async-tester.workspace = true
 demo-backend-error.workspace = true
 demo-btree.workspace = true
@@ -46,3 +45,4 @@ demo-proxy = { workspace = true, features = ["std"] }
 demo-proxy-relay.workspace = true
 demo-proxy-with-gas.workspace = true
 demo-reserve-gas.workspace = true
+gstd = { workspace = true, features = ["debug"] }

--- a/gclient/tests/perf.rs
+++ b/gclient/tests/perf.rs
@@ -193,7 +193,7 @@ async fn send_messages(api: &GearApi, progs: &HashMap<&str, ProgramId>) -> Resul
             }
             .encode(),
         ),
-        ("demo_node", demo_node::Request::Add(42).encode()),
+        ("demo_node", demo_node::Request::Add(42.into()).encode()),
         (
             "demo_program_factory",
             demo_program_factory::CreateProgram::Default.encode(),

--- a/pallets/gear/Cargo.toml
+++ b/pallets/gear/Cargo.toml
@@ -78,7 +78,7 @@ demo-proxy.workspace = true
 demo-proxy-relay.workspace = true
 demo-proxy-with-gas.workspace = true
 demo-proxy-reservation-with-gas.workspace = true
-demo-init-with-value.workspace = true
+demo-init-with-value = { workspace = true, features = ["debug"] } # The `debug` feature is required for assering debug output
 demo-gasless-wasting.workspace = true
 demo-gas-burned.workspace = true
 demo-waiting-proxy.workspace = true
@@ -105,7 +105,6 @@ pallet-gear-scheduler = { workspace = true, features = ["std"] }
 pallet-gear-program = { workspace = true, features = ["std"] }
 gear-runtime-interface = { workspace = true, features = ["std"] }
 gmeta.workspace = true
-gstd = { workspace = true, features = ["debug"] }
 
 [features]
 default = ['std']

--- a/pallets/gear/Cargo.toml
+++ b/pallets/gear/Cargo.toml
@@ -105,6 +105,7 @@ pallet-gear-scheduler = { workspace = true, features = ["std"] }
 pallet-gear-program = { workspace = true, features = ["std"] }
 gear-runtime-interface = { workspace = true, features = ["std"] }
 gmeta.workspace = true
+gstd = { workspace = true, features = ["debug"] }
 
 [features]
 default = ['std']

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -6365,11 +6365,11 @@ fn test_create_program_with_value_lt_ed() {
             // so messages will go to mailbox
             vec![
                 SendMessage::Handle {
-                    destination: msg_receiver_1,
+                    destination: msg_receiver_1.into(),
                     value: 500
                 },
                 SendMessage::Handle {
-                    destination: msg_receiver_2,
+                    destination: msg_receiver_2.into(),
                     value: 500
                 },
                 SendMessage::Init { value: 0 },
@@ -6404,11 +6404,11 @@ fn test_create_program_with_value_lt_ed() {
             // The last message value (which is the value of init message) will end execution with trap
             vec![
                 SendMessage::Handle {
-                    destination: msg_receiver_1,
+                    destination: msg_receiver_1.into(),
                     value: 500
                 },
                 SendMessage::Handle {
-                    destination: msg_receiver_2,
+                    destination: msg_receiver_2.into(),
                     value: 500
                 },
                 SendMessage::Init { value: ed - 1 },
@@ -6470,11 +6470,11 @@ fn test_create_program_with_exceeding_value() {
             b"test1".to_vec(),
             vec![
                 SendMessage::Handle {
-                    destination: random_receiver,
+                    destination: random_receiver.into(),
                     value: sending_to_program / 3
                 },
                 SendMessage::Handle {
-                    destination: random_receiver,
+                    destination: random_receiver.into(),
                     value: sending_to_program / 3
                 },
                 SendMessage::Init {


### PR DESCRIPTION
- The `debug` feature for gstd is thrown away from the default build of examples and can be enabled by the `debug` feature on the example level
- dependencies are sorted alphabetically

@reviewer-or-team
