### PR TITLE
refactor(lazy-pages): use `LimitedStr` for global names

### DIFF
--- a/core-backend/common/src/lazy_pages.rs
+++ b/core-backend/common/src/lazy_pages.rs
@@ -27,7 +27,7 @@ use gear_core::{
 };
 use scale_info::scale::{self, Decode, Encode};
 
-use crate::TrimmedString;
+use crate::utils::LimitedStr;
 
 /// Informs lazy-pages whether they work with native or WASM runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
@@ -76,15 +76,15 @@ pub struct GlobalsAccessError;
 /// Globals access trait.
 pub trait GlobalsAccessor {
     /// Returns global `name` value, if `name` is I64 global export.
-    fn get_i64(&self, name: &TrimmedString) -> Result<i64, GlobalsAccessError>;
+    fn get_i64(&self, name: LimitedStr) -> Result<i64, GlobalsAccessError>;
     /// Set global `name` == `value`, if `name` is I64 global export.
-    fn set_i64(&mut self, name: &TrimmedString, value: i64) -> Result<(), GlobalsAccessError>;
+    fn set_i64(&mut self, name: LimitedStr, value: i64) -> Result<(), GlobalsAccessError>;
     /// Returns global `name` value, if `name` is I32 global export.
-    fn get_i32(&self, _name: &TrimmedString) -> Result<i32, GlobalsAccessError> {
+    fn get_i32(&self, _name: LimitedStr) -> Result<i32, GlobalsAccessError> {
         unimplemented!("Currently has no i32 system globals")
     }
     /// Set global `name` == `value`, if `name` is I32 global export.
-    fn set_i32(&mut self, _name: &TrimmedString, _value: i32) -> Result<(), GlobalsAccessError> {
+    fn set_i32(&mut self, _name: LimitedStr, _value: i32) -> Result<(), GlobalsAccessError> {
         unimplemented!("Currently has no i32 system globals")
     }
     /// Returns as `&mut dyn Any`.

--- a/core-backend/common/src/lazy_pages.rs
+++ b/core-backend/common/src/lazy_pages.rs
@@ -76,15 +76,15 @@ pub struct GlobalsAccessError;
 /// Globals access trait.
 pub trait GlobalsAccessor {
     /// Returns global `name` value, if `name` is I64 global export.
-    fn get_i64(&self, name: TrimmedString) -> Result<i64, GlobalsAccessError>;
+    fn get_i64(&self, name: &TrimmedString) -> Result<i64, GlobalsAccessError>;
     /// Set global `name` == `value`, if `name` is I64 global export.
-    fn set_i64(&mut self, name: TrimmedString, value: i64) -> Result<(), GlobalsAccessError>;
+    fn set_i64(&mut self, name: &TrimmedString, value: i64) -> Result<(), GlobalsAccessError>;
     /// Returns global `name` value, if `name` is I32 global export.
-    fn get_i32(&self, _name: TrimmedString) -> Result<i32, GlobalsAccessError> {
+    fn get_i32(&self, _name: &TrimmedString) -> Result<i32, GlobalsAccessError> {
         unimplemented!("Currently has no i32 system globals")
     }
     /// Set global `name` == `value`, if `name` is I32 global export.
-    fn set_i32(&mut self, _name: TrimmedString, _value: i32) -> Result<(), GlobalsAccessError> {
+    fn set_i32(&mut self, _name: &TrimmedString, _value: i32) -> Result<(), GlobalsAccessError> {
         unimplemented!("Currently has no i32 system globals")
     }
     /// Returns as `&mut dyn Any`.

--- a/core-backend/common/src/lazy_pages.rs
+++ b/core-backend/common/src/lazy_pages.rs
@@ -27,6 +27,8 @@ use gear_core::{
 };
 use scale_info::scale::{self, Decode, Encode};
 
+use crate::TrimmedString;
+
 /// Informs lazy-pages whether they work with native or WASM runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
 #[codec(crate = scale)]
@@ -74,15 +76,15 @@ pub struct GlobalsAccessError;
 /// Globals access trait.
 pub trait GlobalsAccessor {
     /// Returns global `name` value, if `name` is I64 global export.
-    fn get_i64(&self, name: &str) -> Result<i64, GlobalsAccessError>;
+    fn get_i64(&self, name: TrimmedString) -> Result<i64, GlobalsAccessError>;
     /// Set global `name` == `value`, if `name` is I64 global export.
-    fn set_i64(&mut self, name: &str, value: i64) -> Result<(), GlobalsAccessError>;
+    fn set_i64(&mut self, name: TrimmedString, value: i64) -> Result<(), GlobalsAccessError>;
     /// Returns global `name` value, if `name` is I32 global export.
-    fn get_i32(&self, _name: &str) -> Result<i32, GlobalsAccessError> {
+    fn get_i32(&self, _name: TrimmedString) -> Result<i32, GlobalsAccessError> {
         unimplemented!("Currently has no i32 system globals")
     }
     /// Set global `name` == `value`, if `name` is I32 global export.
-    fn set_i32(&mut self, _name: &str, _value: i32) -> Result<(), GlobalsAccessError> {
+    fn set_i32(&mut self, _name: TrimmedString, _value: i32) -> Result<(), GlobalsAccessError> {
         unimplemented!("Currently has no i32 system globals")
     }
     /// Returns as `&mut dyn Any`.

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -61,6 +61,7 @@ use scale_info::{
     TypeInfo,
 };
 
+pub use crate::utils::LimitedStr;
 pub use crate::utils::TrimmedString;
 pub use log;
 

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -61,8 +61,7 @@ use scale_info::{
     TypeInfo,
 };
 
-pub use crate::utils::LimitedStr;
-pub use crate::utils::TrimmedString;
+pub use crate::utils::{LimitedStr, TrimmedString};
 pub use log;
 
 pub const PTR_SPECIAL: u32 = u32::MAX;

--- a/core-backend/common/src/utils.rs
+++ b/core-backend/common/src/utils.rs
@@ -87,6 +87,28 @@ fn smart_truncate(s: &mut String, max_bytes: usize) {
     }
 }
 
+#[derive(Debug, Copy, Clone, derive_more::Display)]
+pub struct LimitedStr<'a>(&'a str);
+impl<'a> LimitedStr<'a> {
+    const INIT_ERROR_MSG: &'static str = concat!(
+        "String must be less than ",
+        stringify!(TRIMMED_MAX_LEN),
+        " bytes."
+    );
+
+    pub fn new(s: &'a str) -> Result<Self, &'static str> {
+        if s.len() > TRIMMED_MAX_LEN {
+            return Err(Self::INIT_ERROR_MSG);
+        }
+
+        Ok(Self(s))
+    }
+
+    pub fn as_str(&self) -> &'a str {
+        self.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -29,7 +29,7 @@ use gear_backend_common::{
     lazy_pages::{GlobalsAccessConfig, GlobalsAccessError, GlobalsAccessMod, GlobalsAccessor},
     ActorTerminationReason, BackendAllocExtError, BackendExt, BackendExtError, BackendReport,
     BackendTermination, Environment, EnvironmentExecutionError, EnvironmentExecutionResult,
-    TrimmedString,
+    LimitedStr,
 };
 use gear_core::{
     env::Ext,
@@ -95,7 +95,7 @@ impl<E: Ext> GlobalsAccessProvider<E> {
 }
 
 impl<E: Ext + 'static> GlobalsAccessor for GlobalsAccessProvider<E> {
-    fn get_i64(&self, name: &TrimmedString) -> Result<i64, GlobalsAccessError> {
+    fn get_i64(&self, name: LimitedStr) -> Result<i64, GlobalsAccessError> {
         self.get_global(name.as_str())
             .and_then(|global| {
                 let store = self.store.as_ref()?;
@@ -108,7 +108,7 @@ impl<E: Ext + 'static> GlobalsAccessor for GlobalsAccessProvider<E> {
             .ok_or(GlobalsAccessError)
     }
 
-    fn set_i64(&mut self, name: &TrimmedString, value: i64) -> Result<(), GlobalsAccessError> {
+    fn set_i64(&mut self, name: LimitedStr, value: i64) -> Result<(), GlobalsAccessError> {
         self.get_global(name.as_str())
             .and_then(|global| {
                 let store = self.store.as_mut()?;

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -29,6 +29,7 @@ use gear_backend_common::{
     lazy_pages::{GlobalsAccessConfig, GlobalsAccessError, GlobalsAccessMod, GlobalsAccessor},
     ActorTerminationReason, BackendAllocExtError, BackendExt, BackendExtError, BackendReport,
     BackendTermination, Environment, EnvironmentExecutionError, EnvironmentExecutionResult,
+    TrimmedString,
 };
 use gear_core::{
     env::Ext,
@@ -94,8 +95,8 @@ impl<E: Ext> GlobalsAccessProvider<E> {
 }
 
 impl<E: Ext + 'static> GlobalsAccessor for GlobalsAccessProvider<E> {
-    fn get_i64(&self, name: &str) -> Result<i64, GlobalsAccessError> {
-        self.get_global(name)
+    fn get_i64(&self, name: TrimmedString) -> Result<i64, GlobalsAccessError> {
+        self.get_global(name.as_str())
             .and_then(|global| {
                 let store = self.store.as_ref()?;
                 if let Value::I64(val) = global.get(store) {
@@ -107,8 +108,8 @@ impl<E: Ext + 'static> GlobalsAccessor for GlobalsAccessProvider<E> {
             .ok_or(GlobalsAccessError)
     }
 
-    fn set_i64(&mut self, name: &str, value: i64) -> Result<(), GlobalsAccessError> {
-        self.get_global(name)
+    fn set_i64(&mut self, name: TrimmedString, value: i64) -> Result<(), GlobalsAccessError> {
+        self.get_global(name.as_str())
             .and_then(|global| {
                 let store = self.store.as_mut()?;
                 global.set(store, Value::I64(value)).ok()

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -95,7 +95,7 @@ impl<E: Ext> GlobalsAccessProvider<E> {
 }
 
 impl<E: Ext + 'static> GlobalsAccessor for GlobalsAccessProvider<E> {
-    fn get_i64(&self, name: TrimmedString) -> Result<i64, GlobalsAccessError> {
+    fn get_i64(&self, name: &TrimmedString) -> Result<i64, GlobalsAccessError> {
         self.get_global(name.as_str())
             .and_then(|global| {
                 let store = self.store.as_ref()?;
@@ -108,7 +108,7 @@ impl<E: Ext + 'static> GlobalsAccessor for GlobalsAccessProvider<E> {
             .ok_or(GlobalsAccessError)
     }
 
-    fn set_i64(&mut self, name: TrimmedString, value: i64) -> Result<(), GlobalsAccessError> {
+    fn set_i64(&mut self, name: &TrimmedString, value: i64) -> Result<(), GlobalsAccessError> {
         self.get_global(name.as_str())
             .and_then(|global| {
                 let store = self.store.as_mut()?;

--- a/lazy-pages/src/globals.rs
+++ b/lazy-pages/src/globals.rs
@@ -80,11 +80,11 @@ struct GlobalsAccessNativeRuntime<'a, 'b> {
 
 impl<'a, 'b> GlobalsAccessor for GlobalsAccessNativeRuntime<'a, 'b> {
     fn get_i64(&self, name: &TrimmedString) -> Result<i64, GlobalsAccessError> {
-        self.inner_access_provider.get_i64(&name)
+        self.inner_access_provider.get_i64(name)
     }
 
     fn set_i64(&mut self, name: &TrimmedString, value: i64) -> Result<(), GlobalsAccessError> {
-        self.inner_access_provider.set_i64(&name, value)
+        self.inner_access_provider.set_i64(name, value)
     }
 
     fn as_any_mut(&mut self) -> &mut dyn Any {

--- a/lazy-pages/src/globals.rs
+++ b/lazy-pages/src/globals.rs
@@ -20,7 +20,10 @@
 
 use crate::common::{Error, GlobalNames};
 use core::any::Any;
-use gear_backend_common::lazy_pages::{GlobalsAccessError, GlobalsAccessMod, GlobalsAccessor};
+use gear_backend_common::{
+    lazy_pages::{GlobalsAccessError, GlobalsAccessMod, GlobalsAccessor},
+    TrimmedString,
+};
 use gear_core::memory::HostPointer;
 use sc_executor_common::sandbox::SandboxInstance;
 use sp_wasm_interface::Value;
@@ -47,9 +50,9 @@ struct GlobalsAccessWasmRuntime<'a> {
 }
 
 impl<'a> GlobalsAccessor for GlobalsAccessWasmRuntime<'a> {
-    fn get_i64(&self, name: &str) -> Result<i64, GlobalsAccessError> {
+    fn get_i64(&self, name: TrimmedString) -> Result<i64, GlobalsAccessError> {
         self.instance
-            .get_global_val(name)
+            .get_global_val(name.as_str())
             .and_then(|value| match value {
                 Value::I64(value) => Some(value),
                 _ => None,
@@ -57,9 +60,9 @@ impl<'a> GlobalsAccessor for GlobalsAccessWasmRuntime<'a> {
             .ok_or(GlobalsAccessError)
     }
 
-    fn set_i64(&mut self, name: &str, value: i64) -> Result<(), GlobalsAccessError> {
+    fn set_i64(&mut self, name: TrimmedString, value: i64) -> Result<(), GlobalsAccessError> {
         self.instance
-            .set_global_val(name, Value::I64(value))
+            .set_global_val(name.as_str(), Value::I64(value))
             .ok()
             .flatten()
             .ok_or(GlobalsAccessError)?;
@@ -76,11 +79,11 @@ struct GlobalsAccessNativeRuntime<'a, 'b> {
 }
 
 impl<'a, 'b> GlobalsAccessor for GlobalsAccessNativeRuntime<'a, 'b> {
-    fn get_i64(&self, name: &str) -> Result<i64, GlobalsAccessError> {
+    fn get_i64(&self, name: TrimmedString) -> Result<i64, GlobalsAccessError> {
         self.inner_access_provider.get_i64(name)
     }
 
-    fn set_i64(&mut self, name: &str, value: i64) -> Result<(), GlobalsAccessError> {
+    fn set_i64(&mut self, name: TrimmedString, value: i64) -> Result<(), GlobalsAccessError> {
         self.inner_access_provider.set_i64(name, value)
     }
 
@@ -94,7 +97,10 @@ fn apply_for_global_internal(
     name: &str,
     mut f: impl FnMut(u64) -> Result<Option<u64>, Error>,
 ) -> Result<u64, Error> {
-    let current_value = globals_access_provider.get_i64(name)? as u64;
+    let name =
+        TrimmedString::try_from(name).map_err(|_| Error::AccessGlobal(GlobalsAccessError))?;
+
+    let current_value = globals_access_provider.get_i64(name.clone())? as u64;
     if let Some(new_value) = f(current_value)? {
         globals_access_provider.set_i64(name, new_value as i64)?;
         Ok(new_value)

--- a/lazy-pages/src/globals.rs
+++ b/lazy-pages/src/globals.rs
@@ -50,7 +50,7 @@ struct GlobalsAccessWasmRuntime<'a> {
 }
 
 impl<'a> GlobalsAccessor for GlobalsAccessWasmRuntime<'a> {
-    fn get_i64(&self, name: TrimmedString) -> Result<i64, GlobalsAccessError> {
+    fn get_i64(&self, name: &TrimmedString) -> Result<i64, GlobalsAccessError> {
         self.instance
             .get_global_val(name.as_str())
             .and_then(|value| match value {
@@ -60,7 +60,7 @@ impl<'a> GlobalsAccessor for GlobalsAccessWasmRuntime<'a> {
             .ok_or(GlobalsAccessError)
     }
 
-    fn set_i64(&mut self, name: TrimmedString, value: i64) -> Result<(), GlobalsAccessError> {
+    fn set_i64(&mut self, name: &TrimmedString, value: i64) -> Result<(), GlobalsAccessError> {
         self.instance
             .set_global_val(name.as_str(), Value::I64(value))
             .ok()
@@ -79,12 +79,12 @@ struct GlobalsAccessNativeRuntime<'a, 'b> {
 }
 
 impl<'a, 'b> GlobalsAccessor for GlobalsAccessNativeRuntime<'a, 'b> {
-    fn get_i64(&self, name: TrimmedString) -> Result<i64, GlobalsAccessError> {
-        self.inner_access_provider.get_i64(name)
+    fn get_i64(&self, name: &TrimmedString) -> Result<i64, GlobalsAccessError> {
+        self.inner_access_provider.get_i64(&name)
     }
 
-    fn set_i64(&mut self, name: TrimmedString, value: i64) -> Result<(), GlobalsAccessError> {
-        self.inner_access_provider.set_i64(name, value)
+    fn set_i64(&mut self, name: &TrimmedString, value: i64) -> Result<(), GlobalsAccessError> {
+        self.inner_access_provider.set_i64(&name, value)
     }
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
@@ -100,9 +100,9 @@ fn apply_for_global_internal(
     let name =
         TrimmedString::try_from(name).map_err(|_| Error::AccessGlobal(GlobalsAccessError))?;
 
-    let current_value = globals_access_provider.get_i64(name.clone())? as u64;
+    let current_value = globals_access_provider.get_i64(&name)? as u64;
     if let Some(new_value) = f(current_value)? {
-        globals_access_provider.set_i64(name, new_value as i64)?;
+        globals_access_provider.set_i64(&name, new_value as i64)?;
         Ok(new_value)
     } else {
         Ok(current_value)

--- a/lazy-pages/src/globals.rs
+++ b/lazy-pages/src/globals.rs
@@ -22,7 +22,7 @@ use crate::common::{Error, GlobalNames};
 use core::any::Any;
 use gear_backend_common::{
     lazy_pages::{GlobalsAccessError, GlobalsAccessMod, GlobalsAccessor},
-    TrimmedString,
+    LimitedStr,
 };
 use gear_core::memory::HostPointer;
 use sc_executor_common::sandbox::SandboxInstance;
@@ -50,7 +50,7 @@ struct GlobalsAccessWasmRuntime<'a> {
 }
 
 impl<'a> GlobalsAccessor for GlobalsAccessWasmRuntime<'a> {
-    fn get_i64(&self, name: &TrimmedString) -> Result<i64, GlobalsAccessError> {
+    fn get_i64(&self, name: LimitedStr) -> Result<i64, GlobalsAccessError> {
         self.instance
             .get_global_val(name.as_str())
             .and_then(|value| match value {
@@ -60,7 +60,7 @@ impl<'a> GlobalsAccessor for GlobalsAccessWasmRuntime<'a> {
             .ok_or(GlobalsAccessError)
     }
 
-    fn set_i64(&mut self, name: &TrimmedString, value: i64) -> Result<(), GlobalsAccessError> {
+    fn set_i64(&mut self, name: LimitedStr, value: i64) -> Result<(), GlobalsAccessError> {
         self.instance
             .set_global_val(name.as_str(), Value::I64(value))
             .ok()
@@ -79,11 +79,11 @@ struct GlobalsAccessNativeRuntime<'a, 'b> {
 }
 
 impl<'a, 'b> GlobalsAccessor for GlobalsAccessNativeRuntime<'a, 'b> {
-    fn get_i64(&self, name: &TrimmedString) -> Result<i64, GlobalsAccessError> {
+    fn get_i64(&self, name: LimitedStr) -> Result<i64, GlobalsAccessError> {
         self.inner_access_provider.get_i64(name)
     }
 
-    fn set_i64(&mut self, name: &TrimmedString, value: i64) -> Result<(), GlobalsAccessError> {
+    fn set_i64(&mut self, name: LimitedStr, value: i64) -> Result<(), GlobalsAccessError> {
         self.inner_access_provider.set_i64(name, value)
     }
 
@@ -97,12 +97,11 @@ fn apply_for_global_internal(
     name: &str,
     mut f: impl FnMut(u64) -> Result<Option<u64>, Error>,
 ) -> Result<u64, Error> {
-    let name =
-        TrimmedString::try_from(name).map_err(|_| Error::AccessGlobal(GlobalsAccessError))?;
+    let name = LimitedStr::new(name).map_err(|_| Error::AccessGlobal(GlobalsAccessError))?;
 
-    let current_value = globals_access_provider.get_i64(&name)? as u64;
+    let current_value = globals_access_provider.get_i64(name)? as u64;
     if let Some(new_value) = f(current_value)? {
-        globals_access_provider.set_i64(&name, new_value as i64)?;
+        globals_access_provider.set_i64(name, new_value as i64)?;
         Ok(new_value)
     } else {
         Ok(current_value)


### PR DESCRIPTION
Resolves #2098.
