### PR TITLE
refactor(runtime): move heuristics from `gear` & `vara` runtimes to `runtime-common`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3873,10 +3873,13 @@ dependencies = [
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
+ "gear-backend-common",
  "gear-common",
+ "gear-core-processor",
  "gear-runtime-primitives",
  "pallet-authorship",
  "pallet-balances",
+ "pallet-gear",
  "sp-runtime",
  "sp-std 5.0.0",
 ]

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -26,6 +26,9 @@ frame-system-benchmarking = { workspace = true, optional = true }
 # Internal deps
 runtime-primitives.workspace = true
 gear-common.workspace = true
+gear-backend-common.workspace = true
+gear-core-processor.workspace = true
+pallet-gear.workspace = true
 
 [features]
 default = ["std"]
@@ -47,7 +50,4 @@ runtime-benchmarks = [
 	"pallet-balances/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 ]
-try-runtime = [
-	"frame-system/try-runtime",
-	"pallet-balances/try-runtime",
-]
+try-runtime = ["frame-system/try-runtime", "pallet-balances/try-runtime"]

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -20,6 +20,7 @@
 
 mod apis;
 pub mod constants;
+pub mod weights;
 
 use frame_support::{
     pallet_prelude::DispatchClass,

--- a/runtime/common/src/weights.rs
+++ b/runtime/common/src/weights.rs
@@ -2,8 +2,8 @@ use gear_backend_common::lazy_pages::LazyPagesWeights;
 use gear_core_processor::configs::PageCosts;
 use pallet_gear::InstructionWeights;
 
-const INSTRUCTIONS_SPREAD: u64 = 50;
-const PAGES_SPREAD: u64 = 10;
+const INSTRUCTIONS_SPREAD: u8 = 50;
+const PAGES_SPREAD: u8 = 10;
 
 #[track_caller]
 fn check_spreading(weight: u64, expected: u64, spread: u8) {

--- a/runtime/common/src/weights.rs
+++ b/runtime/common/src/weights.rs
@@ -1,0 +1,203 @@
+use gear_backend_common::lazy_pages::LazyPagesWeights;
+use gear_core_processor::configs::PageCosts;
+use pallet_gear::InstructionWeights;
+
+const INSTRUCTIONS_SPREAD: u64 = 50;
+const PAGES_SPREAD: u64 = 10;
+
+#[track_caller]
+fn check_spreading(weight: u64, expected: u64, spread: u8) {
+    let left = expected - expected * spread as u64 / 100;
+    let right = expected + expected * spread as u64 / 100;
+
+    assert!(
+        left <= weight && weight <= right,
+        "Weight is {weight} ps. Expected weight is {expected} ps. {spread}% spread interval: [{left} ps, {right} ps]"
+    );
+}
+
+#[track_caller]
+fn check_instruction_weight(weight: u32, expected: u32) {
+    check_spreading(weight.into(), expected.into(), INSTRUCTIONS_SPREAD);
+}
+
+#[track_caller]
+fn check_pages_weight(weight: u64, expected: u64) {
+    check_spreading(weight, expected, PAGES_SPREAD);
+}
+
+/// Check that the weights of instructions are within the expected range
+#[track_caller]
+pub fn check_instructions_weights<T: pallet_gear::Config>(
+    weights: InstructionWeights<T>,
+    expected: InstructionWeights<T>,
+) {
+    check_instruction_weight(weights.i64const, expected.i64const);
+    check_instruction_weight(weights.i64const, expected.i64const);
+    check_instruction_weight(weights.i64load, expected.i64load);
+    check_instruction_weight(weights.i32load, expected.i32load);
+    check_instruction_weight(weights.i64store, expected.i64store);
+    check_instruction_weight(weights.i32store, expected.i32store);
+    check_instruction_weight(weights.select, expected.select);
+    check_instruction_weight(weights.r#if, expected.r#if);
+    check_instruction_weight(weights.br, expected.br);
+    check_instruction_weight(weights.br_if, expected.br_if);
+    check_instruction_weight(weights.br_table, expected.br_table);
+    check_instruction_weight(weights.br_table_per_entry, expected.br_table_per_entry);
+    check_instruction_weight(weights.call, expected.call);
+    check_instruction_weight(weights.call_indirect, expected.call_indirect);
+    check_instruction_weight(
+        weights.call_indirect_per_param,
+        expected.call_indirect_per_param,
+    );
+    check_instruction_weight(weights.call_per_local, expected.call_per_local);
+    check_instruction_weight(weights.local_get, expected.local_get);
+    check_instruction_weight(weights.local_set, expected.local_set);
+    check_instruction_weight(weights.local_tee, expected.local_tee);
+    check_instruction_weight(weights.global_get, expected.global_get);
+    check_instruction_weight(weights.global_set, expected.global_set);
+    check_instruction_weight(weights.memory_current, expected.memory_current);
+    check_instruction_weight(weights.i64clz, expected.i64clz);
+    check_instruction_weight(weights.i32clz, expected.i32clz);
+    check_instruction_weight(weights.i64ctz, expected.i64ctz);
+    check_instruction_weight(weights.i32ctz, expected.i32ctz);
+    check_instruction_weight(weights.i64popcnt, expected.i64popcnt);
+    check_instruction_weight(weights.i32popcnt, expected.i32popcnt);
+    check_instruction_weight(weights.i64eqz, expected.i64eqz);
+    check_instruction_weight(weights.i32eqz, expected.i32eqz);
+    check_instruction_weight(weights.i64extendsi32, expected.i64extendsi32);
+    check_instruction_weight(weights.i64extendui32, expected.i64extendui32);
+    check_instruction_weight(weights.i32wrapi64, expected.i32wrapi64);
+    check_instruction_weight(weights.i64eq, expected.i64eq);
+    check_instruction_weight(weights.i32eq, expected.i32eq);
+    check_instruction_weight(weights.i64ne, expected.i64ne);
+    check_instruction_weight(weights.i32ne, expected.i32ne);
+    check_instruction_weight(weights.i64lts, expected.i64lts);
+    check_instruction_weight(weights.i32lts, expected.i32lts);
+    check_instruction_weight(weights.i64ltu, expected.i64ltu);
+    check_instruction_weight(weights.i32ltu, expected.i32ltu);
+    check_instruction_weight(weights.i64gts, expected.i64gts);
+    check_instruction_weight(weights.i32gts, expected.i32gts);
+    check_instruction_weight(weights.i64gtu, expected.i64gtu);
+    check_instruction_weight(weights.i32gtu, expected.i32gtu);
+    check_instruction_weight(weights.i64les, expected.i64les);
+    check_instruction_weight(weights.i32les, expected.i32les);
+    check_instruction_weight(weights.i64leu, expected.i64leu);
+    check_instruction_weight(weights.i32leu, expected.i32leu);
+    check_instruction_weight(weights.i64ges, expected.i64ges);
+    check_instruction_weight(weights.i32ges, expected.i32ges);
+    check_instruction_weight(weights.i64geu, expected.i64geu);
+    check_instruction_weight(weights.i32geu, expected.i32geu);
+    check_instruction_weight(weights.i64add, expected.i64add);
+    check_instruction_weight(weights.i32add, expected.i32add);
+    check_instruction_weight(weights.i64sub, expected.i64sub);
+    check_instruction_weight(weights.i32sub, expected.i32sub);
+    check_instruction_weight(weights.i64mul, expected.i64mul);
+    check_instruction_weight(weights.i32mul, expected.i32mul);
+    check_instruction_weight(weights.i64divs, expected.i64divs);
+    check_instruction_weight(weights.i32divs, expected.i32divs);
+    check_instruction_weight(weights.i64divu, expected.i64divu);
+    check_instruction_weight(weights.i32divu, expected.i32divu);
+    check_instruction_weight(weights.i64rems, expected.i64rems);
+    check_instruction_weight(weights.i32rems, expected.i32rems);
+    check_instruction_weight(weights.i64remu, expected.i64remu);
+    check_instruction_weight(weights.i32remu, expected.i32remu);
+    check_instruction_weight(weights.i64and, expected.i64and);
+    check_instruction_weight(weights.i32and, expected.i32and);
+    check_instruction_weight(weights.i64or, expected.i64or);
+    check_instruction_weight(weights.i32or, expected.i32or);
+    check_instruction_weight(weights.i64xor, expected.i64xor);
+    check_instruction_weight(weights.i32xor, expected.i32xor);
+    check_instruction_weight(weights.i64shl, expected.i64shl);
+    check_instruction_weight(weights.i32shl, expected.i32shl);
+    check_instruction_weight(weights.i64shrs, expected.i64shrs);
+    check_instruction_weight(weights.i32shrs, expected.i32shrs);
+    check_instruction_weight(weights.i64shru, expected.i64shru);
+    check_instruction_weight(weights.i32shru, expected.i32shru);
+    check_instruction_weight(weights.i64rotl, expected.i64rotl);
+    check_instruction_weight(weights.i32rotl, expected.i32rotl);
+    check_instruction_weight(weights.i64rotr, expected.i64rotr);
+    check_instruction_weight(weights.i32rotr, expected.i32rotr);
+}
+
+/// Check that the weights of page operations are within the expected range
+#[track_caller]
+pub fn check_pages_weights(
+    weights: PageCosts,
+    expected_page_costs: PageCosts,
+    lazy_pages_weights: LazyPagesWeights,
+    expected_lazy_pages_weights: LazyPagesWeights,
+) {
+    check_pages_weight(
+        weights.lazy_pages_signal_read.one(),
+        expected_page_costs.lazy_pages_signal_read.one(),
+    );
+    check_pages_weight(
+        weights.lazy_pages_signal_write.one(),
+        expected_page_costs.lazy_pages_signal_write.one(),
+    );
+    check_pages_weight(
+        weights.lazy_pages_signal_write_after_read.one(),
+        expected_page_costs.lazy_pages_signal_write_after_read.one(),
+    );
+    check_pages_weight(
+        weights.lazy_pages_host_func_read.one(),
+        expected_page_costs.lazy_pages_host_func_read.one(),
+    );
+    check_pages_weight(
+        weights.lazy_pages_host_func_write.one(),
+        expected_page_costs.lazy_pages_host_func_write.one(),
+    );
+    check_pages_weight(
+        weights.lazy_pages_host_func_write_after_read.one(),
+        expected_page_costs
+            .lazy_pages_host_func_write_after_read
+            .one(),
+    );
+    check_pages_weight(
+        weights.load_page_data.one(),
+        expected_page_costs.load_page_data.one(),
+    );
+    check_pages_weight(
+        weights.upload_page_data.one(),
+        expected_page_costs.upload_page_data.one(),
+    );
+    check_pages_weight(
+        weights.static_page.one(),
+        expected_page_costs.static_page.one(),
+    );
+    check_pages_weight(weights.mem_grow.one(), expected_page_costs.mem_grow.one());
+    check_pages_weight(
+        weights.parachain_load_heuristic.one(),
+        expected_page_costs.parachain_load_heuristic.one(),
+    );
+
+    check_pages_weight(
+        lazy_pages_weights.signal_read.one(),
+        expected_lazy_pages_weights.signal_read.one(),
+    );
+    check_pages_weight(
+        lazy_pages_weights.signal_write.one(),
+        expected_lazy_pages_weights.signal_write.one(),
+    );
+    check_pages_weight(
+        lazy_pages_weights.signal_write_after_read.one(),
+        expected_lazy_pages_weights.signal_write_after_read.one(),
+    );
+    check_pages_weight(
+        lazy_pages_weights.host_func_read.one(),
+        expected_lazy_pages_weights.host_func_read.one(),
+    );
+    check_pages_weight(
+        lazy_pages_weights.host_func_write.one(),
+        expected_lazy_pages_weights.host_func_write.one(),
+    );
+    check_pages_weight(
+        lazy_pages_weights.host_func_write_after_read.one(),
+        expected_lazy_pages_weights.host_func_write_after_read.one(),
+    );
+    check_pages_weight(
+        lazy_pages_weights.load_page_storage_data.one(),
+        expected_lazy_pages_weights.load_page_storage_data.one(),
+    );
+}

--- a/runtime/gear/src/tests.rs
+++ b/runtime/gear/src/tests.rs
@@ -21,129 +21,116 @@ use crate::Runtime;
 use gear_backend_common::lazy_pages::LazyPagesWeights;
 use gear_core_processor::configs::PageCosts;
 use pallet_gear::{InstructionWeights, MemoryWeights};
-
-// TODO: move differences check logic to runtime-common #2664.
-
-#[track_caller]
-fn check_spreading(weight: u64, expected: u64, spread: u8) {
-    let left = expected - expected * spread as u64 / 100;
-    let right = expected + expected * spread as u64 / 100;
-
-    assert!(
-        left <= weight && weight <= right,
-        "Weight is {weight} ps. Expected weight is {expected} ps. {spread}% spread interval: [{left} ps, {right} ps]"
-    );
-}
-
-#[track_caller]
-fn check_instruction_weight(weight: u32, expected: u32) {
-    check_spreading(weight.into(), expected.into(), 50);
-}
-
-#[track_caller]
-fn check_pages_weight(weight: u64, expected: u64) {
-    check_spreading(weight, expected, 10);
-}
+use runtime_common::weights::{check_instructions_weights, check_pages_weights};
 
 #[test]
 fn instruction_weights_heuristics_test() {
     let weights = InstructionWeights::<Runtime>::default();
 
-    check_instruction_weight(weights.i64const, 150);
-    check_instruction_weight(weights.i64load, 7_000);
-    check_instruction_weight(weights.i32load, 7_000);
-    check_instruction_weight(weights.i64store, 29_000);
-    check_instruction_weight(weights.i32store, 20_000);
-    check_instruction_weight(weights.select, 7_100);
-    check_instruction_weight(weights.r#if, 8_000);
-    check_instruction_weight(weights.br, 3_300);
-    check_instruction_weight(weights.br_if, 6_000);
-    check_instruction_weight(weights.br_table, 10_900);
-    check_instruction_weight(weights.br_table_per_entry, 300);
+    let expected_weights = InstructionWeights {
+        version: 0,
+        _phantom: core::marker::PhantomData,
 
-    check_instruction_weight(weights.call, 4_900);
-    check_instruction_weight(weights.call_per_local, 0);
-    check_instruction_weight(weights.call_indirect, 22_100);
-    check_instruction_weight(weights.call_indirect_per_param, 2_000);
+        i64const: 150,
+        i64load: 7_000,
+        i32load: 7_000,
+        i64store: 29_000,
+        i32store: 20_000,
+        select: 7_100,
+        r#if: 8_000,
+        br: 3_300,
+        br_if: 6_000,
+        br_table: 10_900,
+        br_table_per_entry: 300,
 
-    check_instruction_weight(weights.local_get, 600);
-    check_instruction_weight(weights.local_set, 1_900);
-    check_instruction_weight(weights.local_tee, 1_500);
-    check_instruction_weight(weights.global_get, 2_000);
-    check_instruction_weight(weights.global_set, 3_000);
-    check_instruction_weight(weights.memory_current, 14_200);
+        call: 4_900,
+        call_per_local: 0,
+        call_indirect: 22_100,
+        call_indirect_per_param: 2_000,
 
-    check_instruction_weight(weights.i64clz, 6_100);
-    check_instruction_weight(weights.i32clz, 6_100);
-    check_instruction_weight(weights.i64ctz, 6_700);
-    check_instruction_weight(weights.i32ctz, 6_700);
-    check_instruction_weight(weights.i64popcnt, 1_000);
-    check_instruction_weight(weights.i32popcnt, 800);
-    check_instruction_weight(weights.i64eqz, 4_000);
-    check_instruction_weight(weights.i32eqz, 2_400);
-    check_instruction_weight(weights.i64extendsi32, 800);
-    check_instruction_weight(weights.i64extendui32, 400);
-    check_instruction_weight(weights.i32wrapi64, 200);
-    check_instruction_weight(weights.i64eq, 4_200);
-    check_instruction_weight(weights.i32eq, 2_200);
-    check_instruction_weight(weights.i64ne, 4_200);
-    check_instruction_weight(weights.i32ne, 2_200);
+        local_get: 600,
+        local_set: 1_900,
+        local_tee: 1_500,
+        global_get: 2_000,
+        global_set: 3_000,
+        memory_current: 14_200,
 
-    check_instruction_weight(weights.i64lts, 4_000);
-    check_instruction_weight(weights.i32lts, 2_000);
-    check_instruction_weight(weights.i64ltu, 4_000);
-    check_instruction_weight(weights.i32ltu, 2_000);
-    check_instruction_weight(weights.i64gts, 4_000);
-    check_instruction_weight(weights.i32gts, 2_000);
-    check_instruction_weight(weights.i64gtu, 4_000);
-    check_instruction_weight(weights.i32gtu, 2_000);
-    check_instruction_weight(weights.i64les, 4_000);
-    check_instruction_weight(weights.i32les, 2_000);
-    check_instruction_weight(weights.i64leu, 4_000);
-    check_instruction_weight(weights.i32leu, 2_000);
+        i64clz: 6_100,
+        i32clz: 6_100,
+        i64ctz: 6_700,
+        i32ctz: 6_700,
+        i64popcnt: 1_000,
+        i32popcnt: 800,
+        i64eqz: 4_000,
+        i32eqz: 2_400,
+        i64extendsi32: 800,
+        i64extendui32: 400,
+        i32wrapi64: 200,
+        i64eq: 4_200,
+        i32eq: 2_200,
+        i64ne: 4_200,
+        i32ne: 2_200,
 
-    check_instruction_weight(weights.i64ges, 4_000);
-    check_instruction_weight(weights.i32ges, 2_000);
-    check_instruction_weight(weights.i64geu, 4_000);
-    check_instruction_weight(weights.i32geu, 2_000);
-    check_instruction_weight(weights.i64add, 2_500);
-    check_instruction_weight(weights.i32add, 1_000);
-    check_instruction_weight(weights.i64sub, 3_000);
-    check_instruction_weight(weights.i32sub, 1_000);
-    check_instruction_weight(weights.i64mul, 4_000);
-    check_instruction_weight(weights.i32mul, 2_300);
-    check_instruction_weight(weights.i64divs, 4_800);
-    check_instruction_weight(weights.i32divs, 3_800);
+        i64lts: 4_000,
+        i32lts: 2_000,
+        i64ltu: 4_000,
+        i32ltu: 2_000,
+        i64gts: 4_000,
+        i32gts: 2_000,
+        i64gtu: 4_000,
+        i32gtu: 2_000,
+        i64les: 4_000,
+        i32les: 2_000,
+        i64leu: 4_000,
+        i32leu: 2_000,
 
-    check_instruction_weight(weights.i64divu, 5_200);
-    check_instruction_weight(weights.i32divu, 4_200);
-    check_instruction_weight(weights.i64rems, 21_100);
-    check_instruction_weight(weights.i32rems, 15_100);
-    check_instruction_weight(weights.i64remu, 4_300);
-    check_instruction_weight(weights.i32remu, 4_300);
-    check_instruction_weight(weights.i64and, 3_000);
-    check_instruction_weight(weights.i32and, 1_000);
-    check_instruction_weight(weights.i64or, 3_000);
-    check_instruction_weight(weights.i32or, 1_000);
-    check_instruction_weight(weights.i64xor, 3_000);
-    check_instruction_weight(weights.i32xor, 1_000);
+        i64ges: 4_000,
+        i32ges: 2_000,
+        i64geu: 4_000,
+        i32geu: 2_000,
+        i64add: 2_500,
+        i32add: 1_000,
+        i64sub: 3_000,
+        i32sub: 1_000,
+        i64mul: 4_000,
+        i32mul: 2_300,
+        i64divs: 4_800,
+        i32divs: 3_800,
 
-    check_instruction_weight(weights.i64shl, 2_500);
-    check_instruction_weight(weights.i32shl, 1_000);
-    check_instruction_weight(weights.i64shrs, 2_500);
-    check_instruction_weight(weights.i32shrs, 1_000);
-    check_instruction_weight(weights.i64shru, 2_500);
-    check_instruction_weight(weights.i32shru, 1_000);
-    check_instruction_weight(weights.i64rotl, 2_000);
-    check_instruction_weight(weights.i32rotl, 1_000);
-    check_instruction_weight(weights.i64rotr, 2_500);
-    check_instruction_weight(weights.i32rotr, 1_000);
+        i64divu: 5_200,
+        i32divu: 4_200,
+        i64rems: 21_100,
+        i32rems: 15_100,
+        i64remu: 4_300,
+        i32remu: 4_300,
+        i64and: 3_000,
+        i32and: 1_000,
+        i64or: 3_000,
+        i32or: 1_000,
+        i64xor: 3_000,
+        i32xor: 1_000,
+
+        i64shl: 2_500,
+        i32shl: 1_000,
+        i64shrs: 2_500,
+        i32shrs: 1_000,
+        i64shru: 2_500,
+        i32shru: 1_000,
+        i64rotl: 2_000,
+        i32rotl: 1_000,
+        i64rotr: 2_500,
+        i32rotr: 1_000,
+    };
+
+    check_instructions_weights(weights, expected_weights);
 }
 
 #[test]
 fn page_costs_heuristic_test() {
     let page_costs: PageCosts = MemoryWeights::<Runtime>::default().into();
-    let expected = PageCosts {
+    let lazy_pages_weights: LazyPagesWeights = page_costs.lazy_pages_weights();
+
+    let expected_pages_costs = PageCosts {
         lazy_pages_signal_read: 28_000_000.into(),
         lazy_pages_signal_write: 33_000_000.into(),
         lazy_pages_signal_write_after_read: 8_600_000.into(),
@@ -156,47 +143,8 @@ fn page_costs_heuristic_test() {
         mem_grow: 100.into(),
         parachain_load_heuristic: 0.into(),
     };
-    check_pages_weight(
-        page_costs.lazy_pages_signal_read.one(),
-        expected.lazy_pages_signal_read.one(),
-    );
-    check_pages_weight(
-        page_costs.lazy_pages_signal_write.one(),
-        expected.lazy_pages_signal_write.one(),
-    );
-    check_pages_weight(
-        page_costs.lazy_pages_signal_write_after_read.one(),
-        expected.lazy_pages_signal_write_after_read.one(),
-    );
-    check_pages_weight(
-        page_costs.lazy_pages_host_func_read.one(),
-        expected.lazy_pages_host_func_read.one(),
-    );
-    check_pages_weight(
-        page_costs.lazy_pages_host_func_write.one(),
-        expected.lazy_pages_host_func_write.one(),
-    );
-    check_pages_weight(
-        page_costs.lazy_pages_host_func_write_after_read.one(),
-        expected.lazy_pages_host_func_write_after_read.one(),
-    );
-    check_pages_weight(
-        page_costs.load_page_data.one(),
-        expected.load_page_data.one(),
-    );
-    check_pages_weight(
-        page_costs.upload_page_data.one(),
-        expected.upload_page_data.one(),
-    );
-    check_pages_weight(page_costs.static_page.one(), expected.static_page.one());
-    check_pages_weight(page_costs.mem_grow.one(), expected.mem_grow.one());
-    check_pages_weight(
-        page_costs.parachain_load_heuristic.one(),
-        expected.parachain_load_heuristic.one(),
-    );
 
-    let lazy_pages_weights: LazyPagesWeights = page_costs.lazy_pages_weights();
-    let expected = LazyPagesWeights {
+    let expected_lazy_pages_weights = LazyPagesWeights {
         signal_read: 28_000_000.into(),
         signal_write: 138_000_000.into(),
         signal_write_after_read: 112_000_000.into(),
@@ -205,32 +153,11 @@ fn page_costs_heuristic_test() {
         host_func_write_after_read: 112_000_000.into(),
         load_page_storage_data: 8_700_000.into(),
     };
-    check_pages_weight(
-        lazy_pages_weights.signal_read.one(),
-        expected.signal_read.one(),
-    );
-    check_pages_weight(
-        lazy_pages_weights.signal_write.one(),
-        expected.signal_write.one(),
-    );
-    check_pages_weight(
-        lazy_pages_weights.signal_write_after_read.one(),
-        expected.signal_write_after_read.one(),
-    );
-    check_pages_weight(
-        lazy_pages_weights.host_func_read.one(),
-        expected.host_func_read.one(),
-    );
-    check_pages_weight(
-        lazy_pages_weights.host_func_write.one(),
-        expected.host_func_write.one(),
-    );
-    check_pages_weight(
-        lazy_pages_weights.host_func_write_after_read.one(),
-        expected.host_func_write_after_read.one(),
-    );
-    check_pages_weight(
-        lazy_pages_weights.load_page_storage_data.one(),
-        expected.load_page_storage_data.one(),
+
+    check_pages_weights(
+        page_costs,
+        expected_pages_costs,
+        lazy_pages_weights,
+        expected_lazy_pages_weights,
     );
 }

--- a/runtime/vara/src/tests.rs
+++ b/runtime/vara/src/tests.rs
@@ -21,129 +21,116 @@ use crate::Runtime;
 use gear_backend_common::lazy_pages::LazyPagesWeights;
 use gear_core_processor::configs::PageCosts;
 use pallet_gear::{InstructionWeights, MemoryWeights};
-
-// TODO: move differences check logic to runtime-common #2664.
-
-#[track_caller]
-fn check_spreading(weight: u64, expected: u64, spread: u8) {
-    let left = expected - expected * spread as u64 / 100;
-    let right = expected + expected * spread as u64 / 100;
-
-    assert!(
-        left <= weight && weight <= right,
-        "Weight is {weight} ps. Expected weight is {expected} ps. {spread}% spread interval: [{left} ps, {right} ps]"
-    );
-}
-
-#[track_caller]
-fn check_instruction_weight(weight: u32, expected: u32) {
-    check_spreading(weight.into(), expected.into(), 50);
-}
-
-#[track_caller]
-fn check_pages_weight(weight: u64, expected: u64) {
-    check_spreading(weight, expected, 10);
-}
+use runtime_common::weights::{check_instructions_weights, check_pages_weights};
 
 #[test]
 fn instruction_weights_heuristics_test() {
     let weights = InstructionWeights::<Runtime>::default();
 
-    check_instruction_weight(weights.i64const, 150);
-    check_instruction_weight(weights.i64load, 7_000);
-    check_instruction_weight(weights.i32load, 7_000);
-    check_instruction_weight(weights.i64store, 29_000);
-    check_instruction_weight(weights.i32store, 20_000);
-    check_instruction_weight(weights.select, 7_100);
-    check_instruction_weight(weights.r#if, 8_000);
-    check_instruction_weight(weights.br, 3_300);
-    check_instruction_weight(weights.br_if, 6_000);
-    check_instruction_weight(weights.br_table, 10_900);
-    check_instruction_weight(weights.br_table_per_entry, 300);
+    let expected_weights = InstructionWeights {
+        version: 0,
+        _phantom: core::marker::PhantomData,
 
-    check_instruction_weight(weights.call, 4_900);
-    check_instruction_weight(weights.call_per_local, 0);
-    check_instruction_weight(weights.call_indirect, 22_100);
-    check_instruction_weight(weights.call_indirect_per_param, 2_000);
+        i64const: 150,
+        i64load: 7_000,
+        i32load: 7_000,
+        i64store: 29_000,
+        i32store: 20_000,
+        select: 7_100,
+        r#if: 8_000,
+        br: 3_300,
+        br_if: 6_000,
+        br_table: 10_900,
+        br_table_per_entry: 300,
 
-    check_instruction_weight(weights.local_get, 600);
-    check_instruction_weight(weights.local_set, 1_900);
-    check_instruction_weight(weights.local_tee, 1_500);
-    check_instruction_weight(weights.global_get, 2_000);
-    check_instruction_weight(weights.global_set, 3_000);
-    check_instruction_weight(weights.memory_current, 14_200);
+        call: 4_900,
+        call_per_local: 0,
+        call_indirect: 22_100,
+        call_indirect_per_param: 2_000,
 
-    check_instruction_weight(weights.i64clz, 6_100);
-    check_instruction_weight(weights.i32clz, 6_100);
-    check_instruction_weight(weights.i64ctz, 6_700);
-    check_instruction_weight(weights.i32ctz, 6_700);
-    check_instruction_weight(weights.i64popcnt, 1_000);
-    check_instruction_weight(weights.i32popcnt, 800);
-    check_instruction_weight(weights.i64eqz, 4_000);
-    check_instruction_weight(weights.i32eqz, 2_400);
-    check_instruction_weight(weights.i64extendsi32, 800);
-    check_instruction_weight(weights.i64extendui32, 400);
-    check_instruction_weight(weights.i32wrapi64, 200);
-    check_instruction_weight(weights.i64eq, 4_200);
-    check_instruction_weight(weights.i32eq, 2_200);
-    check_instruction_weight(weights.i64ne, 4_200);
-    check_instruction_weight(weights.i32ne, 2_200);
+        local_get: 600,
+        local_set: 1_900,
+        local_tee: 1_500,
+        global_get: 2_000,
+        global_set: 3_000,
+        memory_current: 14_200,
 
-    check_instruction_weight(weights.i64lts, 4_000);
-    check_instruction_weight(weights.i32lts, 2_000);
-    check_instruction_weight(weights.i64ltu, 4_000);
-    check_instruction_weight(weights.i32ltu, 2_000);
-    check_instruction_weight(weights.i64gts, 4_000);
-    check_instruction_weight(weights.i32gts, 2_000);
-    check_instruction_weight(weights.i64gtu, 4_000);
-    check_instruction_weight(weights.i32gtu, 2_000);
-    check_instruction_weight(weights.i64les, 4_000);
-    check_instruction_weight(weights.i32les, 2_000);
-    check_instruction_weight(weights.i64leu, 4_000);
-    check_instruction_weight(weights.i32leu, 2_000);
+        i64clz: 6_100,
+        i32clz: 6_100,
+        i64ctz: 6_700,
+        i32ctz: 6_700,
+        i64popcnt: 1_000,
+        i32popcnt: 800,
+        i64eqz: 4_000,
+        i32eqz: 2_400,
+        i64extendsi32: 800,
+        i64extendui32: 400,
+        i32wrapi64: 200,
+        i64eq: 4_200,
+        i32eq: 2_200,
+        i64ne: 4_200,
+        i32ne: 2_200,
 
-    check_instruction_weight(weights.i64ges, 4_000);
-    check_instruction_weight(weights.i32ges, 2_000);
-    check_instruction_weight(weights.i64geu, 4_000);
-    check_instruction_weight(weights.i32geu, 2_000);
-    check_instruction_weight(weights.i64add, 2_500);
-    check_instruction_weight(weights.i32add, 1_000);
-    check_instruction_weight(weights.i64sub, 3_000);
-    check_instruction_weight(weights.i32sub, 1_000);
-    check_instruction_weight(weights.i64mul, 4_000);
-    check_instruction_weight(weights.i32mul, 2_300);
-    check_instruction_weight(weights.i64divs, 4_800);
-    check_instruction_weight(weights.i32divs, 3_800);
+        i64lts: 4_000,
+        i32lts: 2_000,
+        i64ltu: 4_000,
+        i32ltu: 2_000,
+        i64gts: 4_000,
+        i32gts: 2_000,
+        i64gtu: 4_000,
+        i32gtu: 2_000,
+        i64les: 4_000,
+        i32les: 2_000,
+        i64leu: 4_000,
+        i32leu: 2_000,
 
-    check_instruction_weight(weights.i64divu, 5_200);
-    check_instruction_weight(weights.i32divu, 4_200);
-    check_instruction_weight(weights.i64rems, 21_100);
-    check_instruction_weight(weights.i32rems, 15_100);
-    check_instruction_weight(weights.i64remu, 4_300);
-    check_instruction_weight(weights.i32remu, 4_300);
-    check_instruction_weight(weights.i64and, 3_000);
-    check_instruction_weight(weights.i32and, 1_000);
-    check_instruction_weight(weights.i64or, 3_000);
-    check_instruction_weight(weights.i32or, 1_000);
-    check_instruction_weight(weights.i64xor, 3_000);
-    check_instruction_weight(weights.i32xor, 1_000);
+        i64ges: 4_000,
+        i32ges: 2_000,
+        i64geu: 4_000,
+        i32geu: 2_000,
+        i64add: 2_500,
+        i32add: 1_000,
+        i64sub: 3_000,
+        i32sub: 1_000,
+        i64mul: 4_000,
+        i32mul: 2_300,
+        i64divs: 4_800,
+        i32divs: 3_800,
 
-    check_instruction_weight(weights.i64shl, 2_500);
-    check_instruction_weight(weights.i32shl, 1_000);
-    check_instruction_weight(weights.i64shrs, 2_500);
-    check_instruction_weight(weights.i32shrs, 1_000);
-    check_instruction_weight(weights.i64shru, 2_500);
-    check_instruction_weight(weights.i32shru, 1_000);
-    check_instruction_weight(weights.i64rotl, 2_000);
-    check_instruction_weight(weights.i32rotl, 1_000);
-    check_instruction_weight(weights.i64rotr, 2_500);
-    check_instruction_weight(weights.i32rotr, 1_000);
+        i64divu: 5_200,
+        i32divu: 4_200,
+        i64rems: 21_100,
+        i32rems: 15_100,
+        i64remu: 4_300,
+        i32remu: 4_300,
+        i64and: 3_000,
+        i32and: 1_000,
+        i64or: 3_000,
+        i32or: 1_000,
+        i64xor: 3_000,
+        i32xor: 1_000,
+
+        i64shl: 2_500,
+        i32shl: 1_000,
+        i64shrs: 2_500,
+        i32shrs: 1_000,
+        i64shru: 2_500,
+        i32shru: 1_000,
+        i64rotl: 2_000,
+        i32rotl: 1_000,
+        i64rotr: 2_500,
+        i32rotr: 1_000,
+    };
+
+    check_instructions_weights(weights, expected_weights);
 }
 
 #[test]
 fn page_costs_heuristic_test() {
     let page_costs: PageCosts = MemoryWeights::<Runtime>::default().into();
-    let expected = PageCosts {
+    let lazy_pages_weights: LazyPagesWeights = page_costs.lazy_pages_weights();
+
+    let expected_pages_costs = PageCosts {
         lazy_pages_signal_read: 28_000_000.into(),
         lazy_pages_signal_write: 33_000_000.into(),
         lazy_pages_signal_write_after_read: 9_500_000.into(),
@@ -156,47 +143,8 @@ fn page_costs_heuristic_test() {
         mem_grow: 100.into(),
         parachain_load_heuristic: 0.into(),
     };
-    check_pages_weight(
-        page_costs.lazy_pages_signal_read.one(),
-        expected.lazy_pages_signal_read.one(),
-    );
-    check_pages_weight(
-        page_costs.lazy_pages_signal_write.one(),
-        expected.lazy_pages_signal_write.one(),
-    );
-    check_pages_weight(
-        page_costs.lazy_pages_signal_write_after_read.one(),
-        expected.lazy_pages_signal_write_after_read.one(),
-    );
-    check_pages_weight(
-        page_costs.lazy_pages_host_func_read.one(),
-        expected.lazy_pages_host_func_read.one(),
-    );
-    check_pages_weight(
-        page_costs.lazy_pages_host_func_write.one(),
-        expected.lazy_pages_host_func_write.one(),
-    );
-    check_pages_weight(
-        page_costs.lazy_pages_host_func_write_after_read.one(),
-        expected.lazy_pages_host_func_write_after_read.one(),
-    );
-    check_pages_weight(
-        page_costs.load_page_data.one(),
-        expected.load_page_data.one(),
-    );
-    check_pages_weight(
-        page_costs.upload_page_data.one(),
-        expected.upload_page_data.one(),
-    );
-    check_pages_weight(page_costs.static_page.one(), expected.static_page.one());
-    check_pages_weight(page_costs.mem_grow.one(), expected.mem_grow.one());
-    check_pages_weight(
-        page_costs.parachain_load_heuristic.one(),
-        expected.parachain_load_heuristic.one(),
-    );
 
-    let lazy_pages_weights: LazyPagesWeights = page_costs.lazy_pages_weights();
-    let expected = LazyPagesWeights {
+    let expected_lazy_pages_weights = LazyPagesWeights {
         signal_read: 28_000_000.into(),
         signal_write: 138_000_000.into(),
         signal_write_after_read: 112_000_000.into(),
@@ -205,32 +153,11 @@ fn page_costs_heuristic_test() {
         host_func_write_after_read: 112_000_000.into(),
         load_page_storage_data: 8_700_000.into(),
     };
-    check_pages_weight(
-        lazy_pages_weights.signal_read.one(),
-        expected.signal_read.one(),
-    );
-    check_pages_weight(
-        lazy_pages_weights.signal_write.one(),
-        expected.signal_write.one(),
-    );
-    check_pages_weight(
-        lazy_pages_weights.signal_write_after_read.one(),
-        expected.signal_write_after_read.one(),
-    );
-    check_pages_weight(
-        lazy_pages_weights.host_func_read.one(),
-        expected.host_func_read.one(),
-    );
-    check_pages_weight(
-        lazy_pages_weights.host_func_write.one(),
-        expected.host_func_write.one(),
-    );
-    check_pages_weight(
-        lazy_pages_weights.host_func_write_after_read.one(),
-        expected.host_func_write_after_read.one(),
-    );
-    check_pages_weight(
-        lazy_pages_weights.load_page_storage_data.one(),
-        expected.load_page_storage_data.one(),
+
+    check_pages_weights(
+        page_costs,
+        expected_pages_costs,
+        lazy_pages_weights,
+        expected_lazy_pages_weights,
     );
 }


### PR DESCRIPTION
Resolves #2664.

@gear-tech/dev 
