### PR TITLE
refactoring(core): apply unrepeatable nonces for the same reservation id

### DIFF
--- a/core-backend/common/src/mock.rs
+++ b/core-backend/common/src/mock.rs
@@ -28,7 +28,7 @@ use gear_core::{
     gas::{ChargeError, CountersOwner, GasAmount, GasCounter, GasLeft},
     ids::{MessageId, ProgramId, ReservationId},
     memory::{Memory, MemoryInterval, PageU32Size, WasmPage, WASM_PAGE_SIZE},
-    message::{HandlePacket, InitPacket, ReplyPacket, StatusCode},
+    message::{HandlePacket, IncomingDispatch, InitPacket, ReplyPacket, StatusCode},
     reservation::GasReserver,
 };
 use gear_core_errors::MemoryError;
@@ -247,7 +247,11 @@ impl BackendExt for MockExt {
     fn into_ext_info(self, _memory: &impl Memory) -> Result<ExtInfo, MemoryError> {
         Ok(ExtInfo {
             gas_amount: GasCounter::new(0).to_amount(),
-            gas_reserver: GasReserver::new(Default::default(), 0, Default::default(), 1024),
+            gas_reserver: GasReserver::new(
+                &<IncomingDispatch as Default>::default(),
+                Default::default(),
+                1024,
+            ),
             system_reservation_context: SystemReservationContext::default(),
             allocations: Default::default(),
             pages_data: Default::default(),

--- a/core-processor/src/context.rs
+++ b/core-processor/src/context.rs
@@ -123,7 +123,7 @@ impl From<(ContextChargedForMemory, InstrumentedCode, u128, ProgramId)>
                 ContextData {
                     gas_counter,
                     gas_allowance_counter,
-                    mut dispatch,
+                    dispatch,
                     destination_id,
                     actor_data,
                 },
@@ -138,16 +138,8 @@ impl From<(ContextChargedForMemory, InstrumentedCode, u128, ProgramId)>
             actor_data.initialized,
         );
 
-        let gas_reserver = GasReserver::new(
-            dispatch.id(),
-            dispatch
-                .context_mut()
-                .as_mut()
-                .map(|ctx| ctx.fetch_inc_reservation_nonce())
-                .unwrap_or(0),
-            actor_data.gas_reservation_map,
-            max_reservations,
-        );
+        let gas_reserver =
+            GasReserver::new(&dispatch, actor_data.gas_reservation_map, max_reservations);
 
         Self {
             gas_counter,

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -498,12 +498,7 @@ where
     let context = ProcessorContext {
         gas_counter: GasCounter::new(gas_limit),
         gas_allowance_counter: GasAllowanceCounter::new(gas_limit),
-        gas_reserver: GasReserver::new(
-            Default::default(),
-            Default::default(),
-            Default::default(),
-            Default::default(),
-        ),
+        gas_reserver: GasReserver::new(&Default::default(), Default::default(), Default::default()),
         value_counter: ValueCounter::new(Default::default()),
         allocations_context: AllocationsContext::new(allocations, static_pages, 512.into()),
         message_context: MessageContext::new(

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -985,7 +985,7 @@ impl Ext {
             previous_reservation: context_store.system_reservation(),
         };
 
-        context_store.set_reservation_nonce(gas_reserver.nonce());
+        context_store.set_reservation_nonce(&gas_reserver);
         if let Some(reservation) = system_reservation {
             context_store.add_system_reservation(reservation);
         }
@@ -1012,7 +1012,7 @@ impl Ext {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gear_core::message::ContextSettings;
+    use gear_core::message::{ContextSettings, IncomingDispatch};
 
     struct ProcessorContextBuilder(ProcessorContext);
 
@@ -1022,8 +1022,7 @@ mod tests {
                 gas_counter: GasCounter::new(0),
                 gas_allowance_counter: GasAllowanceCounter::new(0),
                 gas_reserver: GasReserver::new(
-                    Default::default(),
-                    Default::default(),
+                    &<IncomingDispatch as Default>::default(),
                     Default::default(),
                     Default::default(),
                 ),

--- a/core/src/message/context.rs
+++ b/core/src/message/context.rs
@@ -22,6 +22,7 @@ use crate::{
         Dispatch, HandleMessage, HandlePacket, IncomingMessage, InitMessage, InitPacket, Payload,
         ReplyMessage, ReplyPacket,
     },
+    reservation::GasReserver,
 };
 use alloc::{
     collections::{BTreeMap, BTreeSet},
@@ -188,16 +189,19 @@ pub struct ContextStore {
 }
 
 impl ContextStore {
-    /// Set reservation nonce.
-    pub fn set_reservation_nonce(&mut self, nonce: u64) {
-        self.reservation_nonce = nonce;
+    /// Returns stored within message context reservation nonce.
+    ///
+    /// Will be non zero, if any reservations were created during
+    /// previous execution of the message. TODO [sab]: type guarantee?
+    pub fn reservation_nonce(&self) -> u64 {
+        self.reservation_nonce
     }
 
-    /// Fetch incremented nonce.
-    pub fn fetch_inc_reservation_nonce(&mut self) -> u64 {
-        let nonce = self.reservation_nonce;
-        self.reservation_nonce = nonce.saturating_add(1);
-        nonce
+    /// Set reservation nonce from gas reserver.
+    ///
+    /// Gas reserver has actual nonce state during/after execution.
+    pub fn set_reservation_nonce(&mut self, gas_reserver: &GasReserver) {
+        self.reservation_nonce = gas_reserver.nonce();
     }
 
     /// Set system reservation.


### PR DESCRIPTION
Resolves #2773

More type-level guarantees on the property of the `GasReserver.nonce` field.

@gear-tech/dev 
