### PR TITLE
feat(gsdk): publish gsdk related packages

### DIFF
--- a/gsdk/codegen/Cargo.toml
+++ b/gsdk/codegen/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+description = "Code generation library for gsdk."
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Resolves #2832 

Remove gear-core dependencies totally since we have already generated the duplicated data structures in the generated API.

- [x] add description for `gsdk-codegen`
- [ ] remove gear dependencies in gsdk
- [ ] remove gear dependencies in gcli
- [ ] remove gear dependencies in gclient

@gear-tech/dev 
