### PR TITLE
ci(docs): add `RUSTDOCFLAGS=-Dwarnings` to env

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   TERM: xterm-256color
   NIGHTLY_TOOLCHAIN_VERSION: ${{ secrets.NIGHTLY_TOOLCHAIN_VERSION }}
+  RUSTDOCFLAGS: -Dwarnings
 
 jobs:
   docs:


### PR DESCRIPTION
For some reason `cargo doc` produces only warnings on missing links. This PR converts all warnings into errors