### PR TITLE
refactor(gstd)!: Fix poor error naming in gstd

### DIFF
--- a/examples/binaries/reserve-gas/src/lib.rs
+++ b/examples/binaries/reserve-gas/src/lib.rs
@@ -66,7 +66,7 @@ pub type BlockCount = u32;
 mod wasm {
     use super::*;
     use gstd::{
-        errors::{ContractError, ExtError, ReservationError},
+        errors::{Error, ExtError, ReservationError},
         exec, msg,
         prelude::*,
         MessageId, ReservationId,
@@ -126,35 +126,35 @@ mod wasm {
             InitAction::CheckArgs { mailbox_threshold } => {
                 assert_eq!(
                     ReservationId::reserve(0, 10),
-                    Err(ContractError::Ext(ExtError::Reservation(
+                    Err(Error::Ext(ExtError::Reservation(
                         ReservationError::ReservationBelowMailboxThreshold
                     )))
                 );
 
                 assert_eq!(
                     ReservationId::reserve(50_000, 0),
-                    Err(ContractError::Ext(ExtError::Reservation(
+                    Err(Error::Ext(ExtError::Reservation(
                         ReservationError::ZeroReservationDuration
                     )))
                 );
 
                 assert_eq!(
                     ReservationId::reserve(mailbox_threshold - 1, 1),
-                    Err(ContractError::Ext(ExtError::Reservation(
+                    Err(Error::Ext(ExtError::Reservation(
                         ReservationError::ReservationBelowMailboxThreshold
                     )))
                 );
 
                 assert_eq!(
                     ReservationId::reserve(mailbox_threshold, u32::MAX),
-                    Err(ContractError::Ext(ExtError::Reservation(
+                    Err(Error::Ext(ExtError::Reservation(
                         ReservationError::InsufficientGasForReservation
                     )))
                 );
 
                 assert_eq!(
                     ReservationId::reserve(u64::MAX, 1),
-                    Err(ContractError::Ext(ExtError::Reservation(
+                    Err(Error::Ext(ExtError::Reservation(
                         ReservationError::InsufficientGasForReservation
                     )))
                 );
@@ -170,7 +170,7 @@ mod wasm {
                 .unwrap();
                 assert_eq!(
                     id.unreserve(),
-                    Err(ContractError::Ext(ExtError::Reservation(
+                    Err(Error::Ext(ExtError::Reservation(
                         ReservationError::InvalidReservationId
                     )))
                 );
@@ -234,7 +234,7 @@ mod wasm {
                 .unwrap();
                 assert_eq!(
                     id.unreserve(),
-                    Err(ContractError::Ext(ExtError::Reservation(
+                    Err(Error::Ext(ExtError::Reservation(
                         ReservationError::InvalidReservationId
                     )))
                 );

--- a/examples/binaries/syscall-error/src/lib.rs
+++ b/examples/binaries/syscall-error/src/lib.rs
@@ -27,7 +27,7 @@ mod code {
 
 #[cfg(feature = "std")]
 pub use code::WASM_BINARY_OPT as WASM_BINARY;
-use gstd::errors::{ContractError, ExtError, MessageError};
+use gstd::errors::{Error, ExtError, MessageError};
 
 #[no_mangle]
 extern "C" fn init() {
@@ -47,7 +47,7 @@ extern "C" fn init() {
     let res = msg::send(ActorId::default(), "dummy", 250);
     assert_eq!(
         res,
-        Err(ContractError::Ext(ExtError::Message(
+        Err(Error::Ext(ExtError::Message(
             MessageError::InsufficientValue {
                 message_value: 250,
                 existential_deposit: 500

--- a/examples/binaries/wait-timeout/src/code.rs
+++ b/examples/binaries/wait-timeout/src/code.rs
@@ -2,7 +2,7 @@ use crate::Command;
 
 use codec::Encode;
 use futures::future;
-use gstd::{errors::ContractError, exec, msg, MessageId};
+use gstd::{errors::Error, exec, msg, MessageId};
 
 static mut TIMEOUT_MESSAGE_ID: Option<MessageId> = None;
 

--- a/examples/binaries/waiter/src/code.rs
+++ b/examples/binaries/waiter/src/code.rs
@@ -1,6 +1,6 @@
 use crate::{Command, WaitSubcommand};
 
-use gstd::{errors::ContractError, exec, msg, MessageId};
+use gstd::{errors::Error, exec, msg, MessageId};
 
 fn process_wait_subcommand(subcommand: WaitSubcommand) {
     match subcommand {

--- a/gstd/codegen/src/lib.rs
+++ b/gstd/codegen/src/lib.rs
@@ -321,7 +321,7 @@ pub fn async_init(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// ```ignore
 /// #[wait_for_reply]
 /// pub fn send_bytes<T: AsRef<[u8]>>(program: ActorId, payload: T, value: u128) -> Result<MessageId> {
-///   gcore::msg::send(program.into(), payload.as_ref(), value).into_contract_result()
+///   gcore::msg::send(program.into(), payload.as_ref(), value).into_result()
 /// }
 /// ```
 ///

--- a/gstd/src/async_runtime/locks.rs
+++ b/gstd/src/async_runtime/locks.rs
@@ -18,7 +18,7 @@
 
 use crate::{
     config::WaitType,
-    errors::{ContractError, Result},
+    errors::{Error, Result},
     exec, BTreeMap, Config, MessageId,
 };
 use core::cmp::Ordering;
@@ -44,7 +44,7 @@ impl Lock {
     /// Wait for
     pub fn exactly(b: u32) -> Result<Self> {
         if b == 0 {
-            return Err(ContractError::EmptyWaitDuration);
+            return Err(Error::EmptyWaitDuration);
         }
 
         Ok(Self {
@@ -56,7 +56,7 @@ impl Lock {
     /// Wait up to
     pub fn up_to(b: u32) -> Result<Self> {
         if b == 0 {
-            return Err(ContractError::EmptyWaitDuration);
+            return Err(Error::EmptyWaitDuration);
         }
 
         Ok(Self {

--- a/gstd/src/common/errors.rs
+++ b/gstd/src/common/errors.rs
@@ -18,7 +18,7 @@
 
 //! Type definitions and helpers for error handling.
 //!
-//! Enumerates possible errors in smart contracts `ContractError`.
+//! Enumerates possible errors in smart contracts `Error`.
 //! Errors related to conversion, decoding, message status code, other internal
 //! errors.
 
@@ -26,12 +26,12 @@ use core::fmt;
 
 pub use gcore::errors::*;
 
-/// `Result` type with a predefined error type ([`ContractError`]).
-pub type Result<T, E = ContractError> = core::result::Result<T, E>;
+/// `Result` type with a predefined error type ([`Error`]).
+pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 /// Common error type returned by API functions from other modules.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum ContractError {
+pub enum Error {
     /// Timeout reached while expecting for reply.
     Timeout(u32, u32),
     /// Conversion error.
@@ -52,47 +52,47 @@ pub enum ContractError {
     ZeroSystemReservationAmount,
 }
 
-impl ContractError {
-    /// Check whether an error is [`ContractError::Timeout`].
+impl Error {
+    /// Check whether an error is [`Error::Timeout`].
     pub fn timed_out(&self) -> bool {
-        matches!(self, ContractError::Timeout(..))
+        matches!(self, Error::Timeout(..))
     }
 }
 
-impl fmt::Display for ContractError {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ContractError::Timeout(expected, now) => {
+            Error::Timeout(expected, now) => {
                 write!(f, "Wait lock timeout at {expected}, now is {now}")
             }
-            ContractError::Convert(e) => write!(f, "Conversion error: {e:?}"),
-            ContractError::Decode(e) => write!(f, "Decoding codec bytes error: {e}"),
-            ContractError::StatusCode(e) => write!(f, "Reply returned exit code {e}"),
-            ContractError::Ext(e) => write!(f, "API error: {e}"),
-            ContractError::EmptyWaitDuration => write!(f, "Wait duration can not be zero."),
-            ContractError::ZeroSystemReservationAmount => {
+            Error::Convert(e) => write!(f, "Conversion error: {e:?}"),
+            Error::Decode(e) => write!(f, "Decoding codec bytes error: {e}"),
+            Error::StatusCode(e) => write!(f, "Reply returned exit code {e}"),
+            Error::Ext(e) => write!(f, "API error: {e}"),
+            Error::EmptyWaitDuration => write!(f, "Wait duration can not be zero."),
+            Error::ZeroSystemReservationAmount => {
                 write!(f, "System reservation amount can not be zero in config.")
             }
         }
     }
 }
 
-impl From<ExtError> for ContractError {
+impl From<ExtError> for Error {
     fn from(err: ExtError) -> Self {
         Self::Ext(err)
     }
 }
 
-pub(crate) trait IntoContractResult<T> {
-    fn into_contract_result(self) -> Result<T>;
+pub(crate) trait IntoResult<T> {
+    fn into_result(self) -> Result<T>;
 }
 
-impl<T, E, V> IntoContractResult<V> for core::result::Result<T, E>
+impl<T, E, V> IntoResult<V> for core::result::Result<T, E>
 where
     T: Into<V>,
-    E: Into<ContractError>,
+    E: Into<Error>,
 {
-    fn into_contract_result(self) -> Result<V> {
+    fn into_result(self) -> Result<V> {
         self.map(Into::into).map_err(Into::into)
     }
 }

--- a/gstd/src/common/primitives.rs
+++ b/gstd/src/common/primitives.rs
@@ -36,7 +36,7 @@
 //! ```
 
 use crate::{
-    errors::{ContractError, IntoContractResult, Result},
+    errors::{Error, IntoResult, Result},
     prelude::{convert::TryFrom, String},
 };
 use primitive_types::H256;
@@ -81,11 +81,11 @@ impl ActorId {
     pub fn from_bs58(address: String) -> Result<Self> {
         let decoded = bs58::decode(address)
             .into_vec()
-            .map_err(|_| ContractError::Convert("Unable to decode bs58 address"))?;
+            .map_err(|_| Error::Convert("Unable to decode bs58 address"))?;
 
         let len = decoded.len();
         if len < BS58_MIN_LEN {
-            Err(ContractError::Convert("Wrong address len"))
+            Err(Error::Convert("Wrong address len"))
         } else {
             Self::from_slice(&decoded[len - 34..len - 2])
         }
@@ -94,7 +94,7 @@ impl ActorId {
     /// Create a new `ActorId` from a byte slice.
     pub fn from_slice(slice: &[u8]) -> Result<Self> {
         if slice.len() != 32 {
-            return Err(ContractError::Convert("Slice should be 32 length"));
+            return Err(Error::Convert("Slice should be 32 length"));
         }
 
         let mut actor_id: Self = Default::default();
@@ -156,7 +156,7 @@ impl From<ActorId> for gcore::ActorId {
 }
 
 impl TryFrom<&[u8]> for ActorId {
-    type Error = ContractError;
+    type Error = Error;
 
     fn try_from(slice: &[u8]) -> Result<Self> {
         Self::from_slice(slice)
@@ -247,7 +247,7 @@ impl CodeId {
     /// Create a new `CodeId` from a byte slice.
     pub fn from_slice(slice: &[u8]) -> Result<Self> {
         if slice.len() != 32 {
-            return Err(ContractError::Convert("Slice should be 32 length"));
+            return Err(Error::Convert("Slice should be 32 length"));
         }
 
         let mut ret: Self = Default::default();
@@ -300,7 +300,7 @@ impl From<CodeId> for gcore::CodeId {
 }
 
 impl TryFrom<&[u8]> for CodeId {
-    type Error = ContractError;
+    type Error = Error;
 
     fn try_from(slice: &[u8]) -> Result<Self> {
         Self::from_slice(slice)
@@ -358,14 +358,14 @@ impl ReservationId {
     /// }
     /// ```
     pub fn reserve(amount: u64, duration: u32) -> Result<Self> {
-        gcore::exec::reserve_gas(amount, duration).into_contract_result()
+        gcore::exec::reserve_gas(amount, duration).into_result()
     }
 
     /// Unreserve unused gas from the reservation.
     ///
     /// If successful, it returns the reserved amount of gas.
     pub fn unreserve(self) -> Result<u64> {
-        gcore::exec::unreserve_gas(self.into()).into_contract_result()
+        gcore::exec::unreserve_gas(self.into()).into_result()
     }
 }
 

--- a/gstd/src/config.rs
+++ b/gstd/src/config.rs
@@ -20,7 +20,7 @@
 //! Gear libs are `#![no_std]`, which makes them lightweight.
 
 //! This module is for configuring `gstd` inside gear programs.
-use crate::errors::{ContractError, Result};
+use crate::errors::{Error, Result};
 
 /// Wait types.
 #[derive(Clone, Copy, Default)]
@@ -86,7 +86,7 @@ impl Config {
     /// Set `wait_for` duration (in blocks).
     pub fn set_wait_for(duration: u32) -> Result<()> {
         if duration == 0 {
-            return Err(ContractError::EmptyWaitDuration);
+            return Err(Error::EmptyWaitDuration);
         }
 
         unsafe { CONFIG.wait_for = duration };
@@ -107,7 +107,7 @@ impl Config {
     /// Set the `wait_up_to` duration (in blocks).
     pub fn set_wait_up_to(duration: u32) -> Result<()> {
         if duration == 0 {
-            return Err(ContractError::EmptyWaitDuration);
+            return Err(Error::EmptyWaitDuration);
         }
 
         unsafe { CONFIG.wait_up_to = duration };
@@ -128,7 +128,7 @@ impl Config {
     /// Set `system_reserve` gas amount.
     pub fn set_system_reserve(amount: u64) -> Result<()> {
         if amount == 0 {
-            return Err(ContractError::ZeroSystemReservationAmount);
+            return Err(Error::ZeroSystemReservationAmount);
         }
 
         unsafe { CONFIG.system_reserve = amount };

--- a/gstd/src/msg/basic.rs
+++ b/gstd/src/msg/basic.rs
@@ -18,7 +18,7 @@
 
 use crate::{
     async_runtime::signals,
-    errors::{IntoContractResult, Result},
+    errors::{IntoResult, Result},
     msg::{utils, CodecMessageFuture, MessageFuture},
     prelude::{convert::AsRef, ops::RangeBounds, vec, Vec},
     ActorId, MessageId, ReservationId,
@@ -71,7 +71,7 @@ impl MessageHandle {
     /// parts. This function initializes a message built in parts and
     /// returns the corresponding `MessageHandle`.
     pub fn init() -> Result<Self> {
-        gcore::msg::send_init().into_contract_result()
+        gcore::msg::send_init().into_result()
     }
 
     /// Push a payload part of the message to be sent in parts.
@@ -79,7 +79,7 @@ impl MessageHandle {
     /// Gear allows programs to work with messages in parts.
     /// This function adds a `payload` part to the message.
     pub fn push<T: AsRef<[u8]>>(&self, payload: T) -> Result<()> {
-        gcore::msg::send_push(self.0, payload.as_ref()).into_contract_result()
+        gcore::msg::send_push(self.0, payload.as_ref()).into_result()
     }
 
     /// Same as [`push`](Self::push) but uses the input buffer as a payload
@@ -108,7 +108,7 @@ impl MessageHandle {
     /// ```
     pub fn push_input<Range: RangeBounds<usize>>(&self, range: Range) -> Result<()> {
         let (offset, len) = utils::decay_range(range);
-        gcore::msg::send_push_input(self.0, offset, len).into_contract_result()
+        gcore::msg::send_push_input(self.0, offset, len).into_result()
     }
 
     /// Finalize and send the message formed in parts.
@@ -122,13 +122,13 @@ impl MessageHandle {
     /// to the message target account.
     #[wait_for_reply(self)]
     pub fn commit(self, program: ActorId, value: u128) -> Result<MessageId> {
-        gcore::msg::send_commit(self.0, program.into(), value).into_contract_result()
+        gcore::msg::send_commit(self.0, program.into(), value).into_result()
     }
 
     /// Same as [`commit`](Self::commit), but sends the message after the
     /// `delay` expressed in block count.
     pub fn commit_delayed(self, program: ActorId, value: u128, delay: u32) -> Result<MessageId> {
-        gcore::msg::send_commit_delayed(self.0, program.into(), value, delay).into_contract_result()
+        gcore::msg::send_commit_delayed(self.0, program.into(), value, delay).into_result()
     }
 
     /// Same as [`commit`](Self::commit), but with an explicit gas
@@ -156,8 +156,7 @@ impl MessageHandle {
         gas_limit: u64,
         value: u128,
     ) -> Result<MessageId> {
-        gcore::msg::send_commit_with_gas(self.0, program.into(), gas_limit, value)
-            .into_contract_result()
+        gcore::msg::send_commit_with_gas(self.0, program.into(), gas_limit, value).into_result()
     }
 
     /// Same as [`commit_with_gas`](Self::commit_with_gas), but sends
@@ -170,7 +169,7 @@ impl MessageHandle {
         delay: u32,
     ) -> Result<MessageId> {
         gcore::msg::send_commit_with_gas_delayed(self.0, program.into(), gas_limit, value, delay)
-            .into_contract_result()
+            .into_result()
     }
 
     /// Same as [`commit`](Self::commit), but it spends gas from the
@@ -204,7 +203,7 @@ impl MessageHandle {
         value: u128,
     ) -> Result<MessageId> {
         gcore::msg::send_commit_from_reservation(id.into(), self.into(), program.into(), value)
-            .into_contract_result()
+            .into_result()
     }
 
     /// Same as [`commit_from_reservation`](Self::commit_from_reservation), but
@@ -223,7 +222,7 @@ impl MessageHandle {
             value,
             delay,
         )
-        .into_contract_result()
+        .into_result()
     }
 }
 
@@ -351,7 +350,7 @@ pub fn load_bytes() -> Result<Vec<u8>> {
 ///   in parts.
 /// - [`send_bytes`] function sends a new message to the program or user.
 pub fn reply_bytes(payload: impl AsRef<[u8]>, value: u128) -> Result<MessageId> {
-    gcore::msg::reply(payload.as_ref(), value).into_contract_result()
+    gcore::msg::reply(payload.as_ref(), value).into_result()
 }
 
 /// Same as [`reply_bytes`], but it spends gas from a reservation instead of
@@ -383,7 +382,7 @@ pub fn reply_bytes_from_reservation(
     payload: impl AsRef<[u8]>,
     value: u128,
 ) -> Result<MessageId> {
-    gcore::msg::reply_from_reservation(id.into(), payload.as_ref(), value).into_contract_result()
+    gcore::msg::reply_from_reservation(id.into(), payload.as_ref(), value).into_result()
 }
 
 /// Same as [`reply_bytes`], but with an explicit gas limit.
@@ -403,7 +402,7 @@ pub fn reply_bytes_with_gas(
     gas_limit: u64,
     value: u128,
 ) -> Result<MessageId> {
-    gcore::msg::reply_with_gas(payload.as_ref(), gas_limit, value).into_contract_result()
+    gcore::msg::reply_with_gas(payload.as_ref(), gas_limit, value).into_result()
 }
 
 /// Finalize and send the current reply message.
@@ -443,7 +442,7 @@ pub fn reply_bytes_with_gas(
 /// - [`MessageHandle::commit`] function finalizes and sends a message formed in
 ///   parts.
 pub fn reply_commit(value: u128) -> Result<MessageId> {
-    gcore::msg::reply_commit(value).into_contract_result()
+    gcore::msg::reply_commit(value).into_result()
 }
 
 /// Same as [`reply_commit`], but it spends gas from a reservation instead of
@@ -467,7 +466,7 @@ pub fn reply_commit(value: u128) -> Result<MessageId> {
 /// - [`reply_push`] function allows forming a reply message in parts.
 /// - [`ReservationId`] struct allows reserve gas for later use.
 pub fn reply_commit_from_reservation(id: ReservationId, value: u128) -> Result<MessageId> {
-    gcore::msg::reply_commit_from_reservation(id.into(), value).into_contract_result()
+    gcore::msg::reply_commit_from_reservation(id.into(), value).into_result()
 }
 
 /// Same as [`reply_commit`], but with an explicit gas limit.
@@ -489,7 +488,7 @@ pub fn reply_commit_from_reservation(id: ReservationId, value: u128) -> Result<M
 ///
 /// - [`reply_push`] function allows forming a reply message in parts.
 pub fn reply_commit_with_gas(gas_limit: u64, value: u128) -> Result<MessageId> {
-    gcore::msg::reply_commit_with_gas(gas_limit, value).into_contract_result()
+    gcore::msg::reply_commit_with_gas(gas_limit, value).into_result()
 }
 
 /// Push a payload part to the current reply message.
@@ -513,7 +512,7 @@ pub fn reply_commit_with_gas(gas_limit: u64, value: u128) -> Result<MessageId> {
 ///
 /// - [`reply_commit`] function finalizes and sends the current reply message.
 pub fn reply_push<T: AsRef<[u8]>>(payload: T) -> Result<()> {
-    gcore::msg::reply_push(payload.as_ref()).into_contract_result()
+    gcore::msg::reply_push(payload.as_ref()).into_result()
 }
 
 /// Get an identifier of the initial message on which the current `handle_reply`
@@ -534,7 +533,7 @@ pub fn reply_push<T: AsRef<[u8]>>(payload: T) -> Result<()> {
 /// }
 /// ```
 pub fn reply_to() -> Result<MessageId> {
-    gcore::msg::reply_to().into_contract_result()
+    gcore::msg::reply_to().into_result()
 }
 
 /// Get an identifier of the message which issued a signal.
@@ -554,7 +553,7 @@ pub fn reply_to() -> Result<MessageId> {
 /// }
 /// ```
 pub fn signal_from() -> Result<MessageId> {
-    gcore::msg::signal_from().into_contract_result()
+    gcore::msg::signal_from().into_result()
 }
 
 /// Same as [`reply_push`] but uses the input buffer as a payload source.
@@ -583,7 +582,7 @@ pub fn signal_from() -> Result<MessageId> {
 pub fn reply_push_input<Range: RangeBounds<usize>>(range: Range) -> Result<()> {
     let (offset, len) = utils::decay_range(range);
 
-    gcore::msg::reply_push_input(offset, len).into_contract_result()
+    gcore::msg::reply_push_input(offset, len).into_result()
 }
 
 /// Send a new message to the program or user.
@@ -623,7 +622,7 @@ pub fn reply_push_input<Range: RangeBounds<usize>>(range: Range) -> Result<()> {
 ///   parts.
 #[wait_for_reply]
 pub fn send_bytes<T: AsRef<[u8]>>(program: ActorId, payload: T, value: u128) -> Result<MessageId> {
-    gcore::msg::send(program.into(), payload.as_ref(), value).into_contract_result()
+    gcore::msg::send(program.into(), payload.as_ref(), value).into_result()
 }
 
 /// Same as [`send_bytes`], but sends the message after the `delay` expressed in
@@ -634,7 +633,7 @@ pub fn send_bytes_delayed<T: AsRef<[u8]>>(
     value: u128,
     delay: u32,
 ) -> Result<MessageId> {
-    gcore::msg::send_delayed(program.into(), payload.as_ref(), value, delay).into_contract_result()
+    gcore::msg::send_delayed(program.into(), payload.as_ref(), value, delay).into_result()
 }
 
 /// Same as [`send_bytes`], but with an explicit gas limit.
@@ -669,8 +668,7 @@ pub fn send_bytes_with_gas<T: AsRef<[u8]>>(
     gas_limit: u64,
     value: u128,
 ) -> Result<MessageId> {
-    gcore::msg::send_with_gas(program.into(), payload.as_ref(), gas_limit, value)
-        .into_contract_result()
+    gcore::msg::send_with_gas(program.into(), payload.as_ref(), gas_limit, value).into_result()
 }
 
 /// Same as [`send_bytes_with_gas`], but sends the message after the `delay`
@@ -683,7 +681,7 @@ pub fn send_bytes_with_gas_delayed<T: AsRef<[u8]>>(
     delay: u32,
 ) -> Result<MessageId> {
     gcore::msg::send_with_gas_delayed(program.into(), payload.as_ref(), gas_limit, value, delay)
-        .into_contract_result()
+        .into_result()
 }
 
 /// Same as [`send_bytes`], but it spends gas from a reservation instead of
@@ -727,7 +725,7 @@ pub fn send_bytes_from_reservation<T: AsRef<[u8]>>(
     value: u128,
 ) -> Result<MessageId> {
     gcore::msg::send_from_reservation(id.into(), program.into(), payload.as_ref(), value)
-        .into_contract_result()
+        .into_result()
 }
 
 /// Same as [`send_bytes_from_reservation`], but sends the message after the
@@ -746,7 +744,7 @@ pub fn send_bytes_delayed_from_reservation<T: AsRef<[u8]>>(
         value,
         delay,
     )
-    .into_contract_result()
+    .into_result()
 }
 
 /// Get the payload size of the message that is being processed.

--- a/gstd/src/msg/encoded.rs
+++ b/gstd/src/msg/encoded.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     async_runtime::signals,
-    errors::{ContractError, IntoContractResult, Result},
+    errors::{Error, IntoResult, Result},
     msg::{utils, CodecMessageFuture, MessageFuture},
     prelude::{convert::AsRef, ops::RangeBounds},
     ActorId, MessageId, ReservationId,
@@ -59,7 +59,7 @@ use scale_info::scale::{Decode, Encode};
 /// - [`load_bytes`](super::load_bytes) function returns a payload as a byte
 ///   vector.
 pub fn load<D: Decode>() -> Result<D> {
-    D::decode(&mut super::load_bytes()?.as_ref()).map_err(ContractError::Decode)
+    D::decode(&mut super::load_bytes()?.as_ref()).map_err(Error::Decode)
 }
 
 /// Send a new message as a reply to the message being
@@ -215,7 +215,7 @@ pub fn reply_with_gas<E: Encode>(payload: E, gas_limit: u64, value: u128) -> Res
 pub fn reply_input<Range: RangeBounds<usize>>(value: u128, range: Range) -> Result<MessageId> {
     let (offset, len) = utils::decay_range(range);
 
-    gcore::msg::reply_input(value, offset, len).into_contract_result()
+    gcore::msg::reply_input(value, offset, len).into_result()
 }
 
 /// Same as [`reply_input`], but with an explicit gas limit.
@@ -226,7 +226,7 @@ pub fn reply_input_with_gas<Range: RangeBounds<usize>>(
 ) -> Result<MessageId> {
     let (offset, len) = utils::decay_range(range);
 
-    gcore::msg::reply_input_with_gas(gas_limit, value, offset, len).into_contract_result()
+    gcore::msg::reply_input_with_gas(gas_limit, value, offset, len).into_result()
 }
 
 /// Same as [`send`] but uses the input buffer as a payload source.
@@ -262,7 +262,7 @@ pub fn send_input<Range: RangeBounds<usize>>(
 ) -> Result<MessageId> {
     let (offset, len) = utils::decay_range(range);
 
-    gcore::msg::send_input(program.into(), value, offset, len).into_contract_result()
+    gcore::msg::send_input(program.into(), value, offset, len).into_result()
 }
 
 /// Same as [`send_input`], but sends the message after the `delay` expressed in
@@ -275,7 +275,7 @@ pub fn send_input_delayed<Range: RangeBounds<usize>>(
 ) -> Result<MessageId> {
     let (offset, len) = utils::decay_range(range);
 
-    gcore::msg::send_input_delayed(program.into(), value, offset, len, delay).into_contract_result()
+    gcore::msg::send_input_delayed(program.into(), value, offset, len, delay).into_result()
 }
 
 /// Same as [`send_input`], but with an explicit gas limit.
@@ -288,8 +288,7 @@ pub fn send_input_with_gas<Range: RangeBounds<usize>>(
 ) -> Result<MessageId> {
     let (offset, len) = utils::decay_range(range);
 
-    gcore::msg::send_input_with_gas(program.into(), gas_limit, value, offset, len)
-        .into_contract_result()
+    gcore::msg::send_input_with_gas(program.into(), gas_limit, value, offset, len).into_result()
 }
 
 /// Same as [`send_input_with_gas`], but sends the message after the `delay`
@@ -304,7 +303,7 @@ pub fn send_input_with_gas_delayed<Range: RangeBounds<usize>>(
     let (offset, len) = utils::decay_range(range);
 
     gcore::msg::send_input_with_gas_delayed(program.into(), gas_limit, value, offset, len, delay)
-        .into_contract_result()
+        .into_result()
 }
 
 /// Send a new message to the program or user.


### PR DESCRIPTION
we have no notion of `Contract`

global error can have no predicate at all