### PR TITLE
refactor(core): remove unused `CountersOwner::refund_gas`

### DIFF
--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -48,7 +48,7 @@ use gear_core::{
     env::Ext as EnvExt,
     gas::{ChargeError, CountersOwner, GasAmount, GasLeft},
     ids::{CodeId, MessageId, ProgramId, ReservationId},
-    memory::{GearPage, IncorrectAllocationDataError, Memory, MemoryInterval, PageBuf, WasmPage},
+    memory::{GearPage, Memory, MemoryInterval, PageBuf, WasmPage},
     message::{
         ContextStore, Dispatch, DispatchKind, IncomingDispatch, MessageWaitedType,
         PayloadSizeError, WasmEntry,
@@ -122,7 +122,6 @@ impl From<ChargeError> for TerminationReason {
             ChargeError::GasLimitExceeded => {
                 ActorTerminationReason::Trap(TrapExplanation::GasLimitExceeded).into()
             }
-            ChargeError::TooManyGasAdded => SystemTerminationReason::TooManyGasAdded.into(),
             ChargeError::GasAllowanceExceeded => {
                 ActorTerminationReason::GasAllowanceExceeded.into()
             }
@@ -154,11 +153,13 @@ pub enum ActorTerminationReason {
     Trap(TrapExplanation),
 }
 
+/// Non-actor related termination reason.
+///
+/// ### NOTICE:
+/// It's currently unused, but is left as a stub, until
+/// further massive errors refactoring is done.
 #[derive(Debug, Clone, Eq, PartialEq, derive_more::Display)]
-pub enum SystemTerminationReason {
-    #[display(fmt = "Too many gas refunded")]
-    TooManyGasAdded,
-}
+pub struct SystemTerminationReason;
 
 #[derive(
     Decode,

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -156,8 +156,6 @@ pub enum ActorTerminationReason {
 
 #[derive(Debug, Clone, Eq, PartialEq, derive_more::Display)]
 pub enum SystemTerminationReason {
-    #[display(fmt = "{_0}")]
-    IncorrectAllocationData(IncorrectAllocationDataError),
     #[display(fmt = "Too many gas refunded")]
     TooManyGasAdded,
 }

--- a/core-backend/common/src/mock.rs
+++ b/core-backend/common/src/mock.rs
@@ -77,10 +77,6 @@ impl CountersOwner for MockExt {
         Ok(())
     }
 
-    fn refund_gas(&mut self, _amount: u64) -> Result<(), ChargeError> {
-        Ok(())
-    }
-
     fn gas_left(&self) -> GasLeft {
         GasLeft {
             gas: 0,

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -446,15 +446,6 @@ impl CountersOwner for Ext {
         )
     }
 
-    fn refund_gas(&mut self, amount: u64) -> Result<(), ChargeError> {
-        if self.context.gas_counter.refund(amount) == ChargeResult::Enough {
-            self.context.gas_allowance_counter.refund(amount);
-            Ok(())
-        } else {
-            Err(ChargeError::TooManyGasAdded)
-        }
-    }
-
     fn gas_left(&self) -> GasLeft {
         GasLeft {
             gas: self.context.gas_counter.left(),
@@ -772,8 +763,8 @@ impl EnvExt for Ext {
     fn unreserve_gas(&mut self, id: ReservationId) -> Result<u64, Self::Error> {
         let amount = self.context.gas_reserver.unreserve(id)?;
 
-        // this statement is like in `Self::refund_gas()` but it won't affect "burned" counter
-        // because we don't actually refund we just rise "left" counter during unreservation
+        // This statement increases `"eft" counter, but do not affect "burned" counter,
+        // because we don't actually refund, we just rise "left" counter during unreserve
         // and it won't affect gas allowance counter because we don't make any actual calculations
         // TODO: uncomment when unreserving in current message features is discussed
         /*if !self.context.gas_counter.increase(amount) {

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -763,7 +763,7 @@ impl EnvExt for Ext {
     fn unreserve_gas(&mut self, id: ReservationId) -> Result<u64, Self::Error> {
         let amount = self.context.gas_reserver.unreserve(id)?;
 
-        // This statement increases `"eft" counter, but do not affect "burned" counter,
+        // This statement is like an op that increases `"eft" counter, but do not affect "burned" counter,
         // because we don't actually refund, we just rise "left" counter during unreserve
         // and it won't affect gas allowance counter because we don't make any actual calculations
         // TODO: uncomment when unreserving in current message features is discussed

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -763,7 +763,7 @@ impl EnvExt for Ext {
     fn unreserve_gas(&mut self, id: ReservationId) -> Result<u64, Self::Error> {
         let amount = self.context.gas_reserver.unreserve(id)?;
 
-        // This statement is like an op that increases `"eft" counter, but do not affect "burned" counter,
+        // This statement is like an op that increases "left" counter, but do not affect "burned" counter,
         // because we don't actually refund, we just rise "left" counter during unreserve
         // and it won't affect gas allowance counter because we don't make any actual calculations
         // TODO: uncomment when unreserving in current message features is discussed

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -768,7 +768,7 @@ impl EnvExt for Ext {
         // and it won't affect gas allowance counter because we don't make any actual calculations
         // TODO: uncomment when unreserving in current message features is discussed
         /*if !self.context.gas_counter.increase(amount) {
-            return Err(ExecutionError::TooManyGasAdded.into());
+            return Err(some_charge_error.into());
         }*/
 
         Ok(amount)

--- a/core/src/gas.rs
+++ b/core/src/gas.rs
@@ -276,9 +276,6 @@ pub enum ChargeError {
     /// An error occurs in attempt to charge more gas than available during execution.
     #[display(fmt = "Not enough gas to continue execution")]
     GasLimitExceeded,
-    /// An error occurs in attempt to refund more gas than burned one.
-    #[display(fmt = "Too many gas refunded")]
-    TooManyGasAdded,
     /// Gas allowance exceeded
     #[display(fmt = "Gas allowance exceeded")]
     GasAllowanceExceeded,

--- a/core/src/gas.rs
+++ b/core/src/gas.rs
@@ -292,8 +292,6 @@ pub trait CountersOwner {
     fn charge_gas_runtime_if_enough(&mut self, cost: RuntimeCosts) -> Result<(), ChargeError>;
     /// Charge gas if enough, else just returns error.
     fn charge_gas_if_enough(&mut self, amount: u64) -> Result<(), ChargeError>;
-    /// Refund gas limit and gas allowance.
-    fn refund_gas(&mut self, amount: u64) -> Result<(), ChargeError>;
     /// Returns gas limit and gas allowance left.
     fn gas_left(&self) -> GasLeft;
     /// Set gas limit and gas allowance left.

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -143,10 +143,6 @@ impl CountersOwner for LazyPagesExt {
         self.inner.charge_gas_if_enough(amount)
     }
 
-    fn refund_gas(&mut self, amount: u64) -> Result<(), ChargeError> {
-        self.inner.refund_gas(amount)
-    }
-
     fn gas_left(&self) -> GasLeft {
         self.inner.gas_left()
     }


### PR DESCRIPTION
`SystemTerminationReason` error variants were completely unused, but removing it completely seems a hasty decision.