### PR TITLE
feat(wasm-builder): Introduce switch for disabling path remapping

### DIFF
--- a/utils/wasm-builder/src/lib.rs
+++ b/utils/wasm-builder/src/lib.rs
@@ -107,7 +107,7 @@ impl WasmBuilder {
         let profile = if profile == "debug" { "dev" } else { profile };
         self.cargo.set_profile(profile.to_string());
         self.cargo.set_features(&self.enabled_features()?);
-        if profile != "dev" {
+        if env::var("__GEAR_WASM_BUILDER_NO_PATH_REMAP").is_err() && profile != "dev" {
             self.cargo.set_paths_to_remap(&self.paths_to_remap()?);
         }
 


### PR DESCRIPTION
Path remapping makes compilation under WSL terrible. Cold rebuild, i.e. when there were no changes in any examples, takes 9 min compared to 45 sec without that remapping

@reviewer-or-team
