### PR TITLE
fix(gear-wasm-instrument): correctly calculate cost of `gas_charge` itself

### DIFF
--- a/utils/wasm-instrument/src/lib.rs
+++ b/utils/wasm-instrument/src/lib.rs
@@ -227,12 +227,17 @@ pub fn inject<R: Rules>(
         None => return Err(mbuilder.build()),
     };
 
+    let cost_push_arg = match rules.instruction_cost(&Instruction::I32Const(0)) {
+        Some(c) => c as u64,
+        None => return Err(mbuilder.build()),
+    };
+
     let cost_call = match rules.instruction_cost(&Instruction::Call(0)) {
         Some(c) => c as u64,
         None => return Err(mbuilder.build()),
     };
 
-    let cost = cost_call + cost_blocks;
+    let cost = cost_push_arg + cost_call + cost_blocks;
     // the cost is added to gas_to_charge which cannot
     // exceed u32::MAX value. This check ensures
     // there is no u64 overflow.


### PR DESCRIPTION
```rust
fn gas_charge(gas_to_charge: u32) {}
```
This function compiles to
```wasm
i32.const $gas_to_charge ; <--- not charged now
call $gas_charge
```
There should be gas charge for this instruction too