### PR TITLE
refactoring(core): remove gas counter from `read`

### DIFF
--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -30,7 +30,7 @@ use gear_backend_codegen::host;
 use gear_core::{
     buffer::RuntimeBuffer,
     costs::RuntimeCosts,
-    env::{DropPayloadLockBoundResult, Externalities},
+    env::{DropPayloadLockBound, Externalities},
     memory::{PageU32Size, WasmPage},
     message::{HandlePacket, InitPacket, ReplyPacket},
 };
@@ -174,14 +174,14 @@ where
 
     #[host(fallible, cost = RuntimeCosts::Read, err_len = LengthBytes)]
     pub fn read(ctx: &mut R, at: u32, len: u32, buffer_ptr: u32) -> Result<(), R::Error> {
-        let payload_holder = ctx.ext_mut().lock_payload(at, len)?;
-        payload_holder
-            .drop_with_job::<MemoryAccessError, _>(|payload_to_slice| {
+        let payload_lock = ctx.ext_mut().lock_payload(at, len)?;
+        payload_lock
+            .unlock_with_job::<MemoryAccessError, _>(|payload_slice| {
                 let write_buffer = ctx.register_write(buffer_ptr, len);
-                let write_res = ctx.write(write_buffer, payload_to_slice.to_slice());
-                let reclaim_res = ctx.ext_mut().unlock_payload(payload_to_slice.into_holder());
+                let write_res = ctx.write(write_buffer, payload_slice.as_slice());
+                let reclaim_res = ctx.ext_mut().unlock_payload(payload_slice.into_lock());
 
-                DropPayloadLockBoundResult::from((reclaim_res, write_res))
+                DropPayloadLockBound::from((reclaim_res, write_res))
             })
             .into_inner()
             .map_err(Into::into)

--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -30,7 +30,7 @@ use gear_backend_codegen::host;
 use gear_core::{
     buffer::RuntimeBuffer,
     costs::RuntimeCosts,
-    env::{Externalities, ReleaseBoundResult},
+    env::{Externalities, UsePayloadHolderBoundResult},
     memory::{PageU32Size, WasmPage},
     message::{HandlePacket, InitPacket, ReplyPacket},
 };
@@ -183,7 +183,7 @@ where
                     .ext_mut()
                     .reclaim_payload(payload_to_slice.into_holder());
 
-                ReleaseBoundResult::from((reclaim_res, write_res))
+                UsePayloadHolderBoundResult::from((reclaim_res, write_res))
             })
             .into_inner()
             .map_err(Into::into)

--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -176,7 +176,7 @@ where
     pub fn read(ctx: &mut R, at: u32, len: u32, buffer_ptr: u32) -> Result<(), R::Error> {
         let payload_lock = ctx.ext_mut().lock_payload(at, len)?;
         payload_lock
-            .unlock_with_job::<MemoryAccessError, _>(|payload_slice| {
+            .drop_with::<MemoryAccessError, _>(|payload_slice| {
                 let write_buffer = ctx.register_write(buffer_ptr, len);
                 let write_res = ctx.write(write_buffer, payload_slice.as_slice());
                 let reclaim_res = ctx.ext_mut().unlock_payload(payload_slice.into_lock());

--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -176,7 +176,7 @@ where
 
     #[host(fallible, cost = RuntimeCosts::Read, err_len = LengthBytes)]
     pub fn read(ctx: &mut R, at: u32, len: u32, buffer_ptr: u32) -> Result<(), R::Error> {
-        let buffer = ctx.ext_mut().read(at, len)?.to_vec();
+        let buffer = ctx.ext_mut().read_inner(at, len)?.to_vec();
 
         let write_buffer = ctx.register_write(buffer_ptr, len);
         ctx.write(write_buffer, &buffer).map_err(Into::into)

--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -176,14 +176,10 @@ where
 
     #[host(fallible, cost = RuntimeCosts::Read, err_len = LengthBytes)]
     pub fn read(ctx: &mut R, at: u32, len: u32, buffer_ptr: u32) -> Result<(), R::Error> {
-        let (buffer, mut gas_left) = ctx.ext_mut().read(at, len)?;
-        let buffer = buffer.to_vec();
+        let buffer = ctx.ext_mut().read(at, len)?.to_vec();
 
         let write_buffer = ctx.register_write(buffer_ptr, len);
-        ctx.memory_manager_write(write_buffer, &buffer, &mut gas_left)?;
-
-        ctx.ext_mut().set_gas_left(gas_left);
-        Ok(())
+        ctx.write(write_buffer, &buffer).map_err(Into::into)
     }
 
     #[host(cost = RuntimeCosts::Size)]

--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -176,12 +176,12 @@ where
     pub fn read(ctx: &mut R, at: u32, len: u32, buffer_ptr: u32) -> Result<(), R::Error> {
         let payload_lock = ctx.ext_mut().lock_payload(at, len)?;
         payload_lock
-            .drop_with::<MemoryAccessError, _>(|payload_slice| {
+            .drop_with::<MemoryAccessError, _>(|payload_access| {
                 let write_buffer = ctx.register_write(buffer_ptr, len);
-                let write_res = ctx.write(write_buffer, payload_slice.as_slice());
-                let reclaim_res = ctx.ext_mut().unlock_payload(payload_slice.into_lock());
+                let write_res = ctx.write(write_buffer, payload_access.as_slice());
+                let unlock_bound = ctx.ext_mut().unlock_payload(payload_access.into_lock());
 
-                DropPayloadLockBound::from((reclaim_res, write_res))
+                DropPayloadLockBound::from((unlock_bound, write_res))
             })
             .into_inner()
             .map_err(Into::into)

--- a/core-backend/common/src/funcs.rs
+++ b/core-backend/common/src/funcs.rs
@@ -174,9 +174,9 @@ where
 
     #[host(fallible, cost = RuntimeCosts::Read, err_len = LengthBytes)]
     pub fn read(ctx: &mut R, at: u32, len: u32, buffer_ptr: u32) -> Result<(), R::Error> {
-        let payload_holder = ctx.ext_mut().hold_payload(at, len)?;
+        let payload_holder = ctx.ext_mut().lend_payload(at, len)?;
         payload_holder
-            .release_with_job::<MemoryAccessError, _>(|payload_to_slice| {
+            .use_with_job::<MemoryAccessError, _>(|payload_to_slice| {
                 let write_buffer = ctx.register_write(buffer_ptr, len);
                 let write_res = ctx.write(write_buffer, payload_to_slice.to_slice());
                 let reclaim_res = ctx

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -45,7 +45,7 @@ use core::{
 };
 use gear_core::{
     buffer::RuntimeBufferSizeError,
-    env::{Either, Externalities},
+    env::{Either, Externalities, ReleaseBoundResult},
     gas::{ChargeError, CountersOwner, GasAmount, GasLeft},
     ids::{CodeId, MessageId, ProgramId, ReservationId},
     memory::{GearPage, Memory, MemoryInterval, PageBuf, WasmPage},

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -45,7 +45,7 @@ use core::{
 };
 use gear_core::{
     buffer::RuntimeBufferSizeError,
-    env::{Either, Externalities, ReleaseBoundResult},
+    env::Externalities,
     gas::{ChargeError, CountersOwner, GasAmount, GasLeft},
     ids::{CodeId, MessageId, ProgramId, ReservationId},
     memory::{GearPage, Memory, MemoryInterval, PageBuf, WasmPage},
@@ -73,15 +73,6 @@ pub enum TerminationReason {
     Actor(ActorTerminationReason),
     System(SystemTerminationReason),
 }
-
-// impl<L: Into<TerminationReason>, R: Into<TerminationReason>> From<Either<L, R>> for TerminationReason {
-//     fn from(either_err: Either<L, R>) -> Self {
-//         match either_err {
-//             Either::Left(l) => l.into(),
-//             Either::Right(r) => r.into()
-//         }
-//     }
-// }
 
 impl From<PayloadSizeError> for TerminationReason {
     fn from(_err: PayloadSizeError) -> Self {

--- a/core-backend/common/src/lib.rs
+++ b/core-backend/common/src/lib.rs
@@ -45,7 +45,7 @@ use core::{
 };
 use gear_core::{
     buffer::RuntimeBufferSizeError,
-    env::Externalities,
+    env::{Either, Externalities},
     gas::{ChargeError, CountersOwner, GasAmount, GasLeft},
     ids::{CodeId, MessageId, ProgramId, ReservationId},
     memory::{GearPage, Memory, MemoryInterval, PageBuf, WasmPage},
@@ -73,6 +73,15 @@ pub enum TerminationReason {
     Actor(ActorTerminationReason),
     System(SystemTerminationReason),
 }
+
+// impl<L: Into<TerminationReason>, R: Into<TerminationReason>> From<Either<L, R>> for TerminationReason {
+//     fn from(either_err: Either<L, R>) -> Self {
+//         match either_err {
+//             Either::Left(l) => l.into(),
+//             Either::Right(r) => r.into()
+//         }
+//     }
+// }
 
 impl From<PayloadSizeError> for TerminationReason {
     fn from(_err: PayloadSizeError) -> Self {

--- a/core-backend/common/src/mock.rs
+++ b/core-backend/common/src/mock.rs
@@ -24,7 +24,7 @@ use alloc::{collections::BTreeSet, vec, vec::Vec};
 use core::{cell::Cell, fmt, fmt::Debug};
 use gear_core::{
     costs::RuntimeCosts,
-    env::{Externalities, PayloadSliceHolder, ReclaimBoundResult},
+    env::{Externalities, PayloadSliceLock, UnlockPayloadBound},
     gas::{ChargeError, CountersOwner, GasAmount, GasCounter, GasLeft},
     ids::{MessageId, ProgramId, ReservationId},
     memory::{Memory, MemoryInterval, PageU32Size, WasmPage, WASM_PAGE_SIZE},
@@ -239,11 +239,11 @@ impl Externalities for MockExt {
         Ok(MessageId::default())
     }
 
-    fn lend_payload(&mut self, _at: u32, _len: u32) -> Result<PayloadSliceHolder, Self::Error> {
+    fn lock_payload(&mut self, _at: u32, _len: u32) -> Result<PayloadSliceLock, Self::Error> {
         unimplemented!()
     }
 
-    fn reclaim_payload(&mut self, _payload_holder: &mut PayloadSliceHolder) -> ReclaimBoundResult {
+    fn unlock_payload(&mut self, _payload_holder: &mut PayloadSliceLock) -> UnlockPayloadBound {
         unimplemented!()
     }
 }

--- a/core-backend/common/src/mock.rs
+++ b/core-backend/common/src/mock.rs
@@ -24,7 +24,7 @@ use alloc::{collections::BTreeSet, vec, vec::Vec};
 use core::{cell::Cell, fmt, fmt::Debug};
 use gear_core::{
     costs::RuntimeCosts,
-    env::Externalities,
+    env::{Externalities, PayloadSliceHolder, ReclaimResult},
     gas::{ChargeError, CountersOwner, GasAmount, GasCounter, GasLeft},
     ids::{MessageId, ProgramId, ReservationId},
     memory::{Memory, MemoryInterval, PageU32Size, WasmPage, WASM_PAGE_SIZE},
@@ -166,9 +166,6 @@ impl Externalities for MockExt {
     fn debug(&self, _data: &str) -> Result<(), Self::Error> {
         Ok(())
     }
-    fn read_inner(&mut self, _at: u32, _len: u32) -> Result<&[u8], Self::Error> {
-        Ok(&[])
-    }
     fn size(&self) -> Result<usize, Self::Error> {
         Ok(0)
     }
@@ -240,6 +237,14 @@ impl Externalities for MockExt {
 
     fn signal_from(&self) -> Result<MessageId, Self::Error> {
         Ok(MessageId::default())
+    }
+
+    fn hold_payload(&mut self, at: u32, len: u32) -> Result<PayloadSliceHolder, Self::Error> {
+        unimplemented!()
+    }
+
+    fn reclaim_payload(&mut self, payload_holder: &mut PayloadSliceHolder) -> ReclaimResult {
+        unimplemented!()
     }
 }
 

--- a/core-backend/common/src/mock.rs
+++ b/core-backend/common/src/mock.rs
@@ -239,11 +239,11 @@ impl Externalities for MockExt {
         Ok(MessageId::default())
     }
 
-    fn lend_payload(&mut self, at: u32, len: u32) -> Result<PayloadSliceHolder, Self::Error> {
+    fn lend_payload(&mut self, _at: u32, _len: u32) -> Result<PayloadSliceHolder, Self::Error> {
         unimplemented!()
     }
 
-    fn reclaim_payload(&mut self, payload_holder: &mut PayloadSliceHolder) -> ReclaimBoundResult {
+    fn reclaim_payload(&mut self, _payload_holder: &mut PayloadSliceHolder) -> ReclaimBoundResult {
         unimplemented!()
     }
 }

--- a/core-backend/common/src/mock.rs
+++ b/core-backend/common/src/mock.rs
@@ -166,8 +166,8 @@ impl Ext for MockExt {
     fn debug(&self, _data: &str) -> Result<(), Self::Error> {
         Ok(())
     }
-    fn read(&mut self, _at: u32, _len: u32) -> Result<(&[u8], GasLeft), Self::Error> {
-        Ok((&[], Default::default()))
+    fn read(&mut self, _at: u32, _len: u32) -> Result<&[u8], Self::Error> {
+        Ok(&[])
     }
     fn size(&self) -> Result<usize, Self::Error> {
         Ok(0)

--- a/core-backend/common/src/mock.rs
+++ b/core-backend/common/src/mock.rs
@@ -24,7 +24,7 @@ use alloc::{collections::BTreeSet, vec, vec::Vec};
 use core::{cell::Cell, fmt, fmt::Debug};
 use gear_core::{
     costs::RuntimeCosts,
-    env::{Externalities, PayloadSliceHolder, ReclaimResult},
+    env::{Externalities, PayloadSliceHolder, ReclaimBoundResult},
     gas::{ChargeError, CountersOwner, GasAmount, GasCounter, GasLeft},
     ids::{MessageId, ProgramId, ReservationId},
     memory::{Memory, MemoryInterval, PageU32Size, WasmPage, WASM_PAGE_SIZE},
@@ -239,11 +239,11 @@ impl Externalities for MockExt {
         Ok(MessageId::default())
     }
 
-    fn hold_payload(&mut self, at: u32, len: u32) -> Result<PayloadSliceHolder, Self::Error> {
+    fn lend_payload(&mut self, at: u32, len: u32) -> Result<PayloadSliceHolder, Self::Error> {
         unimplemented!()
     }
 
-    fn reclaim_payload(&mut self, payload_holder: &mut PayloadSliceHolder) -> ReclaimResult {
+    fn reclaim_payload(&mut self, payload_holder: &mut PayloadSliceHolder) -> ReclaimBoundResult {
         unimplemented!()
     }
 }

--- a/core-backend/common/src/mock.rs
+++ b/core-backend/common/src/mock.rs
@@ -166,7 +166,7 @@ impl Ext for MockExt {
     fn debug(&self, _data: &str) -> Result<(), Self::Error> {
         Ok(())
     }
-    fn read(&mut self, _at: u32, _len: u32) -> Result<&[u8], Self::Error> {
+    fn read_inner(&mut self, _at: u32, _len: u32) -> Result<&[u8], Self::Error> {
         Ok(&[])
     }
     fn size(&self) -> Result<usize, Self::Error> {

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -611,7 +611,7 @@ where
 
     for (dispatch, _, _) in info.generated_dispatches {
         if matches!(dispatch.kind(), DispatchKind::Reply) {
-            return Ok(dispatch.payload().to_vec());
+            return Ok(dispatch.payload_bytes().to_vec());
         }
     }
 

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -714,7 +714,7 @@ impl EnvExt for Ext {
         Ok(())
     }
 
-    fn read(&mut self, at: u32, len: u32) -> Result<(&[u8], GasLeft), Self::Error> {
+    fn read(&mut self, at: u32, len: u32) -> Result<&[u8], Self::Error> {
         // Verify read is correct
         let end = at
             .checked_add(len)
@@ -730,7 +730,7 @@ impl EnvExt for Ext {
             .into());
         }
 
-        Ok((&msg[at as usize..end as usize], self.gas_left()))
+        Ok(&msg[at as usize..end as usize])
     }
 
     fn size(&self) -> Result<usize, Self::Error> {

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -737,7 +737,7 @@ impl Externalities for Ext {
     }
 
     fn size(&self) -> Result<usize, Self::Error> {
-        Ok(self.context.message_context.current().payload().len())
+        Ok(self.context.message_context.current().payload_bytes().len())
     }
 
     fn reserve_gas(&mut self, amount: u64, duration: u32) -> Result<ReservationId, Self::Error> {

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -714,7 +714,7 @@ impl EnvExt for Ext {
         Ok(())
     }
 
-    fn read(&mut self, at: u32, len: u32) -> Result<&[u8], Self::Error> {
+    fn read_inner(&mut self, at: u32, len: u32) -> Result<&[u8], Self::Error> {
         // Verify read is correct
         let end = at
             .checked_add(len)

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -31,7 +31,7 @@ use gear_backend_common::{
 };
 use gear_core::{
     costs::{HostFnWeights, RuntimeCosts},
-    env::{Either, Externalities, PayloadSliceHolder},
+    env::{Either, Externalities, PayloadSliceHolder, ReclaimResult},
     gas::{
         ChargeError, ChargeResult, CountersOwner, GasAllowanceCounter, GasAmount, GasCounter,
         GasLeft, Token, ValueCounter,
@@ -744,9 +744,9 @@ impl Externalities for Ext {
         )
     }
 
-    fn reclaim_payload(&mut self, payload_holder: &mut PayloadSliceHolder) {
+    fn reclaim_payload(&mut self, payload_holder: &mut PayloadSliceHolder) -> ReclaimResult {
         // todo [sab] check that it's the same payload_holder you once created from msg_ctx
-        payload_holder.release_back(&mut self.context.message_context);
+        ReclaimResult::from((&mut self.context.message_context, payload_holder))
     }
 
     fn size(&self) -> Result<usize, Self::Error> {

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -732,7 +732,6 @@ impl Externalities for Ext {
     }
 
     fn reclaim_payload(&mut self, payload_holder: &mut PayloadSliceHolder) -> ReclaimBoundResult {
-        // todo [sab] check that it's the same payload_holder you once created from msg_ctx
         ReclaimBoundResult::from((&mut self.context.message_context, payload_holder))
     }
 

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -30,7 +30,7 @@ use gear_backend_common::{
 };
 use gear_core::{
     costs::{HostFnWeights, RuntimeCosts},
-    env::{Externalities, PayloadSliceHolder, ReclaimResult},
+    env::{Externalities, PayloadSliceHolder, ReclaimBoundResult},
     gas::{
         ChargeError, ChargeResult, CountersOwner, GasAllowanceCounter, GasAmount, GasCounter,
         GasLeft, Token, ValueCounter,
@@ -714,7 +714,7 @@ impl Externalities for Ext {
         Ok(())
     }
 
-    fn hold_payload(&mut self, at: u32, len: u32) -> Result<PayloadSliceHolder, Self::Error> {
+    fn lend_payload(&mut self, at: u32, len: u32) -> Result<PayloadSliceHolder, Self::Error> {
         let end = at
             .checked_add(len)
             .ok_or(MessageError::TooBigReadLen { at, len })?;
@@ -731,9 +731,9 @@ impl Externalities for Ext {
         )
     }
 
-    fn reclaim_payload(&mut self, payload_holder: &mut PayloadSliceHolder) -> ReclaimResult {
+    fn reclaim_payload(&mut self, payload_holder: &mut PayloadSliceHolder) -> ReclaimBoundResult {
         // todo [sab] check that it's the same payload_holder you once created from msg_ctx
-        ReclaimResult::from((&mut self.context.message_context, payload_holder))
+        ReclaimBoundResult::from((&mut self.context.message_context, payload_holder))
     }
 
     fn size(&self) -> Result<usize, Self::Error> {

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -21,7 +21,6 @@ use alloc::{
     collections::{BTreeMap, BTreeSet},
     vec::Vec,
 };
-use core::mem;
 use gear_backend_common::{
     lazy_pages::{GlobalsAccessConfig, LazyPagesWeights, Status},
     memory::ProcessAccessError,
@@ -31,7 +30,7 @@ use gear_backend_common::{
 };
 use gear_core::{
     costs::{HostFnWeights, RuntimeCosts},
-    env::{Either, Externalities, PayloadSliceHolder, ReclaimResult},
+    env::{Externalities, PayloadSliceHolder, ReclaimResult},
     gas::{
         ChargeError, ChargeResult, CountersOwner, GasAllowanceCounter, GasAmount, GasCounter,
         GasLeft, Token, ValueCounter,
@@ -42,7 +41,7 @@ use gear_core::{
         NoopGrowHandler, PageBuf, PageU32Size, WasmPage,
     },
     message::{
-        ContextOutcomeDrain, GasLimit, HandlePacket, InitPacket, MessageContext, Packet, Payload,
+        ContextOutcomeDrain, GasLimit, HandlePacket, InitPacket, MessageContext, Packet,
         ReplyPacket, StatusCode,
     },
     reservation::GasReserver,
@@ -144,18 +143,6 @@ pub enum ExtError {
     #[display(fmt = "Charge error: {_0}")]
     Charge(ChargeError),
 }
-
-// impl<R> From<ExtError> for Either<ExtError, R> {
-//     fn from(err: ExtError) -> Self {
-//         Self::Left(err)
-//     }
-// }
-
-// impl<R> From<R> for Either<ExtError, R> {
-//     fn from(err: R) -> Self {
-//         Either::Right(err)
-//     }
-// }
 
 impl From<MessageError> for ExtError {
     fn from(err: MessageError) -> Self {

--- a/core/src/buffer.rs
+++ b/core/src/buffer.rs
@@ -112,6 +112,7 @@ impl<T: Clone + Default, E: Default, const N: usize> LimitedVec<T, E, N> {
 
     /// Returns ref to the internal data.
     pub fn get(&self) -> &[T] {
+        // todo [sab] inner"
         &self.0
     }
 

--- a/core/src/buffer.rs
+++ b/core/src/buffer.rs
@@ -181,10 +181,10 @@ mod test {
         let _ = TestBuffer::try_from(v2).expect_err("Must be err because of size overflow");
         let z = TestBuffer::try_from(v3).unwrap();
 
-        assert_eq!(x.get().len(), N);
-        assert_eq!(z.get().len(), N - 1);
-        assert_eq!(x.get()[N / 2], 1);
-        assert_eq!(z.get()[N / 2], 1);
+        assert_eq!(x.inner().len(), N);
+        assert_eq!(z.inner().len(), N - 1);
+        assert_eq!(x.inner()[N / 2], 1);
+        assert_eq!(z.inner()[N / 2], 1);
     }
 
     #[test]
@@ -196,9 +196,9 @@ mod test {
         );
         let z = LimitedVec::<Vec<u8>, RuntimeBufferSizeError, N>::try_new_default(0).unwrap();
 
-        assert_eq!(x.get().len(), N);
-        assert_eq!(z.get().len(), 0);
-        assert_eq!(x.get()[N / 2], "");
+        assert_eq!(x.inner().len(), N);
+        assert_eq!(z.inner().len(), 0);
+        assert_eq!(x.inner()[N / 2], "");
     }
 
     #[test]
@@ -207,7 +207,7 @@ mod test {
         let prepend_buf = TestBuffer::try_from(vec![6, 7, 8]).unwrap();
         buf.try_prepend(prepend_buf).unwrap();
 
-        assert_eq!(buf.get(), &[6, 7, 8, 1, 2, 3, 4, 5]);
+        assert_eq!(buf.inner(), &[6, 7, 8, 1, 2, 3, 4, 5]);
     }
 
     #[test]
@@ -229,7 +229,7 @@ mod test {
         y.try_prepend(vec![1, 2, 3].try_into().unwrap()).unwrap();
         z.try_prepend(vec![1, 2, 3].try_into().unwrap()).unwrap();
 
-        z.get_mut()[0] = 0;
+        z.inner_mut()[0] = 0;
 
         assert_eq!(&z.into_vec(), &[0, 2, 3, 42, 1, 2, 3]);
         assert_eq!(TestBuffer::max_len(), N);

--- a/core/src/buffer.rs
+++ b/core/src/buffer.rs
@@ -42,7 +42,7 @@ where
     [T]: AsRef<[u8]>,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "0x{}", hex::encode(self.get()))
+        write!(f, "0x{}", hex::encode(self.inner()))
     }
 }
 
@@ -111,13 +111,12 @@ impl<T: Clone + Default, E: Default, const N: usize> LimitedVec<T, E, N> {
     }
 
     /// Returns ref to the internal data.
-    pub fn get(&self) -> &[T] {
-        // todo [sab] inner"
+    pub fn inner(&self) -> &[T] {
         &self.0
     }
 
     /// Returns mut ref to the internal data slice.
-    pub fn get_mut(&mut self) -> &mut [T] {
+    pub fn inner_mut(&mut self) -> &mut [T] {
         &mut self.0
     }
 

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -46,7 +46,6 @@ use gear_wasm_instrument::syscalls::SysCallName;
 /// is a kind of scope-guard for the data and the [`PayloadToSlice`] is a data access guard.
 ///
 /// For more usage info read [`Self::drop_with_job`] docs.
-
 pub struct PayloadSliceLock {
     /// Locked payload
     payload: Payload,
@@ -77,7 +76,7 @@ impl PayloadSliceLock {
     /// The method actually performs [`mem::swap`] under the hood. It's supposed
     /// to be called from [`Externalities::unlock_payload`], implementor of which
     /// owns provided message context.
-    pub fn unlock_back(&mut self, msg_ctx: &mut MessageContext) {
+    fn unlock_back(&mut self, msg_ctx: &mut MessageContext) {
         mem::swap(msg_ctx.payload_mut(), &mut self.payload);
     }
 
@@ -314,9 +313,9 @@ pub trait Externalities {
     /// to prevent additional memory allocation on payload read op, we give
     /// ownership over payload to the caller. Giving ownership over payload actually
     /// means, that the payload value in the currently executed message will become
-    /// "de-allocated" or just zeroed. To prevent from the risk of payload being
-    /// not "returned" back to the message a [`Externalities::unlock_payload`] is
-    /// introduced. For more info, read docs to [`PayloadSliceLock`], [`DropPayloadLockBoundResult`],
+    /// empty. To prevent from the risk of payload being not "returned" back to the
+    /// message a [`Externalities::unlock_payload`] is introduced. For more info,
+    /// read docs to [`PayloadSliceLock`], [`DropPayloadLockBoundResult`],
     /// [`UnlockPayloadBound`], [`PayloadToSlice`] types and their methods.
     fn lock_payload(&mut self, at: u32, len: u32) -> Result<PayloadSliceLock, Self::Error>;
 

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -62,7 +62,7 @@ impl PayloadSliceHolder {
     /// than payload's length. If the check goes well, the ownership over payload will be
     /// taken from the message context by [`mem::take`].
     pub fn try_new((start, end): (u32, u32), msg_ctx: &mut MessageContext) -> Result<Self, usize> {
-        let payload_len = msg_ctx.payload_mut().get().len();
+        let payload_len = msg_ctx.payload_mut().inner().len();
         if end as usize > payload_len {
             return Err(payload_len);
         }
@@ -107,7 +107,8 @@ impl PayloadSliceHolder {
 
     fn in_range(&self) -> &[u8] {
         let (start, end) = self.range;
-        &self.payload.get()[start..end]
+        // Will not panic as range is checked.
+        &self.payload.inner()[start..end]
     }
 }
 

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -31,21 +31,21 @@ use gear_wasm_instrument::syscalls::SysCallName;
 ///
 /// The type was mainly introduced to establish type safety mechanics
 /// for the read of the payload from externalities. To type's purposes
-/// see [`Externalities::hold_payload`] docs.
+/// see [`Externalities::lend_payload`] docs.
 ///
 /// ### Usage
 /// This type gives access to some slice of the currently executing message
 /// payload, but doesn't do it directly. It gives to the caller the [`PayloadToSlice`]
 /// wrapper, which actually can return the slice of the payload. But this wrapper
-/// is instantiated only inside the [`Self::release_with_job`] method.
+/// is instantiated only inside the [`Self::use_with_job`] method.
 /// This is actually done to prevent a user of the type from holding payload of the
 /// message, which actually moves it, from forgetting to release it back, because
 /// if access to the slice buffer was granted directly from the holder, the type user
 /// could have written the data to memory and then have dropped the holder. As a result
-/// the executing message payload wouldn't have been returned. So [`PayloadSliceHolder::release_with_job`]
+/// the executing message payload wouldn't have been returned. So [`PayloadSliceHolder::use_with_job`]
 /// is a kind of scope-guard for the data and the [`PayloadToSlice`] is a data access guard.
 ///
-/// For more usage info read [`Self::release_with_job`] docs.
+/// For more usage info read [`Self::use_with_job`] docs.
 
 pub struct PayloadSliceHolder {
     /// Held payload
@@ -316,7 +316,7 @@ pub trait Externalities {
     /// "de-allocated" or just zeroed. To prevent from the risk of payload being
     /// not "returned" back to the message a [`Externalities::reclaim_payload`] is
     /// introduced. For more info, read docs to [`PayloadSliceHolder`], [`ReleaseBoundResult`],
-    /// [`ReclaimResult`], [`PayloadToSlice`] types and their methods.
+    /// [`ReclaimBoundResult`], [`PayloadToSlice`] types and their methods.
     fn lend_payload(&mut self, at: u32, len: u32) -> Result<PayloadSliceHolder, Self::Error>;
 
     /// Reclaims ownership from the payload holder over previously taken payload from the

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -27,35 +27,35 @@ use alloc::collections::BTreeSet;
 use core::{fmt::Display, mem};
 use gear_wasm_instrument::syscalls::SysCallName;
 
-/// Holder for the payload of the incoming/currently executing message.
+/// Lock for the payload of the incoming/currently executing message.
 ///
 /// The type was mainly introduced to establish type safety mechanics
 /// for the read of the payload from externalities. To type's purposes
-/// see [`Externalities::lend_payload`] docs.
+/// see [`Externalities::lock_payload`] docs.
 ///
 /// ### Usage
 /// This type gives access to some slice of the currently executing message
 /// payload, but doesn't do it directly. It gives to the caller the [`PayloadToSlice`]
 /// wrapper, which actually can return the slice of the payload. But this wrapper
-/// is instantiated only inside the [`Self::use_with_job`] method.
-/// This is actually done to prevent a user of the type from holding payload of the
-/// message, which actually moves it, from forgetting to release it back, because
+/// is instantiated only inside the [`Self::drop_with_job`] method.
+/// This is actually done to prevent a user of the type from locking payload of the
+/// message, which actually moves it, and forgetting to unlock it back, because
 /// if access to the slice buffer was granted directly from the holder, the type user
 /// could have written the data to memory and then have dropped the holder. As a result
-/// the executing message payload wouldn't have been returned. So [`PayloadSliceHolder::use_with_job`]
+/// the executing message payload wouldn't have been returned. So [`PayloadSliceLock::drop_with_job`]
 /// is a kind of scope-guard for the data and the [`PayloadToSlice`] is a data access guard.
 ///
-/// For more usage info read [`Self::use_with_job`] docs.
+/// For more usage info read [`Self::drop_with_job`] docs.
 
-pub struct PayloadSliceHolder {
-    /// Held payload
+pub struct PayloadSliceLock {
+    /// Locked payload
     payload: Payload,
     /// Range values indicating slice bounds.
     range: (usize, usize),
 }
 
-impl PayloadSliceHolder {
-    /// Creates a new [`PayloadSliceHolder`] from the currently executed message context.
+impl PayloadSliceLock {
+    /// Creates a new [`PayloadSliceLock`] from the currently executed message context.
     ///
     /// The method checks whether received range (slice) is correct, i.e., the end is lower
     /// than payload's length. If the check goes well, the ownership over payload will be
@@ -72,33 +72,33 @@ impl PayloadSliceHolder {
         })
     }
 
-    /// Releases back ownership of the held payload to the message context.
+    /// Releases back ownership of the locked payload to the message context.
     ///
     /// The method actually performs [`mem::swap`] under the hood. It's supposed
-    /// to be called from [`Externalities::reclaim_payload`], implementor of which
+    /// to be called from [`Externalities::unlock_payload`], implementor of which
     /// owns provided message context.
-    pub fn release_back(&mut self, msg_ctx: &mut MessageContext) {
+    pub fn unlock_back(&mut self, msg_ctx: &mut MessageContext) {
         mem::swap(msg_ctx.payload_mut(), &mut self.payload);
     }
 
-    /// Uses the holder in the provided `job` and drops the holder after running it.
+    /// Uses the lock in the provided `job` and drops the lock after running it.
     ///
-    /// [`PayloadSliceHolder`]'s main purpose is to provide safe access to the payload's
+    /// [`PayloadSliceLock`]'s main purpose is to provide safe access to the payload's
     /// slice and ensure it will be returned back to the message.
     ///
     /// Type docs explain how safe access is designed with [`PayloadToSlice`].
     ///
-    /// We ensure that the payload is released back by returning the [`UsePayloadHolderBoundResult`]
+    /// We ensure that the payload is released back by returning the [`DropPayloadLockBoundResult`]
     /// from the `job`. This type can actually be instantiated only from tuple of two:
-    /// [`ReclaimBoundResult`] and some result with err variant type to be `JobErr`.
-    /// The first is returned from [`Externalities::reclaim_payload`], so it means that
+    /// [`UnlockPayloadBound`] and some result with err variant type to be `JobErr`.
+    /// The first is returned from [`Externalities::unlock_payload`], so it means that
     /// that payload was reclaimed by the original owner. The other result stores actual
     /// error of the `Job` as it could have called fallible actions inside it. So,
-    /// [`UsePayloadHolderBoundResult`] gives an opportunity to store the actual result of the job,
+    /// [`DropPayloadLockBoundResult`] gives an opportunity to store the actual result of the job,
     /// but also gives guarantee that payload was reclaimed.
-    pub fn use_with_job<JobErr, Job>(mut self, mut job: Job) -> UsePayloadHolderBoundResult<JobErr>
+    pub fn drop_with_job<JobErr, Job>(mut self, mut job: Job) -> DropPayloadLockBoundResult<JobErr>
     where
-        Job: FnMut(PayloadToSlice<'_>) -> UsePayloadHolderBoundResult<JobErr>,
+        Job: FnMut(PayloadToSlice<'_>) -> DropPayloadLockBoundResult<JobErr>,
     {
         let held_range = PayloadToSlice(&mut self);
         job(held_range)
@@ -111,11 +111,11 @@ impl PayloadSliceHolder {
     }
 }
 
-/// A wrapper over mutable reference to [`PayloadSliceHolder`]
+/// A wrapper over mutable reference to [`PayloadSliceLock`]
 /// which can give to the caller the slice of the held payload.
 ///
-/// For more information read [`PayloadSliceHolder`] docs.
-pub struct PayloadToSlice<'a>(&'a mut PayloadSliceHolder);
+/// For more information read [`PayloadSliceLock`] docs.
+pub struct PayloadToSlice<'a>(&'a mut PayloadSliceLock);
 
 impl<'a> PayloadToSlice<'a> {
     /// Returns slice of the held payload.
@@ -123,50 +123,48 @@ impl<'a> PayloadToSlice<'a> {
         self.0.in_range()
     }
 
-    /// Converts the wrapper into [`PayloadSliceHolder`].
-    pub fn into_holder(self) -> &'a mut PayloadSliceHolder {
+    /// Converts the wrapper into [`PayloadSliceLock`].
+    pub fn into_holder(self) -> &'a mut PayloadSliceLock {
         self.0
     }
 }
 
-/// Result of calling a `job` within [`PayloadSliceHolder::use_with_job`].
+/// Result of calling a `job` within [`PayloadSliceLock::drop_with_job`].
 ///
 /// This is a "bound" type which means it's main purpose is to give
 /// some type-level guarantees. More precisely, it gives guarantee
 /// that payload value was reclaimed by the owner. Also it stores the error
 /// of the `job`, which gives opportunity to handle the actual job's runtime
 /// error, but not bound wrappers.
-pub struct UsePayloadHolderBoundResult<JobError> {
+pub struct DropPayloadLockBoundResult<JobError> {
     job_result: Result<(), JobError>,
 }
 
-impl<JobErr> UsePayloadHolderBoundResult<JobErr> {
-    /// Convert into inner job of the [`PayloadSliceHolder::use_with_job`] result.
+impl<JobErr> DropPayloadLockBoundResult<JobErr> {
+    /// Convert into inner job of the [`PayloadSliceLock::drop_with_job`] result.
     pub fn into_inner(self) -> Result<(), JobErr> {
         self.job_result
     }
 }
 
-impl<JobErr> From<(ReclaimBoundResult, Result<(), JobErr>)>
-    for UsePayloadHolderBoundResult<JobErr>
-{
-    fn from((_token, job_result): (ReclaimBoundResult, Result<(), JobErr>)) -> Self {
-        UsePayloadHolderBoundResult { job_result }
+impl<JobErr> From<(UnlockPayloadBound, Result<(), JobErr>)> for DropPayloadLockBoundResult<JobErr> {
+    fn from((_token, job_result): (UnlockPayloadBound, Result<(), JobErr>)) -> Self {
+        DropPayloadLockBoundResult { job_result }
     }
 }
 
-/// Result of calling [`Externalities::reclaim_payload`].
+/// Result of calling [`Externalities::unlock_payload`].
 ///
 /// This is a "bound" type which means it doesn't store
-/// anything, but gives type-level guarantees that [`PayloadSliceHolder`]
+/// anything, but gives type-level guarantees that [`PayloadSliceLock`]
 /// released the payload back to the message context.
-pub struct ReclaimBoundResult(());
+pub struct UnlockPayloadBound(());
 
-impl From<(&mut MessageContext, &mut PayloadSliceHolder)> for ReclaimBoundResult {
-    fn from((msg_ctx, payload_holder): (&mut MessageContext, &mut PayloadSliceHolder)) -> Self {
-        payload_holder.release_back(msg_ctx);
+impl From<(&mut MessageContext, &mut PayloadSliceLock)> for UnlockPayloadBound {
+    fn from((msg_ctx, payload_holder): (&mut MessageContext, &mut PayloadSliceLock)) -> Self {
+        payload_holder.unlock_back(msg_ctx);
 
-        ReclaimBoundResult(())
+        UnlockPayloadBound(())
     }
 }
 
@@ -308,7 +306,8 @@ pub trait Externalities {
     fn debug(&self, data: &str) -> Result<(), Self::Error>;
 
     /// Takes ownership over payload of the executing message and
-    /// returns it in the wrapper [`PayloadSliceHolder`].
+    /// returns it in the wrapper [`PayloadSliceLock`], which acts
+    /// like lock.
     ///
     /// Due to details of implementation of the runtime which executes gear
     /// sys-calls inside wasm execution environment (either wasmi or sp_sandbox),
@@ -316,14 +315,16 @@ pub trait Externalities {
     /// ownership over payload to the caller. Giving ownership over payload actually
     /// means, that the payload value in the currently executed message will become
     /// "de-allocated" or just zeroed. To prevent from the risk of payload being
-    /// not "returned" back to the message a [`Externalities::reclaim_payload`] is
-    /// introduced. For more info, read docs to [`PayloadSliceHolder`], [`UsePayloadHolderBoundResult`],
-    /// [`ReclaimBoundResult`], [`PayloadToSlice`] types and their methods.
-    fn lend_payload(&mut self, at: u32, len: u32) -> Result<PayloadSliceHolder, Self::Error>;
+    /// not "returned" back to the message a [`Externalities::unlock_payload`] is
+    /// introduced. For more info, read docs to [`PayloadSliceLock`], [`DropPayloadLockBoundResult`],
+    /// [`UnlockPayloadBound`], [`PayloadToSlice`] types and their methods.
+    fn lock_payload(&mut self, at: u32, len: u32) -> Result<PayloadSliceLock, Self::Error>;
 
-    /// Reclaims ownership from the payload holder over previously taken payload from the
-    /// currently executing message.
-    fn reclaim_payload(&mut self, payload_holder: &mut PayloadSliceHolder) -> ReclaimBoundResult;
+    /// Reclaims ownership from the payload lock over previously taken payload from the
+    /// currently executing message..
+    ///
+    /// It's supposed, that the implementation of the method calls [`PayloadSliceLock::unlock_back`].
+    fn unlock_payload(&mut self, payload_holder: &mut PayloadSliceLock) -> UnlockPayloadBound;
 
     /// Size of currently handled message payload.
     fn size(&self) -> Result<usize, Self::Error>;

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -76,7 +76,7 @@ impl PayloadSliceLock {
     /// The method actually performs [`mem::swap`] under the hood. It's supposed
     /// to be called from [`Externalities::unlock_payload`], implementor of which
     /// owns provided message context.
-    fn unlock_back(&mut self, msg_ctx: &mut MessageContext) {
+    fn release(&mut self, msg_ctx: &mut MessageContext) {
         mem::swap(msg_ctx.payload_mut(), &mut self.payload);
     }
 
@@ -161,7 +161,7 @@ pub struct UnlockPayloadBound(());
 
 impl From<(&mut MessageContext, &mut PayloadSliceLock)> for UnlockPayloadBound {
     fn from((msg_ctx, payload_holder): (&mut MessageContext, &mut PayloadSliceLock)) -> Self {
-        payload_holder.unlock_back(msg_ctx);
+        payload_holder.release(msg_ctx);
 
         UnlockPayloadBound(())
     }
@@ -322,7 +322,7 @@ pub trait Externalities {
     /// Reclaims ownership from the payload lock over previously taken payload from the
     /// currently executing message..
     ///
-    /// It's supposed, that the implementation of the method calls `PayloadSliceLock::unlock_back`.
+    /// It's supposed, that the implementation of the method calls `PayloadSliceLock::release`.
     fn unlock_payload(&mut self, payload_holder: &mut PayloadSliceLock) -> UnlockPayloadBound;
 
     /// Size of currently handled message payload.

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -19,7 +19,6 @@
 //! Environment for running a module.
 
 use crate::{
-    gas::GasLeft,
     ids::{MessageId, ProgramId, ReservationId},
     memory::{Memory, WasmPage},
     message::{HandlePacket, InitPacket, ReplyPacket, StatusCode},
@@ -175,9 +174,8 @@ pub trait Ext {
     /// This should be no-op in release builds.
     fn debug(&self, data: &str) -> Result<(), Self::Error>;
 
-    // TODO: remove GasLeft from result #2380
     /// Access currently handled message payload.
-    fn read(&mut self, at: u32, len: u32) -> Result<(&[u8], GasLeft), Self::Error>;
+    fn read(&mut self, at: u32, len: u32) -> Result<&[u8], Self::Error>;
 
     /// Size of currently handled message payload.
     fn size(&self) -> Result<usize, Self::Error>;

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -19,24 +19,16 @@
 //! Environment for running a module.
 
 use crate::{
-    buffer::LimitedVec,
     ids::{MessageId, ProgramId, ReservationId},
     memory::{Memory, WasmPage},
     message::{HandlePacket, InitPacket, MessageContext, Payload, ReplyPacket, StatusCode},
 };
 use alloc::collections::BTreeSet;
 use core::{
-    fmt::{Debug, Display},
+    fmt::Display,
     mem,
-    ops::Deref,
 };
 use gear_wasm_instrument::syscalls::SysCallName;
-use scale_info::scale::{Decode, Encode};
-
-pub enum Either<L, R> {
-    Left(L),
-    Right(R),
-}
 
 pub struct PayloadSliceHolder {
     // todo [sab] add message id to check whether the same message context has come
@@ -92,7 +84,6 @@ impl PayloadSliceHolder {
     where
         Job: FnMut(PayloadToSlice<'_>) -> ReleaseBoundResult<JobErr>,
     {
-        let (start, end) = self.range;
         let held_range = PayloadToSlice(&mut self);
         job(held_range)
     }
@@ -251,7 +242,6 @@ pub trait Externalities {
     /// This should be no-op in release builds.
     fn debug(&self, data: &str) -> Result<(), Self::Error>;
 
-    // todo [sab] #[must_use]
     fn hold_payload(&mut self, at: u32, len: u32) -> Result<PayloadSliceHolder, Self::Error>;
 
     fn reclaim_payload(&mut self, payload_holder: &mut PayloadSliceHolder) -> ReclaimResult;

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -48,7 +48,6 @@ use gear_wasm_instrument::syscalls::SysCallName;
 /// For more usage info read [`Self::release_with_job`] docs.
 
 pub struct PayloadSliceHolder {
-    // todo [sab] add message id to check whether the same message context has come
     /// Held payload
     payload: Payload,
     /// Range values indicating slice bounds.

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -715,7 +715,7 @@ mod tests {
         .expect("cannot init logger");
 
         let mut data = PageBufInner::filled_with(199u8);
-        data.get_mut()[1] = 2;
+        data.inner_mut()[1] = 2;
         let page_buf = PageBuf::from_inner(data);
         log::debug!("page buff = {:?}", page_buf);
     }

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -99,7 +99,7 @@ impl Encode for PageBuf {
     }
 
     fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
-        dest.write(self.0.get())
+        dest.write(self.0.inner())
     }
 }
 
@@ -107,7 +107,7 @@ impl Decode for PageBuf {
     #[inline]
     fn decode<I: Input>(input: &mut I) -> Result<Self, scale::Error> {
         let mut buffer = PageBufInner::new_default();
-        input.read(buffer.get_mut())?;
+        input.read(buffer.inner_mut())?;
         Ok(Self(buffer))
     }
 }
@@ -119,8 +119,8 @@ impl Debug for PageBuf {
         write!(
             f,
             "PageBuf({:?}..{:?})",
-            &self.0.get()[0..10],
-            &self.0.get()[GEAR_PAGE_SIZE - 10..GEAR_PAGE_SIZE]
+            &self.0.inner()[0..10],
+            &self.0.inner()[GEAR_PAGE_SIZE - 10..GEAR_PAGE_SIZE]
         )
     }
 }
@@ -128,13 +128,13 @@ impl Debug for PageBuf {
 impl Deref for PageBuf {
     type Target = [u8];
     fn deref(&self) -> &Self::Target {
-        self.0.get()
+        self.0.inner()
     }
 }
 
 impl DerefMut for PageBuf {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.0.get_mut()
+        self.0.inner_mut()
     }
 }
 

--- a/core/src/message/common.rs
+++ b/core/src/message/common.rs
@@ -104,7 +104,8 @@ impl Message {
 
     /// Message payload reference.
     pub fn payload(&self) -> &[u8] {
-        self.payload.get()
+        // todo [sab] payload bytes
+        self.payload.inner()
     }
 
     /// Message optional gas limit.
@@ -132,7 +133,7 @@ impl Message {
     /// contains string representation of initial bytes,
     /// decoded into given type.
     pub fn with_string_payload<D: Decode + ToString>(self) -> Result<Self, Self> {
-        if let Ok(decoded) = D::decode(&mut self.payload.get()) {
+        if let Ok(decoded) = D::decode(&mut self.payload.inner()) {
             if let Ok(payload) = decoded.to_string().into_bytes().try_into() {
                 Ok(Self { payload, ..self })
             } else {

--- a/core/src/message/common.rs
+++ b/core/src/message/common.rs
@@ -102,9 +102,8 @@ impl Message {
         self.destination
     }
 
-    /// Message payload reference.
-    pub fn payload(&self) -> &[u8] {
-        // todo [sab] payload bytes
+    /// Message payload bytes.
+    pub fn payload_bytes(&self) -> &[u8] {
         self.payload.inner()
     }
 

--- a/core/src/message/context.rs
+++ b/core/src/message/context.rs
@@ -528,6 +528,10 @@ impl MessageContext {
         &self.current
     }
 
+    pub fn payload_mut(&mut self) -> &mut Payload {
+        self.current.payload_mut()
+    }
+
     /// Current program's id.
     pub fn program_id(&self) -> ProgramId {
         self.outcome.program_id

--- a/core/src/message/context.rs
+++ b/core/src/message/context.rs
@@ -374,7 +374,7 @@ impl MessageContext {
             excluded_end,
         } = range;
 
-        data.try_extend_from_slice(&self.current.payload()[offset..excluded_end])
+        data.try_extend_from_slice(&self.current.payload_bytes()[offset..excluded_end])
             .map_err(|_| Error::MaxMessageSizeExceed)?;
 
         Ok(())
@@ -385,7 +385,7 @@ impl MessageContext {
     /// `send_push_input`/`reply_push_input` and has the method `len`
     /// allowing to charge gas before the calls.
     pub fn check_input_range(&self, offset: u32, len: u32) -> CheckedRange {
-        let input = self.current.payload();
+        let input = self.current.payload_bytes();
         let offset = offset as usize;
         if offset >= input.len() {
             return CheckedRange {
@@ -469,7 +469,7 @@ impl MessageContext {
             } = range;
 
             let data = self.store.reply.get_or_insert_with(Default::default);
-            data.try_extend_from_slice(&self.current.payload()[offset..excluded_end])
+            data.try_extend_from_slice(&self.current.payload_bytes()[offset..excluded_end])
                 .map_err(|_| Error::MaxMessageSizeExceed)?;
 
             Ok(())
@@ -723,14 +723,28 @@ mod tests {
 
         // Checking that the `ReplyMessage` matches the passed one
         assert_eq!(
-            context.outcome.reply.as_ref().unwrap().0.payload().to_vec(),
+            context
+                .outcome
+                .reply
+                .as_ref()
+                .unwrap()
+                .0
+                .payload_bytes()
+                .to_vec(),
             vec![1, 2, 3, 0, 0],
         );
 
         // Checking that repeated call `reply_push(...)` returns error and does not do anything
         assert_err!(context.reply_push(&[1]), Error::LateAccess);
         assert_eq!(
-            context.outcome.reply.as_ref().unwrap().0.payload().to_vec(),
+            context
+                .outcome
+                .reply
+                .as_ref()
+                .unwrap()
+                .0
+                .payload_bytes()
+                .to_vec(),
             vec![1, 2, 3, 0, 0],
         );
 
@@ -806,14 +820,14 @@ mod tests {
         // Checking that reply message not lost and matches our initial
         assert!(context.outcome.reply.is_some());
         assert_eq!(
-            context.outcome.reply.as_ref().unwrap().0.payload(),
+            context.outcome.reply.as_ref().unwrap().0.payload_bytes(),
             vec![1, 2, 3, 0, 0]
         );
 
         // Checking that on drain we get only messages that were fully formed (directly sent or committed)
         let (expected_result, _) = context.drain();
         assert_eq!(expected_result.handle.len(), 1);
-        assert_eq!(expected_result.handle[0].0.payload(), vec![5, 7, 9]);
+        assert_eq!(expected_result.handle[0].0.payload_bytes(), vec![5, 7, 9]);
     }
 
     #[test]

--- a/core/src/message/context.rs
+++ b/core/src/message/context.rs
@@ -528,6 +528,7 @@ impl MessageContext {
         &self.current
     }
 
+    /// Mutable reference to currently processed incoming message.
     pub fn payload_mut(&mut self) -> &mut Payload {
         self.current.payload_mut()
     }

--- a/core/src/message/handle.rs
+++ b/core/src/message/handle.rs
@@ -98,7 +98,8 @@ impl HandleMessage {
 
     /// Message payload reference.
     pub fn payload(&self) -> &[u8] {
-        self.payload.get()
+        // todo [sab] payload_bytes
+        self.payload.inner()
     }
 
     /// Message optional gas limit.
@@ -166,7 +167,7 @@ impl HandlePacket {
 
 impl Packet for HandlePacket {
     fn payload(&self) -> &[u8] {
-        self.payload.get()
+        self.payload.inner()
     }
 
     fn gas_limit(&self) -> Option<GasLimit> {

--- a/core/src/message/handle.rs
+++ b/core/src/message/handle.rs
@@ -96,9 +96,8 @@ impl HandleMessage {
         self.destination
     }
 
-    /// Message payload reference.
-    pub fn payload(&self) -> &[u8] {
-        // todo [sab] payload_bytes
+    /// Message payload bytes.
+    pub fn payload_bytes(&self) -> &[u8] {
         self.payload.inner()
     }
 
@@ -166,7 +165,7 @@ impl HandlePacket {
 }
 
 impl Packet for HandlePacket {
-    fn payload(&self) -> &[u8] {
+    fn payload_bytes(&self) -> &[u8] {
         self.payload.inner()
     }
 

--- a/core/src/message/incoming.rs
+++ b/core/src/message/incoming.rs
@@ -93,7 +93,7 @@ impl IncomingMessage {
     /// Message payload reference.
     pub fn payload(&self) -> &[u8] {
         // todo [sab] rename payload bytes
-        self.payload.get()
+        self.payload.inner()
     }
 
     /// Mutable reference to message payload.

--- a/core/src/message/incoming.rs
+++ b/core/src/message/incoming.rs
@@ -39,7 +39,7 @@ pub struct IncomingMessage {
     /// Message source.
     source: ProgramId,
     /// Message payload.
-    payload: Payload,
+    payload: Payload, // todo [sab] Takeable payload
     /// Message gas limit. Required here.
     gas_limit: GasLimit,
     /// Message value.
@@ -92,7 +92,12 @@ impl IncomingMessage {
 
     /// Message payload reference.
     pub fn payload(&self) -> &[u8] {
+        // payload_raw
         self.payload.get()
+    }
+
+    pub fn payload_mut(&mut self) -> &mut Payload {
+        &mut self.payload
     }
 
     /// Message gas limit.

--- a/core/src/message/incoming.rs
+++ b/core/src/message/incoming.rs
@@ -90,9 +90,8 @@ impl IncomingMessage {
         self.source
     }
 
-    /// Message payload reference.
-    pub fn payload(&self) -> &[u8] {
-        // todo [sab] rename payload bytes
+    /// Message payload bytes.
+    pub fn payload_bytes(&self) -> &[u8] {
         self.payload.inner()
     }
 

--- a/core/src/message/incoming.rs
+++ b/core/src/message/incoming.rs
@@ -96,6 +96,7 @@ impl IncomingMessage {
         self.payload.get()
     }
 
+    /// Mutable reference to message payload.
     pub fn payload_mut(&mut self) -> &mut Payload {
         &mut self.payload
     }

--- a/core/src/message/incoming.rs
+++ b/core/src/message/incoming.rs
@@ -92,7 +92,7 @@ impl IncomingMessage {
 
     /// Message payload reference.
     pub fn payload(&self) -> &[u8] {
-        // payload_raw
+        // todo [sab] rename payload bytes
         self.payload.get()
     }
 

--- a/core/src/message/incoming.rs
+++ b/core/src/message/incoming.rs
@@ -39,7 +39,7 @@ pub struct IncomingMessage {
     /// Message source.
     source: ProgramId,
     /// Message payload.
-    payload: Payload, // todo [sab] Takeable payload
+    payload: Payload,
     /// Message gas limit. Required here.
     gas_limit: GasLimit,
     /// Message value.

--- a/core/src/message/init.rs
+++ b/core/src/message/init.rs
@@ -94,9 +94,8 @@ impl InitMessage {
         self.destination
     }
 
-    /// Message payload reference.
-    pub fn payload(&self) -> &[u8] {
-        // todo [sab] rename payload bytes
+    /// Message payload bytes.
+    pub fn payload_bytes(&self) -> &[u8] {
         self.payload.inner()
     }
 
@@ -178,7 +177,7 @@ impl InitPacket {
 }
 
 impl Packet for InitPacket {
-    fn payload(&self) -> &[u8] {
+    fn payload_bytes(&self) -> &[u8] {
         self.payload.inner()
     }
 

--- a/core/src/message/init.rs
+++ b/core/src/message/init.rs
@@ -96,7 +96,8 @@ impl InitMessage {
 
     /// Message payload reference.
     pub fn payload(&self) -> &[u8] {
-        self.payload.get()
+        // todo [sab] rename payload bytes
+        self.payload.inner()
     }
 
     /// Message optional gas limit.
@@ -133,7 +134,7 @@ impl InitPacket {
     /// Create new InitPacket without gas.
     pub fn new(code_id: CodeId, salt: Salt, payload: Payload, value: Value) -> Self {
         Self {
-            program_id: ProgramId::generate(code_id, salt.get()),
+            program_id: ProgramId::generate(code_id, salt.inner()),
             code_id,
             salt,
             payload,
@@ -151,7 +152,7 @@ impl InitPacket {
         value: Value,
     ) -> Self {
         Self {
-            program_id: ProgramId::generate(code_id, salt.get()),
+            program_id: ProgramId::generate(code_id, salt.inner()),
             code_id,
             salt,
             payload,
@@ -172,13 +173,13 @@ impl InitPacket {
 
     /// Salt.
     pub fn salt(&self) -> &[u8] {
-        self.salt.get()
+        self.salt.inner()
     }
 }
 
 impl Packet for InitPacket {
     fn payload(&self) -> &[u8] {
-        self.payload.get()
+        self.payload.inner()
     }
 
     fn gas_limit(&self) -> Option<GasLimit> {

--- a/core/src/message/mod.rs
+++ b/core/src/message/mod.rs
@@ -212,8 +212,8 @@ impl DispatchKind {
 ///
 /// Provides common behavior for any message's packet: accessing to payload, gas limit and value.
 pub trait Packet {
-    /// Packet payload reference.
-    fn payload(&self) -> &[u8];
+    /// Packet payload bytes.
+    fn payload_bytes(&self) -> &[u8];
 
     /// Packet optional gas limit.
     fn gas_limit(&self) -> Option<GasLimit>;

--- a/core/src/message/reply.rs
+++ b/core/src/message/reply.rs
@@ -139,7 +139,8 @@ impl ReplyMessage {
 
     /// Message payload reference.
     pub fn payload(&self) -> &[u8] {
-        self.payload.get()
+        // todo [sab] rename payload bytes
+        self.payload.inner()
     }
 
     /// Message optional gas limit.
@@ -226,7 +227,7 @@ impl ReplyPacket {
 
 impl Packet for ReplyPacket {
     fn payload(&self) -> &[u8] {
-        self.payload.get()
+        self.payload.inner()
     }
 
     fn gas_limit(&self) -> Option<GasLimit> {

--- a/core/src/message/reply.rs
+++ b/core/src/message/reply.rs
@@ -137,9 +137,8 @@ impl ReplyMessage {
         self.id
     }
 
-    /// Message payload reference.
-    pub fn payload(&self) -> &[u8] {
-        // todo [sab] rename payload bytes
+    /// Message payload bytes.
+    pub fn payload_bytes(&self) -> &[u8] {
         self.payload.inner()
     }
 
@@ -226,7 +225,7 @@ impl ReplyPacket {
 }
 
 impl Packet for ReplyPacket {
-    fn payload(&self) -> &[u8] {
+    fn payload_bytes(&self) -> &[u8] {
         self.payload.inner()
     }
 

--- a/core/src/message/stored.rs
+++ b/core/src/message/stored.rs
@@ -99,7 +99,8 @@ impl StoredMessage {
 
     /// Message payload reference.
     pub fn payload(&self) -> &[u8] {
-        self.payload.get()
+        // todo [sab] payload_bytes
+        self.payload.inner()
     }
 
     /// Message value.
@@ -127,7 +128,7 @@ impl StoredMessage {
     /// contains string representation of initial bytes,
     /// decoded into given type.
     pub fn with_string_payload<D: Decode + ToString>(self) -> Result<Self, Self> {
-        if let Ok(decoded) = D::decode(&mut self.payload.get()) {
+        if let Ok(decoded) = D::decode(&mut self.payload.inner()) {
             if let Ok(payload) = decoded.to_string().into_bytes().try_into() {
                 Ok(Self { payload, ..self })
             } else {

--- a/core/src/message/stored.rs
+++ b/core/src/message/stored.rs
@@ -97,9 +97,8 @@ impl StoredMessage {
         self.destination
     }
 
-    /// Message payload reference.
-    pub fn payload(&self) -> &[u8] {
-        // todo [sab] payload_bytes
+    /// Message payload bytes.
+    pub fn payload_bytes(&self) -> &[u8] {
         self.payload.inner()
     }
 

--- a/gclient/tests/memory_dump.rs
+++ b/gclient/tests/memory_dump.rs
@@ -44,7 +44,7 @@ async fn charge_10(
 
         api.claim_value(msg.0.id()).await.unwrap();
 
-        return Ok(String::from_utf8(message.payload().to_vec()).unwrap());
+        return Ok(String::from_utf8(message.payload_bytes().to_vec()).unwrap());
     }
 
     Ok(String::new())

--- a/gclient/tests/upload.rs
+++ b/gclient/tests/upload.rs
@@ -212,8 +212,8 @@ async fn get_mailbox() -> anyhow::Result<()> {
     assert_eq!(mailbox.len(), 5);
 
     for msg in mailbox {
-        assert_eq!(msg.0.payload().len(), 1000 * 1024); // 1MB payload
-        assert!(msg.0.payload().starts_with(b"PONG"));
+        assert_eq!(msg.0.payload_bytes().len(), 1000 * 1024); // 1MB payload
+        assert!(msg.0.payload_bytes().starts_with(b"PONG"));
     }
 
     Ok(())

--- a/gear-test/src/check.rs
+++ b/gear-test/src/check.rs
@@ -278,7 +278,7 @@ pub fn check_messages(
                                     );
 
                                     let new_payload =
-                                        MetaData::CodecBytes((*msg.payload()).to_vec())
+                                        MetaData::CodecBytes((*msg.payload_bytes()).to_vec())
                                             .convert(&path, &meta_type)
                                             .expect("Unable to get bytes")
                                             .into_bytes();
@@ -293,9 +293,9 @@ pub fn check_messages(
                                     );
                                 };
 
-                                !payload.equals(msg.payload())
+                                !payload.equals(msg.payload_bytes())
                             }
-                            _ => !payload.equals(msg.payload()),
+                            _ => !payload.equals(msg.payload_bytes()),
                         })
                         .unwrap_or(false)
                 {
@@ -306,7 +306,7 @@ pub fn check_messages(
                             .expect("Checked above.")
                             .clone()
                             .into_raw(),
-                        (*msg.payload()).to_vec(),
+                        (*msg.payload_bytes()).to_vec(),
                     ))
                 }
 
@@ -561,7 +561,7 @@ where
         }
         if let Some(log) = &exp.log {
             for message in &final_state.log {
-                if let Ok(utf8) = std::str::from_utf8(message.payload()) {
+                if let Ok(utf8) = std::str::from_utf8(message.payload_bytes()) {
                     log::debug!("log(text: {})", utf8);
                 } else {
                     log::debug!("log(<binary>)");

--- a/gtest/src/log.rs
+++ b/gtest/src/log.rs
@@ -47,7 +47,7 @@ impl CoreLog {
     }
 
     pub fn payload(&self) -> &[u8] {
-        self.payload.get()
+        self.payload.inner()
     }
 
     pub fn status_code(&self) -> Option<StatusCode> {
@@ -78,7 +78,7 @@ pub struct DecodedCoreLog<T: Codec + Debug> {
 
 impl<T: Codec + Debug> DecodedCoreLog<T> {
     pub(crate) fn try_from_log(log: CoreLog) -> Option<Self> {
-        let payload = T::decode(&mut log.payload.get()).ok()?;
+        let payload = T::decode(&mut log.payload.inner()).ok()?;
 
         Some(Self {
             id: log.id,
@@ -180,7 +180,7 @@ impl PartialEq<StoredMessage> for Log {
         if matches!(self.destination, Some(dest) if dest != other.destination()) {
             return false;
         }
-        if matches!(&self.payload, Some(payload) if payload.get() != other.payload_bytes()) {
+        if matches!(&self.payload, Some(payload) if payload.inner() != other.payload_bytes()) {
             return false;
         }
         true
@@ -229,7 +229,7 @@ impl PartialEq<CoreLog> for Log {
 
         if self.status_code == 0 {
             if let Some(payload) = &self.payload {
-                if payload.get() != other.payload.get() {
+                if payload.inner() != other.payload.inner() {
                     return false;
                 }
             }

--- a/gtest/src/log.rs
+++ b/gtest/src/log.rs
@@ -61,7 +61,7 @@ impl From<StoredMessage> for CoreLog {
             id: other.id(),
             source: other.source(),
             destination: other.destination(),
-            payload: other.payload().to_vec().try_into().unwrap(),
+            payload: other.payload_bytes().to_vec().try_into().unwrap(),
             status_code: other.status_code(),
         }
     }
@@ -180,7 +180,7 @@ impl PartialEq<StoredMessage> for Log {
         if matches!(self.destination, Some(dest) if dest != other.destination()) {
             return false;
         }
-        if matches!(&self.payload, Some(payload) if payload.get() != other.payload()) {
+        if matches!(&self.payload, Some(payload) if payload.get() != other.payload_bytes()) {
             return false;
         }
         true

--- a/gtest/src/mailbox.rs
+++ b/gtest/src/mailbox.rs
@@ -186,9 +186,12 @@ mod tests {
         assert!(!second_message_result.main_failed);
         assert!(!second_message_result.others_failed);
         assert_eq!(reply_log.len(), 1);
-        assert_eq!(last_reply_log.payload(), encoded_reply_payload.get());
-        assert_eq!(message_log.payload(), encoded_message_payload.get());
-        assert_eq!(second_message_log.payload(), encoded_message_payload.get());
+        assert_eq!(last_reply_log.payload(), encoded_reply_payload.inner());
+        assert_eq!(message_log.payload(), encoded_message_payload.inner());
+        assert_eq!(
+            second_message_log.payload(),
+            encoded_message_payload.inner()
+        );
     }
 
     #[test]
@@ -260,7 +263,7 @@ mod tests {
         let result_log = result.log;
         let last_result_log = result_log.last().expect("No message log in run result");
 
-        assert_eq!(last_result_log.payload(), reply_payload.get());
+        assert_eq!(last_result_log.payload(), reply_payload.inner());
     }
 
     #[test]

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -661,7 +661,7 @@ impl ExtManager {
         let message_id = dispatch.id();
         let source = dispatch.source();
         let program_id = dispatch.destination();
-        let payload = dispatch.payload().to_vec();
+        let payload = dispatch.payload_bytes().to_vec();
 
         let response = match dispatch.kind() {
             DispatchKind::Init => mock.init(payload).map(Mocked::Reply),

--- a/pallets/gear-debug/src/lib.rs
+++ b/pallets/gear-debug/src/lib.rs
@@ -185,7 +185,7 @@ pub mod pallet {
             msg.id(),
             ProgramId::from_origin(source),
             ProgramId::from_origin(destination),
-            (*msg.payload()).to_vec().try_into().unwrap(),
+            (*msg.payload_bytes()).to_vec().try_into().unwrap(),
             msg.value(),
             msg.details(),
         );

--- a/pallets/gear-debug/src/tests.rs
+++ b/pallets/gear-debug/src/tests.rs
@@ -92,7 +92,7 @@ fn vec() {
         run_to_next_block(None);
 
         let reply = maybe_last_message(1).expect("Should be");
-        assert_eq!(reply.payload(), 131072i32.encode());
+        assert_eq!(reply.payload_bytes(), 131072i32.encode());
 
         GearDebug::do_snapshot();
         let snapshot = get_last_snapshot();

--- a/pallets/gear-scheduler/src/tests.rs
+++ b/pallets/gear-scheduler/src/tests.rs
@@ -122,7 +122,7 @@ fn out_of_rent_reply_exists(
             msg.destination() == src
                 && msg.source() == pid
                 && msg.reply() == Some(ReplyDetails::new(mid, err.into_status_code()))
-                && msg.payload() == err.to_string().as_bytes()
+                && msg.payload_bytes() == err.to_string().as_bytes()
         } else {
             false
         }

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -466,7 +466,7 @@ benchmarks! {
     }: _(RawOrigin::Signed(caller.clone()), original_message_id)
     verify {
         let auto_reply = QueueOf::<T>::dequeue().expect("Error in algorithm").expect("Element should be");
-        assert!(auto_reply.payload().is_empty());
+        assert!(auto_reply.payload_bytes().is_empty());
         assert_eq!(auto_reply.status_code().expect("Should be").to_le_bytes()[0], 0);
         assert!(MailboxOf::<T>::is_empty(&caller));
     }

--- a/pallets/gear/src/benchmarking/tests/syscalls_integrity.rs
+++ b/pallets/gear/src/benchmarking/tests/syscalls_integrity.rs
@@ -227,7 +227,7 @@ where
         let post_test = move || {
             assert!(
                 MailboxOf::<T>::iter_key(default_sender)
-                    .any(|(m, _)| m.id() == expected_mid && m.payload() == payload.to_vec()),
+                    .any(|(m, _)| m.id() == expected_mid && m.payload_bytes() == payload.to_vec()),
                 "No message with expected id found in queue"
             );
         };
@@ -277,7 +277,7 @@ where
             assert!(SystemPallet::<T>::events().into_iter().any(|e| {
                 let bytes = e.event.encode();
                 let Ok(gear_event): Result<Event<T>, _> = Event::decode(&mut bytes[1..].as_ref()) else { return false };
-                matches!(gear_event, Event::UserMessageSent { message, .. } if message.id() == expected_mid && message.payload() == payload && message.destination() == source)
+                matches!(gear_event, Event::UserMessageSent { message, .. } if message.id() == expected_mid && message.payload_bytes() == payload && message.destination() == source)
             }), "No message with expected id found in events");
         };
 
@@ -519,7 +519,7 @@ where
         let post_test = move || {
             assert!(
                 MailboxOf::<T>::iter_key(default_sender)
-                    .any(|(m, _)| m.id() == expected_mid && m.payload() == payload.to_vec()),
+                    .any(|(m, _)| m.id() == expected_mid && m.payload_bytes() == payload.to_vec()),
                 "No message with expected id found in queue"
             );
         };
@@ -549,7 +549,7 @@ where
         let post_test = move || {
             assert!(
                 MailboxOf::<T>::iter_key(default_sender)
-                    .any(|(m, _)| m.id() == expected_message_id && m.payload() == payload),
+                    .any(|(m, _)| m.id() == expected_message_id && m.payload_bytes() == payload),
                 "No message with expected id found in queue"
             );
         };
@@ -577,7 +577,7 @@ where
         let post_test = move || {
             assert!(
                 MailboxOf::<T>::iter_key(default_sender)
-                    .any(|(m, _)| m.id() == expected_message_id && m.payload() == payload),
+                    .any(|(m, _)| m.id() == expected_message_id && m.payload_bytes() == payload),
                 "No message with expected id found in queue"
             );
         };
@@ -620,7 +620,7 @@ where
             assert!(SystemPallet::<T>::events().into_iter().any(|e| {
                 let bytes = e.event.encode();
                 let Ok(gear_event): Result<Event<T>, _> = Event::decode(&mut bytes[1..].as_ref()) else { return false };
-                matches!(gear_event, Event::UserMessageSent { message, .. } if message.id() == expected_mid && message.payload() == payload && message.destination() == source)
+                matches!(gear_event, Event::UserMessageSent { message, .. } if message.id() == expected_mid && message.payload_bytes() == payload && message.destination() == source)
             }), "No message with expected id found in events");
         };
 
@@ -651,7 +651,7 @@ where
             assert!(SystemPallet::<T>::events().into_iter().any(|e| {
                 let bytes = e.event.encode();
                 let Ok(gear_event): Result<Event<T>, _> = Event::decode(&mut bytes[1..].as_ref()) else { return false };
-                matches!(gear_event, Event::UserMessageSent { message, .. } if message.id() == expected_message_id && message.payload() == payload && message.destination() == source)
+                matches!(gear_event, Event::UserMessageSent { message, .. } if message.id() == expected_message_id && message.payload_bytes() == payload && message.destination() == source)
             }), "No message with expected id found in events");
         };
 
@@ -678,7 +678,7 @@ where
             assert!(SystemPallet::<T>::events().into_iter().any(|e| {
                 let bytes = e.event.encode();
                 let Ok(gear_event): Result<Event<T>, _> = Event::decode(&mut bytes[1..].as_ref()) else { return false };
-                matches!(gear_event, Event::UserMessageSent { message, .. } if message.id() == expected_message_id && message.payload() == payload && message.destination() == source)
+                matches!(gear_event, Event::UserMessageSent { message, .. } if message.id() == expected_message_id && message.payload_bytes() == payload && message.destination() == source)
             }), "No message with expected id found in events");
         };
 
@@ -1019,7 +1019,7 @@ where
     // let user_mid = get_last_message_id();
     utils::run_to_next_block::<T>(None);
     let ok_mails = MailboxOf::<T>::iter_key(sender)
-        .filter(|(m, _)| m.payload() == b"ok")
+        .filter(|(m, _)| m.payload_bytes() == b"ok")
         .count();
     assert_eq!(ok_mails, 1);
 

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -25,7 +25,7 @@ use gear_backend_common::{
 };
 use gear_core::{
     costs::RuntimeCosts,
-    env::Externalities,
+    env::{Externalities, PayloadSliceHolder, ReclaimResult},
     gas::{ChargeError, CountersOwner, GasAmount, GasLeft},
     ids::{MessageId, ProgramId, ReservationId},
     memory::{GearPage, GrowHandler, Memory, MemoryInterval, PageU32Size, WasmPage},
@@ -267,10 +267,6 @@ impl Externalities for LazyPagesExt {
         self.inner.debug(data)
     }
 
-    fn read_inner(&mut self, at: u32, len: u32) -> Result<&[u8], Self::Error> {
-        self.inner.read_inner(at, len)
-    }
-
     fn size(&self) -> Result<usize, Self::Error> {
         self.inner.size()
     }
@@ -333,5 +329,13 @@ impl Externalities for LazyPagesExt {
 
     fn forbidden_funcs(&self) -> &BTreeSet<SysCallName> {
         &self.inner.context.forbidden_funcs
+    }
+
+    fn hold_payload(&mut self, at: u32, len: u32) -> Result<PayloadSliceHolder, Self::Error> {
+        self.inner.hold_payload(at, len)
+    }
+
+    fn reclaim_payload(&mut self, payload_holder: &mut PayloadSliceHolder) -> ReclaimResult {
+        self.inner.reclaim_payload(payload_holder)
     }
 }

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -267,7 +267,7 @@ impl EnvExt for LazyPagesExt {
         self.inner.debug(data)
     }
 
-    fn read(&mut self, at: u32, len: u32) -> Result<(&[u8], GasLeft), Self::Error> {
+    fn read(&mut self, at: u32, len: u32) -> Result<&[u8], Self::Error> {
         self.inner.read(at, len)
     }
 

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -25,7 +25,7 @@ use gear_backend_common::{
 };
 use gear_core::{
     costs::RuntimeCosts,
-    env::{Externalities, PayloadSliceHolder, ReclaimBoundResult},
+    env::{Externalities, PayloadSliceLock, UnlockPayloadBound},
     gas::{ChargeError, CountersOwner, GasAmount, GasLeft},
     ids::{MessageId, ProgramId, ReservationId},
     memory::{GearPage, GrowHandler, Memory, MemoryInterval, PageU32Size, WasmPage},
@@ -331,11 +331,11 @@ impl Externalities for LazyPagesExt {
         &self.inner.context.forbidden_funcs
     }
 
-    fn lend_payload(&mut self, at: u32, len: u32) -> Result<PayloadSliceHolder, Self::Error> {
-        self.inner.lend_payload(at, len)
+    fn lock_payload(&mut self, at: u32, len: u32) -> Result<PayloadSliceLock, Self::Error> {
+        self.inner.lock_payload(at, len)
     }
 
-    fn reclaim_payload(&mut self, payload_holder: &mut PayloadSliceHolder) -> ReclaimBoundResult {
-        self.inner.reclaim_payload(payload_holder)
+    fn unlock_payload(&mut self, payload_holder: &mut PayloadSliceLock) -> UnlockPayloadBound {
+        self.inner.unlock_payload(payload_holder)
     }
 }

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -267,8 +267,8 @@ impl EnvExt for LazyPagesExt {
         self.inner.debug(data)
     }
 
-    fn read(&mut self, at: u32, len: u32) -> Result<&[u8], Self::Error> {
-        self.inner.read(at, len)
+    fn read_inner(&mut self, at: u32, len: u32) -> Result<&[u8], Self::Error> {
+        self.inner.read_inner(at, len)
     }
 
     fn size(&self) -> Result<usize, Self::Error> {

--- a/pallets/gear/src/ext.rs
+++ b/pallets/gear/src/ext.rs
@@ -25,7 +25,7 @@ use gear_backend_common::{
 };
 use gear_core::{
     costs::RuntimeCosts,
-    env::{Externalities, PayloadSliceHolder, ReclaimResult},
+    env::{Externalities, PayloadSliceHolder, ReclaimBoundResult},
     gas::{ChargeError, CountersOwner, GasAmount, GasLeft},
     ids::{MessageId, ProgramId, ReservationId},
     memory::{GearPage, GrowHandler, Memory, MemoryInterval, PageU32Size, WasmPage},
@@ -331,11 +331,11 @@ impl Externalities for LazyPagesExt {
         &self.inner.context.forbidden_funcs
     }
 
-    fn hold_payload(&mut self, at: u32, len: u32) -> Result<PayloadSliceHolder, Self::Error> {
-        self.inner.hold_payload(at, len)
+    fn lend_payload(&mut self, at: u32, len: u32) -> Result<PayloadSliceHolder, Self::Error> {
+        self.inner.lend_payload(at, len)
     }
 
-    fn reclaim_payload(&mut self, payload_holder: &mut PayloadSliceHolder) -> ReclaimResult {
+    fn reclaim_payload(&mut self, payload_holder: &mut PayloadSliceHolder) -> ReclaimBoundResult {
         self.inner.reclaim_payload(payload_holder)
     }
 }

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -334,7 +334,7 @@ fn auto_reply_out_of_rent_mailbox() {
             .expect("Infallible")
             .expect("Should be");
         let err = SimpleReplyError::OutOfRent;
-        assert_eq!(dispatch.payload(), err.to_string().into_bytes());
+        assert_eq!(dispatch.payload_bytes(), err.to_string().into_bytes());
         assert_eq!(
             dispatch.status_code().expect("Should be"),
             err.into_status_code()
@@ -472,7 +472,10 @@ fn reply_deposit_to_user_reply() {
         assert_total_dequeued(2);
 
         let mail = get_last_mail(USER_2);
-        assert_eq!(mail.payload(), demo_reply_deposit::DESTINATION_MESSAGE);
+        assert_eq!(
+            mail.payload_bytes(),
+            demo_reply_deposit::DESTINATION_MESSAGE
+        );
 
         let user_2_balance = Balances::total_balance(&USER_2);
         assert_balance(USER_2, user_2_balance, 0u128);
@@ -544,7 +547,10 @@ fn reply_deposit_to_user_claim() {
         assert_total_dequeued(2);
 
         let mail = get_last_mail(USER_2);
-        assert_eq!(mail.payload(), demo_reply_deposit::DESTINATION_MESSAGE);
+        assert_eq!(
+            mail.payload_bytes(),
+            demo_reply_deposit::DESTINATION_MESSAGE
+        );
 
         let user_2_balance = Balances::total_balance(&USER_2);
         assert_balance(USER_2, user_2_balance, 0u128);
@@ -610,7 +616,10 @@ fn reply_deposit_to_user_out_of_rent() {
             .next()
             .expect("Element should be");
 
-        assert_eq!(mail.payload(), demo_reply_deposit::DESTINATION_MESSAGE);
+        assert_eq!(
+            mail.payload_bytes(),
+            demo_reply_deposit::DESTINATION_MESSAGE
+        );
 
         let user_2_balance = Balances::total_balance(&USER_2);
         assert_balance(USER_2, user_2_balance, 0u128);
@@ -678,7 +687,7 @@ fn reply_deposit_gstd_async() {
         assert!(Gear::is_active(program_id));
 
         let mail = get_last_mail(USER_2);
-        assert_eq!(mail.payload(), hello);
+        assert_eq!(mail.payload_bytes(), hello);
 
         let hello_reply = b"U2";
         assert_ok!(Gear::send_reply(
@@ -698,7 +707,7 @@ fn reply_deposit_gstd_async() {
             reply.reply().expect("Should be").into_parts(),
             (handle_id, 0)
         );
-        assert_eq!(reply.payload(), hello_reply);
+        assert_eq!(reply.payload_bytes(), hello_reply);
     });
 }
 
@@ -4354,7 +4363,7 @@ fn defer_program_initialization() {
         assert_eq!(
             maybe_last_message(USER_1)
                 .expect("Event should be")
-                .payload(),
+                .payload_bytes(),
             b"Hello, world!".encode()
         );
     })
@@ -4417,7 +4426,7 @@ fn wake_messages_after_program_inited() {
                 MockRuntimeEvent::Gear(Event::UserMessageSent { message, .. })
                     if message.destination().into_origin() == USER_3.into_origin() =>
                 {
-                    assert_eq!(message.payload().to_vec(), b"Hello, world!".encode());
+                    assert_eq!(message.payload_bytes().to_vec(), b"Hello, world!".encode());
                     Some(())
                 }
                 _ => None,
@@ -4884,7 +4893,7 @@ fn test_requeue_after_wait_for_timeout() {
         }));
 
         // Message processed.
-        assert_eq!(get_last_mail(USER_1).payload(), b"ping");
+        assert_eq!(get_last_mail(USER_1).payload_bytes(), b"ping");
     })
 }
 
@@ -5043,7 +5052,7 @@ fn test_wait_timeout() {
 
         // Timeout still works.
         assert!(MailboxOf::<Test>::iter_key(USER_1)
-            .any(|(msg, _bn)| msg.payload().to_vec() == b"timeout"));
+            .any(|(msg, _bn)| msg.payload_bytes().to_vec() == b"timeout"));
     })
 }
 
@@ -5094,14 +5103,14 @@ fn test_join_wait_timeout() {
         // The timeout message has not been triggered yet.
         run_to_target(targets[0]);
         assert!(!MailboxOf::<Test>::iter_key(USER_1)
-            .any(|(msg, _bn)| msg.payload().to_vec() == b"timeout"));
+            .any(|(msg, _bn)| msg.payload_bytes().to_vec() == b"timeout"));
 
         // Run to the end of the second duration.
         //
         // The timeout message has been triggered.
         run_to_target(targets[1]);
         assert!(MailboxOf::<Test>::iter_key(USER_1)
-            .any(|(msg, _bn)| msg.payload().to_vec() == b"timeout"));
+            .any(|(msg, _bn)| msg.payload_bytes().to_vec() == b"timeout"));
     })
 }
 
@@ -5148,7 +5157,7 @@ fn test_select_wait_timeout() {
         run_to_next_block(None);
 
         assert!(MailboxOf::<Test>::iter_key(USER_1)
-            .any(|(msg, _bn)| msg.payload().to_vec() == b"timeout"));
+            .any(|(msg, _bn)| msg.payload_bytes().to_vec() == b"timeout"));
     })
 }
 
@@ -5184,7 +5193,7 @@ fn test_wait_lost() {
         run_to_next_block(None);
 
         assert!(MailboxOf::<Test>::iter_key(USER_1).any(|(msg, _bn)| {
-            if msg.payload() == b"ping" {
+            if msg.payload_bytes() == b"ping" {
                 assert_ok!(Gear::send_reply(
                     RuntimeOrigin::signed(USER_1),
                     msg.id(),
@@ -5211,17 +5220,21 @@ fn test_wait_lost() {
         //
         // The timeout message has been triggered.
         run_to_target(targets[0]);
-        assert!(
-            !MailboxOf::<Test>::iter_key(USER_1).any(|(msg, _bn)| msg.payload() == b"unreachable")
-        );
+        assert!(!MailboxOf::<Test>::iter_key(USER_1)
+            .any(|(msg, _bn)| msg.payload_bytes() == b"unreachable"));
 
         // Run to the end of the second duration.
         //
         // The timeout message has been triggered.
         run_to_target(targets[1]);
-        assert!(MailboxOf::<Test>::iter_key(USER_1).any(|(msg, _bn)| msg.payload() == b"timeout"));
-        assert!(MailboxOf::<Test>::iter_key(USER_1).any(|(msg, _bn)| msg.payload() == b"timeout2"));
-        assert!(MailboxOf::<Test>::iter_key(USER_1).any(|(msg, _bn)| msg.payload() == b"success"));
+        assert!(
+            MailboxOf::<Test>::iter_key(USER_1).any(|(msg, _bn)| msg.payload_bytes() == b"timeout")
+        );
+        assert!(MailboxOf::<Test>::iter_key(USER_1)
+            .any(|(msg, _bn)| msg.payload_bytes() == b"timeout2"));
+        assert!(
+            MailboxOf::<Test>::iter_key(USER_1).any(|(msg, _bn)| msg.payload_bytes() == b"success")
+        );
     })
 }
 
@@ -6266,7 +6279,7 @@ fn resume_program_works() {
         run_to_next_block(None);
 
         let message = maybe_any_last_message().expect("message to user should be sent");
-        let reply = Reply::decode(&mut message.payload()).unwrap();
+        let reply = Reply::decode(&mut message.payload_bytes()).unwrap();
         assert!(matches!(reply, Reply::List(vec) if vec == vec![(0, 1)]));
     })
 }
@@ -7812,7 +7825,7 @@ fn demo_constructor_works() {
         let message_id = MessageId::generate_outgoing(message_id, 0);
 
         let last_mail = maybe_any_last_message().expect("Element should be");
-        assert_eq!(last_mail.payload(), message_id.as_ref());
+        assert_eq!(last_mail.payload_bytes(), message_id.as_ref());
 
         let (first_mail, _bn) = {
             let res = MailboxOf::<Test>::remove(USER_1, message_id);
@@ -7821,7 +7834,7 @@ fn demo_constructor_works() {
         };
 
         assert_eq!(first_mail.value(), 100_000);
-        assert_eq!(first_mail.payload(), b"Hello, user!");
+        assert_eq!(first_mail.payload_bytes(), b"Hello, user!");
 
         let calls = Calls::builder().panic("I just panic every time");
 
@@ -7885,7 +7898,7 @@ fn demo_constructor_value_eq() {
         run_to_next_block(None);
 
         let last_mail = maybe_any_last_message().expect("Element should be");
-        assert_eq!(last_mail.payload(), b"Eq");
+        assert_eq!(last_mail.payload_bytes(), b"Eq");
 
         assert_ok!(Gear::send_message(
             RuntimeOrigin::signed(USER_1),
@@ -7898,7 +7911,7 @@ fn demo_constructor_value_eq() {
         run_to_next_block(None);
 
         let last_mail = maybe_any_last_message().expect("Element should be");
-        assert_eq!(last_mail.payload(), b"Ne");
+        assert_eq!(last_mail.payload_bytes(), b"Ne");
     });
 }
 
@@ -7930,7 +7943,7 @@ fn demo_constructor_is_demo_ping() {
         let (_init_mid, constructor_id) = utils::init_constructor(scheme);
 
         let init_reply = maybe_any_last_message().expect("Element should be");
-        assert_eq!(init_reply.payload(), b"PING");
+        assert_eq!(init_reply.payload_bytes(), b"PING");
 
         let mut message_id_to_reply = None;
 
@@ -7947,7 +7960,7 @@ fn demo_constructor_is_demo_ping() {
             run_to_next_block(None);
 
             let last_mail = maybe_any_last_message().expect("Element should be");
-            assert_eq!(last_mail.payload(), b"PONG");
+            assert_eq!(last_mail.payload_bytes(), b"PONG");
             message_id_to_reply = Some(last_mail.id());
         }
 
@@ -8058,7 +8071,7 @@ fn delayed_sending() {
 
         let auto_reply = maybe_last_message(USER_1).expect("Should be");
         assert!(auto_reply.is_reply());
-        assert!(auto_reply.payload().is_empty());
+        assert!(auto_reply.payload_bytes().is_empty());
 
         System::reset_events();
 
@@ -8071,7 +8084,7 @@ fn delayed_sending() {
         assert_eq!(
             maybe_last_message(USER_1)
                 .expect("Event should be")
-                .payload(),
+                .payload_bytes(),
             b"Delayed hello!".encode()
         );
     });
@@ -8324,7 +8337,8 @@ fn execution_over_blocks() {
         use demo_calc_hash::verify_result;
 
         let last_message = maybe_last_message(USER_1).expect("Get last message failed.");
-        let result = <[u8; 32]>::decode(&mut last_message.payload()).expect("Decode result failed");
+        let result =
+            <[u8; 32]>::decode(&mut last_message.payload_bytes()).expect("Decode result failed");
 
         assert!(verify_result(src, count, result));
 
@@ -8461,7 +8475,7 @@ fn execution_over_blocks() {
         loop {
             let lm = maybe_last_message(USER_1);
 
-            if !(lm.is_none() || lm.unwrap().payload().is_empty()) {
+            if !(lm.is_none() || lm.unwrap().payload_bytes().is_empty()) {
                 break;
             }
 
@@ -8559,7 +8573,7 @@ fn test_async_messages() {
             // check the message sent from the program
             run_to_next_block(None);
             let last_mail = get_last_mail(USER_1);
-            assert_eq!(Kind::decode(&mut last_mail.payload()), Ok(*kind));
+            assert_eq!(Kind::decode(&mut last_mail.payload_bytes()), Ok(*kind));
 
             // reply to the message
             let message_id = last_mail.id();
@@ -8574,7 +8588,7 @@ fn test_async_messages() {
             // check the reply from the program
             run_to_next_block(None);
             let last_mail = get_last_mail(USER_1);
-            assert_eq!(last_mail.payload(), b"PONG");
+            assert_eq!(last_mail.payload_bytes(), b"PONG");
             assert_ok!(Gear::claim_value(
                 RuntimeOrigin::signed(USER_1),
                 last_mail.id()
@@ -8902,7 +8916,7 @@ fn send_from_reservation() {
 
             let msg = get_last_mail(USER_1);
             assert_eq!(msg.value(), 500);
-            assert_eq!(msg.payload(), b"send_to_user");
+            assert_eq!(msg.payload_bytes(), b"send_to_user");
             let map = get_reservation_map(pid).unwrap();
             assert!(map.is_empty());
         }
@@ -8930,7 +8944,7 @@ fn send_from_reservation() {
 
             let msg = get_last_mail(USER_1);
             assert_eq!(msg.value(), 700);
-            assert_eq!(msg.payload(), b"receive_from_program");
+            assert_eq!(msg.payload_bytes(), b"receive_from_program");
             let map = get_reservation_map(pid).unwrap();
             assert!(map.is_empty());
         }
@@ -8954,7 +8968,7 @@ fn send_from_reservation() {
 
             let msg = get_last_mail(USER_1);
             assert_eq!(msg.value(), 600);
-            assert_eq!(msg.payload(), b"send_to_user_delayed");
+            assert_eq!(msg.payload_bytes(), b"send_to_user_delayed");
             let map = get_reservation_map(pid).unwrap();
             assert!(map.is_empty());
         }
@@ -8985,7 +8999,7 @@ fn send_from_reservation() {
 
             let msg = get_last_mail(USER_1);
             assert_eq!(msg.value(), 800);
-            assert_eq!(msg.payload(), b"receive_from_program_delayed");
+            assert_eq!(msg.payload_bytes(), b"receive_from_program_delayed");
             let map = get_reservation_map(pid).unwrap();
             assert!(map.is_empty());
         }
@@ -9035,7 +9049,7 @@ fn reply_from_reservation() {
 
             let msg = maybe_last_message(USER_1).expect("Should be");
             assert_eq!(msg.value(), 900);
-            assert_eq!(msg.payload(), b"reply_to_user");
+            assert_eq!(msg.payload_bytes(), b"reply_to_user");
             let map = get_reservation_map(pid).unwrap();
             assert!(map.is_empty());
         }
@@ -9063,7 +9077,7 @@ fn reply_from_reservation() {
 
             let msg = maybe_last_message(USER_1).expect("Should be");
             assert_eq!(msg.value(), 900);
-            assert_eq!(msg.payload(), b"reply");
+            assert_eq!(msg.payload_bytes(), b"reply");
             let map = get_reservation_map(pid).unwrap();
             assert!(map.is_empty());
         }
@@ -9383,7 +9397,7 @@ fn signal_gas_limit_exceeded_works() {
 
         // check signal dispatch executed
         let mail_msg = get_last_mail(USER_1);
-        assert_eq!(mail_msg.payload(), b"handle_signal");
+        assert_eq!(mail_msg.payload_bytes(), b"handle_signal");
     });
 }
 
@@ -9525,7 +9539,7 @@ fn system_reservation_panic_works() {
 
         // check signal dispatch executed
         let mail_msg = get_last_mail(USER_1);
-        assert_eq!(mail_msg.payload(), b"handle_signal");
+        assert_eq!(mail_msg.payload_bytes(), b"handle_signal");
     });
 }
 
@@ -9566,7 +9580,7 @@ fn system_reservation_exit_works() {
         // check signal dispatch was not executed but `gr_exit` did
         assert_eq!(MailboxOf::<Test>::len(&USER_1), 0);
         let msg = maybe_last_message(USER_1).expect("Should be");
-        assert_eq!(msg.payload(), b"exit");
+        assert_eq!(msg.payload_bytes(), b"exit");
     });
 }
 
@@ -9727,7 +9741,7 @@ fn system_reservation_wait_and_exit_works() {
 
         // check `gr_exit` occurs
         let msg = get_last_mail(USER_1);
-        assert_eq!(msg.payload(), b"wait_and_exit");
+        assert_eq!(msg.payload_bytes(), b"wait_and_exit");
     });
 }
 
@@ -9782,7 +9796,7 @@ fn system_reservation_wait_and_reserve_with_panic_works() {
 
         // check signal dispatch executed
         let mail_msg = get_last_mail(USER_1);
-        assert_eq!(mail_msg.payload(), b"handle_signal");
+        assert_eq!(mail_msg.payload_bytes(), b"handle_signal");
     });
 }
 
@@ -10104,7 +10118,7 @@ fn gas_reservations_fresh_reserve_unreserve() {
 
         assert_succeed(mid);
         let msg = get_last_mail(USER_1);
-        assert_eq!(msg.payload(), b"fresh_reserve_unreserve");
+        assert_eq!(msg.payload_bytes(), b"fresh_reserve_unreserve");
     });
 }
 
@@ -10143,7 +10157,7 @@ fn gas_reservations_existing_reserve_unreserve() {
 
         assert_succeed(mid);
         let msg = get_last_mail(USER_1);
-        assert_eq!(msg.payload(), b"existing_reserve_unreserve");
+        assert_eq!(msg.payload_bytes(), b"existing_reserve_unreserve");
     });
 }
 
@@ -10177,7 +10191,7 @@ fn custom_async_entrypoint_works() {
         run_to_block(3, None);
 
         let msg = get_last_mail(USER_1);
-        assert_eq!(msg.payload(), b"my_handle_signal");
+        assert_eq!(msg.payload_bytes(), b"my_handle_signal");
 
         assert_ok!(Gear::send_reply(
             RuntimeOrigin::signed(USER_1),
@@ -10190,7 +10204,7 @@ fn custom_async_entrypoint_works() {
         run_to_block(4, None);
 
         let msg = get_last_mail(USER_1);
-        assert_eq!(msg.payload(), b"my_handle_reply");
+        assert_eq!(msg.payload_bytes(), b"my_handle_reply");
     });
 }
 
@@ -10410,7 +10424,7 @@ fn signal_on_uninitialized_program() {
         assert_ok!(GasHandlerOf::<Test>::get_system_reserve(init_mid));
 
         let msg = get_last_mail(USER_1);
-        assert_eq!(msg.payload(), b"init");
+        assert_eq!(msg.payload_bytes(), b"init");
 
         assert_ok!(Gear::send_reply(
             RuntimeOrigin::signed(USER_1),
@@ -10528,7 +10542,7 @@ fn async_does_not_duplicate_sync() {
 
         let mail = maybe_any_last_message().expect("Element should be");
         assert_eq!(mail.destination().into_origin(), USER_1.into_origin());
-        assert_eq!(mail.payload(), 1i32.to_le_bytes());
+        assert_eq!(mail.payload_bytes(), 1i32.to_le_bytes());
     })
 }
 
@@ -11424,7 +11438,7 @@ mod utils {
                         && details.status_code().to_le_bytes()[0] != 0
                     {
                         actual_error = Some((
-                            String::from_utf8(message.payload().to_vec())
+                            String::from_utf8(message.payload_bytes().to_vec())
                                 .expect("Unable to decode string from error reply"),
                             details.status_code(),
                         ));
@@ -11876,7 +11890,7 @@ mod utils {
                 if message.destination() == user_id.into() {
                     match assertions[res.len()] {
                         Assertion::Payload(_) => {
-                            res.push(Assertion::Payload(message.payload().to_vec()))
+                            res.push(Assertion::Payload(message.payload_bytes().to_vec()))
                         }
                         Assertion::StatusCode(_) => {
                             res.push(Assertion::StatusCode(message.status_code()))
@@ -12141,7 +12155,10 @@ fn check_random_works() {
             .iter()
             .zip(random_data.iter())
             .for_each(|((msg, _bn), random_data)| {
-                assert_eq!(blake2b(32, &[], random_data).as_bytes(), msg.payload());
+                assert_eq!(
+                    blake2b(32, &[], random_data).as_bytes(),
+                    msg.payload_bytes()
+                );
             });
 
         // // assert_last_dequeued(1);
@@ -12188,7 +12205,9 @@ fn reply_with_small_non_zero_gas() {
         run_to_next_block(None);
         assert_succeed(message_id);
         assert_eq!(
-            maybe_last_message(USER_1).expect("Should be").payload(),
+            maybe_last_message(USER_1)
+                .expect("Should be")
+                .payload_bytes(),
             payload
         );
     });
@@ -12307,7 +12326,7 @@ fn relay_messages() {
                     let Expected { user, payload } = &expected[r];
 
                     if message.destination().into_origin() == user.into_origin() {
-                        assert_eq!(message.payload(), payload, "{label}");
+                        assert_eq!(message.payload_bytes(), payload, "{label}");
                         r + 1
                     } else {
                         r

--- a/utils/gear-runtime-test-cli/src/command.rs
+++ b/utils/gear-runtime-test-cli/src/command.rs
@@ -415,7 +415,7 @@ macro_rules! command {
                                 msg.id(),
                                 msg.source(),
                                 ProgramId::from(id.as_bytes()),
-                                msg.payload().to_vec().try_into().unwrap(),
+                                msg.payload_bytes().to_vec().try_into().unwrap(),
                                 msg.value(),
                                 msg.details(),
                             );
@@ -569,7 +569,7 @@ macro_rules! command {
                     mailbox.into_iter().map(|msg| (msg, 0)).collect();
 
                 for (message, _) in &messages {
-                    if let Ok(utf8) = core::str::from_utf8(message.payload()) {
+                    if let Ok(utf8) = core::str::from_utf8(message.payload_bytes()) {
                         log::trace!("log({})", utf8)
                     }
                 }


### PR DESCRIPTION
Resolves #2380

Introduced changes:
- [x] Rename `LimitedVec::get*` to `LimitedVec::inner*`
- [x] Rename messages method `payload` to `payload_bytes` as they return buffer, not the `Payload` itself. Also the reason for renaming is that `IncomingMessage` now returns `&mut Payload`.
- [x] Introduce type safe mechanics for optimized the `gr_read`. When `gr_read` is called the ownership over payload is taken, but must it be returned back to the message, because other payload usage is impossible. We now have type-level guarantees and compilation error guarding the proper implementation of the `read` in `core-backend::common::funcs`.