### PR TITLE
build(wasm-builder): Propagate toolchain to wasm-builder

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,7 +12,7 @@ derive_more.workspace = true
 enum-iterator.workspace = true
 mutagen = { workspace = true, optional = true }
 hex.workspace = true
-serde.workspace = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 path-clean.workspace = true
 

--- a/utils/wasm-builder/src/builder_error.rs
+++ b/utils/wasm-builder/src/builder_error.rs
@@ -23,10 +23,10 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum BuilderError {
     #[error("invalid manifest path `{0}`")]
-    InvalidManifestPath(PathBuf),
+    ManifestPathInvalid(PathBuf),
 
     #[error("please add \"rlib\" to [lib.crate-type]")]
-    InvalidCrateType,
+    CrateTypeInvalid,
 
     #[error("cargo command run failed: {0}")]
     CargoRunFailed(String),
@@ -41,4 +41,10 @@ pub enum BuilderError {
         "WASM module doesn't contain required export funtions (init/handle) after optimized `{0}`"
     )]
     RequiredExportFnNotFound(PathBuf),
+
+    #[error("cargo path is invalid `{0}`")]
+    CargoPathInvalid(PathBuf),
+
+    #[error("cargo toolchain is invalid `{0}`")]
+    CargoToolchainInvalid(String),
 }

--- a/utils/wasm-builder/src/cargo_toolchain.rs
+++ b/utils/wasm-builder/src/cargo_toolchain.rs
@@ -1,0 +1,88 @@
+// This file is part of Gear.
+
+// Copyright (C) 2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use anyhow::Result;
+use std::{borrow::Cow, ffi::OsStr, path::PathBuf};
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct Toolchain(String);
+
+impl Toolchain {
+    /// Returns `Toolchain` representing the most recent nightly version.
+    pub fn nightly() -> Self {
+        Self("nightly".into())
+    }
+    /// Extracts `Toolchain` from cargo executable path.
+    ///
+    /// WARNING: There is no validation for the `path` argument provided.
+    pub fn try_from_cargo_path(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+
+        // Cargo path format:
+        // "$RUSTUP_HOME/toolchains/**toolchain_name**/bin/cargo"
+        let toolchain_name = path
+            .iter()
+            .nth_back(2)
+            .and_then(OsStr::to_str)
+            .ok_or_else(|| anyhow::anyhow!("Invalid cargo path: {}", path.display()))?;
+
+        // Toolchain name format:
+        // "**toolchain**-arch-arch-arch-arch"
+        let toolchain = toolchain_name
+            .rsplitn(5, '-')
+            .last()
+            .map(String::from)
+            .ok_or_else(|| anyhow::anyhow!("Invalid cargo toolchain name: {}", toolchain_name))?;
+
+        Ok(Self(toolchain))
+    }
+
+    /// Returns toolchain string specification without target triple
+    /// as it was passed during initialization.
+    ///
+    /// <channel>[-<date>]
+    /// <channel> = stable|beta|nightly|<major.minor>|<major.minor.patch>
+    /// <date>    = YYYY-MM-DD
+    pub fn raw_toolchain_str(&'_ self) -> Cow<'_, str> {
+        self.0.as_str().into()
+    }
+
+    /// Returns toolchain string specification without target triple
+    /// with raw <channel> substituted by "nightly".
+    ///
+    /// nightly[-<date>]
+    /// <date>    = YYYY-MM-DD
+    pub fn nightly_toolchain_str(&'_ self) -> Cow<'_, str> {
+        if !self.is_nightly() {
+            let date_start_idx = self
+                .0
+                .find('-')
+                .unwrap_or_else(|| self.raw_toolchain_str().len());
+            let mut toolchain_str = self.0.clone();
+            toolchain_str.replace_range(..date_start_idx, "nightly");
+            toolchain_str.into()
+        } else {
+            self.raw_toolchain_str()
+        }
+    }
+
+    /// Returns bool representing nightly toolchain.
+    fn is_nightly(&self) -> bool {
+        self.0.starts_with("nightly")
+    }
+}

--- a/utils/wasm-builder/src/crate_info.rs
+++ b/utils/wasm-builder/src/crate_info.rs
@@ -40,7 +40,7 @@ impl CrateInfo {
     pub fn from_manifest(manifest_path: &Path) -> Result<Self> {
         anyhow::ensure!(
             manifest_path.exists(),
-            BuilderError::InvalidManifestPath(manifest_path.to_path_buf())
+            BuilderError::ManifestPathInvalid(manifest_path.to_path_buf())
         );
 
         let mut meta_cmd = MetadataCommand::new();
@@ -92,7 +92,7 @@ impl CrateInfo {
             .find(|target| {
                 target.name.eq(&pkg.name) && target.crate_types.iter().any(validated_lib)
             })
-            .ok_or(BuilderError::InvalidCrateType)?;
+            .ok_or(BuilderError::CrateTypeInvalid)?;
 
         Ok(pkg)
     }

--- a/utils/wasm-builder/src/lib.rs
+++ b/utils/wasm-builder/src/lib.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{cargo_command::CargoCommand, wasm_project::WasmProject};
+use crate::{cargo_command::CargoCommand, cargo_toolchain::Toolchain, wasm_project::WasmProject};
 use anyhow::Result;
 use filetime::{set_file_mtime, FileTime};
 use gmeta::{Metadata, MetadataRepr};
@@ -26,6 +26,7 @@ use wasm_project::ProjectType;
 
 mod builder_error;
 mod cargo_command;
+mod cargo_toolchain;
 mod crate_info;
 pub mod optimize;
 mod smart_fs;
@@ -89,9 +90,14 @@ impl WasmBuilder {
     }
 
     fn build_project(mut self) -> Result<()> {
-        // TODO: Check nightly toolchain
+        let cargo_path = env::var("CARGO")?;
+
         self.wasm_project.generate()?;
 
+        self.cargo
+            .set_toolchain(Toolchain::try_from_cargo_path(Path::new(
+                cargo_path.as_str(),
+            ))?);
         self.cargo
             .set_manifest_path(self.wasm_project.manifest_path());
         self.cargo.set_target_dir(self.wasm_project.target_dir());


### PR DESCRIPTION
Resolves #2623.

Original toolchain passed to cargo using one of the [options](https://rust-lang.github.io/rustup/overrides.html#overrides) transformed and propagated down to the build script (wasm-builder).
The transformation rule replaces any channel by the `nightly` one, e.g.
`stable[-date]` -> `nightly[-date]`
`beta[-date]` -> `nightly[-date]`
`major.minor[-date]` -> `nightly[-date]`

@gear-tech/dev 
