### PR TITLE
Change `ExtError::Unsupported` code

### DIFF
--- a/core-errors/src/lib.rs
+++ b/core-errors/src/lib.rs
@@ -277,14 +277,13 @@ impl ExtError {
             ExtError::Wait(err) => err as u32,
             ExtError::Reservation(err) => err as u32,
             ExtError::ProgramRent(err) => err as u32,
-            ExtError::Unsupported => 1,
+            ExtError::Unsupported => u32::MAX,
         }
     }
 
     /// Convert code into error.
     pub fn from_u32(code: u32) -> Option<Self> {
         match code {
-            1 => Some(ExtError::Unsupported),
             100 => Some(ExecutionError::NotEnoughGas.into()),
             101 => Some(ExecutionError::NotEnoughValue.into()),
             102 => Some(ExecutionError::InvalidDebugString.into()),
@@ -323,6 +322,7 @@ impl ExtError {
             600 => Some(ProgramRentError::MaximumBlockCountPaid.into()),
             //
             0xffff => Some(ExtError::SyscallUsage),
+            u32::MAX => Some(ExtError::Unsupported),
             _ => None,
         }
     }


### PR DESCRIPTION
For consistency with `Unsupported` variants of `simple.rs`