### PR TITLE
perf(wasm-builder): invert path remapping logic

### DIFF
--- a/.github/workflows/test-measurements.yaml
+++ b/.github/workflows/test-measurements.yaml
@@ -11,7 +11,6 @@ env:
   TERM: xterm-256color
   COUNT: 100
   BINARYEN_VERSION: version_111
-  __GEAR_WASM_BUILDER_NO_PATH_REMAP: 1
 
 jobs:
   build:

--- a/utils/wasm-builder/src/lib.rs
+++ b/utils/wasm-builder/src/lib.rs
@@ -107,7 +107,7 @@ impl WasmBuilder {
         let profile = if profile == "debug" { "dev" } else { profile };
         self.cargo.set_profile(profile.to_string());
         self.cargo.set_features(&self.enabled_features()?);
-        if env::var("__GEAR_WASM_BUILDER_NO_PATH_REMAP").is_err() && profile != "dev" {
+        if env::var("GEAR_WASM_BUILDER_PATH_REMAPPING").is_ok() {
             self.cargo.set_paths_to_remap(&self.paths_to_remap()?);
         }
 


### PR DESCRIPTION
The ecosystem team can use the "production" profile to remove the username from the wasm binary.