### PR TITLE
refactor(gsdk): Make sign_and_submit_then_watch `Send`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4450,7 +4450,6 @@ name = "gsdk"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-recursion",
  "base64 0.21.2",
  "demo-messager",
  "demo-new-meta",

--- a/gsdk/Cargo.toml
+++ b/gsdk/Cargo.toml
@@ -10,7 +10,6 @@ readme = "./README.md"
 
 [dependencies]
 anyhow.workspace = true
-async-recursion.workspace = true
 base64.workspace = true
 futures-util.workspace = true
 futures.workspace = true

--- a/gsdk/src/signer/calls.rs
+++ b/gsdk/src/signer/calls.rs
@@ -375,7 +375,7 @@ impl Signer {
     }
 
     /// Wrapper for submit and watch with nonce.
-    async fn sign_and_submit<'a>(
+    async fn sign_and_submit_then_watch<'a>(
         &self,
         tx: &DynamicTxPayload<'a>,
     ) -> Result<TxProgressT, SubxtError> {
@@ -398,7 +398,7 @@ impl Signer {
         use subxt::tx::TxStatus::*;
 
         let before = self.balance().await?;
-        let mut process = self.sign_and_submit(&tx).await?;
+        let mut process = self.sign_and_submit_then_watch(&tx).await?;
 
         // Get extrinsic details.
         let (pallet, name) = (tx.pallet_name(), tx.call_name());


### PR DESCRIPTION
Awaiting result inside of async recursion can't be `Send`.

Think about how we can match the error outside of recursion.

@gear-tech/dev 


