### PR TITLE
ci(build-win-native): use symbolic link for pinning toolchain

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -424,7 +424,7 @@ jobs:
       - name: "Install: Pin to specific nightly toolchain"
         if: ${{ env.NIGHTLY_TOOLCHAIN_VERSION != '' }}
         run: |
-          rm -r $env:USERPROFILE\.rustup\toolchains\nightly-x86_64-pc-windows-msvc
+          Remove-Item -Recurse -Force $env:USERPROFILE\.rustup\toolchains\nightly-x86_64-pc-windows-msvc
           New-Item -Path $env:USERPROFILE\.rustup\toolchains\nightly-x86_64-pc-windows-msvc -ItemType SymbolicLink -Value $env:USERPROFILE\.rustup\toolchains\nightly-$env:NIGHTLY_TOOLCHAIN_VERSION-x86_64-pc-windows-msvc
         shell: powershell
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -424,7 +424,7 @@ jobs:
       - name: "Install: Pin to specific nightly toolchain"
         if: ${{ env.NIGHTLY_TOOLCHAIN_VERSION != '' }}
         run: |
-          Remove-Item -Recurse -Force $env:USERPROFILE\.rustup\toolchains\nightly-x86_64-pc-windows-msvc
+          $(Get-Item $env:USERPROFILE\.rustup\toolchains\nightly-x86_64-pc-windows-msvc).Delete()
           New-Item -Path $env:USERPROFILE\.rustup\toolchains\nightly-x86_64-pc-windows-msvc -ItemType SymbolicLink -Value $env:USERPROFILE\.rustup\toolchains\nightly-$env:NIGHTLY_TOOLCHAIN_VERSION-x86_64-pc-windows-msvc
         shell: powershell
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -425,7 +425,7 @@ jobs:
         if: ${{ env.NIGHTLY_TOOLCHAIN_VERSION != '' }}
         run: |
           rm -r $env:USERPROFILE\.rustup\toolchains\nightly-x86_64-pc-windows-msvc
-          mv $env:USERPROFILE\.rustup\toolchains\nightly-$env:NIGHTLY_TOOLCHAIN_VERSION-x86_64-pc-windows-msvc $env:USERPROFILE\.rustup\toolchains\nightly-x86_64-pc-windows-msvc
+          New-Item -Path $env:USERPROFILE\.rustup\toolchains\nightly-x86_64-pc-windows-msvc -ItemType SymbolicLink -Value $env:USERPROFILE\.rustup\toolchains\nightly-$env:NIGHTLY_TOOLCHAIN_VERSION-x86_64-pc-windows-msvc
         shell: powershell
 
       - name: "Install: cargo-nextest"


### PR DESCRIPTION
Resolves #2665 

Previously, this problem may not have been noticed due to the lack of pinning of the toolchain.

The reason we use a symbolic link instead of a move is because the `gear.sh` script runs `cargo build` and for some reason `cargo` decided to reinstall the toolchain without `wasm32-unknown-unknown` target.

The problem appears here:
https://github.com/gear-tech/gear/actions/runs/4729497517/jobs/8963897937#step:15:17
![image](https://github.com/gear-tech/gear/assets/109800286/1f7760ff-b2d2-4d39-aad5-815a91c262cc)
