### PR TITLE
feat(gear,vara): Add proxy and multisig pallets to both vara and gear runtimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3848,6 +3848,8 @@ dependencies = [
  "pallet-gear-rpc-runtime-api",
  "pallet-gear-scheduler",
  "pallet-grandpa",
+ "pallet-multisig",
+ "pallet-proxy",
  "pallet-session",
  "pallet-sudo",
  "pallet-timestamp",
@@ -7302,6 +7304,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-multisig"
+version = "4.0.0-dev"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-polkadot-v0.9.41-canary#34efda72d128b336f3afd72d70098deccd79c6c2"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 5.0.0",
+]
+
+[[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
 source = "git+https://github.com/gear-tech/substrate.git?branch=gear-polkadot-v0.9.41-canary#34efda72d128b336f3afd72d70098deccd79c6c2"
@@ -7313,6 +7331,21 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 5.0.0",
+]
+
+[[package]]
+name = "pallet-proxy"
+version = "4.0.0-dev"
+source = "git+https://github.com/gear-tech/substrate.git?branch=gear-polkadot-v0.9.41-canary#34efda72d128b336f3afd72d70098deccd79c6c2"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
  "sp-io",
  "sp-runtime",
  "sp-std 5.0.0",
@@ -12525,7 +12558,9 @@ dependencies = [
  "pallet-grandpa",
  "pallet-identity",
  "pallet-im-online",
+ "pallet-multisig",
  "pallet-preimage",
+ "pallet-proxy",
  "pallet-ranked-collective",
  "pallet-referenda",
  "pallet-scheduler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,7 +232,9 @@ pallet-election-provider-multi-phase = { version = "4.0.0-dev", git = "https://g
 pallet-grandpa = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.41-canary", default-features = false }
 pallet-identity = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.41-canary", default-features = false }
 pallet-im-online = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.41-canary", default-features = false }
+pallet-multisig = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.41-canary", default-features = false }
 pallet-preimage = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.41-canary", default-features = false }
+pallet-proxy = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.41-canary", default-features = false }
 pallet-ranked-collective = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.41-canary", default-features = false }
 pallet-referenda = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.41-canary", default-features = false }
 pallet-scheduler = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.41-canary", default-features = false }

--- a/runtime/gear/Cargo.toml
+++ b/runtime/gear/Cargo.toml
@@ -27,6 +27,8 @@ pallet-authorship.workspace = true
 pallet-babe.workspace = true
 pallet-balances.workspace = true
 pallet-grandpa.workspace = true
+pallet-multisig.workspace = true
+pallet-proxy.workspace = true
 pallet-session.workspace = true
 pallet-sudo.workspace = true
 pallet-timestamp.workspace = true
@@ -93,6 +95,8 @@ std = [
 	"runtime-primitives/std",
 	"validator-set/std",
 	"pallet-grandpa/std",
+	"pallet-multisig/std",
+	"pallet-proxy/std",
 	"pallet-session/std",
 	"pallet-sudo/std",
 	"pallet-timestamp/std",
@@ -150,6 +154,8 @@ try-runtime = [
 	"pallet-babe/try-runtime",
 	"pallet-balances/try-runtime",
 	"pallet-grandpa/try-runtime",
+	"pallet-multisig/try-runtime",
+	"pallet-proxy/try-runtime",
 	"pallet-session/try-runtime",
 	"pallet-sudo/try-runtime",
 	"pallet-timestamp/try-runtime",

--- a/runtime/gear/src/constants.rs
+++ b/runtime/gear/src/constants.rs
@@ -22,6 +22,11 @@ pub mod currency {
 
     /// The existential deposit.
     pub const EXISTENTIAL_DEPOSIT: Balance = 500;
+
+    // TODO: the actual numbers, if matter, are subject to review
+    pub const fn deposit(items: u32, bytes: u32) -> Balance {
+        items as Balance * 150 + (bytes as Balance) * 60
+    }
 }
 
 /// Time and block constants

--- a/runtime/gear/src/constants.rs
+++ b/runtime/gear/src/constants.rs
@@ -23,7 +23,7 @@ pub mod currency {
     /// The existential deposit.
     pub const EXISTENTIAL_DEPOSIT: Balance = 500;
 
-    // TODO: the actual numbers, if matter, are subject to review
+    // TODO: the actual numbers, if matter, are subject to review (#2655)
     pub const fn deposit(items: u32, bytes: u32) -> Balance {
         items as Balance * 150 + (bytes as Balance) * 60
     }

--- a/runtime/vara/Cargo.toml
+++ b/runtime/vara/Cargo.toml
@@ -35,7 +35,9 @@ pallet-election-provider-multi-phase.workspace = true
 pallet-grandpa.workspace = true
 pallet-identity.workspace = true
 pallet-im-online.workspace = true
+pallet-multisig.workspace = true
 pallet-preimage.workspace = true
+pallet-proxy.workspace = true
 pallet-ranked-collective.workspace = true
 pallet-referenda.workspace = true
 pallet-scheduler.workspace = true
@@ -134,7 +136,9 @@ std = [
 	"pallet-grandpa/std",
 	"pallet-identity/std",
 	"pallet-im-online/std",
+	"pallet-multisig/std",
 	"pallet-preimage/std",
+	"pallet-proxy/std",
 	"pallet-ranked-collective/std",
 	"pallet-referenda/std",
 	"pallet-session/std",
@@ -214,7 +218,9 @@ try-runtime = [
 	"pallet-grandpa/try-runtime",
 	"pallet-identity/try-runtime",
 	"pallet-im-online/try-runtime",
+	"pallet-multisig/try-runtime",
 	"pallet-preimage/try-runtime",
+	"pallet-proxy/try-runtime",
 	"pallet-ranked-collective/try-runtime",
 	"pallet-referenda/try-runtime",
 	"pallet-scheduler/try-runtime",

--- a/runtime/vara/src/constants.rs
+++ b/runtime/vara/src/constants.rs
@@ -29,8 +29,10 @@ pub mod currency {
     pub const CENTS: Balance = DOLLARS / 100; // 200_000_000_000
     pub const MILLICENTS: Balance = CENTS / 1_000; // 200_000_000
 
-    /// Function that defines runtime constants used in voting
+    /// Helper function to calculate various deposits for using pallets' storage
     pub const fn deposit(items: u32, bytes: u32) -> Balance {
+        // TODO: review numbers. Current values are defaults from Substrate. For reference,
+        // in Polkadot/Kusama it's 20 * `DOLLARS` per item and 100 * `MILLICENTS` per byte.
         items as Balance * 15 * CENTS + (bytes as Balance) * 6 * CENTS
     }
 }

--- a/runtime/vara/src/constants.rs
+++ b/runtime/vara/src/constants.rs
@@ -31,8 +31,7 @@ pub mod currency {
 
     /// Helper function to calculate various deposits for using pallets' storage
     pub const fn deposit(items: u32, bytes: u32) -> Balance {
-        // TODO: review numbers. Current values are defaults from Substrate. For reference,
-        // in Polkadot/Kusama it's 20 * `DOLLARS` per item and 100 * `MILLICENTS` per byte.
+        // TODO: review numbers (#2650)
         items as Balance * 15 * CENTS + (bytes as Balance) * 6 * CENTS
     }
 }

--- a/runtime/vara/src/extensions/mod.rs
+++ b/runtime/vara/src/extensions/mod.rs
@@ -63,6 +63,10 @@ impl Contains<RuntimeCall> for ValueTransferCallFilter {
                 }
                 false
             }
+            RuntimeCall::Proxy(pallet_proxy::Call::proxy { call, .. })
+            | RuntimeCall::Proxy(pallet_proxy::Call::proxy_announced { call, .. }) => {
+                Self::contains(call)
+            }
             _ => false,
         }
     }

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -27,14 +27,15 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 use frame_election_provider_support::{onchain, SequentialPhragmen};
 use frame_support::weights::ConstantMultiplier;
 pub use frame_support::{
-    codec::Encode,
+    codec::{Decode, Encode, MaxEncodedLen},
     construct_runtime,
     dispatch::{DispatchClass, WeighData},
     parameter_types,
     traits::{
         ConstU128, ConstU16, ConstU32, Contains, Currency, EitherOf, EitherOfDiverse,
-        EqualPrivilegeOnly, Everything, FindAuthor, KeyOwnerProofSystem, LockIdentifier, Nothing,
-        OnUnbalanced, Randomness, StorageInfo, U128CurrencyToVote, WithdrawReasons,
+        EqualPrivilegeOnly, Everything, FindAuthor, InstanceFilter, KeyOwnerProofSystem,
+        LockIdentifier, Nothing, OnUnbalanced, Randomness, StorageInfo, U128CurrencyToVote,
+        WithdrawReasons,
     },
     weights::{
         constants::{
@@ -43,7 +44,7 @@ pub use frame_support::{
         },
         Weight,
     },
-    PalletId, StorageValue,
+    PalletId, RuntimeDebug, StorageValue,
 };
 use frame_system::{
     limits::{BlockLength, BlockWeights},
@@ -392,6 +393,10 @@ impl Contains<RuntimeCall> for BondCallFilter {
                 }
                 false
             }
+            RuntimeCall::Proxy(pallet_proxy::Call::proxy { call, .. })
+            | RuntimeCall::Proxy(pallet_proxy::Call::proxy_announced { call, .. }) => {
+                Self::contains(call)
+            }
             _ => false,
         }
     }
@@ -604,6 +609,121 @@ impl pallet_utility::Config for Runtime {
     type PalletsOrigin = OriginCaller;
 }
 
+parameter_types! {
+    // One storage item; key size is 32; value is size 4+4+16+32 bytes = 56 bytes.
+    pub const DepositBase: Balance = deposit(1, 88);
+    // Additional storage item size of 32 bytes.
+    pub const DepositFactor: Balance = deposit(0, 32);
+}
+
+impl pallet_multisig::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeCall = RuntimeCall;
+    type Currency = Balances;
+    type DepositBase = DepositBase;
+    type DepositFactor = DepositFactor;
+    type MaxSignatories = ConstU32<100>;
+    type WeightInfo = pallet_multisig::weights::SubstrateWeight<Runtime>;
+}
+
+parameter_types! {
+    // One storage item; key size 32, value size 8; .
+    pub const ProxyDepositBase: Balance = deposit(1, 8);
+    // Additional storage item size of 33 bytes.
+    pub const ProxyDepositFactor: Balance = deposit(0, 33);
+    pub const AnnouncementDepositBase: Balance = deposit(1, 8);
+    pub const AnnouncementDepositFactor: Balance = deposit(0, 66);
+}
+
+/// The type used to represent the kinds of proxying allowed.
+#[derive(
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Encode,
+    Decode,
+    RuntimeDebug,
+    MaxEncodedLen,
+    scale_info::TypeInfo,
+)]
+pub enum ProxyType {
+    Any,
+    NonTransfer,
+    Governance,
+    Staking,
+    IdentityJudgement,
+    CancelProxy,
+}
+
+impl Default for ProxyType {
+    fn default() -> Self {
+        Self::Any
+    }
+}
+
+impl InstanceFilter<RuntimeCall> for ProxyType {
+    fn filter(&self, c: &RuntimeCall) -> bool {
+        match self {
+            ProxyType::Any => true,
+            ProxyType::NonTransfer => !matches!(
+                c,
+                RuntimeCall::Balances(..)
+                    | RuntimeCall::Sudo(..)
+                    | RuntimeCall::Vesting(pallet_vesting::Call::vested_transfer { .. })
+                    | RuntimeCall::Vesting(pallet_vesting::Call::force_vested_transfer { .. })
+            ),
+            ProxyType::Governance => matches!(
+                c,
+                RuntimeCall::Treasury(..)
+                    | RuntimeCall::ConvictionVoting(..)
+                    | RuntimeCall::Referenda(..)
+                    | RuntimeCall::FellowshipCollective(..)
+                    | RuntimeCall::FellowshipReferenda(..)
+                    | RuntimeCall::Whitelist(..)
+            ),
+            ProxyType::Staking => matches!(c, RuntimeCall::Staking(..)),
+            ProxyType::IdentityJudgement => matches!(
+                c,
+                RuntimeCall::Identity(pallet_identity::Call::provide_judgement { .. })
+                    | RuntimeCall::Utility(..)
+            ),
+            ProxyType::CancelProxy => {
+                matches!(
+                    c,
+                    RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. })
+                )
+            }
+        }
+    }
+    fn is_superset(&self, o: &Self) -> bool {
+        match (self, o) {
+            (x, y) if x == y => true,
+            (ProxyType::Any, _) => true,
+            (_, ProxyType::Any) => false,
+            (ProxyType::NonTransfer, _) => true,
+            _ => false,
+        }
+    }
+}
+
+impl pallet_proxy::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeCall = RuntimeCall;
+    type Currency = Balances;
+    type ProxyType = ProxyType;
+    type ProxyDepositBase = ProxyDepositBase;
+    type ProxyDepositFactor = ProxyDepositFactor;
+    type MaxProxies = ConstU32<32>;
+    type WeightInfo = pallet_proxy::weights::SubstrateWeight<Runtime>;
+    type MaxPending = ConstU32<32>;
+    type CallHasher = BlakeTwo256;
+    type AnnouncementDepositBase = AnnouncementDepositBase;
+    type AnnouncementDepositFactor = AnnouncementDepositFactor;
+}
+
 impl pallet_gear_program::Config for Runtime {
     type Scheduler = GearScheduler;
     type CurrentBlockNumber = Gear;
@@ -774,6 +894,8 @@ construct_runtime!(
         Scheduler: pallet_scheduler = 22,
         Preimage: pallet_preimage = 23,
         Identity: pallet_identity = 24,
+        Proxy: pallet_proxy = 25,
+        Multisig: pallet_multisig = 26,
         Utility: pallet_utility = 8,
         GearProgram: pallet_gear_program = 100,
         GearMessenger: pallet_gear_messenger = 101,
@@ -829,6 +951,8 @@ construct_runtime!(
         Scheduler: pallet_scheduler = 22,
         Preimage: pallet_preimage = 23,
         Identity: pallet_identity = 24,
+        Proxy: pallet_proxy = 25,
+        Multisig: pallet_multisig = 26,
         Utility: pallet_utility = 8,
         GearProgram: pallet_gear_program = 100,
         GearMessenger: pallet_gear_messenger = 101,


### PR DESCRIPTION
Add two pallets to both runtimes:
- pallet-proxy
- pallet-multisig.

The `pallet-proxy` in `Gear` runtime lacks proxy types for governance, staking etc. On the other hand, it has the `SudoBalances` instance filter for the `ProxyType` there that doesn't make much sense in `Vara` (hence not included).

The runtime constants are still subject to review and can be changed at later time if necessary.