### PR TITLE
refactor(gmeta)!: change `Reply` type to input only and add new fields

### DIFF
--- a/examples/binaries/new-meta/io/src/lib.rs
+++ b/examples/binaries/new-meta/io/src/lib.rs
@@ -13,7 +13,7 @@ impl Metadata for ProgramMetadata {
     type Init = InOut<MessageInitIn, MessageInitOut>;
     type Handle = InOut<MessageIn, MessageOut>;
     type Others = InOut<MessageAsyncIn, Option<u8>>;
-    type Reply = InOut<String, Vec<u16>>;
+    type Reply = String;
     type Signal = ();
     type State = Vec<Wallet>;
 }

--- a/gcli/src/meta/mod.rs
+++ b/gcli/src/meta/mod.rs
@@ -79,9 +79,13 @@ impl Meta {
         let mut display = fmt.debug_struct("Metadata");
         display.field("init", &Io::new(&meta.init, &registry));
         display.field("handle", &Io::new(&meta.handle, &registry));
-        display.field("reply", &Io::new(&meta.reply, &registry));
         display.field("others", &Io::new(&meta.others, &registry));
-        for (name, ty) in [("signal", meta.signal), ("state", meta.state)].into_iter() {
+        let single_types = [
+            ("reply", meta.reply),
+            ("signal", meta.signal),
+            ("state", meta.state),
+        ];
+        for (name, ty) in single_types {
             if let Some(id) = ty {
                 display.field(name, &registry.derive_id(id).map_err(|_| fmt::Error)?);
             } else {

--- a/gcli/src/meta/mod.rs
+++ b/gcli/src/meta/mod.rs
@@ -143,18 +143,17 @@ impl Meta {
         )?))
     }
 
-    /// Decode matdata from hex bytes.
+    /// Decode metadata from hex bytes.
     pub fn decode_hex(hex: &[u8]) -> Result<Self> {
-        Ok(Self::Data(MetadataRepr::decode(
-            &mut ::hex::decode(hex)?.as_ref(),
-        )?))
+        let meta = MetadataRepr::from_hex(hex).map_err(Error::MetaParseError)?;
+        Ok(Self::Data(meta))
     }
 
     /// Decode program meta.
     ///
     /// Either program metadata or state reading functions.
-    pub fn decode(mut encoded: &[u8]) -> Result<Self> {
-        MetadataRepr::decode(&mut encoded)
+    pub fn decode(encoded: &[u8]) -> Result<Self> {
+        MetadataRepr::from_bytes(encoded)
             .map(Meta::Data)
             .or_else(|_| -> Result<Meta> { Self::decode_wasm(encoded) })
             .map_err(Into::into)

--- a/gcli/src/meta/tests.rs
+++ b/gcli/src/meta/tests.rs
@@ -39,16 +39,13 @@ Metadata {
             res: "Option<Wallet>",
         },
     },
-    reply:  {
-        input: str,
-        output: [u16],
-    },
     others:  {
         input: MessageAsyncIn {
             empty: "()",
         },
         output: Option<u8>,
     },
+    reply: str,
     signal: "()",
     state: [Wallet { id: "Id", person: "Person" }],
 }

--- a/gcli/src/result.rs
+++ b/gcli/src/result.rs
@@ -67,6 +67,8 @@ pub enum Error {
     WasmExecution(String),
     #[error(transparent)]
     Etc(#[from] etc::Error),
+    #[error("Metadata parsing error {0:?}")]
+    MetaParseError(gmeta::MetadataParseError),
 }
 
 impl From<nacl::Error> for Error {

--- a/gcli/tests/cmd/program.rs
+++ b/gcli/tests/cmd/program.rs
@@ -80,16 +80,13 @@ Metadata {
             res: Option<Wallet>,
         },
     },
-    reply:  {
-        input: str,
-        output: [u16],
-    },
     others:  {
         input: MessageAsyncIn {
             empty: (),
         },
         output: Option<u8>,
     },
+    reply: str,
     signal: (),
     state: [Wallet { id: Id, person: Person }],
 }

--- a/gmeta/src/lib.rs
+++ b/gmeta/src/lib.rs
@@ -15,6 +15,9 @@ use alloc::vec::Vec;
 use blake2_rfc::blake2b;
 use core::any::TypeId;
 
+const RUST_LANG_ID: u8 = 0;
+const METADATA_VERSION: u16 = 1;
+
 #[derive(Encode, Debug, Decode, Eq, PartialEq)]
 #[codec(crate = scale)]
 pub struct TypesRepr {
@@ -25,6 +28,8 @@ pub struct TypesRepr {
 #[derive(Encode, Debug, Decode, Eq, PartialEq)]
 #[codec(crate = scale)]
 pub struct MetadataRepr {
+    pub lang_id: u8,
+    pub version: u16,
     pub init: TypesRepr,
     pub handle: TypesRepr,
     pub reply: Option<u32>,
@@ -130,6 +135,8 @@ pub trait Metadata {
         let mut registry = Registry::new();
 
         MetadataRepr {
+            lang_id: RUST_LANG_ID,
+            version: METADATA_VERSION,
             init: Self::Init::register(&mut registry),
             handle: Self::Handle::register(&mut registry),
             reply: Self::Reply::register(&mut registry),

--- a/gmeta/src/lib.rs
+++ b/gmeta/src/lib.rs
@@ -27,7 +27,7 @@ pub struct TypesRepr {
 pub struct MetadataRepr {
     pub init: TypesRepr,
     pub handle: TypesRepr,
-    pub reply: TypesRepr,
+    pub reply: Option<u32>,
     pub others: TypesRepr,
     pub signal: Option<u32>,
     pub state: Option<u32>,
@@ -121,7 +121,7 @@ pub enum MetadataParseError {
 pub trait Metadata {
     type Init: Types;
     type Handle: Types;
-    type Reply: Types;
+    type Reply: Type;
     type Others: Types;
     type Signal: Type;
     type State: Type;

--- a/gmeta/src/lib.rs
+++ b/gmeta/src/lib.rs
@@ -96,14 +96,17 @@ impl MetadataRepr {
         bytes
     }
 
-    pub fn from_hex<T: AsRef<[u8]>>(data: T) -> Result<Self, MetadataParseError> {
-        let data = hex::decode(data)?;
+    pub fn from_bytes(data: impl AsRef<[u8]>) -> Result<Self, MetadataParseError> {
         // Remove preamble before decoding
         let preamble_len = mem::size_of_val(&RUST_LANG_ID) | mem::size_of_val(&METADATA_VERSION);
-        let mut data = &data[preamble_len..];
+        let mut data = &data.as_ref()[preamble_len..];
 
         let this = Self::decode(&mut data)?;
         Ok(this)
+    }
+
+    pub fn from_hex<T: AsRef<[u8]>>(data: T) -> Result<Self, MetadataParseError> {
+        Self::from_bytes(hex::decode(data)?)
     }
 
     pub fn hex(&self) -> String {


### PR DESCRIPTION
Resolves: #2809

- As we can't send a reply from a reply, the outgoing type in `Metedata::Reply` becomes senseless.
- Also, two new fields have been added to the metadata: language ID (0 for Rust, 1 for AssemblyScript), and metadata version (starting from 1).

This is a breaking change for smart contracts and IDEA.

@gear-tech/dev 
