### PR TITLE
feat(node-loader): Spawn batch pool in new thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3871,7 +3871,7 @@ dependencies = [
 
 [[package]]
 name = "gear-node-loader"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/utils/call-gen/src/rand_utils.rs
+++ b/utils/call-gen/src/rand_utils.rs
@@ -22,11 +22,11 @@ use rand::{Rng, RngCore, SeedableRng};
 ///
 /// Auto implemented for the implementors of the aggregated traits.
 #[clonable]
-pub trait CallGenRngCore: RngCore + Clone {}
-impl<T: RngCore + Clone> CallGenRngCore for T {}
+pub trait CallGenRngCore: RngCore + Clone + Send {}
+impl<T: RngCore + Clone + Send> CallGenRngCore for T {}
 
 /// Trait that aggregates `Rng`, `SeedableRng` and `Clone`.
 ///
 /// Auto implemented for the implementors of the aggregated traits.
-pub trait CallGenRng: Rng + SeedableRng + 'static + Clone {}
-impl<T: Rng + SeedableRng + 'static + Clone> CallGenRng for T {}
+pub trait CallGenRng: Rng + SeedableRng + 'static + Clone + Send {}
+impl<T: Rng + SeedableRng + 'static + Clone + Send> CallGenRng for T {}

--- a/utils/node-loader/CHANGELOG.md
+++ b/utils/node-loader/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] 2023-06-19. Spawn batch pool as tokio task and remove all blocking code.
+### Changed
+- Use `tokio::spawn` to spawn `BatchPool`.
+- `listen_events` throws error if no events recieved.
+
 ## [0.2.0] 2023-06-12. Spawn event listener background thread and spawn batch pool tasks.
 ### Changed
 - Use `tokio::spawn` to spawn batch pool tasks

--- a/utils/node-loader/Cargo.toml
+++ b/utils/node-loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gear-node-loader"
-version = "0.2.0"
+version = "0.2.1"
 authors.workspace = true
 edition.workspace = true
 

--- a/utils/node-loader/src/main.rs
+++ b/utils/node-loader/src/main.rs
@@ -33,6 +33,9 @@ async fn run(params: Params) -> Result<()> {
     }
 }
 
+/// Connect to API of provided node address and subscribe for events.
+///
+/// Broadcast new events to recievers.
 async fn listen_events(tx: Sender<subxt::events::Events<GearConfig>>, node: String) -> Result<()> {
     let api = gsdk::Api::new(Some(&node)).await?;
     let mut event_listener = api.finalized_blocks().await?;

--- a/utils/node-loader/src/main.rs
+++ b/utils/node-loader/src/main.rs
@@ -61,5 +61,5 @@ async fn load_node(params: LoadParams) -> Result<()> {
         env!("CARGO_PKG_VERSION"),
     );
 
-    BatchPool::<SmallRng>::run(params, rx).await
+    tokio::spawn(BatchPool::<SmallRng>::run(params, rx)).await?
 }

--- a/utils/node-loader/src/main.rs
+++ b/utils/node-loader/src/main.rs
@@ -37,12 +37,11 @@ async fn listen_events(tx: Sender<subxt::events::Events<GearConfig>>, node: Stri
     let api = gsdk::Api::new(Some(&node)).await?;
     let mut event_listener = api.finalized_blocks().await?;
 
-    loop {
-        while let Some(events) = event_listener.next_events().await {
-            tx.send(events?)?;
-        }
-        break Err(anyhow!("Can't get new events"));
+    while let Some(events) = event_listener.next_events().await {
+        tx.send(events?)?;
     }
+
+    Err(anyhow!("Listen events: Can't get new events"))
 }
 
 async fn load_node(params: LoadParams) -> Result<()> {

--- a/utils/node-loader/src/utils.rs
+++ b/utils/node-loader/src/utils.rs
@@ -1,10 +1,10 @@
-use crate::SmallRng;
 use anyhow::{anyhow, Result};
 use futures::Future;
 use futures_timer::Delay;
 use gclient::{Event, GearApi, GearEvent, WSAddress};
 use gear_call_gen::GearProgGenConfig;
 use gear_core::ids::{MessageId, ProgramId};
+use rand::rngs::SmallRng;
 use reqwest::Client;
 use std::{
     collections::{BTreeSet, HashMap},


### PR DESCRIPTION
Resolves #1876 .

- Use `EventsReciever` to process events.
- Use tokio timeout to catch stopped node.
- Spawn `BatchPool` in new thread.


@gear-tech/dev 
