### PR TITLE
refactor(core-backend): rename generics `core-backend` & `core-processor` so they emphasize their essence

### DIFF
--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -21,7 +21,7 @@
 use crate::{
     memory::{MemoryAccessError, MemoryAccessRecorder, MemoryOwner},
     runtime::Runtime,
-    syscall_trace, ActorTerminationReason, BackendAllocExtError, BackendExt, BackendExtError,
+    syscall_trace, ActorTerminationReason, BackendAllocExtError, BackendExternalities, BackendExtError,
     BackendState, MessageWaitedType, TerminationReason, TrapExplanation, PTR_SPECIAL,
 };
 use alloc::string::{String, ToString};
@@ -49,7 +49,7 @@ pub struct FuncsHandler<E: Externalities + 'static, R> {
 
 impl<E, R> FuncsHandler<E, R>
 where
-    E: BackendExt + 'static,
+    E: BackendExternalities + 'static,
     E::Error: BackendExtError,
     E::AllocError: BackendAllocExtError<ExtError = E::Error>,
     R: Runtime<E> + MemoryOwner + MemoryAccessRecorder + BackendState,

--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -31,7 +31,7 @@ use gear_backend_codegen::host;
 use gear_core::{
     buffer::RuntimeBuffer,
     costs::RuntimeCosts,
-    env::Ext,
+    env::Externalities,
     memory::{PageU32Size, WasmPage},
     message::{HandlePacket, InitPacket, ReplyPacket},
 };
@@ -43,9 +43,8 @@ use gsys::{
 };
 use parity_scale_codec::Encode;
 
-pub struct FuncsHandler<E: Ext + 'static, R> {
-    _phantom_ext: PhantomData<E>,
-    _phantom_runtime: PhantomData<R>,
+pub struct FuncsHandler<E: Externalities + 'static, R> {
+    _phantom: PhantomData<(E, R)>,
 }
 
 impl<E, R> FuncsHandler<E, R>

--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -44,16 +44,16 @@ use gsys::{
 };
 use parity_scale_codec::Encode;
 
-pub struct FuncsHandler<E: Externalities + 'static, R> {
-    _phantom: PhantomData<(E, R)>,
+pub struct FuncsHandler<Ext: Externalities + 'static, Runtime> {
+    _phantom: PhantomData<(Ext, Runtime)>,
 }
 
-impl<E, R> FuncsHandler<E, R>
+impl<Ext, R> FuncsHandler<Ext, R>
 where
-    E: BackendExternalities + 'static,
-    E::Error: BackendExternalitiesError,
-    E::AllocError: BackendAllocExternalitiesError<ExtError = E::Error>,
-    R: Runtime<E> + MemoryOwner + MemoryAccessRecorder + BackendState,
+    Ext: BackendExternalities + 'static,
+    Ext::Error: BackendExternalitiesError,
+    Ext::AllocError: BackendAllocExternalitiesError<ExtError = Ext::Error>,
+    R: Runtime<Ext>,
 {
     /// !!! Usage warning: make sure to do it before any other read/write,
     /// because it may contain registered read.

--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -19,11 +19,9 @@
 //! Syscall implementations generic over wasmi and sandbox backends.
 
 use crate::{
-    memory::{MemoryAccessError, MemoryAccessRecorder, MemoryOwner},
-    runtime::Runtime,
-    syscall_trace, ActorTerminationReason, BackendAllocExternalitiesError, BackendExternalities,
-    BackendExternalitiesError, BackendState, MessageWaitedType, TerminationReason, TrapExplanation,
-    PTR_SPECIAL,
+    memory::MemoryAccessError, runtime::Runtime, syscall_trace, ActorTerminationReason,
+    BackendAllocExternalitiesError, BackendExternalities, BackendExternalitiesError,
+    MessageWaitedType, TerminationReason, TrapExplanation, PTR_SPECIAL,
 };
 use alloc::string::{String, ToString};
 use blake2_rfc::blake2b::blake2b;

--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -21,8 +21,9 @@
 use crate::{
     memory::{MemoryAccessError, MemoryAccessRecorder, MemoryOwner},
     runtime::Runtime,
-    syscall_trace, ActorTerminationReason, BackendAllocExtError, BackendExternalities, BackendExtError,
-    BackendState, MessageWaitedType, TerminationReason, TrapExplanation, PTR_SPECIAL,
+    syscall_trace, ActorTerminationReason, BackendAllocExternalitiesError, BackendExternalities,
+    BackendExternalitiesError, BackendState, MessageWaitedType, TerminationReason, TrapExplanation,
+    PTR_SPECIAL,
 };
 use alloc::string::{String, ToString};
 use blake2_rfc::blake2b::blake2b;
@@ -50,8 +51,8 @@ pub struct FuncsHandler<E: Externalities + 'static, R> {
 impl<E, R> FuncsHandler<E, R>
 where
     E: BackendExternalities + 'static,
-    E::Error: BackendExtError,
-    E::AllocError: BackendAllocExtError<ExtError = E::Error>,
+    E::Error: BackendExternalitiesError,
+    E::AllocError: BackendAllocExternalitiesError<ExtError = E::Error>,
     R: Runtime<E> + MemoryOwner + MemoryAccessRecorder + BackendState,
 {
     /// !!! Usage warning: make sure to do it before any other read/write,

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -310,7 +310,10 @@ where
     /// Memory type for current environment.
     type Memory: Memory;
 
-    /// An error issues in environment.
+    /// That's an error which originally comes from the primary
+    /// wasm execution environment (set by wasmi or sandbox).
+    /// So it's not the error of the `Self` itself, it's a kind
+    /// of wrapper over the underlying executor error.
     type SystemError: Debug + Display;
 
     /// 1) Instantiates wasm binary.

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -233,7 +233,7 @@ pub struct ExtInfo {
     pub context_store: ContextStore,
 }
 
-pub trait BackendExt: Externalities + CountersOwner {
+pub trait BackendExternalities: Externalities + CountersOwner {
     fn into_ext_info(self, memory: &impl Memory) -> Result<ExtInfo, MemoryError>;
 
     fn gas_amount(&self) -> GasAmount;
@@ -298,7 +298,7 @@ pub trait Environment<EntryPoint = DispatchKind>: Sized
 where
     EntryPoint: WasmEntryPoint,
 {
-    type Ext: BackendExt + 'static;
+    type Ext: BackendExternalities + 'static;
 
     /// Memory type for current environment.
     type Memory: Memory;
@@ -382,7 +382,7 @@ pub trait BackendState {
 /// Backend termination aims to return to the caller gear wasm program
 /// execution outcome, which is the state of externalities, memory and
 /// termination reason.
-pub trait BackendTermination<E: BackendExt, M: Sized>: Sized {
+pub trait BackendTermination<E: BackendExternalities, M: Sized>: Sized {
     /// Transforms [`Self`] into tuple of externalities, memory and
     /// termination reason returned after the execution.
     fn into_parts(self) -> (E, M, TerminationReason);

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -389,10 +389,10 @@ pub trait BackendState {
 /// Backend termination aims to return to the caller gear wasm program
 /// execution outcome, which is the state of externalities, memory and
 /// termination reason.
-pub trait BackendTermination<E: BackendExternalities, EnvMem: Sized>: Sized {
+pub trait BackendTermination<Ext: BackendExternalities, EnvMem: Sized>: Sized {
     /// Transforms [`Self`] into tuple of externalities, memory and
     /// termination reason returned after the execution.
-    fn into_parts(self) -> (E, EnvMem, TerminationReason);
+    fn into_parts(self) -> (Ext, EnvMem, TerminationReason);
 
     /// Terminates backend work after execution.
     ///
@@ -414,7 +414,7 @@ pub trait BackendTermination<E: BackendExternalities, EnvMem: Sized>: Sized {
         res: Result<T, WasmCallErr>,
         gas: i64,
         allowance: i64,
-    ) -> (E, EnvMem, TerminationReason) {
+    ) -> (Ext, EnvMem, TerminationReason) {
         log::trace!("Execution result = {res:?}");
 
         let (mut ext, memory, termination_reason) = self.into_parts();

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -377,14 +377,34 @@ pub trait BackendState {
     }
 }
 
+/// A trait for termination of the gear sys-calls execution backend.
+///
+/// Backend termination aims to return to the caller gear wasm program
+/// execution outcome, which is the state of externalities, memory and
+/// termination reason.
 pub trait BackendTermination<E: BackendExt, M: Sized>: Sized {
-    /// Into parts
+    /// Transforms [`Self`] into tuple of externalities, memory and
+    /// termination reason returned after the execution.
     fn into_parts(self) -> (E, M, TerminationReason);
 
-    /// Terminate backend work after execution
-    fn terminate<T: Debug, Err: Debug>(
+    /// Terminates backend work after execution.
+    ///
+    /// The function handles `res`, which is the result of gear wasm
+    /// program entry point invocation, and the termination reason.
+    ///
+    /// If the `res` is `Ok`, then execution considered successful
+    /// and the termination reason will have the corresponding value.
+    ///
+    /// If the `res` is `Err`, then execution is considered to end
+    /// with an error and the actual termination reason, which stores
+    /// more precise information about the error, is returned.
+    ///
+    /// There's a case, when `res` is `Err`, but termination reason has
+    /// a value for the successful ending of the execution. This is the
+    /// case of calling `unreachable` panic in the program.
+    fn terminate<T: Debug, WasmCallErr: Debug>(
         self,
-        res: Result<T, Err>,
+        res: Result<T, WasmCallErr>,
         gas: i64,
         allowance: i64,
     ) -> (E, M, TerminationReason) {

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -45,7 +45,7 @@ use core::{
 };
 use gear_core::{
     buffer::RuntimeBufferSizeError,
-    env::Ext as EnvExt,
+    env::Externalities,
     gas::{ChargeError, CountersOwner, GasAmount, GasLeft},
     ids::{CodeId, MessageId, ProgramId, ReservationId},
     memory::{GearPage, Memory, MemoryInterval, PageBuf, WasmPage},
@@ -233,7 +233,7 @@ pub struct ExtInfo {
     pub context_store: ContextStore,
 }
 
-pub trait BackendExt: EnvExt + CountersOwner {
+pub trait BackendExt: Externalities + CountersOwner {
     fn into_ext_info(self, memory: &impl Memory) -> Result<ExtInfo, MemoryError>;
 
     fn gas_amount(&self) -> GasAmount;
@@ -259,7 +259,7 @@ pub trait BackendAllocExtError: Sized {
 
 pub struct BackendReport<MemWrap, Ext>
 where
-    Ext: EnvExt,
+    Ext: Externalities,
 {
     pub termination_reason: TerminationReason,
     pub memory_wrap: MemWrap,

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -129,7 +129,7 @@ impl From<ChargeError> for TerminationReason {
     }
 }
 
-impl<E: BackendExtError> From<E> for TerminationReason {
+impl<E: BackendExternalitiesError> From<E> for TerminationReason {
     fn from(err: E) -> Self {
         err.into_termination_reason()
     }
@@ -246,13 +246,13 @@ pub trait BackendExternalities: Externalities + CountersOwner {
     ) -> Result<(), ProcessAccessError>;
 }
 
-pub trait BackendExtError: Clone + Sized {
+pub trait BackendExternalitiesError: Clone + Sized {
     fn into_termination_reason(self) -> TerminationReason;
 }
 
 // TODO: consider to remove this trait and use Result<Result<Page, AllocError>, GasError> instead #2571
-pub trait BackendAllocExtError: Sized {
-    type ExtError: BackendExtError;
+pub trait BackendAllocExternalitiesError: Sized {
+    type ExtError: BackendExternalitiesError;
 
     fn into_backend_error(self) -> Result<Self::ExtError, Self>;
 }
@@ -363,7 +363,7 @@ pub trait BackendState {
     }
 
     /// Process alloc function result
-    fn process_alloc_func_result<T: Sized, E: BackendAllocExtError>(
+    fn process_alloc_func_result<T: Sized, E: BackendAllocExternalitiesError>(
         &mut self,
         res: Result<T, E>,
     ) -> Result<Result<T, E>, TerminationReason> {

--- a/core-backend/common/src/memory.rs
+++ b/core-backend/common/src/memory.rs
@@ -18,7 +18,7 @@
 
 //! Work with WASM program memory in backends.
 
-use crate::BackendExt;
+use crate::BackendExternalities;
 use alloc::vec::Vec;
 use core::{
     fmt::Debug,
@@ -198,7 +198,7 @@ impl<E> MemoryAccessRecorder for MemoryAccessManager<E> {
     }
 }
 
-impl<E: BackendExt> MemoryAccessManager<E> {
+impl<E: BackendExternalities> MemoryAccessManager<E> {
     /// Call pre-processing of registered memory accesses. Clear `self.reads` and `self.writes`.
     pub(crate) fn pre_process_memory_accesses(
         &mut self,

--- a/core-backend/common/src/memory.rs
+++ b/core-backend/common/src/memory.rs
@@ -129,14 +129,14 @@ pub trait MemoryOwner {
 /// manager.write_as(write1, 111).unwrap();
 /// ```
 #[derive(Debug)]
-pub struct MemoryAccessManager<E> {
+pub struct MemoryAccessManager<Ext> {
     // Contains non-zero length intervals only.
     pub(crate) reads: Vec<MemoryInterval>,
     pub(crate) writes: Vec<MemoryInterval>,
-    pub(crate) _phantom: PhantomData<E>,
+    pub(crate) _phantom: PhantomData<Ext>,
 }
 
-impl<E> Default for MemoryAccessManager<E> {
+impl<Ext> Default for MemoryAccessManager<Ext> {
     fn default() -> Self {
         Self {
             reads: Vec::new(),
@@ -146,7 +146,7 @@ impl<E> Default for MemoryAccessManager<E> {
     }
 }
 
-impl<E> MemoryAccessRecorder for MemoryAccessManager<E> {
+impl<Ext> MemoryAccessRecorder for MemoryAccessManager<Ext> {
     fn register_read(&mut self, ptr: u32, size: u32) -> WasmMemoryRead {
         if size > 0 {
             self.reads.push(MemoryInterval { offset: ptr, size });
@@ -198,7 +198,7 @@ impl<E> MemoryAccessRecorder for MemoryAccessManager<E> {
     }
 }
 
-impl<E: BackendExternalities> MemoryAccessManager<E> {
+impl<Ext: BackendExternalities> MemoryAccessManager<Ext> {
     /// Call pre-processing of registered memory accesses. Clear `self.reads` and `self.writes`.
     pub(crate) fn pre_process_memory_accesses(
         &mut self,
@@ -208,7 +208,7 @@ impl<E: BackendExternalities> MemoryAccessManager<E> {
             return Ok(());
         }
 
-        let res = E::pre_process_memory_accesses(&self.reads, &self.writes, gas_left);
+        let res = Ext::pre_process_memory_accesses(&self.reads, &self.writes, gas_left);
 
         self.reads.clear();
         self.writes.clear();

--- a/core-backend/common/src/mock.rs
+++ b/core-backend/common/src/mock.rs
@@ -24,7 +24,7 @@ use alloc::{collections::BTreeSet, vec, vec::Vec};
 use core::{cell::Cell, fmt, fmt::Debug};
 use gear_core::{
     costs::RuntimeCosts,
-    env::Ext,
+    env::Externalities,
     gas::{ChargeError, CountersOwner, GasAmount, GasCounter, GasLeft},
     ids::{MessageId, ProgramId, ReservationId},
     memory::{Memory, MemoryInterval, PageU32Size, WasmPage, WASM_PAGE_SIZE},
@@ -87,7 +87,7 @@ impl CountersOwner for MockExt {
     fn set_gas_left(&mut self, _gas_left: GasLeft) {}
 }
 
-impl Ext for MockExt {
+impl Externalities for MockExt {
     type Error = Error;
     type AllocError = Error;
 

--- a/core-backend/common/src/mock.rs
+++ b/core-backend/common/src/mock.rs
@@ -17,7 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    memory::ProcessAccessError, BackendAllocExtError, BackendExt, BackendExtError, ExtInfo,
+    memory::ProcessAccessError, BackendAllocExtError, BackendExternalities, BackendExtError, ExtInfo,
     SystemReservationContext, TerminationReason,
 };
 use alloc::{collections::BTreeSet, vec, vec::Vec};
@@ -243,7 +243,7 @@ impl Externalities for MockExt {
     }
 }
 
-impl BackendExt for MockExt {
+impl BackendExternalities for MockExt {
     fn into_ext_info(self, _memory: &impl Memory) -> Result<ExtInfo, MemoryError> {
         Ok(ExtInfo {
             gas_amount: GasCounter::new(0).to_amount(),

--- a/core-backend/common/src/mock.rs
+++ b/core-backend/common/src/mock.rs
@@ -17,8 +17,8 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    memory::ProcessAccessError, BackendAllocExtError, BackendExternalities, BackendExtError, ExtInfo,
-    SystemReservationContext, TerminationReason,
+    memory::ProcessAccessError, BackendAllocExternalitiesError, BackendExternalities,
+    BackendExternalitiesError, ExtInfo, SystemReservationContext, TerminationReason,
 };
 use alloc::{collections::BTreeSet, vec, vec::Vec};
 use core::{cell::Cell, fmt, fmt::Debug};
@@ -46,13 +46,13 @@ impl fmt::Display for Error {
     }
 }
 
-impl BackendExtError for Error {
+impl BackendExternalitiesError for Error {
     fn into_termination_reason(self) -> TerminationReason {
         unimplemented!()
     }
 }
 
-impl BackendAllocExtError for Error {
+impl BackendAllocExternalitiesError for Error {
     type ExtError = Self;
 
     fn into_backend_error(self) -> Result<Self::ExtError, Self> {

--- a/core-backend/common/src/runtime.rs
+++ b/core-backend/common/src/runtime.rs
@@ -25,7 +25,9 @@ use crate::{
 use gear_core::{costs::RuntimeCosts, gas::GasLeft, memory::WasmPage};
 use gear_core_errors::ExtError;
 
-pub trait Runtime<E: BackendExternalities>: MemoryOwner + MemoryAccessRecorder + BackendState {
+pub trait Runtime<E: BackendExternalities>:
+    MemoryOwner + MemoryAccessRecorder + BackendState
+{
     type Error;
 
     fn unreachable_error() -> Self::Error;

--- a/core-backend/common/src/runtime.rs
+++ b/core-backend/common/src/runtime.rs
@@ -20,12 +20,12 @@
 
 use crate::{
     memory::{MemoryAccessError, MemoryAccessRecorder, MemoryOwner, WasmMemoryWrite},
-    BackendExt, BackendState, TerminationReason,
+    BackendExternalities, BackendState, TerminationReason,
 };
 use gear_core::{costs::RuntimeCosts, gas::GasLeft, memory::WasmPage};
 use gear_core_errors::ExtError;
 
-pub trait Runtime<E: BackendExt>: MemoryOwner + MemoryAccessRecorder + BackendState {
+pub trait Runtime<E: BackendExternalities>: MemoryOwner + MemoryAccessRecorder + BackendState {
     type Error;
 
     fn unreachable_error() -> Self::Error;

--- a/core-backend/common/src/runtime.rs
+++ b/core-backend/common/src/runtime.rs
@@ -25,7 +25,7 @@ use crate::{
 use gear_core::{costs::RuntimeCosts, gas::GasLeft, memory::WasmPage};
 use gear_core_errors::ExtError;
 
-pub trait Runtime<E: BackendExternalities>:
+pub trait Runtime<Ext: BackendExternalities>:
     MemoryOwner + MemoryAccessRecorder + BackendState
 {
     type Error;
@@ -34,7 +34,7 @@ pub trait Runtime<E: BackendExternalities>:
 
     fn fallible_syscall_error(&self) -> Option<&ExtError>;
 
-    fn ext_mut(&mut self) -> &mut E;
+    fn ext_mut(&mut self) -> &mut Ext;
 
     fn run_any<T, F>(&mut self, cost: RuntimeCosts, f: F) -> Result<T, Self::Error>
     where
@@ -50,7 +50,7 @@ pub trait Runtime<E: BackendExternalities>:
         F: FnOnce(&mut Self) -> Result<T, TerminationReason>,
         R: From<Result<T, u32>> + Sized;
 
-    fn alloc(&mut self, pages: u32) -> Result<WasmPage, E::AllocError>;
+    fn alloc(&mut self, pages: u32) -> Result<WasmPage, Ext::AllocError>;
 
     fn memory_manager_write(
         &mut self,

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -27,7 +27,7 @@ use core::{convert::Infallible, fmt::Display};
 use gear_backend_common::{
     funcs::FuncsHandler,
     lazy_pages::{GlobalsAccessConfig, GlobalsAccessMod},
-    ActorTerminationReason, BackendAllocExtError, BackendExt, BackendExtError, BackendReport,
+    ActorTerminationReason, BackendAllocExtError, BackendExternalities, BackendExtError, BackendReport,
     BackendTermination, Environment, EnvironmentError, EnvironmentExecutionResult,
 };
 use gear_core::{
@@ -143,7 +143,7 @@ pub enum SandboxEnvironmentSystemError {
 /// Environment to run one module at a time providing Ext.
 pub struct SandboxEnvironment<E, EntryPoint = DispatchKind>
 where
-    E: BackendExt,
+    E: BackendExternalities,
     EntryPoint: WasmEntryPoint,
 {
     instance: Instance<Runtime<E>>,
@@ -154,7 +154,7 @@ where
 
 // A helping wrapper for `EnvironmentDefinitionBuilder` and `forbidden_funcs`.
 // It makes adding functions to `EnvironmentDefinitionBuilder` shorter.
-struct EnvBuilder<E: BackendExt> {
+struct EnvBuilder<E: BackendExternalities> {
     env_def_builder: EnvironmentDefinitionBuilder<Runtime<E>>,
     forbidden_funcs: BTreeSet<SysCallName>,
     funcs_count: usize,
@@ -162,7 +162,7 @@ struct EnvBuilder<E: BackendExt> {
 
 impl<E> EnvBuilder<E>
 where
-    E: BackendExt + 'static,
+    E: BackendExternalities + 'static,
     E::Error: BackendExtError,
     E::AllocError: BackendAllocExtError<ExtError = E::Error>,
 {
@@ -185,7 +185,7 @@ where
     }
 }
 
-impl<E: BackendExt> From<EnvBuilder<E>> for EnvironmentDefinitionBuilder<Runtime<E>> {
+impl<E: BackendExternalities> From<EnvBuilder<E>> for EnvironmentDefinitionBuilder<Runtime<E>> {
     fn from(builder: EnvBuilder<E>) -> Self {
         builder.env_def_builder
     }
@@ -193,7 +193,7 @@ impl<E: BackendExt> From<EnvBuilder<E>> for EnvironmentDefinitionBuilder<Runtime
 
 impl<E, EntryPoint> SandboxEnvironment<E, EntryPoint>
 where
-    E: BackendExt + 'static,
+    E: BackendExternalities + 'static,
     E::Error: BackendExtError,
     E::AllocError: BackendAllocExtError<ExtError = E::Error>,
     EntryPoint: WasmEntryPoint,
@@ -263,7 +263,7 @@ where
 
 impl<E, EntryPoint> Environment<EntryPoint> for SandboxEnvironment<E, EntryPoint>
 where
-    E: BackendExt + 'static,
+    E: BackendExternalities + 'static,
     E::Error: BackendExtError,
     E::AllocError: BackendAllocExtError<ExtError = E::Error>,
     EntryPoint: WasmEntryPoint,

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -130,7 +130,7 @@ macro_rules! wrap_common_func {
 }
 
 #[derive(Debug, derive_more::Display)]
-pub enum SandboxEnvironmentSystemError {
+pub enum SandboxEnvironmentError {
     #[display(fmt = "Failed to create env memory: {_0:?}")]
     CreateEnvMemory(sp_sandbox::Error),
     #[display(fmt = "Globals are not supported")]
@@ -273,7 +273,7 @@ where
 {
     type Ext = EnvExt;
     type Memory = MemoryWrap;
-    type SystemError = SandboxEnvironmentSystemError;
+    type SystemError = SandboxEnvironmentError;
 
     fn new(
         ext: Self::Ext,
@@ -283,7 +283,7 @@ where
         mem_size: WasmPage,
     ) -> Result<Self, EnvironmentError<Self::SystemError, Infallible>> {
         use EnvironmentError::*;
-        use SandboxEnvironmentSystemError::*;
+        use SandboxEnvironmentError::*;
 
         let entry_forbidden = entry_point
             .try_into_kind()
@@ -355,7 +355,7 @@ where
         PrepareMemoryError: Display,
     {
         use EnvironmentError::*;
-        use SandboxEnvironmentSystemError::*;
+        use SandboxEnvironmentError::*;
 
         let Self {
             mut instance,

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -33,7 +33,7 @@ use gear_backend_common::{
 use gear_core::{
     gas::GasLeft,
     memory::{PageU32Size, WasmPage},
-    message::{DispatchKind, WasmEntry},
+    message::{DispatchKind, WasmEntryPoint},
 };
 use gear_wasm_instrument::{
     syscalls::SysCallName::{self, *},
@@ -144,7 +144,7 @@ pub enum SandboxEnvironmentError {
 pub struct SandboxEnvironment<E, EP = DispatchKind>
 where
     E: BackendExt,
-    EP: WasmEntry,
+    EP: WasmEntryPoint,
 {
     instance: Instance<Runtime<E>>,
     runtime: Runtime<E>,
@@ -196,7 +196,7 @@ where
     E: BackendExt + 'static,
     E::Error: BackendExtError,
     E::AllocError: BackendAllocExtError<ExtError = E::Error>,
-    EP: WasmEntry,
+    EP: WasmEntryPoint,
 {
     #[rustfmt::skip]
     fn bind_funcs(builder: &mut EnvBuilder<E>) {
@@ -266,7 +266,7 @@ where
     E: BackendExt + 'static,
     E::Error: BackendExtError,
     E::AllocError: BackendAllocExtError<ExtError = E::Error>,
-    EP: WasmEntry,
+    EP: WasmEntryPoint,
 {
     type Ext = E;
     type Memory = MemoryWrap;

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -186,7 +186,9 @@ where
     }
 }
 
-impl<Ext: BackendExternalities> From<EnvBuilder<Ext>> for EnvironmentDefinitionBuilder<Runtime<Ext>> {
+impl<Ext: BackendExternalities> From<EnvBuilder<Ext>>
+    for EnvironmentDefinitionBuilder<Runtime<Ext>>
+{
     fn from(builder: EnvBuilder<Ext>) -> Self {
         builder.env_def_builder
     }

--- a/core-backend/sandbox/src/env.rs
+++ b/core-backend/sandbox/src/env.rs
@@ -27,8 +27,9 @@ use core::{convert::Infallible, fmt::Display};
 use gear_backend_common::{
     funcs::FuncsHandler,
     lazy_pages::{GlobalsAccessConfig, GlobalsAccessMod},
-    ActorTerminationReason, BackendAllocExtError, BackendExternalities, BackendExtError, BackendReport,
-    BackendTermination, Environment, EnvironmentError, EnvironmentExecutionResult,
+    ActorTerminationReason, BackendAllocExternalitiesError, BackendExternalities,
+    BackendExternalitiesError, BackendReport, BackendTermination, Environment, EnvironmentError,
+    EnvironmentExecutionResult,
 };
 use gear_core::{
     gas::GasLeft,
@@ -163,8 +164,8 @@ struct EnvBuilder<E: BackendExternalities> {
 impl<E> EnvBuilder<E>
 where
     E: BackendExternalities + 'static,
-    E::Error: BackendExtError,
-    E::AllocError: BackendAllocExtError<ExtError = E::Error>,
+    E::Error: BackendExternalitiesError,
+    E::AllocError: BackendAllocExternalitiesError<ExtError = E::Error>,
 {
     fn add_func(&mut self, name: SysCallName, f: HostFuncType<Runtime<E>>) {
         if self.forbidden_funcs.contains(&name) {
@@ -194,8 +195,8 @@ impl<E: BackendExternalities> From<EnvBuilder<E>> for EnvironmentDefinitionBuild
 impl<E, EntryPoint> SandboxEnvironment<E, EntryPoint>
 where
     E: BackendExternalities + 'static,
-    E::Error: BackendExtError,
-    E::AllocError: BackendAllocExtError<ExtError = E::Error>,
+    E::Error: BackendExternalitiesError,
+    E::AllocError: BackendAllocExternalitiesError<ExtError = E::Error>,
     EntryPoint: WasmEntryPoint,
 {
     #[rustfmt::skip]
@@ -264,8 +265,8 @@ where
 impl<E, EntryPoint> Environment<EntryPoint> for SandboxEnvironment<E, EntryPoint>
 where
     E: BackendExternalities + 'static,
-    E::Error: BackendExtError,
-    E::AllocError: BackendAllocExtError<ExtError = E::Error>,
+    E::Error: BackendExternalitiesError,
+    E::AllocError: BackendAllocExternalitiesError<ExtError = E::Error>,
     EntryPoint: WasmEntryPoint,
 {
     type Ext = E;

--- a/core-backend/sandbox/src/runtime.rs
+++ b/core-backend/sandbox/src/runtime.rs
@@ -27,7 +27,7 @@ use gear_backend_common::{
         WasmMemoryReadAs, WasmMemoryReadDecoded, WasmMemoryWrite, WasmMemoryWriteAs,
     },
     runtime::Runtime as CommonRuntime,
-    BackendExt, BackendState, BackendTermination, TerminationReason,
+    BackendExternalities, BackendState, BackendTermination, TerminationReason,
 };
 use gear_core::{costs::RuntimeCosts, gas::GasLeft, memory::WasmPage};
 use gear_core_errors::ExtError;
@@ -51,7 +51,7 @@ pub(crate) struct Runtime<E> {
     pub memory_manager: MemoryAccessManager<E>,
 }
 
-impl<E: BackendExt> CommonRuntime<E> for Runtime<E> {
+impl<E: BackendExternalities> CommonRuntime<E> for Runtime<E> {
     type Error = HostError;
 
     fn ext_mut(&mut self) -> &mut E {
@@ -114,7 +114,7 @@ impl<E: BackendExt> CommonRuntime<E> for Runtime<E> {
     }
 }
 
-impl<E: BackendExt> Runtime<E> {
+impl<E: BackendExternalities> Runtime<E> {
     // Cleans `memory_manager`, updates ext counters based on globals.
     fn prepare_run(&mut self) {
         self.memory_manager = Default::default();
@@ -180,7 +180,7 @@ impl<E: BackendExt> Runtime<E> {
     }
 }
 
-impl<E: BackendExt> MemoryAccessRecorder for Runtime<E> {
+impl<E: BackendExternalities> MemoryAccessRecorder for Runtime<E> {
     fn register_read(&mut self, ptr: u32, size: u32) -> WasmMemoryRead {
         self.memory_manager.register_read(ptr, size)
     }
@@ -205,7 +205,7 @@ impl<E: BackendExt> MemoryAccessRecorder for Runtime<E> {
     }
 }
 
-impl<E: BackendExt> MemoryOwner for Runtime<E> {
+impl<E: BackendExternalities> MemoryOwner for Runtime<E> {
     fn read(&mut self, read: WasmMemoryRead) -> Result<Vec<u8>, MemoryAccessError> {
         self.with_memory(move |manager, memory, gas_left| manager.read(memory, read, gas_left))
     }
@@ -250,7 +250,7 @@ impl<E> BackendState for Runtime<E> {
     }
 }
 
-impl<E: BackendExt> BackendTermination<E, MemoryWrap> for Runtime<E> {
+impl<E: BackendExternalities> BackendTermination<E, MemoryWrap> for Runtime<E> {
     fn into_parts(self) -> (E, MemoryWrap, TerminationReason) {
         let Self {
             ext,

--- a/core-backend/sandbox/src/runtime.rs
+++ b/core-backend/sandbox/src/runtime.rs
@@ -41,20 +41,20 @@ pub(crate) fn as_i64(v: Value) -> Option<i64> {
     }
 }
 
-pub(crate) struct Runtime<E> {
-    pub ext: E,
+pub(crate) struct Runtime<Ext> {
+    pub ext: Ext,
     pub memory: MemoryWrap,
     pub fallible_syscall_error: Option<ExtError>,
     pub termination_reason: TerminationReason,
     pub globals: sp_sandbox::default_executor::InstanceGlobals,
     // TODO: make wrapper around runtime and move memory_manager there (issue #2067)
-    pub memory_manager: MemoryAccessManager<E>,
+    pub memory_manager: MemoryAccessManager<Ext>,
 }
 
-impl<E: BackendExternalities> CommonRuntime<E> for Runtime<E> {
+impl<Ext: BackendExternalities> CommonRuntime<Ext> for Runtime<Ext> {
     type Error = HostError;
 
-    fn ext_mut(&mut self) -> &mut E {
+    fn ext_mut(&mut self) -> &mut Ext {
         &mut self.ext
     }
 
@@ -99,7 +99,7 @@ impl<E: BackendExternalities> CommonRuntime<E> for Runtime<E> {
         .map(|_| ())
     }
 
-    fn alloc(&mut self, pages: u32) -> Result<WasmPage, <E>::AllocError> {
+    fn alloc(&mut self, pages: u32) -> Result<WasmPage, <Ext>::AllocError> {
         self.ext.alloc(pages, &mut self.memory)
     }
 
@@ -114,7 +114,7 @@ impl<E: BackendExternalities> CommonRuntime<E> for Runtime<E> {
     }
 }
 
-impl<E: BackendExternalities> Runtime<E> {
+impl<Ext: BackendExternalities> Runtime<Ext> {
     // Cleans `memory_manager`, updates ext counters based on globals.
     fn prepare_run(&mut self) {
         self.memory_manager = Default::default();
@@ -168,7 +168,7 @@ impl<E: BackendExternalities> Runtime<E> {
     fn with_memory<R, F>(&mut self, f: F) -> Result<R, MemoryAccessError>
     where
         F: FnOnce(
-            &mut MemoryAccessManager<E>,
+            &mut MemoryAccessManager<Ext>,
             &mut MemoryWrap,
             &mut GasLeft,
         ) -> Result<R, MemoryAccessError>,
@@ -180,7 +180,7 @@ impl<E: BackendExternalities> Runtime<E> {
     }
 }
 
-impl<E: BackendExternalities> MemoryAccessRecorder for Runtime<E> {
+impl<Ext: BackendExternalities> MemoryAccessRecorder for Runtime<Ext> {
     fn register_read(&mut self, ptr: u32, size: u32) -> WasmMemoryRead {
         self.memory_manager.register_read(ptr, size)
     }
@@ -205,7 +205,7 @@ impl<E: BackendExternalities> MemoryAccessRecorder for Runtime<E> {
     }
 }
 
-impl<E: BackendExternalities> MemoryOwner for Runtime<E> {
+impl<Ext: BackendExternalities> MemoryOwner for Runtime<Ext> {
     fn read(&mut self, read: WasmMemoryRead) -> Result<Vec<u8>, MemoryAccessError> {
         self.with_memory(move |manager, memory, gas_left| manager.read(memory, read, gas_left))
     }
@@ -240,7 +240,7 @@ impl<E: BackendExternalities> MemoryOwner for Runtime<E> {
     }
 }
 
-impl<E> BackendState for Runtime<E> {
+impl<Ext> BackendState for Runtime<Ext> {
     fn set_termination_reason(&mut self, reason: TerminationReason) {
         self.termination_reason = reason;
     }
@@ -250,8 +250,8 @@ impl<E> BackendState for Runtime<E> {
     }
 }
 
-impl<E: BackendExternalities> BackendTermination<E, MemoryWrap> for Runtime<E> {
-    fn into_parts(self) -> (E, MemoryWrap, TerminationReason) {
+impl<Ext: BackendExternalities> BackendTermination<Ext, MemoryWrap> for Runtime<Ext> {
+    fn into_parts(self) -> (Ext, MemoryWrap, TerminationReason) {
         let Self {
             ext,
             memory,

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -203,13 +203,13 @@ where
         })
     }
 
-    fn execute<F, T>(
+    fn execute<PrepareMemory, PrepareMemoryError>(
         self,
-        pre_execution_handler: F,
-    ) -> EnvironmentExecutionResult<T, Self, EntryPoint>
+        prepare_memory: PrepareMemory,
+    ) -> EnvironmentExecutionResult<PrepareMemoryError, Self, EntryPoint>
     where
-        F: FnOnce(&mut Self::Memory, Option<u32>, GlobalsAccessConfig) -> Result<(), T>,
-        T: Display,
+        PrepareMemory: FnOnce(&mut Self::Memory, Option<u32>, GlobalsAccessConfig) -> Result<(), PrepareMemoryError>,
+        PrepareMemoryError: Display,
     {
         use EnvironmentExecutionError::*;
         use WasmiEnvironmentError::*;
@@ -274,7 +274,7 @@ where
         };
 
         let mut memory_wrap = MemoryWrap::new(memory, store);
-        pre_execution_handler(&mut memory_wrap, stack_end, globals_config).map_err(|e| {
+        prepare_memory(&mut memory_wrap, stack_end, globals_config).map_err(|e| {
             let store = &memory_wrap.store;
             PrepareMemory(gas_amount!(store), e)
         })?;

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -27,7 +27,7 @@ use alloc::{collections::BTreeSet, format, string::ToString};
 use core::{any::Any, convert::Infallible, fmt::Display};
 use gear_backend_common::{
     lazy_pages::{GlobalsAccessConfig, GlobalsAccessError, GlobalsAccessMod, GlobalsAccessor},
-    ActorTerminationReason, BackendAllocExtError, BackendExt, BackendExtError, BackendReport,
+    ActorTerminationReason, BackendAllocExtError, BackendExternalities, BackendExtError, BackendReport,
     BackendTermination, Environment, EnvironmentError, EnvironmentExecutionResult, LimitedStr,
 };
 use gear_core::{
@@ -123,7 +123,7 @@ impl<E: Externalities + 'static> GlobalsAccessor for GlobalsAccessProvider<E> {
 
 impl<E, EntryPoint> Environment<EntryPoint> for WasmiEnvironment<E, EntryPoint>
 where
-    E: BackendExt + 'static,
+    E: BackendExternalities + 'static,
     E::Error: BackendExtError,
     E::AllocError: BackendAllocExtError<ExtError = E::Error>,
     EntryPoint: WasmEntryPoint,

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -27,8 +27,9 @@ use alloc::{collections::BTreeSet, format, string::ToString};
 use core::{any::Any, convert::Infallible, fmt::Display};
 use gear_backend_common::{
     lazy_pages::{GlobalsAccessConfig, GlobalsAccessError, GlobalsAccessMod, GlobalsAccessor},
-    ActorTerminationReason, BackendAllocExtError, BackendExternalities, BackendExtError, BackendReport,
-    BackendTermination, Environment, EnvironmentError, EnvironmentExecutionResult, LimitedStr,
+    ActorTerminationReason, BackendAllocExternalitiesError, BackendExternalities,
+    BackendExternalitiesError, BackendReport, BackendTermination, Environment, EnvironmentError,
+    EnvironmentExecutionResult, LimitedStr,
 };
 use gear_core::{
     env::Externalities,
@@ -124,8 +125,8 @@ impl<E: Externalities + 'static> GlobalsAccessor for GlobalsAccessProvider<E> {
 impl<E, EntryPoint> Environment<EntryPoint> for WasmiEnvironment<E, EntryPoint>
 where
     E: BackendExternalities + 'static,
-    E::Error: BackendExtError,
-    E::AllocError: BackendAllocExtError<ExtError = E::Error>,
+    E::Error: BackendExternalitiesError,
+    E::AllocError: BackendAllocExternalitiesError<ExtError = E::Error>,
     EntryPoint: WasmEntryPoint,
 {
     type Ext = E;

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -31,7 +31,7 @@ use gear_backend_common::{
     BackendTermination, Environment, EnvironmentError, EnvironmentExecutionResult, LimitedStr,
 };
 use gear_core::{
-    env::Ext,
+    env::Externalities,
     gas::GasLeft,
     memory::{HostPointer, PageU32Size, WasmPage},
     message::{DispatchKind, WasmEntryPoint},
@@ -69,7 +69,7 @@ macro_rules! gas_amount {
 /// Environment to run one module at a time providing Ext.
 pub struct WasmiEnvironment<E, EntryPoint = DispatchKind>
 where
-    E: Ext,
+    E: Externalities,
     EntryPoint: WasmEntryPoint,
 {
     instance: Instance,
@@ -79,12 +79,12 @@ where
     entry_point: EntryPoint,
 }
 
-struct GlobalsAccessProvider<E: Ext> {
+struct GlobalsAccessProvider<E: Externalities> {
     instance: Instance,
     store: Option<Store<HostState<E>>>,
 }
 
-impl<E: Ext> GlobalsAccessProvider<E> {
+impl<E: Externalities> GlobalsAccessProvider<E> {
     fn get_global(&self, name: &str) -> Option<Global> {
         let store = self.store.as_ref()?;
         self.instance
@@ -93,7 +93,7 @@ impl<E: Ext> GlobalsAccessProvider<E> {
     }
 }
 
-impl<E: Ext + 'static> GlobalsAccessor for GlobalsAccessProvider<E> {
+impl<E: Externalities + 'static> GlobalsAccessor for GlobalsAccessProvider<E> {
     fn get_i64(&self, name: LimitedStr) -> Result<i64, GlobalsAccessError> {
         self.get_global(name.as_str())
             .and_then(|global| {

--- a/core-backend/wasmi/src/env.rs
+++ b/core-backend/wasmi/src/env.rs
@@ -43,7 +43,7 @@ use wasmi::{
 };
 
 #[derive(Debug, derive_more::Display, derive_more::From)]
-pub enum WasmiEnvironmentSystemError {
+pub enum WasmiEnvironmentError {
     #[from]
     #[display(fmt = "Failed to create env memory: {_0:?}")]
     CreateEnvMemory(wasmi::errors::MemoryError),
@@ -131,7 +131,7 @@ where
 {
     type Ext = EnvExt;
     type Memory = MemoryWrap<EnvExt>;
-    type SystemError = WasmiEnvironmentSystemError;
+    type SystemError = WasmiEnvironmentError;
 
     fn new(
         ext: Self::Ext,
@@ -141,7 +141,7 @@ where
         mem_size: WasmPage,
     ) -> Result<Self, EnvironmentError<Self::SystemError, Infallible>> {
         use EnvironmentError::*;
-        use WasmiEnvironmentSystemError::*;
+        use WasmiEnvironmentError::*;
 
         let engine = Engine::default();
         let mut store: Store<HostState<EnvExt>> = Store::new(&engine, None);
@@ -216,7 +216,7 @@ where
         PrepareMemoryError: Display,
     {
         use EnvironmentError::*;
-        use WasmiEnvironmentSystemError::*;
+        use WasmiEnvironmentError::*;
 
         let Self {
             instance,

--- a/core-backend/wasmi/src/funcs_tree.rs
+++ b/core-backend/wasmi/src/funcs_tree.rs
@@ -21,7 +21,7 @@
 use crate::{runtime::CallerWrap, state::HostState, wasmi::Caller};
 use alloc::collections::{BTreeMap, BTreeSet};
 use gear_backend_common::{
-    funcs::FuncsHandler as CommonFuncsHandler, BackendAllocExtError, BackendExt, BackendExtError,
+    funcs::FuncsHandler as CommonFuncsHandler, BackendAllocExtError, BackendExternalities, BackendExtError,
 };
 use gear_wasm_instrument::syscalls::SysCallName::{self, *};
 use wasmi::{core::Trap, Func, Memory, Store};
@@ -94,7 +94,7 @@ pub(crate) fn build<E>(
     forbidden_funcs: BTreeSet<SysCallName>,
 ) -> BTreeMap<SysCallName, Func>
 where
-    E: BackendExt + 'static,
+    E: BackendExternalities + 'static,
     E::Error: BackendExtError,
     E::AllocError: BackendAllocExtError<ExtError = E::Error>,
 {

--- a/core-backend/wasmi/src/funcs_tree.rs
+++ b/core-backend/wasmi/src/funcs_tree.rs
@@ -43,7 +43,7 @@ impl FunctionBuilder {
 macro_rules! wrap_common_func_internal_ret {
     ($func:path, $($arg_name:ident),*) => {
         |store: &mut Store<_>, forbidden, memory| {
-            let func = move |caller: Caller<'_, HostState<E>>, $($arg_name,)*| -> Result<(_, ), Trap>
+            let func = move |caller: Caller<'_, HostState<Ext>>, $($arg_name,)*| -> Result<(_, ), Trap>
             {
                 let mut ctx = CallerWrap::prepare(caller, forbidden, memory)?;
                 $func(&mut ctx, $($arg_name,)*).map(|ret| (ret,))
@@ -56,7 +56,7 @@ macro_rules! wrap_common_func_internal_ret {
 macro_rules! wrap_common_func_internal_no_ret {
     ($func:path, $($arg_name:ident),*) => {
         |store: &mut Store<_>, forbidden, memory| {
-            let func = move |caller: Caller<'_, HostState<E>>, $($arg_name,)*| -> Result<(), Trap>
+            let func = move |caller: Caller<'_, HostState<Ext>>, $($arg_name,)*| -> Result<(), Trap>
             {
                 let mut ctx = CallerWrap::prepare(caller, forbidden, memory)?;
                 $func(&mut ctx, $($arg_name,)*)
@@ -89,15 +89,15 @@ macro_rules! wrap_common_func {
     ($func:path, (8) -> (1)) => { wrap_common_func_internal_ret!($func, a, b, c, d, e, f, g, h)};
 }
 
-pub(crate) fn build<E>(
-    store: &mut Store<HostState<E>>,
+pub(crate) fn build<Ext>(
+    store: &mut Store<HostState<Ext>>,
     memory: Memory,
     forbidden_funcs: BTreeSet<SysCallName>,
 ) -> BTreeMap<SysCallName, Func>
 where
-    E: BackendExternalities + 'static,
-    E::Error: BackendExternalitiesError,
-    E::AllocError: BackendAllocExternalitiesError<ExtError = E::Error>,
+    Ext: BackendExternalities + 'static,
+    Ext::Error: BackendExternalitiesError,
+    Ext::AllocError: BackendAllocExternalitiesError<ExtError = Ext::Error>,
 {
     let f = FunctionBuilder(forbidden_funcs);
 

--- a/core-backend/wasmi/src/funcs_tree.rs
+++ b/core-backend/wasmi/src/funcs_tree.rs
@@ -21,7 +21,8 @@
 use crate::{runtime::CallerWrap, state::HostState, wasmi::Caller};
 use alloc::collections::{BTreeMap, BTreeSet};
 use gear_backend_common::{
-    funcs::FuncsHandler as CommonFuncsHandler, BackendAllocExtError, BackendExternalities, BackendExtError,
+    funcs::FuncsHandler as CommonFuncsHandler, BackendAllocExternalitiesError,
+    BackendExternalities, BackendExternalitiesError,
 };
 use gear_wasm_instrument::syscalls::SysCallName::{self, *};
 use wasmi::{core::Trap, Func, Memory, Store};
@@ -95,8 +96,8 @@ pub(crate) fn build<E>(
 ) -> BTreeMap<SysCallName, Func>
 where
     E: BackendExternalities + 'static,
-    E::Error: BackendExtError,
-    E::AllocError: BackendAllocExtError<ExtError = E::Error>,
+    E::Error: BackendExternalitiesError,
+    E::AllocError: BackendAllocExternalitiesError<ExtError = E::Error>,
 {
     let f = FunctionBuilder(forbidden_funcs);
 

--- a/core-backend/wasmi/src/memory.rs
+++ b/core-backend/wasmi/src/memory.rs
@@ -20,18 +20,18 @@
 
 use crate::state::HostState;
 use gear_core::{
-    env::Ext,
+    env::Externalities,
     memory::{HostPointer, Memory, PageU32Size, WasmPage},
 };
 use gear_core_errors::MemoryError;
 use wasmi::{core::memory_units::Pages, Memory as WasmiMemory, Store, StoreContextMut};
 
-pub(crate) struct MemoryWrapRef<'a, E: Ext + 'static> {
+pub(crate) struct MemoryWrapRef<'a, E: Externalities + 'static> {
     pub memory: WasmiMemory,
     pub store: StoreContextMut<'a, HostState<E>>,
 }
 
-impl<'a, E: Ext + 'static> Memory for MemoryWrapRef<'a, E> {
+impl<'a, E: Externalities + 'static> Memory for MemoryWrapRef<'a, E> {
     type GrowError = wasmi::errors::MemoryError;
 
     fn grow(&mut self, pages: WasmPage) -> Result<(), Self::GrowError> {
@@ -63,12 +63,12 @@ impl<'a, E: Ext + 'static> Memory for MemoryWrapRef<'a, E> {
 }
 
 /// Wrapper for [`wasmi::Memory`].
-pub struct MemoryWrap<E: Ext + 'static> {
+pub struct MemoryWrap<E: Externalities + 'static> {
     pub(crate) memory: WasmiMemory,
     pub(crate) store: Store<HostState<E>>,
 }
 
-impl<E: Ext + 'static> MemoryWrap<E> {
+impl<E: Externalities + 'static> MemoryWrap<E> {
     /// Wrap [`wasmi::Memory`] for Memory trait.
     pub(crate) fn new(memory: WasmiMemory, store: Store<HostState<E>>) -> Self {
         MemoryWrap { memory, store }
@@ -79,7 +79,7 @@ impl<E: Ext + 'static> MemoryWrap<E> {
 }
 
 /// Memory interface for the allocator.
-impl<E: Ext + 'static> Memory for MemoryWrap<E> {
+impl<E: Externalities + 'static> Memory for MemoryWrap<E> {
     type GrowError = wasmi::errors::MemoryError;
 
     fn grow(&mut self, pages: WasmPage) -> Result<(), Self::GrowError> {

--- a/core-backend/wasmi/src/memory.rs
+++ b/core-backend/wasmi/src/memory.rs
@@ -26,12 +26,12 @@ use gear_core::{
 use gear_core_errors::MemoryError;
 use wasmi::{core::memory_units::Pages, Memory as WasmiMemory, Store, StoreContextMut};
 
-pub(crate) struct MemoryWrapRef<'a, E: Externalities + 'static> {
+pub(crate) struct MemoryWrapRef<'a, Ext: Externalities + 'static> {
     pub memory: WasmiMemory,
-    pub store: StoreContextMut<'a, HostState<E>>,
+    pub store: StoreContextMut<'a, HostState<Ext>>,
 }
 
-impl<'a, E: Externalities + 'static> Memory for MemoryWrapRef<'a, E> {
+impl<'a, Ext: Externalities + 'static> Memory for MemoryWrapRef<'a, Ext> {
     type GrowError = wasmi::errors::MemoryError;
 
     fn grow(&mut self, pages: WasmPage) -> Result<(), Self::GrowError> {
@@ -63,23 +63,23 @@ impl<'a, E: Externalities + 'static> Memory for MemoryWrapRef<'a, E> {
 }
 
 /// Wrapper for [`wasmi::Memory`].
-pub struct MemoryWrap<E: Externalities + 'static> {
+pub struct MemoryWrap<Ext: Externalities + 'static> {
     pub(crate) memory: WasmiMemory,
-    pub(crate) store: Store<HostState<E>>,
+    pub(crate) store: Store<HostState<Ext>>,
 }
 
-impl<E: Externalities + 'static> MemoryWrap<E> {
+impl<Ext: Externalities + 'static> MemoryWrap<Ext> {
     /// Wrap [`wasmi::Memory`] for Memory trait.
-    pub(crate) fn new(memory: WasmiMemory, store: Store<HostState<E>>) -> Self {
+    pub(crate) fn new(memory: WasmiMemory, store: Store<HostState<Ext>>) -> Self {
         MemoryWrap { memory, store }
     }
-    pub(crate) fn into_store(self) -> Store<HostState<E>> {
+    pub(crate) fn into_store(self) -> Store<HostState<Ext>> {
         self.store
     }
 }
 
 /// Memory interface for the allocator.
-impl<E: Externalities + 'static> Memory for MemoryWrap<E> {
+impl<Ext: Externalities + 'static> Memory for MemoryWrap<Ext> {
     type GrowError = wasmi::errors::MemoryError;
 
     fn grow(&mut self, pages: WasmPage) -> Result<(), Self::GrowError> {

--- a/core-backend/wasmi/src/runtime.rs
+++ b/core-backend/wasmi/src/runtime.rs
@@ -48,7 +48,9 @@ pub(crate) fn caller_host_state_mut<'a, 'b: 'a, Ext>(
         .unwrap_or_else(|| unreachable!("host_state must be set before execution"))
 }
 
-pub(crate) fn caller_host_state_take<'a, 'b: 'a, Ext>(caller: &'a mut Caller<'b, Option<Ext>>) -> Ext {
+pub(crate) fn caller_host_state_take<'a, 'b: 'a, Ext>(
+    caller: &'a mut Caller<'b, Option<Ext>>,
+) -> Ext {
     caller
         .host_data_mut()
         .take()

--- a/core-backend/wasmi/src/runtime.rs
+++ b/core-backend/wasmi/src/runtime.rs
@@ -27,7 +27,7 @@ use gear_backend_common::{
         WasmMemoryReadAs, WasmMemoryReadDecoded, WasmMemoryWrite, WasmMemoryWriteAs,
     },
     runtime::Runtime,
-    ActorTerminationReason, BackendExt, BackendState, TerminationReason, TrapExplanation,
+    ActorTerminationReason, BackendExternalities, BackendState, TerminationReason, TrapExplanation,
 };
 use gear_core::{costs::RuntimeCosts, gas::GasLeft, memory::WasmPage};
 use gear_core_errors::ExtError;
@@ -61,7 +61,7 @@ pub(crate) struct CallerWrap<'a, E> {
     pub memory: WasmiMemory,
 }
 
-impl<'a, E: BackendExt + 'static> Runtime<E> for CallerWrap<'a, E> {
+impl<'a, E: BackendExternalities + 'static> Runtime<E> for CallerWrap<'a, E> {
     type Error = Trap;
 
     fn ext_mut(&mut self) -> &mut E {
@@ -138,7 +138,7 @@ impl<'a, E: BackendExt + 'static> Runtime<E> for CallerWrap<'a, E> {
     }
 }
 
-impl<'a, E: BackendExt + 'static> CallerWrap<'a, E> {
+impl<'a, E: BackendExternalities + 'static> CallerWrap<'a, E> {
     #[track_caller]
     pub fn prepare(
         caller: Caller<'a, HostState<E>>,
@@ -288,7 +288,7 @@ impl<E> BackendState for CallerWrap<'_, E> {
     }
 }
 
-impl<'a, E: BackendExt + 'static> MemoryOwner for CallerWrap<'a, E> {
+impl<'a, E: BackendExternalities + 'static> MemoryOwner for CallerWrap<'a, E> {
     fn read(&mut self, read: WasmMemoryRead) -> Result<Vec<u8>, MemoryAccessError> {
         self.with_memory(|manager, memory, gas_left| manager.read(memory, read, gas_left))
     }

--- a/core-backend/wasmi/src/runtime.rs
+++ b/core-backend/wasmi/src/runtime.rs
@@ -39,32 +39,32 @@ use wasmi::{
 
 use crate::state::State;
 
-pub(crate) fn caller_host_state_mut<'a, 'b: 'a, E>(
-    caller: &'a mut Caller<'b, Option<E>>,
-) -> &'a mut E {
+pub(crate) fn caller_host_state_mut<'a, 'b: 'a, Ext>(
+    caller: &'a mut Caller<'b, Option<Ext>>,
+) -> &'a mut Ext {
     caller
         .host_data_mut()
         .as_mut()
         .unwrap_or_else(|| unreachable!("host_state must be set before execution"))
 }
 
-pub(crate) fn caller_host_state_take<'a, 'b: 'a, E>(caller: &'a mut Caller<'b, Option<E>>) -> E {
+pub(crate) fn caller_host_state_take<'a, 'b: 'a, Ext>(caller: &'a mut Caller<'b, Option<Ext>>) -> Ext {
     caller
         .host_data_mut()
         .take()
         .unwrap_or_else(|| unreachable!("host_state must be set before execution"))
 }
 
-pub(crate) struct CallerWrap<'a, E> {
-    pub caller: Caller<'a, HostState<E>>,
-    pub manager: MemoryAccessManager<E>,
+pub(crate) struct CallerWrap<'a, Ext> {
+    pub caller: Caller<'a, HostState<Ext>>,
+    pub manager: MemoryAccessManager<Ext>,
     pub memory: WasmiMemory,
 }
 
-impl<'a, E: BackendExternalities + 'static> Runtime<E> for CallerWrap<'a, E> {
+impl<'a, Ext: BackendExternalities + 'static> Runtime<Ext> for CallerWrap<'a, Ext> {
     type Error = Trap;
 
-    fn ext_mut(&mut self) -> &mut E {
+    fn ext_mut(&mut self) -> &mut Ext {
         &mut self
             .caller
             .host_data_mut()
@@ -119,7 +119,7 @@ impl<'a, E: BackendExternalities + 'static> Runtime<E> for CallerWrap<'a, E> {
         })
     }
 
-    fn alloc(&mut self, pages: u32) -> Result<WasmPage, <E>::AllocError> {
+    fn alloc(&mut self, pages: u32) -> Result<WasmPage, <Ext>::AllocError> {
         let mut state = caller_host_state_take(&mut self.caller);
         let mut mem = CallerWrap::memory(&mut self.caller, self.memory);
         let res = state.ext.alloc(pages, &mut mem);
@@ -138,10 +138,10 @@ impl<'a, E: BackendExternalities + 'static> Runtime<E> for CallerWrap<'a, E> {
     }
 }
 
-impl<'a, E: BackendExternalities + 'static> CallerWrap<'a, E> {
+impl<'a, Ext: BackendExternalities + 'static> CallerWrap<'a, Ext> {
     #[track_caller]
     pub fn prepare(
-        caller: Caller<'a, HostState<E>>,
+        caller: Caller<'a, HostState<Ext>>,
         forbidden: bool,
         memory: WasmiMemory,
     ) -> Result<Self, Trap> {
@@ -181,15 +181,15 @@ impl<'a, E: BackendExternalities + 'static> CallerWrap<'a, E> {
     }
 
     #[track_caller]
-    pub fn host_state_mut(&mut self) -> &mut State<E> {
+    pub fn host_state_mut(&mut self) -> &mut State<Ext> {
         caller_host_state_mut(&mut self.caller)
     }
 
     #[track_caller]
     pub fn memory<'b, 'c: 'b>(
-        caller: &'b mut Caller<'c, Option<State<E>>>,
+        caller: &'b mut Caller<'c, Option<State<Ext>>>,
         memory: WasmiMemory,
-    ) -> MemoryWrapRef<'b, E> {
+    ) -> MemoryWrapRef<'b, Ext> {
         MemoryWrapRef::<'b, _> {
             memory,
             store: caller.as_context_mut(),
@@ -222,8 +222,8 @@ impl<'a, E: BackendExternalities + 'static> CallerWrap<'a, E> {
     fn with_memory<R, F>(&mut self, f: F) -> Result<R, MemoryAccessError>
     where
         F: FnOnce(
-            &mut MemoryAccessManager<E>,
-            &mut MemoryWrapRef<E>,
+            &mut MemoryAccessManager<Ext>,
+            &mut MemoryWrapRef<Ext>,
             &mut GasLeft,
         ) -> Result<R, MemoryAccessError>,
     {
@@ -253,7 +253,7 @@ impl<'a, E: BackendExternalities + 'static> CallerWrap<'a, E> {
     }
 }
 
-impl<'a, E> MemoryAccessRecorder for CallerWrap<'a, E> {
+impl<'a, Ext> MemoryAccessRecorder for CallerWrap<'a, Ext> {
     fn register_read(&mut self, ptr: u32, size: u32) -> WasmMemoryRead {
         self.manager.register_read(ptr, size)
     }
@@ -278,7 +278,7 @@ impl<'a, E> MemoryAccessRecorder for CallerWrap<'a, E> {
     }
 }
 
-impl<E> BackendState for CallerWrap<'_, E> {
+impl<Ext> BackendState for CallerWrap<'_, Ext> {
     fn set_termination_reason(&mut self, reason: TerminationReason) {
         caller_host_state_mut(&mut self.caller).set_termination_reason(reason);
     }
@@ -288,7 +288,7 @@ impl<E> BackendState for CallerWrap<'_, E> {
     }
 }
 
-impl<'a, E: BackendExternalities + 'static> MemoryOwner for CallerWrap<'a, E> {
+impl<'a, Ext: BackendExternalities + 'static> MemoryOwner for CallerWrap<'a, Ext> {
     fn read(&mut self, read: WasmMemoryRead) -> Result<Vec<u8>, MemoryAccessError> {
         self.with_memory(|manager, memory, gas_left| manager.read(memory, read, gas_left))
     }

--- a/core-backend/wasmi/src/state.rs
+++ b/core-backend/wasmi/src/state.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use gear_backend_common::{BackendExt, BackendState, BackendTermination, TerminationReason};
+use gear_backend_common::{BackendExternalities, BackendState, BackendTermination, TerminationReason};
 use gear_core_errors::ExtError;
 
 pub(crate) type HostState<E> = Option<State<E>>;
@@ -28,7 +28,7 @@ pub(crate) struct State<E> {
     pub termination_reason: TerminationReason,
 }
 
-impl<E: BackendExt> BackendTermination<E, ()> for State<E> {
+impl<E: BackendExternalities> BackendTermination<E, ()> for State<E> {
     fn into_parts(self) -> (E, (), TerminationReason) {
         let State {
             ext,

--- a/core-backend/wasmi/src/state.rs
+++ b/core-backend/wasmi/src/state.rs
@@ -21,17 +21,17 @@ use gear_backend_common::{
 };
 use gear_core_errors::ExtError;
 
-pub(crate) type HostState<E> = Option<State<E>>;
+pub(crate) type HostState<Ext> = Option<State<Ext>>;
 
 /// It's supposed that `E` implements [BackendExt]
-pub(crate) struct State<E> {
-    pub ext: E,
+pub(crate) struct State<Ext> {
+    pub ext: Ext,
     pub fallible_syscall_error: Option<ExtError>,
     pub termination_reason: TerminationReason,
 }
 
-impl<E: BackendExternalities> BackendTermination<E, ()> for State<E> {
-    fn into_parts(self) -> (E, (), TerminationReason) {
+impl<Ext: BackendExternalities> BackendTermination<Ext, ()> for State<Ext> {
+    fn into_parts(self) -> (Ext, (), TerminationReason) {
         let State {
             ext,
             termination_reason,
@@ -41,7 +41,7 @@ impl<E: BackendExternalities> BackendTermination<E, ()> for State<E> {
     }
 }
 
-impl<E> BackendState for State<E> {
+impl<Ext> BackendState for State<Ext> {
     fn set_termination_reason(&mut self, reason: TerminationReason) {
         self.termination_reason = reason;
     }

--- a/core-backend/wasmi/src/state.rs
+++ b/core-backend/wasmi/src/state.rs
@@ -16,7 +16,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use gear_backend_common::{BackendExternalities, BackendState, BackendTermination, TerminationReason};
+use gear_backend_common::{
+    BackendExternalities, BackendState, BackendTermination, TerminationReason,
+};
 use gear_core_errors::ExtError;
 
 pub(crate) type HostState<E> = Option<State<E>>;

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -133,8 +133,8 @@ fn lazy_pages_check_initial_data(
 }
 
 /// Writes initial pages data to memory and prepare memory for execution.
-fn prepare_memory<ProcessorExt: ProcessorExternalities, M: Memory>(
-    mem: &mut M,
+fn prepare_memory<ProcessorExt: ProcessorExternalities, EnvMem: Memory>(
+    mem: &mut EnvMem,
     program_id: ProgramId,
     pages_data: &mut BTreeMap<GearPage, PageBuf>,
     static_pages: WasmPage,

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -32,7 +32,7 @@ use alloc::{
 };
 use gear_backend_common::{
     lazy_pages::{GlobalsAccessConfig, LazyPagesWeights, Status},
-    ActorTerminationReason, BackendExt, BackendExtError, BackendReport, Environment,
+    ActorTerminationReason, BackendExternalities, BackendExtError, BackendReport, Environment,
     EnvironmentError, TerminationReason, TrapExplanation,
 };
 use gear_core::{
@@ -258,7 +258,7 @@ pub fn execute_wasm<E>(
 ) -> Result<DispatchResult, ExecutionError>
 where
     E: Environment,
-    E::Ext: ProcessorExternalities + BackendExt + 'static,
+    E::Ext: ProcessorExternalities + BackendExternalities + 'static,
     <E::Ext as Externalities>::Error: BackendExtError,
 {
     let WasmExecutionContext {
@@ -473,7 +473,7 @@ pub fn execute_for_reply<E, EP>(
 ) -> Result<Vec<u8>, String>
 where
     E: Environment<EP>,
-    E::Ext: ProcessorExternalities + BackendExt + 'static,
+    E::Ext: ProcessorExternalities + BackendExternalities + 'static,
     <E::Ext as Externalities>::Error: BackendExtError,
     EP: WasmEntryPoint,
 {

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -42,7 +42,8 @@ use gear_core::{
     ids::ProgramId,
     memory::{AllocationsContext, GearPage, Memory, PageBuf, PageU32Size, WasmPage},
     message::{
-        ContextSettings, DispatchKind, IncomingDispatch, IncomingMessage, MessageContext, WasmEntry,
+        ContextSettings, DispatchKind, IncomingDispatch, IncomingMessage, MessageContext,
+        WasmEntryPoint,
     },
     program::Program,
     reservation::GasReserver,
@@ -477,7 +478,7 @@ where
     E: Environment<EP>,
     E::Ext: ProcessorExt + BackendExt + 'static,
     <E::Ext as Ext>::Error: BackendExtError,
-    EP: WasmEntry,
+    EP: WasmEntryPoint,
 {
     let program = Program::new(program_id.unwrap_or_default(), instrumented_code);
     let mut pages_initial_data: BTreeMap<GearPage, PageBuf> =

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -33,7 +33,7 @@ use alloc::{
 use gear_backend_common::{
     lazy_pages::{GlobalsAccessConfig, LazyPagesWeights, Status},
     ActorTerminationReason, BackendExt, BackendExtError, BackendReport, Environment,
-    EnvironmentExecutionError, TerminationReason, TrapExplanation,
+    EnvironmentError, TerminationReason, TrapExplanation,
 };
 use gear_core::{
     code::InstrumentedCode,
@@ -339,7 +339,7 @@ where
             program.code().exports().clone(),
             memory_size,
         )
-        .map_err(EnvironmentExecutionError::from_infallible)?;
+        .map_err(EnvironmentError::from_infallible)?;
         env.execute(|memory, stack_end, globals_config| {
             prepare_memory::<E::Ext, E::Memory>(
                 memory,
@@ -385,24 +385,21 @@ where
 
             (termination, memory, ext)
         }
-        Err(EnvironmentExecutionError::System(e)) => {
+        Err(EnvironmentError::System(e)) => {
             return Err(ExecutionError::System(SystemExecutionError::Environment(
                 e.to_string(),
             )))
         }
-        Err(EnvironmentExecutionError::PrepareMemory(gas_amount, PrepareMemoryError::Actor(e))) => {
+        Err(EnvironmentError::PrepareMemory(gas_amount, PrepareMemoryError::Actor(e))) => {
             return Err(ExecutionError::Actor(ActorExecutionError {
                 gas_amount,
                 reason: ActorExecutionErrorReason::PrepareMemory(e),
             }))
         }
-        Err(EnvironmentExecutionError::PrepareMemory(
-            _gas_amount,
-            PrepareMemoryError::System(e),
-        )) => {
+        Err(EnvironmentError::PrepareMemory(_gas_amount, PrepareMemoryError::System(e))) => {
             return Err(ExecutionError::System(e.into()));
         }
-        Err(EnvironmentExecutionError::Actor(gas_amount, err)) => {
+        Err(EnvironmentError::Actor(gas_amount, err)) => {
             return Err(ExecutionError::Actor(ActorExecutionError {
                 gas_amount,
                 reason: ActorExecutionErrorReason::Environment(err.into()),
@@ -559,7 +556,7 @@ where
             program.code().exports().clone(),
             memory_size,
         )
-        .map_err(EnvironmentExecutionError::from_infallible)?;
+        .map_err(EnvironmentError::from_infallible)?;
         env.execute(|memory, stack_end, globals_config| {
             prepare_memory::<E::Ext, E::Memory>(
                 memory,

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -37,7 +37,7 @@ use gear_backend_common::{
 };
 use gear_core::{
     code::InstrumentedCode,
-    env::Ext,
+    env::Externalities,
     gas::{GasAllowanceCounter, GasCounter, ValueCounter},
     ids::ProgramId,
     memory::{AllocationsContext, GearPage, Memory, PageBuf, PageU32Size, WasmPage},
@@ -259,7 +259,7 @@ pub fn execute_wasm<E>(
 where
     E: Environment,
     E::Ext: ProcessorExt + BackendExt + 'static,
-    <E::Ext as Ext>::Error: BackendExtError,
+    <E::Ext as Externalities>::Error: BackendExtError,
 {
     let WasmExecutionContext {
         gas_counter,
@@ -474,7 +474,7 @@ pub fn execute_for_reply<E, EP>(
 where
     E: Environment<EP>,
     E::Ext: ProcessorExt + BackendExt + 'static,
-    <E::Ext as Ext>::Error: BackendExtError,
+    <E::Ext as Externalities>::Error: BackendExtError,
     EP: WasmEntryPoint,
 {
     let program = Program::new(program_id.unwrap_or_default(), instrumented_code);

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -32,8 +32,8 @@ use alloc::{
 };
 use gear_backend_common::{
     lazy_pages::{GlobalsAccessConfig, LazyPagesWeights, Status},
-    ActorTerminationReason, BackendExternalities, BackendExtError, BackendReport, Environment,
-    EnvironmentError, TerminationReason, TrapExplanation,
+    ActorTerminationReason, BackendExternalities, BackendExternalitiesError, BackendReport,
+    Environment, EnvironmentError, TerminationReason, TrapExplanation,
 };
 use gear_core::{
     code::InstrumentedCode,
@@ -259,7 +259,7 @@ pub fn execute_wasm<E>(
 where
     E: Environment,
     E::Ext: ProcessorExternalities + BackendExternalities + 'static,
-    <E::Ext as Externalities>::Error: BackendExtError,
+    <E::Ext as Externalities>::Error: BackendExternalitiesError,
 {
     let WasmExecutionContext {
         gas_counter,
@@ -474,7 +474,7 @@ pub fn execute_for_reply<E, EP>(
 where
     E: Environment<EP>,
     E::Ext: ProcessorExternalities + BackendExternalities + 'static,
-    <E::Ext as Externalities>::Error: BackendExtError,
+    <E::Ext as Externalities>::Error: BackendExternalitiesError,
     EP: WasmEntryPoint,
 {
     let program = Program::new(program_id.unwrap_or_default(), instrumented_code);

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -29,7 +29,7 @@ use gear_backend_common::{
 };
 use gear_core::{
     costs::{HostFnWeights, RuntimeCosts},
-    env::Ext as EnvExt,
+    env::Externalities,
     gas::{
         ChargeError, ChargeResult, CountersOwner, GasAllowanceCounter, GasAmount, GasCounter,
         GasLeft, Token, ValueCounter,
@@ -175,9 +175,7 @@ impl From<ExecutionError> for ExtError {
 impl BackendExtError for ExtError {
     fn into_termination_reason(self) -> TerminationReason {
         match self {
-            ExtError::Core(err) => {
-                ActorTerminationReason::Trap(TrapExplanation::Ext(err)).into()
-            }
+            ExtError::Core(err) => ActorTerminationReason::Trap(TrapExplanation::Ext(err)).into(),
             ExtError::ForbiddenFunction => {
                 ActorTerminationReason::Trap(TrapExplanation::ForbiddenFunction).into()
             }
@@ -485,7 +483,7 @@ impl CountersOwner for Ext {
     }
 }
 
-impl EnvExt for Ext {
+impl Externalities for Ext {
     type Error = ExtError;
     type AllocError = ExtAllocError;
 
@@ -1258,7 +1256,7 @@ mod tests {
         }
 
         #[track_caller]
-        fn assert_alloc_error(err: <Ext as EnvExt>::AllocError) {
+        fn assert_alloc_error(err: <Ext as Externalities>::AllocError) {
             match err {
                 ExtAllocError::Alloc(
                     AllocError::IncorrectAllocationData(_) | AllocError::ProgramAllocOutOfBounds,
@@ -1268,7 +1266,7 @@ mod tests {
         }
 
         #[track_caller]
-        fn assert_free_error(err: <Ext as EnvExt>::AllocError) {
+        fn assert_free_error(err: <Ext as Externalities>::AllocError) {
             match err {
                 ExtAllocError::Alloc(AllocError::InvalidFree(_)) => {}
                 err => Err(err).unwrap(),

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -47,7 +47,8 @@ use gear_core::{
     reservation::GasReserver,
 };
 use gear_core_errors::{
-    ExecutionError, ExtError, MemoryError, MessageError, ReservationError, WaitError,
+    ExecutionError, ExtError as ExtErrorCore, MemoryError, MessageError, ReservationError,
+    WaitError,
 };
 use gear_wasm_instrument::syscalls::SysCallName;
 
@@ -134,7 +135,7 @@ pub trait ProcessorExternalities {
 pub enum ExtError {
     /// Basic error
     #[display(fmt = "{_0}")]
-    Core(ExtError),
+    Core(ExtErrorCore),
     /// An error occurs in attempt to call forbidden sys-call.
     #[display(fmt = "Unable to call a forbidden function")]
     ForbiddenFunction,
@@ -145,31 +146,31 @@ pub enum ExtError {
 
 impl From<MessageError> for ExtError {
     fn from(err: MessageError) -> Self {
-        Self::Core(ExtError::Message(err))
+        Self::Core(ExtErrorCore::Message(err))
     }
 }
 
 impl From<MemoryError> for ExtError {
     fn from(err: MemoryError) -> Self {
-        Self::Core(ExtError::Memory(err))
+        Self::Core(ExtErrorCore::Memory(err))
     }
 }
 
 impl From<WaitError> for ExtError {
     fn from(err: WaitError) -> Self {
-        Self::Core(ExtError::Wait(err))
+        Self::Core(ExtErrorCore::Wait(err))
     }
 }
 
 impl From<ReservationError> for ExtError {
     fn from(err: ReservationError) -> Self {
-        Self::Core(ExtError::Reservation(err))
+        Self::Core(ExtErrorCore::Reservation(err))
     }
 }
 
 impl From<ExecutionError> for ExtError {
     fn from(err: ExecutionError) -> Self {
-        Self::Core(ExtError::Execution(err))
+        Self::Core(ExtErrorCore::Execution(err))
     }
 }
 

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -24,7 +24,7 @@ use alloc::{
 use gear_backend_common::{
     lazy_pages::{GlobalsAccessConfig, LazyPagesWeights, Status},
     memory::ProcessAccessError,
-    ActorTerminationReason, BackendAllocExtError, BackendExt, BackendExtError, ExtInfo,
+    ActorTerminationReason, BackendAllocExtError, BackendExternalities, BackendExtError, ExtInfo,
     SystemReservationContext, TerminationReason, TrapExplanation,
 };
 use gear_core::{
@@ -245,7 +245,7 @@ impl ProcessorExternalities for Ext {
     }
 }
 
-impl BackendExt for Ext {
+impl BackendExternalities for Ext {
     fn into_ext_info(self, memory: &impl Memory) -> Result<ExtInfo, MemoryError> {
         let pages_for_data =
             |static_pages: WasmPage, allocations: &BTreeSet<WasmPage>| -> Vec<GearPage> {

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -105,7 +105,7 @@ pub struct ProcessorContext {
 
 /// Trait to which ext must have to work in processor wasm executor.
 /// Currently used only for lazy-pages support.
-pub trait ProcessorExt {
+pub trait ProcessorExternalities {
     /// Whether this extension works with lazy pages.
     const LAZY_PAGES_ENABLED: bool;
 
@@ -216,7 +216,7 @@ pub struct Ext {
 }
 
 /// Empty implementation for non-substrate (and non-lazy-pages) using
-impl ProcessorExt for Ext {
+impl ProcessorExternalities for Ext {
     const LAZY_PAGES_ENABLED: bool = false;
 
     fn new(context: ProcessorContext) -> Self {

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -24,8 +24,9 @@ use alloc::{
 use gear_backend_common::{
     lazy_pages::{GlobalsAccessConfig, LazyPagesWeights, Status},
     memory::ProcessAccessError,
-    ActorTerminationReason, BackendAllocExtError, BackendExternalities, BackendExtError, ExtInfo,
-    SystemReservationContext, TerminationReason, TrapExplanation,
+    ActorTerminationReason, BackendAllocExternalitiesError, BackendExternalities,
+    BackendExternalitiesError, ExtInfo, SystemReservationContext, TerminationReason,
+    TrapExplanation,
 };
 use gear_core::{
     costs::{HostFnWeights, RuntimeCosts},
@@ -172,7 +173,7 @@ impl From<ExecutionError> for ExtError {
     }
 }
 
-impl BackendExtError for ExtError {
+impl BackendExternalitiesError for ExtError {
     fn into_termination_reason(self) -> TerminationReason {
         match self {
             ExtError::Core(err) => ActorTerminationReason::Trap(TrapExplanation::Ext(err)).into(),
@@ -195,7 +196,7 @@ pub enum ExtAllocError {
     Alloc(AllocError),
 }
 
-impl BackendAllocExtError for ExtAllocError {
+impl BackendAllocExternalitiesError for ExtAllocError {
     type ExtError = ExtError;
 
     fn into_backend_error(self) -> Result<Self::ExtError, Self> {

--- a/core-processor/src/lib.rs
+++ b/core-processor/src/lib.rs
@@ -38,7 +38,7 @@ pub use context::{
     ContextChargedForCode, ContextChargedForInstrumentation, ProcessExecutionContext,
 };
 pub use executor::{execute_wasm, ActorPrepareMemoryError};
-pub use ext::{Ext, ProcessorAllocError, ProcessorContext, ProcessorError, ProcessorExt};
+pub use ext::{Ext, ExtAllocError, ProcessorContext, ExtError, ProcessorExt};
 pub use handler::handle_journal;
 pub use precharge::{
     calculate_gas_for_code, calculate_gas_for_program, precharge_for_code,

--- a/core-processor/src/lib.rs
+++ b/core-processor/src/lib.rs
@@ -38,7 +38,7 @@ pub use context::{
     ContextChargedForCode, ContextChargedForInstrumentation, ProcessExecutionContext,
 };
 pub use executor::{execute_wasm, ActorPrepareMemoryError};
-pub use ext::{Ext, ExtAllocError, ExtError, ProcessorContext, ProcessorExt};
+pub use ext::{Ext, ExtAllocError, ExtError, ProcessorContext, ProcessorExternalities};
 pub use handler::handle_journal;
 pub use precharge::{
     calculate_gas_for_code, calculate_gas_for_program, precharge_for_code,

--- a/core-processor/src/lib.rs
+++ b/core-processor/src/lib.rs
@@ -38,7 +38,7 @@ pub use context::{
     ContextChargedForCode, ContextChargedForInstrumentation, ProcessExecutionContext,
 };
 pub use executor::{execute_wasm, ActorPrepareMemoryError};
-pub use ext::{Ext, ExtAllocError, ProcessorContext, ExtError, ProcessorExt};
+pub use ext::{Ext, ExtAllocError, ExtError, ProcessorContext, ProcessorExt};
 pub use handler::handle_journal;
 pub use precharge::{
     calculate_gas_for_code, calculate_gas_for_program, precharge_for_code,

--- a/core-processor/src/processing.rs
+++ b/core-processor/src/processing.rs
@@ -24,7 +24,7 @@ use crate::{
     configs::{BlockConfig, ExecutionSettings},
     context::*,
     executor,
-    ext::ProcessorExt,
+    ext::ProcessorExternalities,
     precharge::SuccessfulDispatchResultKind,
 };
 use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
@@ -47,7 +47,7 @@ pub fn process<E>(
 ) -> Result<Vec<JournalNote>, SystemExecutionError>
 where
     E: Environment,
-    E::Ext: ProcessorExt + BackendExt + 'static,
+    E::Ext: ProcessorExternalities + BackendExt + 'static,
     <E::Ext as Externalities>::Error: BackendExtError,
 {
     use crate::precharge::SuccessfulDispatchResultKind::*;

--- a/core-processor/src/processing.rs
+++ b/core-processor/src/processing.rs
@@ -28,7 +28,9 @@ use crate::{
     precharge::SuccessfulDispatchResultKind,
 };
 use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
-use gear_backend_common::{BackendExternalities, BackendExtError, Environment, SystemReservationContext};
+use gear_backend_common::{
+    BackendExternalities, BackendExternalitiesError, Environment, SystemReservationContext,
+};
 use gear_core::{
     env::Externalities,
     ids::{MessageId, ProgramId},
@@ -48,7 +50,7 @@ pub fn process<E>(
 where
     E: Environment,
     E::Ext: ProcessorExternalities + BackendExternalities + 'static,
-    <E::Ext as Externalities>::Error: BackendExtError,
+    <E::Ext as Externalities>::Error: BackendExternalitiesError,
 {
     use crate::precharge::SuccessfulDispatchResultKind::*;
 

--- a/core-processor/src/processing.rs
+++ b/core-processor/src/processing.rs
@@ -28,7 +28,7 @@ use crate::{
     precharge::SuccessfulDispatchResultKind,
 };
 use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
-use gear_backend_common::{BackendExt, BackendExtError, Environment, SystemReservationContext};
+use gear_backend_common::{BackendExternalities, BackendExtError, Environment, SystemReservationContext};
 use gear_core::{
     env::Externalities,
     ids::{MessageId, ProgramId},
@@ -47,7 +47,7 @@ pub fn process<E>(
 ) -> Result<Vec<JournalNote>, SystemExecutionError>
 where
     E: Environment,
-    E::Ext: ProcessorExternalities + BackendExt + 'static,
+    E::Ext: ProcessorExternalities + BackendExternalities + 'static,
     <E::Ext as Externalities>::Error: BackendExtError,
 {
     use crate::precharge::SuccessfulDispatchResultKind::*;

--- a/core-processor/src/processing.rs
+++ b/core-processor/src/processing.rs
@@ -30,7 +30,7 @@ use crate::{
 use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
 use gear_backend_common::{BackendExt, BackendExtError, Environment, SystemReservationContext};
 use gear_core::{
-    env::Ext,
+    env::Externalities,
     ids::{MessageId, ProgramId},
     memory::{GearPage, PageBuf},
     message::{ContextSettings, DispatchKind, IncomingDispatch, ReplyMessage, StoredDispatch},
@@ -48,7 +48,7 @@ pub fn process<E>(
 where
     E: Environment,
     E::Ext: ProcessorExt + BackendExt + 'static,
-    <E::Ext as Ext>::Error: BackendExtError,
+    <E::Ext as Externalities>::Error: BackendExtError,
 {
     use crate::precharge::SuccessfulDispatchResultKind::*;
 

--- a/core/src/code.rs
+++ b/core/src/code.rs
@@ -21,7 +21,7 @@
 use crate::{
     ids::CodeId,
     memory::{PageU32Size, WasmPage},
-    message::{DispatchKind, WasmEntry},
+    message::{DispatchKind, WasmEntryPoint},
 };
 use alloc::{collections::BTreeSet, vec, vec::Vec};
 use gear_wasm_instrument::{

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -40,11 +40,13 @@ pub enum PageAction {
     None,
 }
 
-/// External api for managing memory, messages, and gas-counting.
-pub trait Ext {
-    /// An error issued in api
+/// External api and data for managing memory and messages,
+/// use by an executing program to trigger state transition
+/// in runtime.
+pub trait Externalities {
+    /// An error issued in api.
     type Error;
-    /// An error issued during allocation
+    /// An error issued during allocation.
     type AllocError: Display;
 
     /// Allocate number of pages.

--- a/core/src/message/mod.rs
+++ b/core/src/message/mod.rs
@@ -120,7 +120,7 @@ pub enum DispatchKind {
 }
 
 /// Trait defining type could be used as entry point for a wasm module.
-pub trait WasmEntry: Sized {
+pub trait WasmEntryPoint: Sized {
     /// Converting self into entry point name.
     fn as_entry(&self) -> &str;
 
@@ -129,11 +129,11 @@ pub trait WasmEntry: Sized {
 
     /// Tries to convert self into `DispatchKind`.
     fn try_into_kind(&self) -> Option<DispatchKind> {
-        <DispatchKind as WasmEntry>::try_from_entry(self.as_entry())
+        <DispatchKind as WasmEntryPoint>::try_from_entry(self.as_entry())
     }
 }
 
-impl WasmEntry for String {
+impl WasmEntryPoint for String {
     fn as_entry(&self) -> &str {
         self
     }
@@ -143,7 +143,7 @@ impl WasmEntry for String {
     }
 }
 
-impl WasmEntry for DispatchKind {
+impl WasmEntryPoint for DispatchKind {
     fn as_entry(&self) -> &str {
         match self {
             Self::Init => "init",

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -68,7 +68,7 @@ use common::{
 use core_processor::{
     common::{DispatchOutcome, JournalNote},
     configs::{BlockConfig, PageCosts, TESTS_MAX_PAGES_NUMBER},
-    ProcessExecutionContext, ProcessorContext, ProcessorExt,
+    ProcessExecutionContext, ProcessorContext, ProcessorExternalities,
 };
 use frame_benchmarking::{benchmarks, whitelisted_caller};
 use frame_support::{

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -17,7 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use alloc::{collections::BTreeSet, vec::Vec};
-use core_processor::{Ext, ExtAllocError, ProcessorContext, ExtError, ProcessorExt};
+use core_processor::{Ext, ExtAllocError, ExtError, ProcessorContext, ProcessorExt};
 use gear_backend_common::{
     lazy_pages::{GlobalsAccessConfig, LazyPagesWeights, Status},
     memory::ProcessAccessError,
@@ -25,7 +25,7 @@ use gear_backend_common::{
 };
 use gear_core::{
     costs::RuntimeCosts,
-    env::Ext as EnvExt,
+    env::Externalities,
     gas::{ChargeError, CountersOwner, GasAmount, GasLeft},
     ids::{MessageId, ProgramId, ReservationId},
     memory::{GearPage, GrowHandler, Memory, MemoryInterval, PageU32Size, WasmPage},
@@ -152,7 +152,7 @@ impl CountersOwner for LazyPagesExt {
     }
 }
 
-impl EnvExt for LazyPagesExt {
+impl Externalities for LazyPagesExt {
     type Error = ExtError;
     type AllocError = ExtAllocError;
 

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -17,7 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use alloc::{collections::BTreeSet, vec::Vec};
-use core_processor::{Ext, ProcessorAllocError, ProcessorContext, ProcessorError, ProcessorExt};
+use core_processor::{Ext, ExtAllocError, ProcessorContext, ExtError, ProcessorExt};
 use gear_backend_common::{
     lazy_pages::{GlobalsAccessConfig, LazyPagesWeights, Status},
     memory::ProcessAccessError,
@@ -153,8 +153,8 @@ impl CountersOwner for LazyPagesExt {
 }
 
 impl EnvExt for LazyPagesExt {
-    type Error = ProcessorError;
-    type AllocError = ProcessorAllocError;
+    type Error = ExtError;
+    type AllocError = ExtAllocError;
 
     fn alloc(
         &mut self,

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -21,7 +21,7 @@ use core_processor::{Ext, ExtAllocError, ExtError, ProcessorContext, ProcessorEx
 use gear_backend_common::{
     lazy_pages::{GlobalsAccessConfig, LazyPagesWeights, Status},
     memory::ProcessAccessError,
-    BackendExt, ExtInfo,
+    BackendExternalities, ExtInfo,
 };
 use gear_core::{
     costs::RuntimeCosts,
@@ -40,7 +40,7 @@ pub struct LazyPagesExt {
     inner: Ext,
 }
 
-impl BackendExt for LazyPagesExt {
+impl BackendExternalities for LazyPagesExt {
     fn into_ext_info(self, memory: &impl Memory) -> Result<ExtInfo, MemoryError> {
         let pages_for_data =
             |static_pages: WasmPage, allocations: &BTreeSet<WasmPage>| -> Vec<GearPage> {

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -17,7 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use alloc::{collections::BTreeSet, vec::Vec};
-use core_processor::{Ext, ExtAllocError, ExtError, ProcessorContext, ProcessorExt};
+use core_processor::{Ext, ExtAllocError, ExtError, ProcessorContext, ProcessorExternalities};
 use gear_backend_common::{
     lazy_pages::{GlobalsAccessConfig, LazyPagesWeights, Status},
     memory::ProcessAccessError,
@@ -69,7 +69,7 @@ impl BackendExt for LazyPagesExt {
     }
 }
 
-impl ProcessorExt for LazyPagesExt {
+impl ProcessorExternalities for LazyPagesExt {
     const LAZY_PAGES_ENABLED: bool = true;
 
     fn new(context: ProcessorContext) -> Self {


### PR DESCRIPTION
Resolves #2654 

This PR actually **renames** only several traits/types:
- `EnvironmentExecutionError` -> `EnvironmentError` (as environment actually doesn't execute, errors aren't much related to execution).
- `ProcessorError` -> `ExtError` (`ProcessorExt` trait can have `ProcessorExt` error, but there's no such associated type in this trait. What's more there's no additional helping context with "Processor*" prefix to the error, especially if we look at the type definition). Same for `ProcessorAllocError` -> `ExtAllocError`.

All other changes are **name extensions** (instead of short names or one-letter generic names, which made it hard to understand the code and definitions of some types):
- generic `EP` -> EntryPoint
- generic `A` in some functions of `core_processor::execute` -> `ProcessorExt`
- trait `Ext` -> `Externalities`
- trait `ProcessorExt` -> `ProcessorExternalities`
- generic `PrepMem` (and just `T` in some places) -> `PrepareMemoryError`
- generic `E` -> `Ext`. That was the most important as `E` is used in the same crate/package for `Environment`, some error and `Externalities` too.

Some rules used for changes:
- Traits are given full names
- Generics, associated types and common types can have either full or short name (like `Externalities` trait implementor is `Ext`).