### PR TITLE
chore(workspace): consistent toml style for workspace usages

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,39 +1,39 @@
 [package]
 name = "gear-common"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 primitive-types = { workspace = true, features = ["scale-info"] }
-log.workspace = true
-derive_more.workspace = true
-enum-iterator.workspace = true
+log = { workspace = true }
+derive_more = { workspace = true }
+enum-iterator = { workspace = true }
 mutagen = { workspace = true, optional = true }
-hex.workspace = true
+hex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json.workspace = true
-path-clean.workspace = true
+serde_json = { workspace = true }
+path-clean = { workspace = true }
 
 # Internal deps
-gear-core.workspace = true
-gear-common-codegen.workspace = true
+gear-core = { workspace = true }
+gear-common-codegen = { workspace = true }
 gear-wasm-instrument = { workspace = true, optional = true }
 
 # Substrate deps
-sp-core.workspace = true
-sp-io.workspace = true
-sp-std.workspace = true
-sp-arithmetic.workspace = true
-frame-support.workspace = true
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-std = { workspace = true }
+sp-arithmetic = { workspace = true }
+frame-support = { workspace = true }
 frame-system = { workspace = true, optional = true }
 frame-benchmarking = { workspace = true, optional = true }
 
 [dev-dependencies]
-hex-literal.workspace = true
-proptest.workspace = true
-gear-utils.workspace = true
+hex-literal = { workspace = true }
+proptest = { workspace = true }
+gear-utils = { workspace = true }
 
 [features]
 default = ["std"]

--- a/common/codegen/Cargo.toml
+++ b/common/codegen/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "gear-common-codegen"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 proc-macro = true
 
 [dependencies]
-quote.workspace = true
-syn.workspace = true
+quote = { workspace = true }
+syn = { workspace = true }

--- a/common/lazy-pages/Cargo.toml
+++ b/common/lazy-pages/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "gear-lazy-pages-common"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-derive_more.workspace = true
-log.workspace = true
+derive_more = { workspace = true }
+log = { workspace = true }
 
-gear-core.workspace = true
-gear-backend-common.workspace = true
-gear-common.workspace = true
-gear-runtime-interface.workspace = true
-gear-wasm-instrument.workspace = true
+gear-core = { workspace = true }
+gear-backend-common = { workspace = true }
+gear-common = { workspace = true }
+gear-runtime-interface = { workspace = true }
+gear-wasm-instrument = { workspace = true }
 
-sp-std.workspace = true
+sp-std = { workspace = true }
 
 [features]
 default = ["std"]

--- a/core-backend/common/Cargo.toml
+++ b/core-backend/common/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "gear-backend-common"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-gear-core.workspace = true
+gear-core = { workspace = true }
 gear-core-errors = { workspace = true, features = ["codec"] }
-gear-wasm-instrument.workspace = true
+gear-wasm-instrument = { workspace = true }
 
-log.workspace = true
-derive_more.workspace = true
+log = { workspace = true }
+derive_more = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core-backend/sandbox/Cargo.toml
+++ b/core-backend/sandbox/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "gear-backend-sandbox"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-gear-core.workspace = true
+gear-core = { workspace = true }
 gear-core-errors = { workspace = true, features = ["codec"] }
-gear-backend-common.workspace = true
+gear-backend-common = { workspace = true }
 gsys ={ workspace = true }
 
-gear-wasm-instrument.workspace = true
+gear-wasm-instrument = { workspace = true }
 sp-sandbox = { workspace = true, features = ["host-sandbox"] }
 # Use max_level_debug feature to remove tracing in sys-calls by default.
-log.workspace = true
-derive_more.workspace = true
-codec.workspace = true
-blake2-rfc.workspace = true
+log = { workspace = true }
+derive_more = { workspace = true }
+codec = { workspace = true }
+blake2-rfc = { workspace = true }
 
 [features]
 default = ["std"]

--- a/core-backend/wasmi/Cargo.toml
+++ b/core-backend/wasmi/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "gear-backend-wasmi"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-gear-core.workspace = true
+gear-core = { workspace = true }
 gear-core-errors = { workspace = true, features = ["codec"] }
-gear-backend-common.workspace = true
+gear-backend-common = { workspace = true }
 gsys ={ workspace = true }
 
-gear-wasm-instrument.workspace = true
-wasmi.workspace = true
-log.workspace = true
-derive_more.workspace = true
-codec.workspace = true
-blake2-rfc.workspace = true
+gear-wasm-instrument = { workspace = true }
+wasmi = { workspace = true }
+log = { workspace = true }
+derive_more = { workspace = true }
+codec = { workspace = true }
+blake2-rfc = { workspace = true }
 
 [dev-dependencies]
 gear-backend-common = { workspace = true, features = ["mock"] }

--- a/core-errors/Cargo.toml
+++ b/core-errors/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "gear-core-errors"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 scale-info = { workspace = true, features = ["derive"], optional = true }
-derive_more.workspace = true
-enum-iterator.workspace = true
+derive_more = { workspace = true }
+enum-iterator = { workspace = true }
 
 [features]
 codec = ["scale-info"]

--- a/core-processor/Cargo.toml
+++ b/core-processor/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
 name = "gear-core-processor"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-gear-core.workspace = true
+gear-core = { workspace = true }
 gear-core-errors = { workspace = true, features = ["codec"] }
-gear-backend-common.workspace = true
-gear-wasm-instrument.workspace = true
+gear-backend-common = { workspace = true }
+gear-wasm-instrument = { workspace = true }
 
 scale-info = { workspace = true, features = ["derive"] }
-log.workspace = true
-derive_more.workspace = true
-static_assertions.workspace = true
+log = { workspace = true }
+derive_more = { workspace = true }
+static_assertions = { workspace = true }
 
 [dev-dependencies]
-proptest.workspace = true
-env_logger.workspace = true
-enum-iterator.workspace = true
+proptest = { workspace = true }
+env_logger = { workspace = true }
+enum-iterator = { workspace = true }
 
 [features]
 strict = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,27 +1,27 @@
 [package]
 name = "gear-core"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-gear-core-errors.workspace = true
-blake2-rfc.workspace = true
+gear-core-errors = { workspace = true }
+blake2-rfc = { workspace = true }
 parity-scale-codec = { workspace = true, features = [ "derive", "max-encoded-len" ] }
 scale-info = { workspace = true, features = ["derive"] }
-derive_more.workspace = true
-log.workspace = true
-gear-wasm-instrument.workspace = true
-wasmparser.workspace = true
+derive_more = { workspace = true }
+log = { workspace = true }
+gear-wasm-instrument = { workspace = true }
+wasmparser = { workspace = true }
 hex = { workspace = true, features = ["alloc"] }
-hashbrown.workspace = true
-static_assertions.workspace = true
+hashbrown = { workspace = true }
+static_assertions = { workspace = true }
 paste = { workspace = true }
 
 [dev-dependencies]
-wabt.workspace = true
-env_logger.workspace = true
+wabt = { workspace = true }
+env_logger = { workspace = true }
 
 [features]
 strict = []

--- a/examples/async-init/Cargo.toml
+++ b/examples/async-init/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "demo-async-init"
 version = "0.1.0"
-edition.workspace = true
+edition = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/examples/async-multisig/Cargo.toml
+++ b/examples/async-multisig/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "demo-async-multisig"
 version = "0.1.0"
-edition.workspace = true
+edition = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/examples/async-recursion/Cargo.toml
+++ b/examples/async-recursion/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "demo-async-recursion"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/async-sign/Cargo.toml
+++ b/examples/async-sign/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "demo-async-sign"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "demo-async"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }

--- a/examples/binaries/async-custom-entry/Cargo.toml
+++ b/examples/binaries/async-custom-entry/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "demo-async-custom-entry"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [dev-dependencies]
-gtest.workspace = true
+gtest = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/async-signal-entry/Cargo.toml
+++ b/examples/binaries/async-signal-entry/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "demo-async-signal-entry"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [dev-dependencies]
-gtest.workspace = true
+gtest = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/async-tester/Cargo.toml
+++ b/examples/binaries/async-tester/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "demo-async-tester"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [features]
 debug = ["gstd/debug"]

--- a/examples/binaries/backend-error/Cargo.toml
+++ b/examples/binaries/backend-error/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "demo-backend-error"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd.workspace = true
-gsys.workspace = true
+gstd = { workspace = true }
+gsys = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/btree/Cargo.toml
+++ b/examples/binaries/btree/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "demo-btree"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [dev-dependencies]
-gtest.workspace = true
+gtest = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/calc-hash/Cargo.toml
+++ b/examples/binaries/calc-hash/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "demo-calc-hash"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
@@ -11,4 +11,4 @@ codec = { package = "parity-scale-codec", version = "3.4.0", default-features = 
 sha2 = { version = "0.10.6", default-features = false }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }

--- a/examples/binaries/calc-hash/in-one-block/Cargo.toml
+++ b/examples/binaries/calc-hash/in-one-block/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "demo-calc-hash-in-one-block"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"]}
-gstd.workspace = true
+gstd = { workspace = true }
 shared = { path = "..", package = "demo-calc-hash" }
 
 [build-dependencies]

--- a/examples/binaries/calc-hash/over-blocks/Cargo.toml
+++ b/examples/binaries/calc-hash/over-blocks/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "demo-calc-hash-over-blocks"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"]}
-gstd.workspace = true
+gstd = { workspace = true }
 shared = { path = "../", package = "demo-calc-hash" }
 
 [build-dependencies]

--- a/examples/binaries/compose/Cargo.toml
+++ b/examples/binaries/compose/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "demo-compose"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/contract-template/Cargo.toml
+++ b/examples/binaries/contract-template/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "demo-contract-template"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 rand = { version = "0.8.5", default-features = false, features = ["std_rng"] }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/delayed-sender/Cargo.toml
+++ b/examples/binaries/delayed-sender/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "demo-delayed-sender"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [features]
 debug = ["gstd/debug"]

--- a/examples/binaries/distributor/Cargo.toml
+++ b/examples/binaries/distributor/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "demo-distributor"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [dev-dependencies]
 gstd = { workspace = true, features = ["debug"] }
-gtest.workspace = true
+gtest = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/exit-handle-sender/Cargo.toml
+++ b/examples/binaries/exit-handle-sender/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "demo-exit-handle-sender"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/exit-handle/Cargo.toml
+++ b/examples/binaries/exit-handle/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "demo-exit-handle"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/exit-init/Cargo.toml
+++ b/examples/binaries/exit-init/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "demo-exit-init"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gcore.workspace = true
-gstd.workspace = true
+gcore = { workspace = true }
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/gas-burned/Cargo.toml
+++ b/examples/binaries/gas-burned/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "demo-gas-burned"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [dev-dependencies]
-gtest.workspace = true
+gtest = { workspace = true }
 
 [features]
 std = []

--- a/examples/binaries/gasless-wasting/Cargo.toml
+++ b/examples/binaries/gasless-wasting/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "demo-gasless-wasting"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/init-fail-sender/Cargo.toml
+++ b/examples/binaries/init-fail-sender/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "demo-init-fail-sender"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/init-wait-reply-exit/Cargo.toml
+++ b/examples/binaries/init-wait-reply-exit/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "demo-init-wait-reply-exit"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/init-wait/Cargo.toml
+++ b/examples/binaries/init-wait/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "demo-init-wait"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/init-with-value/Cargo.toml
+++ b/examples/binaries/init-with-value/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "demo-init-with-value"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 hex-literal = "*"
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/meta/Cargo.toml
+++ b/examples/binaries/meta/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "demo-meta"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [features]
 debug = ["gstd/debug"]

--- a/examples/binaries/mul-by-const/Cargo.toml
+++ b/examples/binaries/mul-by-const/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "demo-mul-by-const"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/ncompose/Cargo.toml
+++ b/examples/binaries/ncompose/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "demo-ncompose"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/new-meta/Cargo.toml
+++ b/examples/binaries/new-meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "demo-new-meta"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
@@ -12,14 +12,14 @@ demo-meta-io = { path = "io" }
 demo-meta-state-v1 = { path = "state-v1", default-features = false, optional = true }
 demo-meta-state-v2 = { path = "state-v2", default-features = false, optional = true }
 demo-meta-state-v3 = { path = "state-v3", default-features = false, optional = true }
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
 demo-meta-io = { path = "io" }
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [dev-dependencies]
-gtest.workspace = true
+gtest = { workspace = true }
 
 [features]
 debug = ["gstd/debug"]

--- a/examples/binaries/new-meta/state-v1/Cargo.toml
+++ b/examples/binaries/new-meta/state-v1/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 gmeta = { path = "../../../../gmeta", features = ["codegen"] }
 demo-meta-io = { path = "../io" }
 

--- a/examples/binaries/new-meta/state-v2/Cargo.toml
+++ b/examples/binaries/new-meta/state-v2/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 gmeta = { path = "../../../../gmeta", features = ["codegen"] }
 demo-meta-io = { path = "../io" }
 

--- a/examples/binaries/new-meta/state-v3/Cargo.toml
+++ b/examples/binaries/new-meta/state-v3/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 gmeta = { path = "../../../../gmeta", features = ["codegen"] }
 demo-meta-io = { path = "../io" }
 

--- a/examples/binaries/node/Cargo.toml
+++ b/examples/binaries/node/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "demo-node"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [dev-dependencies]
 gstd = { workspace = true, features = ["debug"] }
-gtest.workspace = true
+gtest = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/out-of-memory/Cargo.toml
+++ b/examples/binaries/out-of-memory/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "demo-out-of-memory"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [features]
 debug = ["gstd/debug"]

--- a/examples/binaries/program-factory/Cargo.toml
+++ b/examples/binaries/program-factory/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "demo-program-factory"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 hex-literal = "*"
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [dev-dependencies]
-gtest.workspace = true
+gtest = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/proxy-relay/Cargo.toml
+++ b/examples/binaries/proxy-relay/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "demo-proxy-relay"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/proxy-reservation-with-gas/Cargo.toml
+++ b/examples/binaries/proxy-reservation-with-gas/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "demo-proxy-reservation-with-gas"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/proxy-with-gas/Cargo.toml
+++ b/examples/binaries/proxy-with-gas/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "demo-proxy-with-gas"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/proxy/Cargo.toml
+++ b/examples/binaries/proxy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "demo-proxy"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
@@ -12,7 +12,7 @@ codec = { package = "parity-scale-codec", version = "3.4.0", default-features = 
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/reserve-gas/Cargo.toml
+++ b/examples/binaries/reserve-gas/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "demo-reserve-gas"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [dev-dependencies]
-gtest.workspace = true
+gtest = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/send-from-reservation/Cargo.toml
+++ b/examples/binaries/send-from-reservation/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "demo-send-from-reservation"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [dev-dependencies]
-gtest.workspace = true
+gtest = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/signal-entry/Cargo.toml
+++ b/examples/binaries/signal-entry/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "demo-signal-entry"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [dev-dependencies]
-gtest.workspace = true
+gtest = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/sys-calls/Cargo.toml
+++ b/examples/binaries/sys-calls/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test-syscalls"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
@@ -11,7 +11,7 @@ gstd = { workspace = true }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/syscall-error/Cargo.toml
+++ b/examples/binaries/syscall-error/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "demo-syscall-error"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
-gsys.workspace = true
+gstd = { workspace = true }
+gsys = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [dev-dependencies]
-gtest.workspace = true
+gtest = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/unchecked-mul/Cargo.toml
+++ b/examples/binaries/unchecked-mul/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "demo-unchecked-mul"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/value-sender/Cargo.toml
+++ b/examples/binaries/value-sender/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "demo-value-sender"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/wait-timeout/Cargo.toml
+++ b/examples/binaries/wait-timeout/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "demo-wait-timeout"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [dev-dependencies]
 

--- a/examples/binaries/wait_wake/Cargo.toml
+++ b/examples/binaries/wait_wake/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "demo-wait-wake"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [dev-dependencies]
-gtest.workspace = true
+gtest = { workspace = true }
 
 [lib]
 

--- a/examples/binaries/waiter/Cargo.toml
+++ b/examples/binaries/waiter/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "demo-waiter"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [dev-dependencies]
 

--- a/examples/binaries/waiting-proxy/Cargo.toml
+++ b/examples/binaries/waiting-proxy/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "demo-waiting-proxy"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0"
 workspace = "../../../"
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 
 [build-dependencies]
-gear-wasm-builder.workspace = true
+gear-wasm-builder = { workspace = true }
 
 [lib]
 

--- a/examples/block-info/Cargo.toml
+++ b/examples/block-info/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-block-info"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/bot/Cargo.toml
+++ b/examples/bot/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "demo-bot"
 version = "0.1.0"
-edition.workspace = true
+edition = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/capacitor/Cargo.toml
+++ b/examples/capacitor/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-capacitor"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-chat"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }

--- a/examples/chat/bot/Cargo.toml
+++ b/examples/chat/bot/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "bot"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/chat/room/Cargo.toml
+++ b/examples/chat/room/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "room"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/collector/Cargo.toml
+++ b/examples/collector/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-collector"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/create-program/Cargo.toml
+++ b/examples/create-program/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-create-program"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/decoder/Cargo.toml
+++ b/examples/decoder/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-decoder"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/fib/Cargo.toml
+++ b/examples/fib/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-fib"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/fungible-token/Cargo.toml
+++ b/examples/fungible-token/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "fungible-token"
 version = "0.1.0"
-edition.workspace = true
-license.workspace = true
-authors.workspace = true
+edition = { workspace = true }
+license = { workspace = true }
+authors = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/examples/futures-unordered/Cargo.toml
+++ b/examples/futures-unordered/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "demo-futures-unordered"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/guestbook/Cargo.toml
+++ b/examples/guestbook/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "guestbook"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/gui-test/Cargo.toml
+++ b/examples/gui-test/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "demo-gui-test"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/incomplete_async_payloads/Cargo.toml
+++ b/examples/incomplete_async_payloads/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "demo-incomplete-async-payloads"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/light_sr25519/Cargo.toml
+++ b/examples/light_sr25519/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "light_sr25519"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies.schnorrkel]
 version = "0.10.2"

--- a/examples/loop/Cargo.toml
+++ b/examples/loop/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-loop"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/mem/Cargo.toml
+++ b/examples/mem/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-mem"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/minimal/Cargo.toml
+++ b/examples/minimal/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-minimal"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/multiping/Cargo.toml
+++ b/examples/multiping/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-multiping"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/mutex/Cargo.toml
+++ b/examples/mutex/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "demo-mutex"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/panicker/Cargo.toml
+++ b/examples/panicker/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-panicker"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/piggy-bank/Cargo.toml
+++ b/examples/piggy-bank/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-piggy-bank"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/ping-gas/Cargo.toml
+++ b/examples/ping-gas/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-ping-gas"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/ping/Cargo.toml
+++ b/examples/ping/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "demo-ping"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-galloc.workspace = true
-gcore.workspace = true
+galloc = { workspace = true }
+gcore = { workspace = true }

--- a/examples/program-id/Cargo.toml
+++ b/examples/program-id/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-program-id"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/program_generator/Cargo.toml
+++ b/examples/program_generator/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "demo-program-generator"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-gstd.workspace = true
+gstd = { workspace = true }
 hex-literal = "0.3.4"

--- a/examples/rwlock/Cargo.toml
+++ b/examples/rwlock/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "demo-rwlock"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/rwlock_write/Cargo.toml
+++ b/examples/rwlock_write/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "demo-rwlock-write"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/state_rollback/Cargo.toml
+++ b/examples/state_rollback/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-state-rollback"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/status-code/Cargo.toml
+++ b/examples/status-code/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-status-code"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/sum/Cargo.toml
+++ b/examples/sum/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-sum"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/sync_duplicate/Cargo.toml
+++ b/examples/sync_duplicate/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "demo-sync-duplicate"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/token-vendor/Cargo.toml
+++ b/examples/token-vendor/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "token-vendor"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/token-vendor/workshop-example/Cargo.toml
+++ b/examples/token-vendor/workshop-example/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "workshop-example"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/vec/Cargo.toml
+++ b/examples/vec/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-vec"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wait/Cargo.toml
+++ b/examples/wait/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "demo-wait"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/galloc/Cargo.toml
+++ b/galloc/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "galloc"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 # add "checks" feature to enable hard checks in allocator

--- a/gcli/Cargo.toml
+++ b/gcli/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "gcli"
 version = "0.1.6"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 description = "gear program cli"
 repository = "https://github.com/gear-tech/gear/tree/master/program"
-license.workspace = true
+license = { workspace = true }
 documentation = "https://docs.rs/gear-program"
 homepage = "https://github.com/gear-tech/gear/tree/master/program"
 keywords = ["gear", "cli", "wasm"]
@@ -16,37 +16,37 @@ path = "bin/gcli.rs"
 name = "gcli"
 
 [dependencies]
-gsdk.workspace = true
-anyhow.workspace = true
-base64.workspace = true
-color-eyre.workspace = true
-dirs.workspace = true
-env_logger.workspace = true
-gmeta.workspace = true
-gear-core.workspace = true
-hex.workspace = true
+gsdk = { workspace = true }
+anyhow = { workspace = true }
+base64 = { workspace = true }
+color-eyre = { workspace = true }
+dirs = { workspace = true }
+env_logger = { workspace = true }
+gmeta = { workspace = true }
+gear-core = { workspace = true }
+hex = { workspace = true }
 jsonrpsee = { workspace = true, features = [ "http-client", "ws-client" ] }
-keyring.workspace = true
-lazy_static.workspace = true
+keyring = { workspace = true }
+lazy_static = { workspace = true }
 libp2p = { workspace = true, features = [ "identify" ], optional = true }
-log.workspace = true
-nacl.workspace = true
-scale-info.workspace = true
-schnorrkel.workspace = true
-serde.workspace = true
-serde_json.workspace = true
+log = { workspace = true }
+nacl = { workspace = true }
+scale-info = { workspace = true }
+schnorrkel = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-thiserror.workspace = true
+thiserror = { workspace = true }
 tokio = { workspace = true, features = [ "full" ] }
-whoami.workspace = true
-core-processor.workspace = true
+whoami = { workspace = true }
+core-processor = { workspace = true }
 gear-backend-wasmi = { workspace = true, features = [ "std" ] }
 
 [dev-dependencies]
-rand.workspace = true
+rand = { workspace = true }
 messager = { path = "./res/messager" }
-demo-new-meta.workspace = true
-demo-waiter.workspace = true
+demo-new-meta = { workspace = true }
+demo-waiter = { workspace = true }
 gsdk = { workspace = true, features = ["testing"] }
 
 [features]

--- a/gcli/res/messager/Cargo.toml
+++ b/gcli/res/messager/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "messager"
 version = "0.1.0"
-edition.workspace = true
+edition = { workspace = true }
 
 [dependencies]
 gstd = { path = "../../../gstd" }

--- a/gclient/Cargo.toml
+++ b/gclient/Cargo.toml
@@ -1,51 +1,51 @@
 [package]
 name = "gclient"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-gear-utils.workspace = true
+gear-utils = { workspace = true }
 gsdk = { workspace = true, features = ["testing"] }
-gear-core.workspace = true
+gear-core = { workspace = true }
 gear-common = { workspace = true, default-features = true }
 
-futures.workspace = true
-anyhow.workspace = true
-hex.workspace = true
-subxt.workspace = true
-parity-scale-codec.workspace = true
-rand.workspace = true
-thiserror.workspace = true
-futures-timer.workspace = true
-async-trait.workspace = true
-url.workspace = true
-wabt.workspace = true
-gstd.workspace = true
-static_assertions.workspace = true
+futures = { workspace = true }
+anyhow = { workspace = true }
+hex = { workspace = true }
+subxt = { workspace = true }
+parity-scale-codec = { workspace = true }
+rand = { workspace = true }
+thiserror = { workspace = true }
+futures-timer = { workspace = true }
+async-trait = { workspace = true }
+url = { workspace = true }
+wabt = { workspace = true }
+gstd = { workspace = true }
+static_assertions = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-wat.workspace = true
-env_logger.workspace = true
-hex-literal.workspace = true
-log.workspace = true
-demo-async-tester.workspace = true
-demo-backend-error.workspace = true
-demo-btree.workspace = true
-demo-calc-hash.workspace = true
-demo-calc-hash-in-one-block.workspace = true
-demo-distributor.workspace = true
-demo-exit-handle-sender.workspace = true
-demo-gasless-wasting.workspace = true
-demo-meta.workspace = true
-demo-meta-io.workspace = true
-demo-mul-by-const.workspace = true
-demo-node.workspace = true
-demo-program-factory.workspace = true
+wat = { workspace = true }
+env_logger = { workspace = true }
+hex-literal = { workspace = true }
+log = { workspace = true }
+demo-async-tester = { workspace = true }
+demo-backend-error = { workspace = true }
+demo-btree = { workspace = true }
+demo-calc-hash = { workspace = true }
+demo-calc-hash-in-one-block = { workspace = true }
+demo-distributor = { workspace = true }
+demo-exit-handle-sender = { workspace = true }
+demo-gasless-wasting = { workspace = true }
+demo-meta = { workspace = true }
+demo-meta-io = { workspace = true }
+demo-mul-by-const = { workspace = true }
+demo-node = { workspace = true }
+demo-program-factory = { workspace = true }
 demo-proxy = { workspace = true, features = ["std"] }
-demo-proxy-relay.workspace = true
-demo-proxy-with-gas.workspace = true
-demo-reserve-gas.workspace = true
+demo-proxy-relay = { workspace = true }
+demo-proxy-with-gas = { workspace = true }
+demo-reserve-gas = { workspace = true }
 gstd = { workspace = true, features = ["debug"] }

--- a/gcore/Cargo.toml
+++ b/gcore/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "gcore"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-gsys.workspace = true
-gear-core-errors.workspace = true
+gsys = { workspace = true }
+gear-core-errors = { workspace = true }
 codec = { workspace = true, optional = true }
-static_assertions.workspace = true
+static_assertions = { workspace = true }
 
 [dev-dependencies]
-hex-literal.workspace = true
-galloc.workspace = true
+hex-literal = { workspace = true }
+galloc = { workspace = true }
 
 [features]
 codec = ["dep:codec", "gear-core-errors/codec"]

--- a/gear-test/Cargo.toml
+++ b/gear-test/Cargo.toml
@@ -1,35 +1,35 @@
 [package]
 name = "gear-test"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-anyhow.workspace = true
+anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-derive_more.workspace = true
-env_logger.workspace = true
-colored.workspace = true
-regex.workspace = true
-serde_yaml.workspace = true
-hex.workspace = true
+derive_more = { workspace = true }
+env_logger = { workspace = true }
+colored = { workspace = true }
+regex = { workspace = true }
+serde_yaml = { workspace = true }
+hex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json.workspace = true
-log.workspace = true
-rayon.workspace = true
-rand.workspace = true
-gear-wasm-instrument.workspace = true
+serde_json = { workspace = true }
+log = { workspace = true }
+rayon = { workspace = true }
+rand = { workspace = true }
+gear-wasm-instrument = { workspace = true }
 primitive-types = { workspace = true, features = ["scale-info"] }
-once_cell.workspace = true
+once_cell = { workspace = true }
 
 # Internal deps
-gear-core.workspace = true
-gear-core-errors.workspace = true
-common.workspace = true
-core-processor.workspace = true
-gear-backend-common.workspace = true
-gear-backend-wasmi.workspace = true
+gear-core = { workspace = true }
+gear-core-errors = { workspace = true }
+common = { workspace = true }
+core-processor = { workspace = true }
+gear-backend-common = { workspace = true }
+gear-backend-wasmi = { workspace = true }
 
 [dev-dependencies]
 parity-scale-codec = { workspace = true, features = ["derive"] }

--- a/gmeta/Cargo.toml
+++ b/gmeta/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "gmeta"
 version = "0.1.0"
-edition.workspace = true
+edition = { workspace = true }
 
 [dependencies]
-scale-info.workspace = true
-blake2-rfc.workspace = true
+scale-info = { workspace = true }
+blake2-rfc = { workspace = true }
 hex = { workspace = true, features = ["alloc"] }
 gmeta-codegen = { path = "codegen", optional = true }
-derive_more.workspace = true
+derive_more = { workspace = true }
 
 [features]
 codegen = ["gmeta-codegen"]

--- a/gmeta/codegen/Cargo.toml
+++ b/gmeta/codegen/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "gmeta-codegen"
 version = "0.1.0"
-edition.workspace = true
+edition = { workspace = true }
 
 [lib]
 proc-macro = true
 
 [dependencies]
 syn = { workspace = true, features = ["full", "printing", "parsing", "proc-macro", "extra-traits"] }
-quote.workspace = true
-proc-macro2.workspace = true
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [dev-dependencies]
 gmeta = { workspace = true, features = ["codegen"] }
-gstd.workspace = true
-parity-scale-codec.workspace = true
-scale-info.workspace = true
+gstd = { workspace = true }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }

--- a/gsdk/Cargo.toml
+++ b/gsdk/Cargo.toml
@@ -1,31 +1,31 @@
 [package]
 name = "gsdk"
 version = "0.1.0"
-edition.workspace = true
-authors.workspace = true
+edition = { workspace = true }
+authors = { workspace = true }
 description = "Gear network rust sdk."
-license.workspace = true
+license = { workspace = true }
 homepage = "https://github.com/gear-tech/gear/tree/master/gsdk"
 readme = "./README.md"
 
 [dependencies]
-anyhow.workspace = true
-async-recursion.workspace = true
-base64.workspace = true
-futures-util.workspace = true
-futures.workspace = true
-gear-core.workspace = true
-hex.workspace = true
+anyhow = { workspace = true }
+async-recursion = { workspace = true }
+base64 = { workspace = true }
+futures-util = { workspace = true }
+futures = { workspace = true }
+gear-core = { workspace = true }
+hex = { workspace = true }
 jsonrpsee = { workspace = true, features = [ "http-client", "ws-client" ] }
-log.workspace = true
-parity-scale-codec.workspace = true
+log = { workspace = true }
+parity-scale-codec = { workspace = true }
 primitive-types = { workspace = true, features = ["codec", "scale-info", "serde"] }
-serde.workspace = true
-serde_json.workspace = true
-subxt.workspace = true
-thiserror.workspace = true
+serde = { workspace = true }
+serde_json = { workspace = true }
+subxt = { workspace = true }
+thiserror = { workspace = true }
 sp-runtime = { workspace = true, features = [ "std" ] }
-sp-core.workspace = true
+sp-core = { workspace = true }
 
 # deps for features `testing`
 rand = { workspace = true, optional = true }

--- a/gstd/Cargo.toml
+++ b/gstd/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "gstd"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-galloc.workspace = true
+galloc = { workspace = true }
 gcore = { workspace = true, features = ["codec"] }
 gstd-codegen = { path = "codegen" }
-gear-core-errors.workspace = true
-hashbrown.workspace = true
+gear-core-errors = { workspace = true }
+hashbrown = { workspace = true }
 bs58 = { workspace = true, features = ["alloc"] }
 hex = { workspace = true, features = ["alloc"] }
 primitive-types = { workspace = true, features = ["scale-info"]}
 scale-info = { workspace = true, features = ["derive"] }
 futures = { workspace = true, features = ["alloc"] }
 
-static_assertions.workspace = true
+static_assertions = { workspace = true }
 
 [features]
 debug = ["galloc/debug", "gcore/debug"]

--- a/gstd/codegen/Cargo.toml
+++ b/gstd/codegen/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "gstd-codegen"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 proc-macro = true
 
 [dependencies]
 syn = { workspace = true, features = ["full"] }
-quote.workspace = true
-proc-macro2.workspace = true
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [dev-dependencies]
 gstd = { path = ".." }
-trybuild.workspace = true
+trybuild = { workspace = true }

--- a/gsys/Cargo.toml
+++ b/gsys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gsys"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }

--- a/gtest/Cargo.toml
+++ b/gtest/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
 name = "gtest"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-gear-core.workspace = true
-gear-core-errors.workspace = true
-gear-backend-common.workspace = true
+gear-core = { workspace = true }
+gear-core-errors = { workspace = true }
+gear-backend-common = { workspace = true }
 gear-backend-wasmi = { workspace = true, features = [ "std" ] }
-core-processor.workspace = true
-gear-wasm-builder.workspace = true
+core-processor = { workspace = true }
+gear-wasm-builder = { workspace = true }
 gear-common = { workspace = true, default-features = true }
 
-anyhow.workspace = true
+anyhow = { workspace = true }
 codec = { workspace = true, features = ["derive"] }
-logger.workspace = true
-hex.workspace = true
-colored.workspace = true
+logger = { workspace = true }
+hex = { workspace = true }
+colored = { workspace = true }
 derive_more = { workspace = true, features = ["add", "add_assign", "display", "mul", "mul_assign"] }
-env_logger.workspace = true
-path-clean.workspace = true
+env_logger = { workspace = true }
+path-clean = { workspace = true }
 rand = { workspace = true, features = ["std", "std_rng"] }
-gear-wasm-instrument.workspace = true
+gear-wasm-instrument = { workspace = true }

--- a/lazy-pages/Cargo.toml
+++ b/lazy-pages/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "gear-lazy-pages"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 description = "Gear lazy-pages support"
-edition.workspace = true
-license.workspace = true
+edition = { workspace = true }
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 
@@ -13,26 +13,26 @@ log = { workspace = true, features = ["std"] }
 sp-io = { workspace = true, features = ["std"] }
 sp-std = { workspace = true, features = ["std"] }
 sp-wasm-interface = { workspace = true, features = ["std"] }
-sc-executor-common.workspace = true
-cfg-if.workspace = true
-region.workspace = true
-derive_more.workspace = true
-static_assertions.workspace = true
-once_cell.workspace = true
+sc-executor-common = { workspace = true }
+cfg-if = { workspace = true }
+region = { workspace = true }
+derive_more = { workspace = true }
+static_assertions = { workspace = true }
+once_cell = { workspace = true }
 
-gear-core.workspace = true
-gear-backend-common.workspace = true
+gear-core = { workspace = true }
+gear-backend-common = { workspace = true }
 
 [target."cfg(target_vendor = \"apple\")".dependencies.mach]
 version = "0.3.2"
 
 [target.'cfg(unix)'.dependencies]
-nix.workspace = true
-libc.workspace = true
-errno.workspace = true
+nix = { workspace = true }
+libc = { workspace = true }
+errno = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { workspace = true, features = ["excpt", "memoryapi"] }
 
 [dev-dependencies]
-env_logger.workspace = true
+env_logger = { workspace = true }

--- a/node/authorship/Cargo.toml
+++ b/node/authorship/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "gear-authorship"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 description = "Gear Node"
-edition.workspace = true
-license.workspace = true
+edition = { workspace = true }
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 
@@ -13,9 +13,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { workspace = true, features = ["derive"] }
-futures.workspace = true
-futures-timer.workspace = true
-log.workspace = true
+futures = { workspace = true }
+futures-timer = { workspace = true }
+log = { workspace = true }
 
 # Gear
 runtime-primitives = { workspace = true, features = ["std"] }
@@ -23,27 +23,27 @@ common = { workspace = true, features = ["std"] }
 pallet-gear-rpc-runtime-api = { workspace = true, features = ["std"] }
 
 # Substrate Client
-sc-block-builder.workspace = true
-sc-telemetry.workspace = true
-sc-transaction-pool.workspace = true
-sc-transaction-pool-api.workspace = true
-sc-client-api.workspace = true
-sc-proposer-metrics.workspace = true
+sc-block-builder = { workspace = true }
+sc-telemetry = { workspace = true }
+sc-transaction-pool = { workspace = true }
+sc-transaction-pool-api = { workspace = true }
+sc-client-api = { workspace = true }
+sc-proposer-metrics = { workspace = true }
 
 # Substrate Primitives
 sp-core = { workspace = true, features = ["std"] }
 sp-api = { workspace = true, features = ["std"] }
-sp-consensus.workspace = true
+sp-consensus = { workspace = true }
 sp-runtime = { workspace = true, features = ["std"] }
-sp-blockchain.workspace = true
+sp-blockchain = { workspace = true }
 sp-inherents = { workspace = true, features = ["std"] }
 
 # Substrate Other
 frame-system = { workspace = true, features = ["std"] }
-prometheus-endpoint.workspace = true
+prometheus-endpoint = { workspace = true }
 
 [dev-dependencies]
-sc-transaction-pool.workspace = true
+sc-transaction-pool = { workspace = true }
 frame-support = { workspace = true, features = ["std"] }
 sp-io = { workspace = true, features = ["std"] }
 sp-std = { workspace = true, features = ["std"] }
@@ -54,6 +54,6 @@ pallet-sudo  = { workspace = true, features = ["std"] }
 pallet-timestamp = { workspace = true, features = ["std"] }
 pallet-gear = { workspace = true, features = ["std"] }
 pallet-gear-messenger  = { workspace = true, features = ["std"] }
-testing.workspace = true
+testing = { workspace = true }
 vara-runtime  = { workspace = true, features = ["std"] }
-demo-mul-by-const.workspace = true
+demo-mul-by-const = { workspace = true }

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "gear-cli"
 version = "0.1.6"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,14 +18,14 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 mimalloc = { workspace = true, default-features = false }
-scale-info.workspace = true
+scale-info = { workspace = true }
 log = { workspace = true, features = ["std"] }
-futures.workspace = true
+futures = { workspace = true }
 
 # Gear
-runtime-primitives.workspace = true
+runtime-primitives = { workspace = true }
 gear-runtime-test-cli = { workspace = true, optional = true }
-service.workspace = true
+service = { workspace = true }
 pallet-gear-payment = { workspace = true, features = ["std"] }
 pallet-gear-staking-rewards = { workspace = true, optional = true, features = ["std"] }
 
@@ -34,16 +34,16 @@ gear-runtime = { workspace = true, optional = true, features = ["std"] }
 vara-runtime = { workspace = true, optional = true, features = ["std"] }
 
 # Substrate client
-sc-cli.workspace = true
-sc-executor.workspace = true
-sc-service.workspace = true
-sc-client-api.workspace = true
+sc-cli = { workspace = true }
+sc-executor = { workspace = true }
+sc-service = { workspace = true }
+sc-client-api = { workspace = true }
 
 # Substrate primitives
 sp-core = { workspace = true, features = ["std"] }
 sp-io = { workspace = true, features = ["std"] }
 sp-inherents = { workspace = true, features = ["std"] }
-sp-keyring.workspace = true
+sp-keyring = { workspace = true }
 sp-runtime = { workspace = true, features = ["std"] }
 sp-timestamp = { workspace = true, features = ["std"] }
 
@@ -57,7 +57,7 @@ try-runtime-cli = { workspace = true, optional = true }
 gcli = { workspace = true, optional = true }
 
 [build-dependencies]
-substrate-build-script-utils.workspace = true
+substrate-build-script-utils = { workspace = true }
 
 [features]
 default = ["gear-native", "vara-native", "lazy-pages"]

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "gear-service"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 description = "Gear Node"
-edition.workspace = true
-license.workspace = true
+edition = { workspace = true }
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 
@@ -13,19 +13,19 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { workspace = true, features = ["derive"] }
-futures.workspace = true
-futures-timer.workspace = true
-hex-literal.workspace = true
+futures = { workspace = true }
+futures-timer = { workspace = true }
+hex-literal = { workspace = true }
 jsonrpsee = { workspace = true, features = ["server"] }
-log.workspace = true
+log = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 
 # Gear
-pallet-gear-rpc.workspace = true
+pallet-gear-rpc = { workspace = true }
 pallet-gear-rpc-runtime-api = { workspace = true, features = ["std"] }
 runtime-primitives = { workspace = true, features = ["std"] }
 gear-runtime-interface = { workspace = true, features = ["std"] }
-authorship.workspace = true
+authorship = { workspace = true }
 
 # Gear Runtimes
 common = { workspace = true, features = ["std"] }
@@ -34,44 +34,44 @@ gear-runtime = { workspace = true, optional = true, features = ["std"] }
 vara-runtime = { workspace = true, optional = true, features = ["std"] }
 
 # Substrate Client
-sc-block-builder.workspace = true
-sc-chain-spec.workspace = true
-sc-authority-discovery.workspace = true
+sc-block-builder = { workspace = true }
+sc-chain-spec = { workspace = true }
+sc-authority-discovery = { workspace = true }
 sc-executor = { workspace = true, features = [ "host-sandbox", "wasmer-cache" ] }
-sc-service.workspace = true
-sc-telemetry.workspace = true
-sc-keystore.workspace = true
-sc-network.workspace = true
-sc-network-common.workspace = true
-sc-network-sync.workspace = true
-sc-consensus-slots.workspace = true
-sc-transaction-pool.workspace = true
-sc-transaction-pool-api.workspace = true
-sc-rpc-api.workspace = true
-sc-consensus.workspace = true
-sc-consensus-epochs.workspace = true
-sc-consensus-babe.workspace = true
-sc-consensus-babe-rpc.workspace = true
-sc-consensus-grandpa.workspace = true
-sc-consensus-grandpa-rpc.workspace = true
-sc-client-api.workspace = true
-sc-rpc.workspace = true
-sc-rpc-spec-v2.workspace = true
-sc-sync-state-rpc.workspace = true
-sc-sysinfo.workspace = true
+sc-service = { workspace = true }
+sc-telemetry = { workspace = true }
+sc-keystore = { workspace = true }
+sc-network = { workspace = true }
+sc-network-common = { workspace = true }
+sc-network-sync = { workspace = true }
+sc-consensus-slots = { workspace = true }
+sc-transaction-pool = { workspace = true }
+sc-transaction-pool-api = { workspace = true }
+sc-rpc-api = { workspace = true }
+sc-consensus = { workspace = true }
+sc-consensus-epochs = { workspace = true }
+sc-consensus-babe = { workspace = true }
+sc-consensus-babe-rpc = { workspace = true }
+sc-consensus-grandpa = { workspace = true }
+sc-consensus-grandpa-rpc = { workspace = true }
+sc-client-api = { workspace = true }
+sc-rpc = { workspace = true }
+sc-rpc-spec-v2 = { workspace = true }
+sc-sync-state-rpc = { workspace = true }
+sc-sysinfo = { workspace = true }
 
 # Substrate Primitives
 sp-core = { workspace = true, features = ["std"] }
 sp-api = { workspace = true, features = ["std"] }
 sp-authority-discovery = { workspace = true, optional = true, features = ["std"] }
-sp-consensus.workspace = true
+sp-consensus = { workspace = true }
 sp-consensus-babe = { workspace = true, features = ["std"] }
 sp-transaction-pool = { workspace = true, features = ["std"] }
 sp-transaction-storage-proof = { workspace = true, features = ["std"] }
 sp-consensus-grandpa = { workspace = true, features = ["std"] }
 sp-runtime = { workspace = true, features = ["std"] }
 sp-timestamp = { workspace = true, features = ["std"] }
-sp-blockchain.workspace = true
+sp-blockchain = { workspace = true }
 sp-block-builder = { workspace = true, features = ["std"] }
 sp-keystore = { workspace = true, features = ["std"] }
 sp-trie = { workspace = true, features = ["std"] }
@@ -80,24 +80,24 @@ sp-offchain = { workspace = true, features = ["std"] }
 sp-session = { workspace = true, features = ["std"] }
 
 # Frame Pallets
-pallet-transaction-payment.workspace = true
-pallet-transaction-payment-rpc.workspace = true
+pallet-transaction-payment = { workspace = true }
+pallet-transaction-payment-rpc = { workspace = true }
 pallet-transaction-payment-rpc-runtime-api = { workspace = true, features = ["std"] }
 pallet-staking = { workspace = true, optional = true }
 pallet-im-online = { workspace = true, optional = true }
 
 # Substrate Other
 frame-benchmarking = { workspace = true, features = ["std"] }
-frame-benchmarking-cli.workspace = true
-substrate-frame-rpc-system.workspace = true
+frame-benchmarking-cli = { workspace = true }
+substrate-frame-rpc-system = { workspace = true }
 frame-support = { workspace = true, features = ["std"] }
 frame-system = { workspace = true, features = ["std"] }
 frame-system-rpc-runtime-api = { workspace = true, features = ["std"] }
-substrate-state-trie-migration-rpc.workspace = true
+substrate-state-trie-migration-rpc = { workspace = true }
 try-runtime-cli = { workspace = true, optional = true }
 
 [build-dependencies]
-substrate-build-script-utils.workspace = true
+substrate-build-script-utils = { workspace = true }
 
 [features]
 gear-native = [

--- a/node/testing/Cargo.toml
+++ b/node/testing/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "gear-node-testing"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 description = "Gear Node"
-edition.workspace = true
-license.workspace = true
+edition = { workspace = true }
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 
@@ -13,46 +13,46 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { workspace = true, features = ["derive"] }
-futures.workspace = true
-futures-timer.workspace = true
-log.workspace = true
-parking_lot.workspace = true
+futures = { workspace = true }
+futures-timer = { workspace = true }
+log = { workspace = true }
+parking_lot = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }
 
 # Gear
-runtime-primitives.workspace = true
-common.workspace = true
-pallet-gear-rpc-runtime-api.workspace = true
+runtime-primitives = { workspace = true }
+common = { workspace = true }
+pallet-gear-rpc-runtime-api = { workspace = true }
 gear-runtime = { workspace = true, optional = true }
 vara-runtime = { workspace = true, optional = true }
-gear-runtime-interface.workspace = true
+gear-runtime-interface = { workspace = true }
 
 # Substrate Client
-sc-block-builder.workspace = true
-sc-client-api.workspace = true
-sc-client-db.workspace = true
-sc-proposer-metrics.workspace = true
+sc-block-builder = { workspace = true }
+sc-client-api = { workspace = true }
+sc-client-db = { workspace = true }
+sc-proposer-metrics = { workspace = true }
 sc-service = { workspace = true, features = [ "test-helpers", "rocksdb" ] }
-sc-telemetry.workspace = true
-sc-transaction-pool.workspace = true
-sc-transaction-pool-api.workspace = true
-substrate-test-client.workspace = true
+sc-telemetry = { workspace = true }
+sc-transaction-pool = { workspace = true }
+sc-transaction-pool-api = { workspace = true }
+substrate-test-client = { workspace = true }
 
 # Substrate Primitives
-sp-core.workspace = true
-sp-api.workspace = true
-sp-consensus.workspace = true
-sp-keyring.workspace = true
-sp-runtime.workspace = true
-sp-blockchain.workspace = true
-sp-inherents.workspace = true
-sp-io.workspace = true
-sp-std.workspace = true
+sp-core = { workspace = true }
+sp-api = { workspace = true }
+sp-consensus = { workspace = true }
+sp-keyring = { workspace = true }
+sp-runtime = { workspace = true }
+sp-blockchain = { workspace = true }
+sp-inherents = { workspace = true }
+sp-io = { workspace = true }
+sp-std = { workspace = true }
 
 # Substrate Other
-frame-system.workspace = true
-frame-support.workspace = true
-frame-benchmarking.workspace = true
+frame-system = { workspace = true }
+frame-support = { workspace = true }
+frame-benchmarking = { workspace = true }
 
 [features]
 default = ["std", "vara-native"]

--- a/pallets/airdrop/Cargo.toml
+++ b/pallets/airdrop/Cargo.toml
@@ -3,7 +3,7 @@ name = "pallet-airdrop"
 version = "1.0.0"
 authors = ['Gear Technologies']
 edition = '2021'
-license.workspace = true
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 description = "Airdrop pallet"
@@ -15,23 +15,23 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 parity-scale-codec = { workspace = true, features = ["derive", "max-encoded-len"] }
 scale-info = { workspace = true, features = ["derive"] }
-log.workspace = true
+log = { workspace = true }
 
 # Internal deps
-common.workspace = true
-pallet-gear.workspace = true
+common = { workspace = true }
+pallet-gear = { workspace = true }
 
 # Substrate deps
-frame-support.workspace = true
-frame-system.workspace = true
+frame-support = { workspace = true }
+frame-system = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
-sp-runtime.workspace = true
-sp-std.workspace = true
-pallet-balances.workspace = true
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+pallet-balances = { workspace = true }
 
 [dev-dependencies]
-serde.workspace = true
-env_logger.workspace = true
+serde = { workspace = true }
+env_logger = { workspace = true }
 sp-core = { workspace = true, features = ["std"] }
 sp-io = { workspace = true, features = ["std"] }
 pallet-authorship = { workspace = true, features = ["std"] }

--- a/pallets/gas/Cargo.toml
+++ b/pallets/gas/Cargo.toml
@@ -3,7 +3,7 @@ name = "pallet-gear-gas"
 version = "2.0.0"
 authors = ['Gear Technologies']
 edition = '2021'
-license.workspace = true
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 description = "Gear main pallet"
@@ -15,27 +15,27 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 parity-scale-codec = { workspace = true, features = ["derive", "max-encoded-len"] }
 scale-info = { workspace = true, features = ["derive"] }
-log.workspace = true
+log = { workspace = true }
 parity-wasm = { workspace = true, optional = true }
 primitive-types = { workspace = true, features = ["scale-info"] }
 
 # Internal deps
-common.workspace = true
-gear-core.workspace = true
+common = { workspace = true }
+gear-core = { workspace = true }
 
 # Substrate deps
-frame-support.workspace = true
-frame-system.workspace = true
+frame-support = { workspace = true }
+frame-system = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
-sp-std.workspace = true
-sp-runtime.workspace = true
-pallet-balances.workspace = true
+sp-std = { workspace = true }
+sp-runtime = { workspace = true }
+pallet-balances = { workspace = true }
 
 [dev-dependencies]
-serde.workspace = true
-env_logger.workspace = true
+serde = { workspace = true }
+env_logger = { workspace = true }
 common = { workspace = true, features = ["std"] }
-gear-core.workspace = true
+gear-core = { workspace = true }
 sp-core = {workspace = true, features = ["std"] }
 sp-io = { workspace = true, features = ["std"] }
 frame-support-test = { workspace = true, features = ["std"] }

--- a/pallets/gear-debug/Cargo.toml
+++ b/pallets/gear-debug/Cargo.toml
@@ -3,7 +3,7 @@ name = "pallet-gear-debug"
 version = "2.0.0"
 authors = ['Gear Technologies']
 edition = '2021'
-license.workspace = true
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 description = "Gear main pallet"
@@ -16,37 +16,37 @@ targets = ["x86_64-unknown-linux-gnu"]
 parity-scale-codec = { workspace = true, features = ["derive"] }
 scale-info = { workspace = true, features = ["derive"] }
 primitive-types = { workspace = true, features = ["scale-info"] }
-log.workspace = true
+log = { workspace = true }
 
 # Internal deps
-common.workspace = true
-gear-core.workspace = true
-pallet-gear.workspace = true
+common = { workspace = true }
+gear-core = { workspace = true }
+pallet-gear = { workspace = true }
 
 # Substrate deps
-frame-support.workspace = true
-frame-system.workspace = true
+frame-support = { workspace = true }
+frame-system = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
-sp-core.workspace = true
-sp-std.workspace = true
-sp-io.workspace = true
-sp-runtime.workspace = true
-pallet-balances.workspace = true
-pallet-authorship.workspace = true
+sp-core = { workspace = true }
+sp-std = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-authorship = { workspace = true }
 
 [dev-dependencies]
-serde.workspace = true
-env_logger.workspace = true
-wabt.workspace = true
-gear-backend-sandbox.workspace = true
-hex-literal.workspace = true
+serde = { workspace = true }
+env_logger = { workspace = true }
+wabt = { workspace = true }
+gear-backend-sandbox = { workspace = true }
+hex-literal = { workspace = true }
 frame-support-test = { workspace = true, features = ["std"] }
 pallet-timestamp = { workspace = true, features = ["std"] }
 pallet-gear-gas = { workspace = true, features = ["std"] }
 pallet-gear-messenger = { workspace = true, features = ["std"] }
 pallet-gear-scheduler = { workspace = true, features = ["std"] }
 pallet-gear-program = { workspace = true, features = ["debug-mode", "std"] }
-gear-wasm-instrument.workspace = true
+gear-wasm-instrument = { workspace = true }
 
 [features]
 default = ['std']

--- a/pallets/gear-messenger/Cargo.toml
+++ b/pallets/gear-messenger/Cargo.toml
@@ -3,7 +3,7 @@ name = "pallet-gear-messenger"
 version = "1.0.0"
 authors = ['Gear Technologies']
 edition = '2021'
-license.workspace = true
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 description = "Gear pallet to work with messages"
@@ -13,21 +13,21 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-parity-scale-codec.workspace = true
+parity-scale-codec = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }
 primitive-types = { workspace = true, features = ["scale-info"] }
-log.workspace = true
+log = { workspace = true }
 
 # Internal deps
-common.workspace = true
-gear-core.workspace = true
+common = { workspace = true }
+gear-core = { workspace = true }
 
 # Substrate deps
-frame-support.workspace = true
-frame-system.workspace = true
+frame-support = { workspace = true }
+frame-system = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
 sp-std = { workspace = true }
-sp-io.workspace = true
+sp-io = { workspace = true }
 
 [dev-dependencies]
 pallet-gear-gas = { workspace = true, features = ["std"] }
@@ -35,7 +35,7 @@ sp-runtime = { workspace = true, features = ["std"] }
 pallet-balances = { workspace = true, features = ["std"] }
 pallet-authorship = { workspace = true, features = ["std"] }
 pallet-timestamp = { workspace = true, features = ["std"] }
-env_logger.workspace = true
+env_logger = { workspace = true }
 
 [features]
 default = ['std']

--- a/pallets/gear-program/Cargo.toml
+++ b/pallets/gear-program/Cargo.toml
@@ -3,7 +3,7 @@ name = "pallet-gear-program"
 version = "2.0.0"
 authors = ['Gear Technologies']
 edition = '2021'
-license.workspace = true
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 description = "Gear pallet to work with programs"
@@ -13,24 +13,24 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-parity-scale-codec.workspace = true
+parity-scale-codec = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }
 primitive-types = { workspace = true, features = ["scale-info"] }
-log.workspace = true
-hashbrown.workspace = true
-static_assertions.workspace = true
+log = { workspace = true }
+hashbrown = { workspace = true }
+static_assertions = { workspace = true }
 
 # Internal deps
-common.workspace = true
-gear-core.workspace = true
+common = { workspace = true }
+gear-core = { workspace = true }
 
 # Substrate deps
-frame-support.workspace = true
-frame-system.workspace = true
-sp-core.workspace = true
-sp-std.workspace = true
-sp-io.workspace = true
-sp-runtime.workspace = true
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-core = { workspace = true }
+sp-std = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
 
 [features]
 default = ['std']

--- a/pallets/gear-scheduler/Cargo.toml
+++ b/pallets/gear-scheduler/Cargo.toml
@@ -3,7 +3,7 @@ name = "pallet-gear-scheduler"
 version = "1.0.0"
 authors = ['Gear Technologies']
 edition = '2021'
-license.workspace = true
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 description = "Gear pallet to work with delayed tasks"
@@ -16,22 +16,22 @@ targets = ["x86_64-unknown-linux-gnu"]
 parity-scale-codec = { workspace = true, features = ["derive"] }
 scale-info = { workspace = true, features = ["derive"] }
 primitive-types = { workspace = true, features = ["scale-info"] }
-log.workspace = true
+log = { workspace = true }
 
 # Internal deps
-common.workspace = true
-gear-core.workspace = true
-gear-core-errors.workspace = true
+common = { workspace = true }
+gear-core = { workspace = true }
+gear-core-errors = { workspace = true }
 
 # Substrate deps
-frame-support.workspace = true
-frame-system.workspace = true
+frame-support = { workspace = true }
+frame-system = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
-sp-std.workspace = true
-sp-io.workspace = true
+sp-std = { workspace = true }
+sp-io = { workspace = true }
 
 [dev-dependencies]
-core-processor.workspace = true
+core-processor = { workspace = true }
 pallet-gear = { workspace = true, features = ["std"] }
 pallet-gear-messenger = { workspace = true, features = ["std"] }
 pallet-gear-program = { workspace = true, features = ["std"] }
@@ -42,7 +42,7 @@ frame-support-test = { workspace = true, features = ["std"] }
 pallet-balances = { workspace = true, features = ["std"] }
 pallet-authorship = { workspace = true, features = ["std"] }
 pallet-timestamp = { workspace = true, features = ["std"] }
-env_logger.workspace = true
+env_logger = { workspace = true }
 
 [features]
 default = ['std']

--- a/pallets/gear/Cargo.toml
+++ b/pallets/gear/Cargo.toml
@@ -3,7 +3,7 @@ name = "pallet-gear"
 version = "2.0.0"
 authors = ['Gear Technologies']
 edition = '2021'
-license.workspace = true
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 description = "Gear main pallet"
@@ -15,37 +15,37 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 parity-scale-codec = { workspace = true, features = ["derive"] }
 scale-info = { workspace = true, features = ["derive"] }
-log.workspace = true
+log = { workspace = true }
 primitive-types = { workspace = true, features = ["scale-info"] }
-gear-wasm-instrument.workspace = true
-derive_more.workspace = true
+gear-wasm-instrument = { workspace = true }
+derive_more = { workspace = true }
 env_logger = { workspace = true, optional = true }
-scopeguard.workspace = true
+scopeguard = { workspace = true }
 
 # Internal deps
-common.workspace = true
+common = { workspace = true }
 gear-lazy-pages-common = { workspace = true, optional = true }
-core-processor.workspace = true
-gear-core.workspace = true
-gear-core-errors.workspace = true
-gear-backend-common.workspace = true
-gear-backend-sandbox.workspace = true
+core-processor = { workspace = true }
+gear-core = { workspace = true }
+gear-core-errors = { workspace = true }
+gear-backend-common = { workspace = true }
+gear-backend-sandbox = { workspace = true }
 gear-backend-wasmi = { workspace = true, optional = true }
 pallet-gear-proc-macro = { version = "2.0.0", path = "proc-macro" }
 gsys = { workspace = true, optional = true }
 
 # Substrate deps
-frame-support.workspace = true
-frame-system.workspace = true
+frame-support = { workspace = true }
+frame-system = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
-sp-core.workspace = true
-sp-std.workspace = true
-sp-io.workspace = true
-sp-runtime.workspace = true
-sp-externalities.workspace = true
-pallet-balances.workspace = true
-pallet-authorship.workspace = true
-pallet-timestamp.workspace = true
+sp-core = { workspace = true }
+sp-std = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-externalities = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-authorship = { workspace = true }
+pallet-timestamp = { workspace = true }
 sp-consensus-babe = { workspace = true, optional = true}
 
 # Benchmark deps
@@ -58,53 +58,53 @@ test-syscalls = { workspace = true, optional = true }
 demo-proxy = { workspace = true, optional = true }
 
 [dev-dependencies]
-wabt.workspace = true
-hex.workspace = true
-blake2-rfc.workspace = true
-demo-async-tester.workspace = true
-demo-backend-error.workspace = true
-demo-btree.workspace = true
-demo-delayed-sender.workspace = true
-demo-distributor.workspace = true
-demo-init-fail-sender.workspace = true
-demo-init-wait.workspace = true
-demo-init-wait-reply-exit.workspace = true
-demo-new-meta.workspace = true
-demo-exit-init.workspace = true
-demo-exit-handle.workspace = true
-demo-exit-handle-sender.workspace = true
-demo-program-factory.workspace = true
-demo-proxy.workspace = true
-demo-proxy-relay.workspace = true
-demo-proxy-with-gas.workspace = true
-demo-proxy-reservation-with-gas.workspace = true
+wabt = { workspace = true }
+hex = { workspace = true }
+blake2-rfc = { workspace = true }
+demo-async-tester = { workspace = true }
+demo-backend-error = { workspace = true }
+demo-btree = { workspace = true }
+demo-delayed-sender = { workspace = true }
+demo-distributor = { workspace = true }
+demo-init-fail-sender = { workspace = true }
+demo-init-wait = { workspace = true }
+demo-init-wait-reply-exit = { workspace = true }
+demo-new-meta = { workspace = true }
+demo-exit-init = { workspace = true }
+demo-exit-handle = { workspace = true }
+demo-exit-handle-sender = { workspace = true }
+demo-program-factory = { workspace = true }
+demo-proxy = { workspace = true }
+demo-proxy-relay = { workspace = true }
+demo-proxy-with-gas = { workspace = true }
+demo-proxy-reservation-with-gas = { workspace = true }
 demo-init-with-value = { workspace = true, features = ["debug"] } # The `debug` feature is required for assering debug output
-demo-gasless-wasting.workspace = true
-demo-gas-burned.workspace = true
-demo-waiting-proxy.workspace = true
-demo-calc-hash.workspace = true
-demo-calc-hash-over-blocks.workspace = true
-demo-calc-hash-in-one-block.workspace = true
-demo-compose.workspace = true
-demo-mul-by-const.workspace = true
-demo-value-sender.workspace = true
-demo-waiter.workspace = true
-demo-wait-timeout.workspace = true
-demo-wait-wake.workspace = true
-demo-reserve-gas.workspace = true
-demo-send-from-reservation.workspace = true
-demo-signal-entry.workspace = true
-demo-async-signal-entry.workspace = true
-demo-async-custom-entry.workspace = true
-demo-out-of-memory.workspace = true
-page_size.workspace = true
+demo-gasless-wasting = { workspace = true }
+demo-gas-burned = { workspace = true }
+demo-waiting-proxy = { workspace = true }
+demo-calc-hash = { workspace = true }
+demo-calc-hash-over-blocks = { workspace = true }
+demo-calc-hash-in-one-block = { workspace = true }
+demo-compose = { workspace = true }
+demo-mul-by-const = { workspace = true }
+demo-value-sender = { workspace = true }
+demo-waiter = { workspace = true }
+demo-wait-timeout = { workspace = true }
+demo-wait-wake = { workspace = true }
+demo-reserve-gas = { workspace = true }
+demo-send-from-reservation = { workspace = true }
+demo-signal-entry = { workspace = true }
+demo-async-signal-entry = { workspace = true }
+demo-async-custom-entry = { workspace = true }
+demo-out-of-memory = { workspace = true }
+page_size = { workspace = true }
 frame-support-test = { workspace = true, features = ["std"] }
 pallet-gear-gas = { workspace = true, features = ["std"] }
 pallet-gear-messenger = { workspace = true, features = ["std"] }
 pallet-gear-scheduler = { workspace = true, features = ["std"] }
 pallet-gear-program = { workspace = true, features = ["std"] }
 gear-runtime-interface = { workspace = true, features = ["std"] }
-gmeta.workspace = true
+gmeta = { workspace = true }
 
 [features]
 default = ['std']

--- a/pallets/gear/proc-macro/Cargo.toml
+++ b/pallets/gear/proc-macro/Cargo.toml
@@ -3,7 +3,7 @@ name = "pallet-gear-proc-macro"
 version = "2.0.0"
 authors = ['Gear Technologies']
 edition = '2021'
-license.workspace = true
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 description = "Procedural macros used in pallet_gear"
@@ -15,8 +15,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 proc-macro = true
 
 [dependencies]
-proc-macro2.workspace = true
-quote.workspace = true
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
 syn = { workspace = true, features = ["full"] }
 
 [dev-dependencies]

--- a/pallets/gear/rpc/Cargo.toml
+++ b/pallets/gear/rpc/Cargo.toml
@@ -3,7 +3,7 @@ name = "pallet-gear-rpc"
 version = "2.0.0"
 authors = ['Gear Technologies']
 edition = '2021'
-license.workspace = true
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 
@@ -11,13 +11,13 @@ repository = "https://github.com/gear-tech/gear"
 jsonrpsee = { workspace = true, features = ["server", "macros"] }
 
 # Substrate packages
-sp-api.workspace = true
-sp-blockchain.workspace = true
-sp-core.workspace = true
-sp-rpc.workspace = true
-sp-runtime.workspace = true
+sp-api = { workspace = true }
+sp-blockchain = { workspace = true }
+sp-core = { workspace = true }
+sp-rpc = { workspace = true }
+sp-runtime = { workspace = true }
 
 # Local packages
-gear-core.workspace = true
-gear-common.workspace = true
-pallet-gear-rpc-runtime-api.workspace = true
+gear-core = { workspace = true }
+gear-common = { workspace = true }
+pallet-gear-rpc-runtime-api = { workspace = true }

--- a/pallets/gear/rpc/runtime-api/Cargo.toml
+++ b/pallets/gear/rpc/runtime-api/Cargo.toml
@@ -3,16 +3,16 @@ name = "pallet-gear-rpc-runtime-api"
 version = "2.0.0"
 authors = ['Gear Technologies']
 edition = '2021'
-license.workspace = true
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 
 [dependencies]
-sp-api.workspace = true
-sp-core.workspace = true
-sp-runtime.workspace = true
-sp-std.workspace = true
-pallet-gear.workspace = true
+sp-api = { workspace = true }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+pallet-gear = { workspace = true }
 
 [features]
 default = ["std"]

--- a/pallets/payment/Cargo.toml
+++ b/pallets/payment/Cargo.toml
@@ -3,7 +3,7 @@ name = "pallet-gear-payment"
 version = "0.1.0"
 authors = ['Gear Technologies']
 edition = '2021'
-license.workspace = true
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 description = "Gear main pallet"
@@ -15,28 +15,28 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 parity-scale-codec = { workspace = true, features = ["derive", "max-encoded-len"] }
 scale-info = { workspace = true, features = ["derive"] }
-log.workspace = true
+log = { workspace = true }
 parity-wasm = { workspace = true, optional = true }
 primitive-types = { workspace = true, features = ["scale-info"] }
 
 # Internal dependencies
-common.workspace = true
+common = { workspace = true }
 
 # Substrate deps
-frame-support.workspace = true
-frame-system.workspace = true
+frame-support = { workspace = true }
+frame-system = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
-sp-std.workspace = true
-sp-runtime.workspace = true
-pallet-authorship.workspace = true
-pallet-balances.workspace = true
-pallet-transaction-payment.workspace = true
+sp-std = { workspace = true }
+sp-runtime = { workspace = true }
+pallet-authorship = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-transaction-payment = { workspace = true }
 
 [dev-dependencies]
-serde.workspace = true
-env_logger.workspace = true
-wabt.workspace = true
-gear-core.workspace = true
+serde = { workspace = true }
+env_logger = { workspace = true }
+wabt = { workspace = true }
+gear-core = { workspace = true }
 sp-io = { workspace = true, features = ["std"] }
 frame-support-test = { workspace = true, features = ["std"] }
 pallet-timestamp = { workspace = true, features = ["std"] }

--- a/pallets/staking-rewards/Cargo.toml
+++ b/pallets/staking-rewards/Cargo.toml
@@ -3,7 +3,7 @@ name = "pallet-gear-staking-rewards"
 version = "1.0.0"
 authors = ['Gear Technologies']
 edition = '2021'
-license.workspace = true
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 description = "Gear tokenomics implementation"
@@ -16,18 +16,18 @@ targets = ["x86_64-unknown-linux-gnu"]
 parity-scale-codec = { workspace = true, features = ["derive"] }
 scale-info = { workspace = true, features = ["derive"] }
 primitive-types = { workspace = true, features = ["scale-info"] }
-log.workspace = true
-impl-trait-for-tuples.workspace = true
+log = { workspace = true }
+impl-trait-for-tuples = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 
 frame-support = { workspace = true }
-frame-system.workspace = true
+frame-system = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
-sp-std.workspace = true
-sp-runtime.workspace = true
-pallet-balances.workspace = true
-pallet-staking.workspace = true
-pallet-staking-reward-fn.workspace = true
+sp-std = { workspace = true }
+sp-runtime = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-staking = { workspace = true }
+pallet-staking-reward-fn = { workspace = true }
 
 [dev-dependencies]
 sp-core = { workspace = true, features = ["std"] }
@@ -42,7 +42,7 @@ pallet-sudo = { workspace = true, features = ["std"] }
 pallet-bags-list = { workspace = true, features = ["std"] }
 pallet-utility = { workspace = true, features = ["std"] }
 frame-executive = { workspace = true, features = ["std"] }
-env_logger.workspace = true
+env_logger = { workspace = true }
 
 [features]
 default = ["std"]

--- a/runtime-interface/Cargo.toml
+++ b/runtime-interface/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
 name = "gear-runtime-interface"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 description = "Gear Runtime Interface"
-edition.workspace = true
-license.workspace = true
+edition = { workspace = true }
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 
 [dependencies]
-gear-core.workspace = true
+gear-core = { workspace = true }
 gear-backend-common = { workspace = true }
 log = { workspace = true, optional = true }
-libc.workspace = true
-sp-runtime-interface.workspace = true
-sp-std.workspace = true
+libc = { workspace = true }
+sp-runtime-interface = { workspace = true }
+sp-std = { workspace = true }
 gear-lazy-pages = { workspace = true, optional = true }
 codec = { workspace = true }
-derive_more.workspace = true
-static_assertions.workspace = true
+derive_more = { workspace = true }
+static_assertions = { workspace = true }
 region = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "gear-runtime-common"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 
@@ -12,20 +12,20 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # Substrate deps
-frame-support.workspace = true
-frame-system.workspace = true
-pallet-authorship.workspace = true
-pallet-balances.workspace = true
-sp-runtime.workspace = true
-sp-std.workspace = true
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+pallet-authorship = { workspace = true }
+pallet-balances = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # Used for runtime benchmarking
 frame-benchmarking = { workspace = true, optional = true }
 frame-system-benchmarking = { workspace = true, optional = true }
 
 # Internal deps
-runtime-primitives.workspace = true
-gear-common.workspace = true
+runtime-primitives = { workspace = true }
+gear-common = { workspace = true }
 
 [features]
 default = ["std"]

--- a/runtime/gear/Cargo.toml
+++ b/runtime/gear/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "gear-runtime"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 build = "build.rs"
-license.workspace = true
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 
@@ -12,41 +12,41 @@ repository = "https://github.com/gear-tech/gear"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-log.workspace = true
-parity-scale-codec.workspace = true
+log = { workspace = true }
+parity-scale-codec = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }
 
-validator-set.workspace = true
+validator-set = { workspace = true }
 
 # Substrate deps
-frame-support.workspace = true
-frame-system.workspace = true
+frame-support = { workspace = true }
+frame-system = { workspace = true }
 frame-try-runtime = { workspace = true, optional = true }
-frame-executive.workspace = true
-pallet-authorship.workspace = true
-pallet-babe.workspace = true
-pallet-balances.workspace = true
-pallet-grandpa.workspace = true
-pallet-session.workspace = true
-pallet-sudo.workspace = true
-pallet-timestamp.workspace = true
-pallet-transaction-payment.workspace = true
-pallet-utility.workspace = true
-sp-api.workspace = true
-sp-block-builder.workspace = true
-sp-consensus-babe.workspace = true
-sp-core.workspace = true
-sp-inherents.workspace = true
-sp-offchain.workspace = true
-sp-runtime.workspace = true
-sp-session.workspace = true
-sp-std.workspace = true
-sp-transaction-pool.workspace = true
-sp-version.workspace = true
+frame-executive = { workspace = true }
+pallet-authorship = { workspace = true }
+pallet-babe = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-grandpa = { workspace = true }
+pallet-session = { workspace = true }
+pallet-sudo = { workspace = true }
+pallet-timestamp = { workspace = true }
+pallet-transaction-payment = { workspace = true }
+pallet-utility = { workspace = true }
+sp-api = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-consensus-babe = { workspace = true }
+sp-core = { workspace = true }
+sp-inherents = { workspace = true }
+sp-offchain = { workspace = true }
+sp-runtime = { workspace = true }
+sp-session = { workspace = true }
+sp-std = { workspace = true }
+sp-transaction-pool = { workspace = true }
+sp-version = { workspace = true }
 
 # Used for the node template's RPCs
-frame-system-rpc-runtime-api.workspace = true
-pallet-transaction-payment-rpc-runtime-api.workspace = true
+frame-system-rpc-runtime-api = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
 
 # Used for runtime benchmarking
 frame-benchmarking = { workspace = true, optional = true }
@@ -54,17 +54,17 @@ frame-system-benchmarking = { workspace = true, optional = true }
 hex-literal = { workspace = true, optional = true }
 
 # Internal deps
-common.workspace = true
-runtime-common.workspace = true
-pallet-gear-scheduler.workspace = true
-pallet-gear-messenger.workspace = true
-pallet-gear-program.workspace = true
-pallet-gear.workspace = true
+common = { workspace = true }
+runtime-common = { workspace = true }
+pallet-gear-scheduler = { workspace = true }
+pallet-gear-messenger = { workspace = true }
+pallet-gear-program = { workspace = true }
+pallet-gear = { workspace = true }
 pallet-gear-debug = { workspace = true, optional = true }
-pallet-gear-gas.workspace = true
-pallet-gear-payment.workspace = true
-pallet-gear-rpc-runtime-api.workspace = true
-runtime-primitives.workspace = true
+pallet-gear-gas = { workspace = true }
+pallet-gear-payment = { workspace = true }
+pallet-gear-rpc-runtime-api = { workspace = true }
+runtime-primitives = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { workspace = true, optional = true }

--- a/runtime/primitives/Cargo.toml
+++ b/runtime/primitives/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "gear-runtime-primitives"
 version = "0.1.0"
-authors.workspace = true
+authors = { workspace = true }
 description = "Gear Runtime primitives"
-edition.workspace = true
-license.workspace = true
+edition = { workspace = true }
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 
@@ -12,8 +12,8 @@ repository = "https://github.com/gear-tech/gear"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-core.workspace = true
-sp-runtime.workspace = true
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]

--- a/runtime/vara/Cargo.toml
+++ b/runtime/vara/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "vara-runtime"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 build = "build.rs"
-license.workspace = true
+license = { workspace = true }
 homepage = "https://gear-tech.io"
 repository = "https://github.com/gear-tech/gear"
 
@@ -12,63 +12,63 @@ repository = "https://github.com/gear-tech/gear"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-log.workspace = true
-parity-scale-codec.workspace = true
+log = { workspace = true }
+parity-scale-codec = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }
-static_assertions.workspace = true
+static_assertions = { workspace = true }
 
 # Frame deps
-frame-support.workspace = true
-frame-system.workspace = true
+frame-support = { workspace = true }
+frame-system = { workspace = true }
 frame-try-runtime = { workspace = true, optional = true }
-frame-election-provider-support.workspace = true
-frame-executive.workspace = true
+frame-election-provider-support = { workspace = true }
+frame-executive = { workspace = true }
 
 # Substrate pallet deps
-pallet-authority-discovery.workspace = true
-pallet-authorship.workspace = true
-pallet-babe.workspace = true
-pallet-bags-list.workspace = true
-pallet-balances.workspace = true
-pallet-conviction-voting.workspace = true
-pallet-election-provider-multi-phase.workspace = true
-pallet-grandpa.workspace = true
-pallet-identity.workspace = true
-pallet-im-online.workspace = true
-pallet-preimage.workspace = true
-pallet-ranked-collective.workspace = true
-pallet-referenda.workspace = true
-pallet-scheduler.workspace = true
+pallet-authority-discovery = { workspace = true }
+pallet-authorship = { workspace = true }
+pallet-babe = { workspace = true }
+pallet-bags-list = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-conviction-voting = { workspace = true }
+pallet-election-provider-multi-phase = { workspace = true }
+pallet-grandpa = { workspace = true }
+pallet-identity = { workspace = true }
+pallet-im-online = { workspace = true }
+pallet-preimage = { workspace = true }
+pallet-ranked-collective = { workspace = true }
+pallet-referenda = { workspace = true }
+pallet-scheduler = { workspace = true }
 pallet-session = { workspace = true, features = [ "historical" ] }
-pallet-staking.workspace = true
-pallet-sudo.workspace = true
-pallet-timestamp.workspace = true
-pallet-transaction-payment.workspace = true
-pallet-treasury.workspace = true
-pallet-utility.workspace = true
-pallet-vesting.workspace = true
-pallet-whitelist.workspace = true
+pallet-staking = { workspace = true }
+pallet-sudo = { workspace = true }
+pallet-timestamp = { workspace = true }
+pallet-transaction-payment = { workspace = true }
+pallet-treasury = { workspace = true }
+pallet-utility = { workspace = true }
+pallet-vesting = { workspace = true }
+pallet-whitelist = { workspace = true }
 
 # Primitives
-sp-arithmetic.workspace = true
-sp-api.workspace = true
-sp-authority-discovery.workspace = true
-sp-block-builder.workspace = true
-sp-consensus-babe.workspace = true
-sp-core.workspace = true
-sp-inherents.workspace = true
-sp-npos-elections.workspace = true
-sp-offchain.workspace = true
-sp-runtime.workspace = true
-sp-session.workspace = true
-sp-staking.workspace = true
-sp-std.workspace = true
-sp-transaction-pool.workspace = true
-sp-version.workspace = true
+sp-arithmetic = { workspace = true }
+sp-api = { workspace = true }
+sp-authority-discovery = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-consensus-babe = { workspace = true }
+sp-core = { workspace = true }
+sp-inherents = { workspace = true }
+sp-npos-elections = { workspace = true }
+sp-offchain = { workspace = true }
+sp-runtime = { workspace = true }
+sp-session = { workspace = true }
+sp-staking = { workspace = true }
+sp-std = { workspace = true }
+sp-transaction-pool = { workspace = true }
+sp-version = { workspace = true }
 
 # Used for the node template's RPCs
-frame-system-rpc-runtime-api.workspace = true
-pallet-transaction-payment-rpc-runtime-api.workspace = true
+frame-system-rpc-runtime-api = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
 
 # Used for runtime benchmarking
 frame-benchmarking = { workspace = true, optional = true }
@@ -76,28 +76,28 @@ frame-system-benchmarking = { workspace = true, optional = true }
 hex-literal = { workspace = true, optional = true }
 
 # Internal deps
-common.workspace = true
-runtime-common.workspace = true
-pallet-gear-scheduler.workspace = true
-pallet-gear-messenger.workspace = true
-pallet-gear-program.workspace = true
-pallet-gear.workspace = true
+common = { workspace = true }
+runtime-common = { workspace = true }
+pallet-gear-scheduler = { workspace = true }
+pallet-gear-messenger = { workspace = true }
+pallet-gear-program = { workspace = true }
+pallet-gear = { workspace = true }
 pallet-gear-debug = { workspace = true, optional = true }
-pallet-gear-gas.workspace = true
-pallet-gear-payment.workspace = true
-pallet-gear-staking-rewards.workspace = true
-pallet-gear-rpc-runtime-api.workspace = true
-runtime-primitives.workspace = true
-pallet-airdrop.workspace = true
+pallet-gear-gas = { workspace = true }
+pallet-gear-payment = { workspace = true }
+pallet-gear-staking-rewards = { workspace = true }
+pallet-gear-rpc-runtime-api = { workspace = true }
+runtime-primitives = { workspace = true }
+pallet-airdrop = { workspace = true }
 
 # Authority add/remove
-validator-set.workspace = true
+validator-set = { workspace = true }
 
 [dev-dependencies]
-sp-io.workspace = true
-sp-keyring.workspace = true
-env_logger.workspace = true
-wat.workspace = true
+sp-io = { workspace = true }
+sp-keyring = { workspace = true }
+env_logger = { workspace = true }
+wat = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { workspace = true, optional = true }

--- a/utils/bags-thresholds/Cargo.toml
+++ b/utils/bags-thresholds/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "gear-bags-thresholds"
 version = "1.0.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-vara-runtime.workspace = true
-generate-bags.workspace = true
+vara-runtime = { workspace = true }
+generate-bags = { workspace = true }
 
 # third-party
 clap = { workspace = true, features = ["derive"] }

--- a/utils/call-gen/Cargo.toml
+++ b/utils/call-gen/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "gear-call-gen"
 version = "0.1.0"
-edition.workspace = true
+edition = { workspace = true }
 
 [dependencies]
 # Internal deps
-gear-wasm-gen.workspace = true
-gear-core.workspace = true
-gear-utils.workspace = true
+gear-wasm-gen = { workspace = true }
+gear-core = { workspace = true }
+gear-utils = { workspace = true }
 
 # External deps
-arbitrary.workspace = true
-dyn-clonable.workspace = true
-hex.workspace = true
-log.workspace = true
-rand.workspace = true
-thiserror.workspace = true
+arbitrary = { workspace = true }
+dyn-clonable = { workspace = true }
+hex = { workspace = true }
+log = { workspace = true }
+rand = { workspace = true }
+thiserror = { workspace = true }

--- a/utils/gear-runtime-test-cli/Cargo.toml
+++ b/utils/gear-runtime-test-cli/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
 name = "gear-runtime-test-cli"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-anyhow.workspace = true
+anyhow = { workspace = true }
 codec = { workspace = true, features = ["derive"] }
-colored.workspace = true
+colored = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-log.workspace = true
-serde_json.workspace = true
+log = { workspace = true }
+serde_json = { workspace = true }
 quick-xml = { workspace = true, features = [ "serialize" ] }
-rayon.workspace = true
+rayon = { workspace = true }
 
 # Substrate
 frame-support = { workspace = true, features = ["std"] }
 frame-system = { workspace = true, features = ["std"] }
-sc-cli.workspace = true
-sc-service.workspace = true
+sc-cli = { workspace = true }
+sc-service = { workspace = true }
 sp-authority-discovery = { workspace = true, optional = true, features = ["std"]  }
 sp-core = { workspace = true, features = ["std"] }
 sp-io = { workspace = true, features = ["std"] }
@@ -34,16 +34,16 @@ pallet-im-online = { workspace = true, optional = true, features = ["std"]  }
 # Gear
 runtime-primitives = { workspace = true, features = ["std"] }
 gear-common = { workspace = true, features = ["std"] }
-gear-core.workspace = true
+gear-core = { workspace = true }
 gear-runtime = { workspace = true, optional = true, features = ["debug-mode", "std"] }
 vara-runtime = { workspace = true, optional = true, features = ["debug-mode", "std"] }
-gear-test.workspace = true
+gear-test = { workspace = true }
 pallet-gear = { workspace = true, features = ["std"] }
 pallet-gear-gas = { workspace = true, features = ["std"] }
 pallet-gear-messenger = { workspace = true, features = ["std"] }
 pallet-gear-debug = { workspace = true, features = ["std"] }
-gear-core-processor.workspace = true
-junit-common.workspace = true
+gear-core-processor = { workspace = true }
+junit-common = { workspace = true }
 
 [features]
 gear-native = ["gear-runtime"]

--- a/utils/junit-common/Cargo.toml
+++ b/utils/junit-common/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "junit-common"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/utils/node-loader/Cargo.toml
+++ b/utils/node-loader/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "gear-node-loader"
 version = "0.1.6"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 
 [[bin]]
 name = "gear-node-loader"
@@ -10,27 +10,27 @@ path = "src/main.rs"
 
 [dependencies]
 # internal dependencies
-gear-call-gen.workspace = true
-gclient.workspace = true
-gear-core.workspace = true
-gear-utils.workspace = true
+gear-call-gen = { workspace = true }
+gclient = { workspace = true }
+gear-core = { workspace = true }
+gear-utils = { workspace = true }
 
 # external dependencies
-anyhow.workspace = true
-arbitrary.workspace = true
+anyhow = { workspace = true }
+arbitrary = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-dyn-clonable.workspace = true
-futures.workspace = true
-futures-timer.workspace = true
-hex.workspace = true
+dyn-clonable = { workspace = true }
+futures = { workspace = true }
+futures-timer = { workspace = true }
+hex = { workspace = true }
 names = "0.14.0"
-once_cell.workspace = true
-parking_lot.workspace = true
+once_cell = { workspace = true }
+parking_lot = { workspace = true }
 primitive-types = { workspace = true, features = ["scale-info"] }
 rand = { workspace = true, features = ["small_rng"] }
-reqwest.workspace = true
-thiserror.workspace = true
+reqwest = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = [ "macros", "rt-multi-thread" ] }
-tracing.workspace = true
-tracing-appender.workspace = true
+tracing = { workspace = true }
+tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = [ "env-filter", "json" ] }

--- a/utils/regression-analysis/Cargo.toml
+++ b/utils/regression-analysis/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "regression-analysis"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 quick-xml = { workspace = true, features = [ "serialize" ] }
-tabled.workspace = true
-junit-common.workspace = true
+tabled = { workspace = true }
+junit-common = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json.workspace = true
-thousands.workspace = true
+serde_json = { workspace = true }
+thousands = { workspace = true }
 
-gear-runtime.workspace = true
-pallet-gear.workspace = true
-frame-support.workspace = true
+gear-runtime = { workspace = true }
+pallet-gear = { workspace = true }
+frame-support = { workspace = true }

--- a/utils/runtime-fuzzer/Cargo.toml
+++ b/utils/runtime-fuzzer/Cargo.toml
@@ -1,38 +1,38 @@
 [package]
 name = "runtime-fuzzer"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
-anyhow.workspace = true
-arbitrary.workspace = true
+anyhow = { workspace = true }
+arbitrary = { workspace = true }
 codec = { workspace = true, features = ["derive"] }
-hex.workspace = true
-log.workspace = true
-once_cell.workspace = true
-parking_lot.workspace = true
+hex = { workspace = true }
+log = { workspace = true }
+once_cell = { workspace = true }
+parking_lot = { workspace = true }
 rand = { workspace = true, features = ["small_rng"] }
 
 # Temporary deps for the reproducing crash script until #2313 is implemented
 clap = { workspace = true, features = ["derive"] }
 
-gear-call-gen.workspace = true
-runtime-primitives.workspace = true
-gear-common.workspace = true
-gear-core.workspace = true
-gear-utils.workspace = true
+gear-call-gen = { workspace = true }
+runtime-primitives = { workspace = true }
+gear-common = { workspace = true }
+gear-core = { workspace = true }
+gear-utils = { workspace = true }
 gear-runtime = { workspace = true, features = ["std", "fuzz", "lazy-pages"] }
-pallet-gear.workspace = true
+pallet-gear = { workspace = true }
 
-frame-support.workspace = true
-frame-system.workspace = true
-sp-core.workspace = true
-sp-io.workspace = true
-sp-keyring.workspace = true
-sp-runtime.workspace = true
-pallet-balances.workspace = true
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-keyring = { workspace = true }
+sp-runtime = { workspace = true }
+pallet-balances = { workspace = true }
 sp-consensus-slots = { workspace = true }
-sp-consensus-babe.workspace = true
-sp-consensus-grandpa.workspace = true
-pallet-authorship.workspace = true
+sp-consensus-babe = { workspace = true }
+sp-consensus-grandpa = { workspace = true }
+pallet-authorship = { workspace = true }

--- a/utils/runtime-fuzzer/fuzz/Cargo.toml
+++ b/utils/runtime-fuzzer/fuzz/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "runtime-fuzzer-fuzz"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
 
 [package.metadata]
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys.workspace = true
+libfuzzer-sys = { workspace = true }
 runtime-fuzzer = { path = ".." }
-gear-utils.workspace = true
-env_logger.workspace = true
-log.workspace = true
-once_cell.workspace = true
+gear-utils = { workspace = true }
+env_logger = { workspace = true }
+log = { workspace = true }
+once_cell = { workspace = true }
 
 [[bin]]
 name = "main"

--- a/utils/utils/Cargo.toml
+++ b/utils/utils/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "gear-utils"
 version = "0.1.0"
-edition.workspace = true
+edition = { workspace = true }
 
 [dependencies]
-nonempty.workspace = true
-env_logger.workspace = true
+nonempty = { workspace = true }
+env_logger = { workspace = true }

--- a/utils/validator-checks/Cargo.toml
+++ b/utils/validator-checks/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "gear-validator-checks"
 version = "0.1.0"
-edition.workspace = true
+edition = { workspace = true }
 
 [[bin]]
 name = "validator-checks"
 path = "bin/validator-checks.rs"
 
 [dependencies]
-gsdk.workspace = true
+gsdk = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-subxt.workspace = true
-thiserror.workspace = true
-futures-util.workspace = true
-log.workspace = true
-env_logger.workspace = true
+subxt = { workspace = true }
+thiserror = { workspace = true }
+futures-util = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }
 tokio = { workspace = true, features = [ "full" ] }
-parity-scale-codec.workspace = true
-sp-consensus-babe.workspace = true
+parity-scale-codec = { workspace = true }
+sp-consensus-babe = { workspace = true }

--- a/utils/wasm-builder/Cargo.toml
+++ b/utils/wasm-builder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gear-wasm-builder"
 version = "0.1.2"
-edition.workspace = true
+edition = { workspace = true }
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 description = "Utility for building Gear programs"
 include = ["src/**/*", "Cargo.toml", "README.md"]
@@ -9,24 +9,24 @@ repository = "https://github.com/gear-tech/gear"
 readme = "README.md"
 
 [dependencies]
-anyhow.workspace = true
-cargo_metadata.workspace = true
+anyhow = { workspace = true }
+cargo_metadata = { workspace = true }
 pwasm-utils = { workspace = true, features = ["sign_ext"] }
-toml.workspace = true
-thiserror.workspace = true
-log.workspace = true
-pathdiff.workspace = true
-which.workspace = true
-colored.workspace = true
-gmeta.workspace = true
-gear-wasm-instrument.workspace = true
+toml = { workspace = true }
+thiserror = { workspace = true }
+log = { workspace = true }
+pathdiff = { workspace = true }
+which = { workspace = true }
+colored = { workspace = true }
+gmeta = { workspace = true }
+gear-wasm-instrument = { workspace = true }
 wasm-opt = { workspace = true, optional = true }
-wasmparser.workspace = true
-regex.workspace = true
+wasmparser = { workspace = true }
+regex = { workspace = true }
 filetime = "0.2"
 
 [dev-dependencies]
-wabt.workspace = true
+wabt = { workspace = true }
 
 [features]
 metawasm = ["gmeta/codegen"]

--- a/utils/wasm-gen/Cargo.toml
+++ b/utils/wasm-gen/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "gear-wasm-gen"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-wasm-smith.workspace = true
+wasm-smith = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }
-gear-wasm-instrument.workspace = true
-wasmprinter.workspace = true
-gsys.workspace = true
+gear-wasm-instrument = { workspace = true }
+wasmprinter = { workspace = true }
+gsys = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true, features = ["small_rng"] }
-wasmparser.workspace = true
-wat.workspace = true
-indicatif.workspace = true
-proptest.workspace = true
+wasmparser = { workspace = true }
+wat = { workspace = true }
+indicatif = { workspace = true }
+proptest = { workspace = true }

--- a/utils/wasm-info/Cargo.toml
+++ b/utils/wasm-info/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "wasm-info"
 version = "0.1.0"
-edition.workspace = true
+edition = { workspace = true }
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 hex = { workspace = true, features = ["std"] }
-parity-wasm.workspace = true
+parity-wasm = { workspace = true }

--- a/utils/wasm-instrument/Cargo.toml
+++ b/utils/wasm-instrument/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "gear-wasm-instrument"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 wasm-instrument = { workspace = true, features = ["sign_ext"] }
-enum-iterator.workspace = true
+enum-iterator = { workspace = true }
 
 [dev-dependencies]
-wasmparser.workspace = true
-wat.workspace = true
-gear-backend-wasmi.workspace = true
+wasmparser = { workspace = true }
+wat = { workspace = true }
+gear-backend-wasmi = { workspace = true }
 gear-backend-common = { workspace = true, features = ["mock"] }
-gear-core.workspace = true
+gear-core = { workspace = true }
 
 [features]
 default = ["std"]

--- a/utils/wasm-proc/Cargo.toml
+++ b/utils/wasm-proc/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "wasm-proc"
 version = "0.1.0"
-edition.workspace = true
+edition = { workspace = true }
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
-log.workspace = true
-env_logger.workspace = true
-thiserror.workspace = true
-gear-wasm-builder.workspace = true
-parity-wasm.workspace = true
+log = { workspace = true }
+env_logger = { workspace = true }
+thiserror = { workspace = true }
+gear-wasm-builder = { workspace = true }
+parity-wasm = { workspace = true }
 
 [features]
 default = ["wasm-opt"]


### PR DESCRIPTION
Resolves # .

```toml
xx.workspace -> xx = { workspace = true }
```

new disscussions about the toml style stuff https://github.com/gear-tech/gear/pull/2643#discussion_r1190871879

the previous one https://github.com/gear-tech/gear/pull/2427#discussion_r1151730537

plz share your options here if you like the short style @gear-tech/dev 

### refs

- https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace
