### PR TITLE
feat: restrict mutable globals to be export in gear

### DIFF
--- a/core/src/code.rs
+++ b/core/src/code.rs
@@ -23,12 +23,11 @@ use crate::{
     memory::{PageU32Size, WasmPage},
     message::{DispatchKind, WasmEntry},
 };
-use alloc::{collections::BTreeSet, vec::Vec};
-use core::ops::ControlFlow;
+use alloc::{collections::BTreeSet, vec, vec::Vec};
 use gear_wasm_instrument::{
     parity_wasm::{
         self,
-        elements::{Instruction, Internal, Module},
+        elements::{ExportEntry, GlobalEntry, GlobalType, InitExpr, Instruction, Internal, Module},
     },
     wasm_instrument::{
         self,
@@ -72,61 +71,108 @@ fn get_exports(
     Ok(exports)
 }
 
-fn get_stack_end_init_code(module: &Module) -> Option<&[Instruction]> {
-    let global_index = module
+fn get_export_entry<'a>(module: &'a Module, name: &str) -> Option<&'a ExportEntry> {
+    module
         .export_section()?
         .entries()
         .iter()
-        .try_for_each(|entry| match entry.internal() {
-            Internal::Global(index) if entry.field() == STACK_END_EXPORT_NAME => {
-                ControlFlow::Break(*index)
-            }
-            _ => ControlFlow::Continue(()),
-        });
-
-    let ControlFlow::Break(global_index) = global_index else {
-        return None;
-    };
-
-    let section = module.global_section()?;
-    let entry = &section.entries()[global_index as usize];
-
-    Some(entry.init_expr().code())
+        .find(|export| export.field() == name)
 }
 
-fn get_offset_i32(init_code: &[Instruction]) -> Option<u32> {
-    use Instruction::{End, I32Const};
+fn get_export_entry_mut<'a>(module: &'a mut Module, name: &str) -> Option<&'a mut ExportEntry> {
+    module
+        .export_section_mut()?
+        .entries_mut()
+        .iter_mut()
+        .find(|export| export.field() == name)
+}
 
-    if init_code.len() != 2 {
-        return None;
-    }
-
-    match (&init_code[0], &init_code[1]) {
-        (I32Const(stack_end), End) => Some(*stack_end as u32),
+fn get_export_global_index<'a>(module: &'a Module, name: &str) -> Option<&'a u32> {
+    match get_export_entry(module, name)?.internal() {
+        Internal::Global(index) => Some(index),
         _ => None,
     }
 }
 
-fn check_gear_stack_end(module: &Module) -> Result<(), CodeError> {
-    let Some(init_expr) = get_stack_end_init_code(module) else {
+fn get_export_global_index_mut<'a>(module: &'a mut Module, name: &str) -> Option<&'a mut u32> {
+    match get_export_entry_mut(module, name)?.internal_mut() {
+        Internal::Global(index) => Some(index),
+        _ => None,
+    }
+}
+
+fn get_init_expr_const_i32(init_expr: &InitExpr) -> Option<i32> {
+    let init_code = init_expr.code();
+    if init_code.len() != 2 {
+        return None;
+    }
+    match (&init_code[0], &init_code[1]) {
+        (Instruction::I32Const(const_i32), Instruction::End) => Some(*const_i32),
+        _ => None,
+    }
+}
+
+fn get_global_entry(module: &Module, global_index: u32) -> Option<&GlobalEntry> {
+    module
+        .global_section()?
+        .entries()
+        .get(global_index as usize)
+}
+
+fn get_global_init_const_i32(module: &Module, global_index: u32) -> Result<i32, CodeError> {
+    let init_expr = get_global_entry(module, global_index)
+        .ok_or(CodeError::IncorrectGlobalIndex)?
+        .init_expr();
+    get_init_expr_const_i32(init_expr).ok_or(CodeError::StackEndInitialization)
+}
+
+fn check_and_canonize_gear_stack_end(module: &mut Module) -> Result<(), CodeError> {
+    let Some(&stack_end_global_index) = get_export_global_index(module, STACK_END_EXPORT_NAME) else {
         return Ok(());
     };
+    let stack_end_offset = get_global_init_const_i32(module, stack_end_global_index)?;
 
-    let stack_end = get_offset_i32(init_expr).ok_or(CodeError::StackEndInitialization)?;
-    let Some(section) = module.data_section() else {
-        return Ok(());
-    };
+    // Checks, that each data segment does not overlap with stack.
+    if let Some(data_section) = module.data_section() {
+        for data_segment in data_section.entries() {
+            let offset = data_segment
+                .offset()
+                .as_ref()
+                .and_then(get_init_expr_const_i32)
+                .ok_or(CodeError::DataSegmentInitialization)?;
 
-    for data_segment in section.entries() {
-        let offset = data_segment
-            .offset()
-            .as_ref()
-            .and_then(|init_expr| get_offset_i32(init_expr.code()))
-            .ok_or(CodeError::DataSegmentInitialization)?;
-
-        if offset < stack_end {
-            return Err(CodeError::StackEndOverlaps);
+            if offset < stack_end_offset {
+                return Err(CodeError::StackEndOverlaps);
+            }
         }
+    };
+
+    // If [STACK_END_EXPORT_NAME] points to mutable global, then make new const global
+    // with the same init expr and change the export internal to point to the new global.
+    if get_global_entry(module, stack_end_global_index)
+        .ok_or(CodeError::IncorrectGlobalIndex)?
+        .global_type()
+        .is_mutable()
+    {
+        // Panic is impossible, because we have checked above, that global section exists.
+        let global_section = module
+            .global_section_mut()
+            .unwrap_or_else(|| unreachable!("Cannot find global section"));
+        let new_global_index = u32::try_from(global_section.entries().len())
+            .map_err(|_| CodeError::IncorrectGlobalIndex)?;
+        global_section.entries_mut().push(GlobalEntry::new(
+            GlobalType::new(parity_wasm::elements::ValueType::I32, false),
+            InitExpr::new(vec![
+                Instruction::I32Const(stack_end_offset),
+                Instruction::End,
+            ]),
+        ));
+
+        // Panic is impossible, because we have checked above,
+        // that stack end export exists and it points to global.
+        get_export_global_index_mut(module, STACK_END_EXPORT_NAME)
+            .map(|global_index| *global_index = new_global_index)
+            .unwrap_or_else(|| unreachable!("Cannot find stack end export"))
     }
 
     Ok(())
@@ -188,7 +234,7 @@ pub enum CodeError {
     StackEndOverlaps,
     /// Incorrect global export index. Can occur when export refers to not existing global index.
     #[display(fmt = "Global index in export is incorrect")]
-    IncorrectGlobalExport,
+    IncorrectGlobalIndex,
     /// Gear protocol restriction for now.
     #[display(fmt = "Program cannot have mutable globals in export section")]
     MutGlobalExport,
@@ -208,19 +254,14 @@ pub struct Code {
     instruction_weights_version: u32,
 }
 
-fn check_for_mut_global_exports(module: &Module) -> Result<(), CodeError> {
+fn check_mut_global_exports(module: &Module) -> Result<(), CodeError> {
     let global_exports_indexes = module
         .export_section()
         .iter()
         .flat_map(|export_section| export_section.entries().iter())
-        .filter_map(|export| {
-            if export.field() == STACK_END_EXPORT_NAME {
-                return None;
-            }
-            match export.internal() {
-                Internal::Global(index) => Some(*index as usize),
-                _ => None,
-            }
+        .filter_map(|export| match export.internal() {
+            Internal::Global(index) => Some(*index as usize),
+            _ => None,
         })
         .collect::<Vec<_>>();
 
@@ -231,10 +272,9 @@ fn check_for_mut_global_exports(module: &Module) -> Result<(), CodeError> {
     if let Some(globals_section) = module.global_section() {
         for index in global_exports_indexes {
             if globals_section
-                .clone()
                 .entries()
                 .get(index)
-                .ok_or(CodeError::IncorrectGlobalExport)?
+                .ok_or(CodeError::IncorrectGlobalIndex)?
                 .global_type()
                 .is_mutable()
             {
@@ -260,10 +300,11 @@ impl Code {
     {
         wasmparser::validate(&raw_code).map_err(|_| CodeError::Decode)?;
 
-        let module: Module =
+        let mut module: Module =
             parity_wasm::deserialize_buffer(&raw_code).map_err(|_| CodeError::Decode)?;
 
-        check_for_mut_global_exports(&module)?;
+        check_and_canonize_gear_stack_end(&mut module)?;
+        check_mut_global_exports(&module)?;
 
         if module.start_section().is_some() {
             log::debug!("Found start section in contract code, which is not allowed");
@@ -287,8 +328,6 @@ impl Code {
         if static_pages.raw() > MAX_WASM_PAGE_COUNT as u32 {
             return Err(CodeError::InvalidStaticPageCount);
         }
-
-        check_gear_stack_end(&module)?;
 
         let exports = get_exports(&module, true)?;
 

--- a/pallets/gear-program/src/mock.rs
+++ b/pallets/gear-program/src/mock.rs
@@ -16,6 +16,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(unused)]
+
 use crate as pallet_gear_program;
 use crate::*;
 use frame_support::{
@@ -40,11 +42,8 @@ type AccountId = u64;
 type BlockNumber = u64;
 type Balance = u128;
 
-#[allow(unused)]
 pub(crate) const USER_1: AccountId = 1;
-#[allow(unused)]
 pub(crate) const USER_2: AccountId = 2;
-#[allow(unused)]
 pub(crate) const USER_3: AccountId = 3;
 pub(crate) const LOW_BALANCE_USER: AccountId = 4;
 pub(crate) const BLOCK_AUTHOR: AccountId = 255;
@@ -166,7 +165,6 @@ impl pallet_timestamp::Config for Test {
 }
 
 // Build genesis storage according to the mock runtime.
-#[allow(unused)]
 pub fn new_test_ext() -> sp_io::TestExternalities {
     let mut t = system::GenesisConfig::default()
         .build_storage::<Test>()

--- a/pallets/gear-program/src/mock.rs
+++ b/pallets/gear-program/src/mock.rs
@@ -40,8 +40,11 @@ type AccountId = u64;
 type BlockNumber = u64;
 type Balance = u128;
 
+#[allow(unused)]
 pub(crate) const USER_1: AccountId = 1;
+#[allow(unused)]
 pub(crate) const USER_2: AccountId = 2;
+#[allow(unused)]
 pub(crate) const USER_3: AccountId = 3;
 pub(crate) const LOW_BALANCE_USER: AccountId = 4;
 pub(crate) const BLOCK_AUTHOR: AccountId = 255;
@@ -163,6 +166,7 @@ impl pallet_timestamp::Config for Test {
 }
 
 // Build genesis storage according to the mock runtime.
+#[allow(unused)]
 pub fn new_test_ext() -> sp_io::TestExternalities {
     let mut t = system::GenesisConfig::default()
         .build_storage::<Test>()

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -1089,7 +1089,7 @@ pub mod pallet {
             code
         }
 
-        pub(crate) fn check_code(code: Vec<u8>) -> Result<CodeAndId, DispatchError> {
+        pub(crate) fn try_new_code(code: Vec<u8>) -> Result<CodeAndId, DispatchError> {
             let schedule = T::Schedule::get();
 
             ensure!(
@@ -1271,7 +1271,8 @@ pub mod pallet {
         pub fn upload_code(origin: OriginFor<T>, code: Vec<u8>) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
 
-            let code_id = Self::set_code_with_metadata(Self::check_code(code)?, who.into_origin())?;
+            let code_id =
+                Self::set_code_with_metadata(Self::try_new_code(code)?, who.into_origin())?;
 
             // TODO: replace this temporary (`None`) value
             // for expiration block number with properly
@@ -1338,7 +1339,7 @@ pub mod pallet {
 
             Self::check_gas_limit_and_value(gas_limit, value)?;
 
-            let code_and_id = Self::check_code(code)?;
+            let code_and_id = Self::try_new_code(code)?;
             let code_info = CodeInfo::from_code_and_id(&code_and_id);
             let packet = Self::init_packet(
                 who.clone(),

--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -748,7 +748,7 @@ impl Default for Limits {
 impl<T: Config> Default for InstructionWeights<T> {
     fn default() -> Self {
         Self {
-            version: 6,
+            version: 7,
             i64const: cost_instr!(instr_i64const, 1),
             i64load: cost_instr!(instr_i64load, 0),
             i32load: cost_instr!(instr_i32load, 0),

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -11324,7 +11324,7 @@ fn check_mutable_global_exports_restriction() {
     new_test_ext().execute_with(|| {
         assert_ok!(upload_program_default(
             USER_1,
-            ProgramCodeKind::CustomInvalid(wat_correct)
+            ProgramCodeKind::CustomInvalid(&wat_correct)
         ));
         assert_noop!(
             upload_program_default(USER_1, ProgramCodeKind::CustomInvalid(wat_incorrect)),

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -11324,10 +11324,10 @@ fn check_mutable_global_exports_restriction() {
     new_test_ext().execute_with(|| {
         assert_ok!(upload_program_default(
             USER_1,
-            ProgramCodeKind::CustomInvalid(&wat_correct)
+            ProgramCodeKind::CustomInvalid(wat_correct)
         ));
         assert_noop!(
-            upload_program_default(USER_1, ProgramCodeKind::CustomInvalid(&wat_incorrect)),
+            upload_program_default(USER_1, ProgramCodeKind::CustomInvalid(wat_incorrect)),
             Error::<Test>::ProgramConstructionFailed
         );
     });


### PR DESCRIPTION
restrict mutable globals to be export in gear on instrumentation. Exception is GEAR_STACK_END but only temporary.  In nearest feature GEAR_STACK_END will point to self const export.