### PR TITLE
feat(gstd)!: expand `gstd::debug!` behaviour

### DIFF
--- a/examples/binaries/btree/src/lib.rs
+++ b/examples/binaries/btree/src/lib.rs
@@ -61,7 +61,7 @@ mod wasm {
         let reply = match msg::load() {
             Ok(request) => process(request),
             Err(e) => {
-                debug!("Error processing request: {:?}", e);
+                debug!("Error processing request: {e:?}");
                 Reply::Error
             }
         };

--- a/examples/binaries/compose/src/lib.rs
+++ b/examples/binaries/compose/src/lib.rs
@@ -63,11 +63,10 @@ mod wasm {
 
         async fn compose(&mut self, input: Vec<u8>) -> Result<Vec<u8>, &'static str> {
             debug!(
-                "[0x{} compose::compose] Composing programs 0x{} and 0x{} on input {:?}",
+                "[0x{} compose::compose] Composing programs 0x{} and 0x{} on input {input:?}",
                 hex::encode(exec::program_id()),
                 hex::encode(self.contract_a.handle),
                 hex::encode(self.contract_b.handle),
-                input
             );
             debug!(
                 "[0x{} compose::compose] Calling contract #1 at 0x{}",
@@ -82,9 +81,8 @@ mod wasm {
             );
             let output = self.contract_b.call(output_a).await?;
             debug!(
-                "[0x{} compose::compose] Composition output: {:?}",
+                "[0x{} compose::compose] Composition output: {output:?}",
                 hex::encode(exec::program_id()),
-                output
             );
 
             Ok(output)
@@ -122,17 +120,15 @@ mod wasm {
     async fn main() {
         let input = msg::load_bytes().expect("Failed to load payload bytes");
         debug!(
-            "[0x{} compose::handle] input = {:?}, gas_available = {}",
+            "[0x{} compose::handle] input = {input:?}, gas_available = {}",
             hex::encode(exec::program_id()),
-            input,
             exec::gas_available()
         );
 
         if let Ok(outcome) = (unsafe { STATE.compose(input) }).await {
             debug!(
-                "[0x{} compose::handle] Composition output: {:?}",
+                "[0x{} compose::handle] Composition output: {outcome:?}",
                 hex::encode(exec::program_id()),
-                outcome
             );
             msg::reply(outcome, 0).unwrap();
         }

--- a/examples/binaries/constructor/src/call.rs
+++ b/examples/binaries/constructor/src/call.rs
@@ -118,8 +118,7 @@ mod wasm {
             let value = extra_encode.then(|| value.encode()).unwrap_or(value);
 
             debug!(
-                "\t[CONSTRUCTOR] >> Storing {:?}: {:?}",
-                key,
+                "\t[CONSTRUCTOR] >> Storing {key:?}: {:?}",
                 &value[extra_encode as usize..]
             );
 
@@ -278,7 +277,7 @@ mod wasm {
         }
 
         pub(crate) fn process(self, previous: Option<CallResult>) -> CallResult {
-            debug!("\t[CONSTRUCTOR] >> Processing {:?}", self);
+            debug!("\t[CONSTRUCTOR] >> Processing {self:?}");
             let call = self.clone();
 
             let value = match self {

--- a/examples/binaries/distributor/src/lib.rs
+++ b/examples/binaries/distributor/src/lib.rs
@@ -130,7 +130,7 @@ mod wasm {
                     Request::Report => Self::handle_report().await,
                 },
                 Err(e) => {
-                    debug!("Error processing request: {:?}", e);
+                    debug!("Error processing request: {e:?}");
                     Reply::Failure
                 }
             };
@@ -140,7 +140,7 @@ mod wasm {
         }
 
         async fn handle_receive(amount: u64) -> Reply {
-            debug!("Handling receive {}", amount);
+            debug!("Handling receive {amount}");
 
             let nodes = Program::nodes().lock().await;
             let subnodes_count = nodes.as_ref().len() as u64;
@@ -159,10 +159,10 @@ mod wasm {
                     }
                 }
 
-                debug!("Set own amount to: {}", left_over);
+                debug!("Set own amount to: {left_over}");
                 *Self::amount() = *Self::amount() + left_over;
             } else {
-                debug!("Set own amount to: {}", amount);
+                debug!("Set own amount to: {amount}");
                 *Self::amount() = *Self::amount() + amount;
             }
 
@@ -178,7 +178,7 @@ mod wasm {
 
         async fn handle_report() -> Reply {
             let mut amount = *Program::amount();
-            debug!("Own amount: {}", amount);
+            debug!("Own amount: {amount}");
 
             let nodes = Program::nodes().lock().await;
 
@@ -186,7 +186,7 @@ mod wasm {
                 debug!("Querying next node");
                 amount += match program.do_report().await {
                     Ok(amount) => {
-                        debug!("Sub-node result: {}", amount);
+                        debug!("Sub-node result: {amount}");
                         amount
                     }
                     Err(_) => {

--- a/examples/binaries/fungible-token/src/contract.rs
+++ b/examples/binaries/fungible-token/src/contract.rs
@@ -246,7 +246,7 @@ extern "C" fn init() {
 extern "C" fn meta_state() -> *mut [i32; 2] {
     let query: State = msg::load().expect("failed to decode input argument");
     let ft: &mut FungibleToken = unsafe { FUNGIBLE_TOKEN.get_or_insert(Default::default()) };
-    debug!("{:?}", query);
+    debug!("{query:?}");
     let encoded = match query {
         State::Name => StateReply::Name(ft.name.clone()),
         State::Symbol => StateReply::Name(ft.symbol.clone()),

--- a/examples/binaries/mul-by-const/src/lib.rs
+++ b/examples/binaries/mul-by-const/src/lib.rs
@@ -61,8 +61,8 @@ mod wasm {
                 .checked_mul(other)
                 .expect("Multiplication overflow");
             debug!(
-                "[0x{} mul_by_const::unchecked_mul] Calculated {} x {} == {}",
-                DEBUG.me, self.intrinsic, other, z
+                "[0x{} mul_by_const::unchecked_mul] Calculated {} x {other} == {z}",
+                DEBUG.me, self.intrinsic
             );
             z
         }
@@ -86,9 +86,8 @@ mod wasm {
         }
         msg::reply_bytes([], 0).unwrap();
         debug!(
-            "[0x{} mul_by_const::init] Program initialized with input {}",
+            "[0x{} mul_by_const::init] Program initialized with input {val}",
             unsafe { &DEBUG.me },
-            val
         );
     }
 }

--- a/examples/binaries/ncompose/src/lib.rs
+++ b/examples/binaries/ncompose/src/lib.rs
@@ -101,9 +101,8 @@ mod wasm {
             );
             let output = self.me.call(output_other).await?;
             debug!(
-                "[0x{} ncompose::compose_with_self] Composition output: {:?}",
+                "[0x{} ncompose::compose_with_self] Composition output: {output:?}",
                 hex::encode(exec::program_id()),
-                output
             );
 
             Ok(output)
@@ -141,16 +140,14 @@ mod wasm {
     async fn main() {
         let input = msg::load_bytes().expect("Failed to load payload bytes");
         debug!(
-            "[0x{} ncompose::handle] input = {:?}",
+            "[0x{} ncompose::handle] input = {input:?}",
             hex::encode(unsafe { STATE.me.handle }),
-            input
         );
 
         if let Ok(outcome) = (unsafe { STATE.compose_with_self(input) }).await {
             debug!(
-                "[0x{} ncompose::handle] Composition output: {:?}",
+                "[0x{} ncompose::handle] Composition output: {outcome:?}",
                 hex::encode(exec::program_id()),
-                outcome
             );
             msg::reply(outcome, 0).unwrap();
         }

--- a/examples/binaries/node/src/lib.rs
+++ b/examples/binaries/node/src/lib.rs
@@ -87,7 +87,7 @@ extern "C" fn handle() {
     let reply = match msg::load() {
         Ok(request) => process(request),
         Err(e) => {
-            debug!("Error processing request: {:?}", e);
+            debug!("Error processing request: {e:?}");
             Reply::Failure
         }
     };
@@ -260,7 +260,7 @@ extern "C" fn handle_reply() {
             }
             Err(e) => {
                 transition.state = TransitionState::Failed;
-                debug!("Error processing reply: {:?}", e);
+                debug!("Error processing reply: {e:?}");
                 exec::wake(transition.message_id).unwrap();
             }
         }

--- a/examples/binaries/piggy-bank/src/lib.rs
+++ b/examples/binaries/piggy-bank/src/lib.rs
@@ -33,10 +33,11 @@ mod wasm {
     #[no_mangle]
     extern "C" fn handle() {
         let available_value = exec::value_available();
-        debug!("inserted: {}, total: {}", msg::value(), available_value);
+        let value = msg::value();
+        debug!("inserted: {value}, total: {available_value}");
 
         if msg::load_bytes().expect("Failed to load payload bytes") == b"smash" {
-            debug!("smashing, total: {}", available_value);
+            debug!("smashing, total: {available_value}");
             msg::reply_bytes(b"send", available_value).unwrap();
         }
     }

--- a/examples/binaries/vec/src/lib.rs
+++ b/examples/binaries/vec/src/lib.rs
@@ -38,7 +38,7 @@ mod wasm {
 
         let request = format!("Request: size = {size}");
 
-        debug!(request);
+        debug!("{request}");
         unsafe { MESSAGE_LOG.push(request) };
 
         let vec = vec![42u8; size];
@@ -46,8 +46,8 @@ mod wasm {
 
         debug!("vec.len() = {:?}", vec.len());
         debug!(
-            "vec[{}]: {:p} -> {:#04x}",
-            last_idx, &vec[last_idx], vec[last_idx]
+            "vec[{last_idx}]: {:p} -> {:#04x}",
+            &vec[last_idx], vec[last_idx]
         );
 
         msg::reply(size as i32, 0).expect("Failed to send reply");
@@ -56,9 +56,10 @@ mod wasm {
         // so we must skip `v` destruction.
         core::mem::forget(vec);
 
-        debug!("Total requests amount: {}", unsafe { MESSAGE_LOG.len() });
+        let requests_amount = unsafe { MESSAGE_LOG.len() };
+        debug!("Total requests amount: {requests_amount}");
         unsafe {
-            MESSAGE_LOG.iter().for_each(|log| debug!(log));
+            MESSAGE_LOG.iter().for_each(|log| debug!("{log}"));
         }
     }
 }

--- a/examples/capacitor/src/lib.rs
+++ b/examples/capacitor/src/lib.rs
@@ -15,9 +15,9 @@ extern "C" fn handle() {
 
     unsafe {
         CHARGE += to_add;
-        debug!("Charge capacitor with {}, new charge {}", to_add, CHARGE);
+        debug!("Charge capacitor with {to_add}, new charge {CHARGE}");
         if CHARGE >= LIMIT {
-            debug!("Discharge #{} due to limit {}", CHARGE, LIMIT);
+            debug!("Discharge #{CHARGE} due to limit {LIMIT}");
             msg::send_bytes(msg::source(), format!("Discharged: {CHARGE}"), 0).unwrap();
             DISCHARGE_HISTORY.push(CHARGE);
             CHARGE = 0;
@@ -32,9 +32,5 @@ extern "C" fn init() {
         .expect("Invalid message: should be utf-8");
     let limit = u32::from_str(initstr.as_ref()).expect("Invalid number");
     unsafe { LIMIT = limit };
-    debug!(
-        "Init capacitor with limit capacity {}, {}",
-        unsafe { LIMIT },
-        initstr
-    );
+    debug!("Init capacitor with limit capacity {limit}, {initstr}");
 }

--- a/examples/wait/src/lib.rs
+++ b/examples/wait/src/lib.rs
@@ -12,7 +12,7 @@ static mut MSG_ID_2: MessageId = MessageId([0; 32]);
 #[no_mangle]
 extern "C" fn handle() {
     let state = unsafe { &mut STATE };
-    gstd::debug!(state);
+    gstd::debug!("{state}");
     match *state {
         0 => {
             *state = 1;

--- a/gstd/src/macros/debug.rs
+++ b/gstd/src/macros/debug.rs
@@ -48,14 +48,8 @@
 #[cfg(any(feature = "debug", debug_assertions))]
 #[macro_export]
 macro_rules! debug {
-    ($arg:literal) => {
-        $crate::ext::debug(&$crate::prelude::format!("{}", $arg)).unwrap()
-    };
-    ($arg:expr) => {
-        $crate::ext::debug(&$crate::prelude::format!("{:?}", $arg)).unwrap()
-    };
-    ($fmt:literal $(, $args:expr)+) => {
-        $crate::ext::debug(&$crate::prelude::format!($fmt $(, $args)+)).unwrap()
+    ($($arg:tt)*) => {
+        $crate::ext::debug(&$crate::prelude::format!($($arg)*)).unwrap()
     };
 }
 
@@ -64,9 +58,5 @@ macro_rules! debug {
 #[allow(missing_docs)]
 #[macro_export]
 macro_rules! debug {
-    ($arg:expr) => { let _ = $arg; };
-    ($fmt:literal $(, $args:expr)+) => {
-        let _ = $fmt;
-        $(let _ = $args;) +
-    };
+    ($($arg:tt)*) => {};
 }

--- a/gstd/src/macros/debug.rs
+++ b/gstd/src/macros/debug.rs
@@ -40,9 +40,9 @@
 ///     debug!("String literal");
 ///
 ///     let value = 42;
-///     debug!(value);
+///     debug!("{value}");
 ///
-///     debug!("Formatted: value = {}", value);
+///     debug!("Formatted: value = {value}");
 /// }
 /// ```
 #[cfg(any(feature = "debug", debug_assertions))]


### PR DESCRIPTION
Resolves #2813

Unfortunately this change causes backwards compatibility break. 
```rust
debug!("String literal"); //($arg:literal)

let value = 42;
debug!(value); //($arg:expr)
```

This code will not work because we cannot distinguish at the macro level `debug!("String literal")` and `debug!("fmt {var1}")`. That's why it will probably break backwards compatibility.