### PR TITLE
ci: bump `codecov/codecov-action` to `v3`

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -325,7 +325,7 @@ jobs:
 
       - name: "Coverage: Publish"
         if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'E0-forcecoverage')
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: ./lcov.info
 


### PR DESCRIPTION
>  Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: codecov/codecov-action@v1

this PR fixes deprecated dependency
link to successful build: https://github.com/gear-tech/gear/actions/runs/5098563452/jobs/9166327352#step:38:1