### PR TITLE
refactor(backend-common): Avoid memory accesses on zero size reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3536,6 +3536,7 @@ dependencies = [
  "gear-core-errors",
  "gear-wasm-instrument",
  "log",
+ "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
 ]

--- a/core-backend/common/Cargo.toml
+++ b/core-backend/common/Cargo.toml
@@ -15,6 +15,7 @@ derive_more.workspace = true
 scale-info = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
+parity-scale-codec = { workspace = true }
 rand = { workspace = true, features = ["std", "std_rng"] }
 
 [features]

--- a/lazy-pages/src/host_func.rs
+++ b/lazy-pages/src/host_func.rs
@@ -111,7 +111,6 @@ fn accesses_pages(
         .try_for_each(|access| -> Result<(), Error> {
             // TODO: here we suppose zero byte access like one byte access, because
             // backend memory impl can access memory even in case access has size 0.
-            // We can optimize this if will ignore zero bytes access in core-backend (issue #2095).
             let last_byte = access
                 .offset
                 .checked_add(access.size.saturating_sub(1))


### PR DESCRIPTION
Partially resolves #2095.

- do not access memory on zero size reads

It is not quite clear what needs to be changed/optimised in [lazy-pages](https://github.com/gear-tech/gear/blob/master/lazy-pages/src/host_func.rs#L112) with regards to it. @grishasobol can you please clarify?

@reviewer-or-team
