### PR TITLE
refactor(gear-wasm-instrument): optimize `gas_charge` function

### DIFF
--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -742,7 +742,7 @@ impl Default for Limits {
 impl<T: Config> Default for InstructionWeights<T> {
     fn default() -> Self {
         Self {
-            version: 7,
+            version: 8,
             i64const: cost_instr!(instr_i64const, 1),
             i64load: cost_instr!(instr_i64load, 0),
             i32load: cost_instr!(instr_i32load, 0),

--- a/utils/wasm-instrument/src/lib.rs
+++ b/utils/wasm-instrument/src/lib.rs
@@ -204,20 +204,20 @@ pub fn inject<R: Rules>(
     ];
 
     // determine cost for successful execution
-    let mut scopes = 0isize;
+    let mut block_of_code = false;
 
     let cost_blocks = match elements
         .iter()
         .filter(|instruction| match instruction {
             Instruction::If(_) => {
-                scopes += 1;
-                scopes == 1
+                block_of_code = true;
+                true
             }
             Instruction::End => {
-                scopes -= 1;
+                block_of_code = false;
                 false
             }
-            _ => scopes == 0,
+            _ => !block_of_code,
         })
         .try_fold(0u64, |cost, instruction| {
             rules

--- a/utils/wasm-instrument/src/lib.rs
+++ b/utils/wasm-instrument/src/lib.rs
@@ -238,7 +238,9 @@ pub fn inject<R: Rules>(
         None => return Err(mbuilder.build()),
     };
 
-    let cost = cost_push_arg + cost_call + cost_blocks;
+    let cost_local_var = rules.call_per_local_cost() as u64;
+
+    let cost = cost_push_arg + cost_call + cost_local_var + cost_blocks;
     // the cost is added to gas_to_charge which cannot
     // exceed u32::MAX value. This check ensures
     // there is no u64 overflow.

--- a/utils/wasm-instrument/src/lib.rs
+++ b/utils/wasm-instrument/src/lib.rs
@@ -200,10 +200,11 @@ pub fn inject<R: Rules>(
         Instruction::I64Sub,
         Instruction::SetGlobal(allowance_index),
         // }
+        Instruction::End,
     ];
 
     // determine cost for successful execution
-    let mut scopes = 0usize;
+    let mut scopes = 0isize;
 
     let cost_blocks = match elements
         .iter()
@@ -260,6 +261,7 @@ pub fn inject<R: Rules>(
             .with_param(ValueType::I32)
             .build()
             .body()
+            .with_locals(vec![elements::Local::new(1, ValueType::I64)])
             .with_instructions(elements::Instructions::new(elements))
             .build()
             .build(),


### PR DESCRIPTION
Resolves #1706

Changes:
- bump version in schedule to force re-instrumentation
- make it easier to read the code that determines the cost of successful execution
- optimize the `gas_charge` function by using the `local.tee` instruction to store `total_gas_to_charge` in a local variable
  ```wasm
  i32.const 10
  local.tee 1 ;; <--- sets 10 to local variable with index 1 & pushes 10 onto the stack
  
  ;; for example 10 can be used as an argument
  call $func ;; func(10)
  ```
  The performance of the `gas_charge` function has increased by ~14%. (cost of calling this function: 47133 -> 40992, tested on gear-runtime).

@gear-tech/dev