### PR TITLE
refactor(node): Add program rent parameters to metadata

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -160,21 +160,6 @@ pub trait GasPrice {
     }
 }
 
-/// Trait defines basic parameters of programs rent charging.
-pub trait ProgramRentConfig {
-    /// Type representing an index of a block.
-    type BlockNumber;
-    /// Type representing a quantity of value.
-    type Balance: BaseArithmetic + From<u32> + Copy + Unsigned;
-
-    /// The free of charge period of rent.
-    type FreePeriod: Get<Self::BlockNumber>;
-    /// The program rent cost per block.
-    type CostPerBlock: Get<Self::Balance>;
-    /// The minimal amount of blocks to resume.
-    type MinimalResumePeriod: Get<Self::BlockNumber>;
-}
-
 pub trait QueueRunner {
     type Gas;
 

--- a/pallets/airdrop/src/mock.rs
+++ b/pallets/airdrop/src/mock.rs
@@ -151,17 +151,6 @@ parameter_types! {
     pub RentResumePeriod: BlockNumber = 100;
 }
 
-pub struct ProgramRentConfig;
-
-impl common::ProgramRentConfig for ProgramRentConfig {
-    type BlockNumber = BlockNumber;
-    type Balance = Balance;
-
-    type FreePeriod = RentFreePeriod;
-    type CostPerBlock = RentCostPerBlock;
-    type MinimalResumePeriod = RentResumePeriod;
-}
-
 impl pallet_gear::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type Randomness = TestRandomness<Self>;
@@ -180,7 +169,9 @@ impl pallet_gear::Config for Test {
     type BlockLimiter = GearGas;
     type Scheduler = GearScheduler;
     type QueueRunner = Gear;
-    type ProgramRentConfig = ProgramRentConfig;
+    type ProgramRentFreePeriod = RentFreePeriod;
+    type ProgramRentMinimalResumePeriod = RentResumePeriod;
+    type ProgramRentCostPerBlock = RentCostPerBlock;
 }
 
 impl pallet_gear_scheduler::Config for Test {

--- a/pallets/gear-debug/src/mock.rs
+++ b/pallets/gear-debug/src/mock.rs
@@ -142,17 +142,6 @@ parameter_types! {
     pub RentResumePeriod: BlockNumber = 100;
 }
 
-pub struct ProgramRentConfig;
-
-impl common::ProgramRentConfig for ProgramRentConfig {
-    type BlockNumber = BlockNumber;
-    type Balance = Balance;
-
-    type FreePeriod = RentFreePeriod;
-    type CostPerBlock = RentCostPerBlock;
-    type MinimalResumePeriod = RentResumePeriod;
-}
-
 impl pallet_gear::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type Randomness = TestRandomness<Self>;
@@ -171,7 +160,9 @@ impl pallet_gear::Config for Test {
     type BlockLimiter = GearGas;
     type Scheduler = GearScheduler;
     type QueueRunner = Gear;
-    type ProgramRentConfig = ProgramRentConfig;
+    type ProgramRentFreePeriod = RentFreePeriod;
+    type ProgramRentMinimalResumePeriod = RentResumePeriod;
+    type ProgramRentCostPerBlock = RentCostPerBlock;
 }
 
 impl pallet_gear_messenger::Config for Test {

--- a/pallets/gear-scheduler/src/mock.rs
+++ b/pallets/gear-scheduler/src/mock.rs
@@ -132,17 +132,6 @@ parameter_types! {
     pub RentResumePeriod: BlockNumber = 100;
 }
 
-pub struct ProgramRentConfig;
-
-impl common::ProgramRentConfig for ProgramRentConfig {
-    type BlockNumber = BlockNumber;
-    type Balance = Balance;
-
-    type FreePeriod = RentFreePeriod;
-    type CostPerBlock = RentCostPerBlock;
-    type MinimalResumePeriod = RentResumePeriod;
-}
-
 impl pallet_gear::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type Randomness = TestRandomness<Self>;
@@ -161,7 +150,9 @@ impl pallet_gear::Config for Test {
     type BlockLimiter = GearGas;
     type Scheduler = GearScheduler;
     type QueueRunner = Gear;
-    type ProgramRentConfig = ProgramRentConfig;
+    type ProgramRentFreePeriod = RentFreePeriod;
+    type ProgramRentMinimalResumePeriod = RentResumePeriod;
+    type ProgramRentCostPerBlock = RentCostPerBlock;
 }
 
 impl pallet_gear_scheduler::Config for Test {

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -53,7 +53,7 @@ use alloc::{format, string::String};
 use common::{
     self, event::*, gas_provider::GasNodeId, scheduler::*, storage::*, BlockLimiter, CodeMetadata,
     CodeStorage, GasPrice, GasProvider, GasTree, Origin, PausedProgramStorage, Program,
-    ProgramRentConfig, ProgramState, ProgramStorage, QueueRunner,
+    ProgramState, ProgramStorage, QueueRunner,
 };
 use core::marker::PhantomData;
 use core_processor::{
@@ -129,9 +129,8 @@ pub type GasNodeIdOf<T> = <GasHandlerOf<T> as GasTree>::NodeId;
 pub type BlockGasLimitOf<T> = <<T as Config>::BlockLimiter as BlockLimiter>::BlockGasLimit;
 pub type GasBalanceOf<T> = <<T as Config>::GasProvider as GasProvider>::Balance;
 pub type ProgramStorageOf<T> = <T as Config>::ProgramStorage;
-pub type RentFreePeriodOf<T> = <<T as Config>::ProgramRentConfig as ProgramRentConfig>::FreePeriod;
-pub type RentCostPerBlockOf<T> =
-    <<T as Config>::ProgramRentConfig as ProgramRentConfig>::CostPerBlock;
+pub type RentFreePeriodOf<T> = <T as Config>::ProgramRentFreePeriod;
+pub type RentCostPerBlockOf<T> = <T as Config>::ProgramRentCostPerBlock;
 
 /// The current storage version.
 const GEAR_STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
@@ -264,10 +263,17 @@ pub mod pallet {
         /// Message Queue processing routing provider.
         type QueueRunner: QueueRunner<Gas = GasBalanceOf<Self>>;
 
-        type ProgramRentConfig: ProgramRentConfig<
-            BlockNumber = Self::BlockNumber,
-            Balance = BalanceOf<Self>,
-        >;
+        /// The free of charge period of rent.
+        #[pallet::constant]
+        type ProgramRentFreePeriod: Get<BlockNumberFor<Self>>;
+
+        /// The minimal amount of blocks to resume.
+        #[pallet::constant]
+        type ProgramRentMinimalResumePeriod: Get<BlockNumberFor<Self>>;
+
+        /// The program rent cost per block.
+        #[pallet::constant]
+        type ProgramRentCostPerBlock: Get<BalanceOf<Self>>;
     }
 
     #[pallet::pallet]

--- a/pallets/gear/src/mock.rs
+++ b/pallets/gear/src/mock.rs
@@ -157,17 +157,6 @@ parameter_types! {
     pub RentResumePeriod: BlockNumber = 100;
 }
 
-pub struct ProgramRentConfig;
-
-impl common::ProgramRentConfig for ProgramRentConfig {
-    type BlockNumber = BlockNumber;
-    type Balance = Balance;
-
-    type FreePeriod = RentFreePeriod;
-    type CostPerBlock = RentCostPerBlock;
-    type MinimalResumePeriod = RentResumePeriod;
-}
-
 impl pallet_gear::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type Randomness = TestRandomness<Self>;
@@ -186,7 +175,9 @@ impl pallet_gear::Config for Test {
     type BlockLimiter = GearGas;
     type Scheduler = GearScheduler;
     type QueueRunner = Gear;
-    type ProgramRentConfig = ProgramRentConfig;
+    type ProgramRentFreePeriod = RentFreePeriod;
+    type ProgramRentMinimalResumePeriod = RentResumePeriod;
+    type ProgramRentCostPerBlock = RentCostPerBlock;
 }
 
 impl pallet_gear_scheduler::Config for Test {

--- a/pallets/payment/src/mock.rs
+++ b/pallets/payment/src/mock.rs
@@ -172,17 +172,6 @@ parameter_types! {
     pub RentResumePeriod: BlockNumber = 100;
 }
 
-pub struct ProgramRentConfig;
-
-impl common::ProgramRentConfig for ProgramRentConfig {
-    type BlockNumber = BlockNumber;
-    type Balance = Balance;
-
-    type FreePeriod = RentFreePeriod;
-    type CostPerBlock = RentCostPerBlock;
-    type MinimalResumePeriod = RentResumePeriod;
-}
-
 impl pallet_gear::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type Randomness = TestRandomness<Self>;
@@ -201,7 +190,9 @@ impl pallet_gear::Config for Test {
     type BlockLimiter = GearGas;
     type Scheduler = GearScheduler;
     type QueueRunner = Gear;
-    type ProgramRentConfig = ProgramRentConfig;
+    type ProgramRentFreePeriod = RentFreePeriod;
+    type ProgramRentMinimalResumePeriod = RentResumePeriod;
+    type ProgramRentCostPerBlock = RentCostPerBlock;
 }
 
 impl pallet_gear_program::Config for Test {

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -441,17 +441,6 @@ parameter_types! {
     pub Schedule: pallet_gear::Schedule<Runtime> = Default::default();
 }
 
-pub struct ProgramRentConfig;
-
-impl common::ProgramRentConfig for ProgramRentConfig {
-    type BlockNumber = BlockNumber;
-    type Balance = Balance;
-
-    type FreePeriod = ConstU32<RENT_FREE_PERIOD>;
-    type CostPerBlock = ConstU128<RENT_COST_PER_BLOCK>;
-    type MinimalResumePeriod = ConstU32<RENT_RESUME_PERIOD>;
-}
-
 impl pallet_gear::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Randomness = pallet_babe::RandomnessFromOneEpochAgo<Runtime>;
@@ -470,7 +459,9 @@ impl pallet_gear::Config for Runtime {
     type BlockLimiter = GearGas;
     type Scheduler = GearScheduler;
     type QueueRunner = Gear;
-    type ProgramRentConfig = ProgramRentConfig;
+    type ProgramRentFreePeriod = ConstU32<RENT_FREE_PERIOD>;
+    type ProgramRentMinimalResumePeriod = ConstU32<RENT_RESUME_PERIOD>;
+    type ProgramRentCostPerBlock = ConstU128<RENT_COST_PER_BLOCK>;
 }
 
 #[cfg(feature = "debug-mode")]

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -750,17 +750,6 @@ parameter_types! {
     pub Schedule: pallet_gear::Schedule<Runtime> = Default::default();
 }
 
-pub struct ProgramRentConfig;
-
-impl common::ProgramRentConfig for ProgramRentConfig {
-    type BlockNumber = BlockNumber;
-    type Balance = Balance;
-
-    type FreePeriod = ConstU32<RENT_FREE_PERIOD>;
-    type CostPerBlock = ConstU128<RENT_COST_PER_BLOCK>;
-    type MinimalResumePeriod = ConstU32<RENT_RESUME_PERIOD>;
-}
-
 impl pallet_gear::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Randomness = pallet_babe::RandomnessFromOneEpochAgo<Runtime>;
@@ -779,7 +768,9 @@ impl pallet_gear::Config for Runtime {
     type BlockLimiter = GearGas;
     type Scheduler = GearScheduler;
     type QueueRunner = Gear;
-    type ProgramRentConfig = ProgramRentConfig;
+    type ProgramRentFreePeriod = ConstU32<RENT_FREE_PERIOD>;
+    type ProgramRentMinimalResumePeriod = ConstU32<RENT_RESUME_PERIOD>;
+    type ProgramRentCostPerBlock = ConstU128<RENT_COST_PER_BLOCK>;
 }
 
 #[cfg(feature = "debug-mode")]


### PR DESCRIPTION
Use `#[pallet::constant]` attribute to add program rent parameters to metadata so frontends are able to get them.

@gear-tech/dev 
