### PR TITLE
ci(events): trigger the building workflow for labeled PRs

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -7,7 +7,6 @@ on:
     branches: [master, vara-stage-1, vara-stage-2, vara-stage-3]
   pull_request:
     branches: [master, vara-stage-1, vara-stage-2, vara-stage-3]
-    types: [labeled]
 
   workflow_dispatch:
 


### PR DESCRIPTION
Resolves #2871

The `labeled` event just for prs that just labeled which is not actually the labeled we want

@gear-tech/dev 
