### PR TITLE
chore: bump version to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "gcli"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "gear-cli"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "clap 4.3.2",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "gcli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "gear-cli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "clap 4.3.2",
  "frame-benchmarking",

--- a/gcli/Cargo.toml
+++ b/gcli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcli"
-version = "0.1.7"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 description = "gear program cli"

--- a/gcli/Cargo.toml
+++ b/gcli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcli"
-version = "0.1.6"
+version = "0.1.7"
 authors.workspace = true
 edition.workspace = true
 description = "gear program cli"

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gear-cli"
-version = "0.1.7"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gear-cli"
-version = "0.1.6"
+version = "0.1.7"
 authors.workspace = true
 edition.workspace = true
 

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -109,7 +109,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 160,
+    spec_version: 170,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -109,7 +109,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 170,
+    spec_version: 200,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 170,
+    spec_version: 200,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 160,
+    spec_version: 170,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
- Version bumped to distinguish the node and runtime from the released version.