### PR TITLE
fix(gstd): Allow mutex/read/write lock guard access by holder only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,9 +2294,12 @@ dependencies = [
 name = "demo-waiter"
 version = "0.1.0"
 dependencies = [
+ "demo-waiter",
  "futures",
+ "gear-core",
  "gear-wasm-builder",
  "gstd",
+ "gtest",
  "parity-scale-codec",
 ]
 

--- a/examples/binaries/waiter/Cargo.toml
+++ b/examples/binaries/waiter/Cargo.toml
@@ -15,6 +15,9 @@ gstd.workspace = true
 gear-wasm-builder.workspace = true
 
 [dev-dependencies]
+gtest.workspace = true
+gear-core.workspace = true
+demo-waiter = { path = ".", features = ["debug"] }
 
 [lib]
 

--- a/examples/binaries/waiter/src/code.rs
+++ b/examples/binaries/waiter/src/code.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Command, MxLockContinuation, MxLockStaticAccessSubcommand, RwLockContinuation, RwLockType,
-    SleepForWaitType, WaitSubcommand,
+    Command, LockContinuation, LockStaticAccessSubcommand, MxLockContinuation, RwLockContinuation,
+    RwLockType, SleepForWaitType, WaitSubcommand,
 };
 use core::ops::{Deref, DerefMut};
 use futures::future;
@@ -9,6 +9,8 @@ use gstd::{errors::Error, exec, format, lock, msg, MessageId};
 static mut MUTEX: lock::Mutex<()> = lock::Mutex::new(());
 static mut MUTEX_LOCK_GUARD: Option<lock::MutexGuard<()>> = None;
 static mut RW_LOCK: lock::RwLock<()> = lock::RwLock::new(());
+static mut R_LOCK_GUARD: Option<lock::RwLockReadGuard<()>> = None;
+static mut W_LOCK_GUARD: Option<lock::RwLockWriteGuard<()>> = None;
 
 #[gstd::async_main]
 async fn main() {
@@ -80,23 +82,46 @@ async fn main() {
         }
         Command::MxLock(continuation) => {
             let lock_guard = unsafe { MUTEX.lock().await };
-            process_mx_lock_continuation(lock_guard, continuation).await;
+            process_mx_lock_continuation(
+                unsafe { &mut MUTEX_LOCK_GUARD },
+                lock_guard,
+                continuation,
+            )
+            .await;
         }
         Command::MxLockStaticAccess(subcommand) => {
-            process_mx_lock_static_access_subcommand(subcommand);
+            process_lock_static_access_subcommand_mut(unsafe { &mut MUTEX_LOCK_GUARD }, subcommand);
         }
         Command::RwLock(lock_type, continuation) => {
             match lock_type {
                 RwLockType::Read => {
-                    let _lock_guard = unsafe { RW_LOCK.read().await };
-                    process_rw_lock_continuation(continuation).await;
+                    let lock_guard = unsafe { RW_LOCK.read().await };
+                    process_rw_lock_continuation(
+                        unsafe { &mut R_LOCK_GUARD },
+                        lock_guard,
+                        continuation,
+                    )
+                    .await;
                 }
                 RwLockType::Write => {
-                    let _lock_guard = unsafe { RW_LOCK.write().await };
-                    process_rw_lock_continuation(continuation).await;
+                    let lock_guard = unsafe { RW_LOCK.write().await };
+                    process_rw_lock_continuation(
+                        unsafe { &mut W_LOCK_GUARD },
+                        lock_guard,
+                        continuation,
+                    )
+                    .await;
                 }
             };
         }
+        Command::RwLockStaticAccess(lock_type, subcommand) => match lock_type {
+            RwLockType::Read => {
+                process_lock_static_access_subcommand(unsafe { &mut R_LOCK_GUARD }, subcommand);
+            }
+            RwLockType::Write => {
+                process_lock_static_access_subcommand_mut(unsafe { &mut W_LOCK_GUARD }, subcommand);
+            }
+        },
     }
 }
 
@@ -109,41 +134,76 @@ fn process_wait_subcommand(subcommand: WaitSubcommand) {
 }
 
 async fn process_mx_lock_continuation(
+    static_lock_guard: &'static mut Option<lock::MutexGuard<'static, ()>>,
     lock_guard: lock::MutexGuard<'static, ()>,
     continuation: MxLockContinuation,
 ) {
     match continuation {
-        MxLockContinuation::Nothing => {}
-        MxLockContinuation::SleepFor(duration) => exec::sleep_for(duration).await,
-        MxLockContinuation::MoveToStatic => unsafe {
-            MUTEX_LOCK_GUARD = Some(lock_guard);
-        },
+        MxLockContinuation::General(continuation) => {
+            process_lock_continuation(static_lock_guard, lock_guard, continuation).await
+        }
     }
 }
 
-fn process_mx_lock_static_access_subcommand(subcommand: MxLockStaticAccessSubcommand) {
-    match subcommand {
-        MxLockStaticAccessSubcommand::Drop => unsafe {
-            MUTEX_LOCK_GUARD = None;
-        },
-        MxLockStaticAccessSubcommand::AsRef => unsafe {
-            let _ = MUTEX_LOCK_GUARD.as_ref().unwrap().as_ref();
-        },
-        MxLockStaticAccessSubcommand::AsMut => unsafe {
-            let _ = MUTEX_LOCK_GUARD.as_mut().unwrap().as_mut();
-        },
-        MxLockStaticAccessSubcommand::Deref => unsafe {
-            let _ = MUTEX_LOCK_GUARD.as_ref().unwrap().deref();
-        },
-        MxLockStaticAccessSubcommand::DerefMut => unsafe {
-            let _ = MUTEX_LOCK_GUARD.as_mut().unwrap().deref_mut();
-        },
-    }
-}
-
-async fn process_rw_lock_continuation(continuation: RwLockContinuation) {
+async fn process_rw_lock_continuation<G>(
+    static_lock_guard: &'static mut Option<G>,
+    lock_guard: G,
+    continuation: RwLockContinuation,
+) {
     match continuation {
-        RwLockContinuation::Nothing => {}
-        RwLockContinuation::SleepFor(duration) => exec::sleep_for(duration).await,
+        RwLockContinuation::General(continuation) => {
+            process_lock_continuation(static_lock_guard, lock_guard, continuation).await
+        }
+    }
+}
+
+async fn process_lock_continuation<G>(
+    static_lock_guard: &'static mut Option<G>,
+    lock_guard: G,
+    continuation: LockContinuation,
+) {
+    match continuation {
+        LockContinuation::Nothing => {}
+        LockContinuation::SleepFor(duration) => exec::sleep_for(duration).await,
+        LockContinuation::MoveToStatic => unsafe {
+            *static_lock_guard = Some(lock_guard);
+        },
+    }
+}
+
+fn process_lock_static_access_subcommand<G, V>(
+    lock_guard: &mut Option<G>,
+    subcommand: LockStaticAccessSubcommand,
+) where
+    G: Deref + AsRef<V>,
+{
+    match subcommand {
+        LockStaticAccessSubcommand::Drop => {
+            *lock_guard = None;
+        }
+        LockStaticAccessSubcommand::AsRef => {
+            let _ = lock_guard.as_ref().unwrap().as_ref();
+        }
+        LockStaticAccessSubcommand::Deref => {
+            let _ = lock_guard.as_ref().unwrap().deref();
+        }
+        _ => unreachable!("Invalid lock static access subcommand {:?}", subcommand),
+    }
+}
+
+fn process_lock_static_access_subcommand_mut<G, V>(
+    lock_guard: &mut Option<G>,
+    subcommand: LockStaticAccessSubcommand,
+) where
+    G: Deref + DerefMut + AsRef<V> + AsMut<V>,
+{
+    match subcommand {
+        LockStaticAccessSubcommand::AsMut => {
+            let _ = lock_guard.as_mut().unwrap().as_mut();
+        }
+        LockStaticAccessSubcommand::DerefMut => {
+            let _ = lock_guard.as_mut().unwrap().deref_mut();
+        }
+        _ => process_lock_static_access_subcommand(lock_guard, subcommand),
     }
 }

--- a/examples/binaries/waiter/src/lib.rs
+++ b/examples/binaries/waiter/src/lib.rs
@@ -56,14 +56,20 @@ pub enum SleepForWaitType {
 }
 
 #[derive(Debug, Encode, Decode)]
-pub enum MxLockContinuation {
+pub enum LockContinuation {
     Nothing,
     SleepFor(u32),
     MoveToStatic,
 }
 
 #[derive(Debug, Encode, Decode)]
-pub enum MxLockStaticAccessSubcommand {
+pub enum MxLockContinuation {
+    // Here will be Lock
+    General(LockContinuation),
+}
+
+#[derive(Debug, Encode, Decode)]
+pub enum LockStaticAccessSubcommand {
     Drop,
     AsRef,
     AsMut,
@@ -79,8 +85,8 @@ pub enum RwLockType {
 
 #[derive(Debug, Encode, Decode)]
 pub enum RwLockContinuation {
-    Nothing,
-    SleepFor(u32),
+    // Here will be Lock(RwLockType)
+    General(LockContinuation),
 }
 
 #[derive(Debug, Encode, Decode)]
@@ -94,6 +100,7 @@ pub enum Command {
     SleepFor(Vec<u32>, SleepForWaitType),
     WakeUp([u8; 32]),
     MxLock(MxLockContinuation),
-    MxLockStaticAccess(MxLockStaticAccessSubcommand),
+    MxLockStaticAccess(LockStaticAccessSubcommand),
     RwLock(RwLockType, RwLockContinuation),
+    RwLockStaticAccess(RwLockType, LockStaticAccessSubcommand),
 }

--- a/examples/binaries/waiter/src/lib.rs
+++ b/examples/binaries/waiter/src/lib.rs
@@ -77,7 +77,7 @@ pub enum LockStaticAccessSubcommand {
     DerefMut,
 }
 
-#[derive(Debug, Encode, Decode)]
+#[derive(Debug, Encode, Decode, Clone, Copy)]
 pub enum RwLockType {
     Read,
     Write,

--- a/examples/binaries/waiter/src/lib.rs
+++ b/examples/binaries/waiter/src/lib.rs
@@ -59,6 +59,16 @@ pub enum SleepForWaitType {
 pub enum MxLockContinuation {
     Nothing,
     SleepFor(u32),
+    MoveToStatic,
+}
+
+#[derive(Debug, Encode, Decode)]
+pub enum MxLockStaticAccessSubcommand {
+    Drop,
+    AsRef,
+    AsMut,
+    Deref,
+    DerefMut,
 }
 
 #[derive(Debug, Encode, Decode)]
@@ -84,5 +94,6 @@ pub enum Command {
     SleepFor(Vec<u32>, SleepForWaitType),
     WakeUp([u8; 32]),
     MxLock(MxLockContinuation),
+    MxLockStaticAccess(MxLockStaticAccessSubcommand),
     RwLock(RwLockType, RwLockContinuation),
 }

--- a/examples/binaries/waiter/tests/mx_lock_access.rs
+++ b/examples/binaries/waiter/tests/mx_lock_access.rs
@@ -50,7 +50,7 @@ fn access_mx_lock_guard_from_different_msg_fails(
 }
 
 fn init_fixture(system: &System) -> (Program<'_>, MessageId) {
-    system.init_logger_with_fallback_filter("");
+    system.init_logger_with_default_filter("");
     let program = Program::current(system);
     program.send_bytes(USER_ID, []);
     let lock_result = program.send(

--- a/examples/binaries/waiter/tests/mx_lock_access.rs
+++ b/examples/binaries/waiter/tests/mx_lock_access.rs
@@ -1,0 +1,132 @@
+use demo_waiter::{Command, MxLockContinuation, MxLockStaticAccessSubcommand};
+use gear_core::ids::MessageId;
+use gstd::errors::{ErrorReplyReason, ReplyCode, SimpleExecutionError};
+use gtest::{Program, RunResult, System};
+
+const USER_ID: u64 = 10;
+
+#[test]
+fn drop_mx_lock_guard_from_different_msg_fails() {
+    let system = System::new();
+    let (program, lock_msg_id) = init_fixture(&system);
+
+    let lock_access_result = program.send(
+        USER_ID,
+        Command::MxLockStaticAccess(MxLockStaticAccessSubcommand::Drop),
+    );
+
+    assert_paniced(
+        &lock_access_result,
+        &format!(
+            "Mutex guard held by message {} is being accessed by message {}",
+            lock_msg_id,
+            lock_access_result.sent_message_id()
+        ),
+    );
+}
+
+#[test]
+fn as_ref_mx_lock_guard_from_different_msg_fails() {
+    let system = System::new();
+    let (program, lock_msg_id) = init_fixture(&system);
+
+    let lock_access_result = program.send(
+        USER_ID,
+        Command::MxLockStaticAccess(MxLockStaticAccessSubcommand::AsRef),
+    );
+
+    assert_paniced(
+        &lock_access_result,
+        &format!(
+            "Mutex guard held by message {} is being accessed by message {}",
+            lock_msg_id,
+            lock_access_result.sent_message_id()
+        ),
+    );
+}
+
+#[test]
+fn as_mut_mx_lock_guard_from_different_msg_fails() {
+    let system = System::new();
+    let (program, lock_msg_id) = init_fixture(&system);
+
+    let lock_access_result = program.send(
+        USER_ID,
+        Command::MxLockStaticAccess(MxLockStaticAccessSubcommand::AsMut),
+    );
+
+    assert_paniced(
+        &lock_access_result,
+        &format!(
+            "Mutex guard held by message {} is being accessed by message {}",
+            lock_msg_id,
+            lock_access_result.sent_message_id()
+        ),
+    );
+}
+
+#[test]
+fn deref_mx_lock_guard_from_different_msg_fails() {
+    let system = System::new();
+    let (program, lock_msg_id) = init_fixture(&system);
+
+    let lock_access_result = program.send(
+        USER_ID,
+        Command::MxLockStaticAccess(MxLockStaticAccessSubcommand::Deref),
+    );
+
+    assert_paniced(
+        &lock_access_result,
+        &format!(
+            "Mutex guard held by message {} is being accessed by message {}",
+            lock_msg_id,
+            lock_access_result.sent_message_id()
+        ),
+    );
+}
+
+#[test]
+fn deref_mut_mx_lock_guard_from_different_msg_fails() {
+    let system = System::new();
+    let (program, lock_msg_id) = init_fixture(&system);
+
+    let lock_access_result = program.send(
+        USER_ID,
+        Command::MxLockStaticAccess(MxLockStaticAccessSubcommand::DerefMut),
+    );
+
+    assert_paniced(
+        &lock_access_result,
+        &format!(
+            "Mutex guard held by message {} is being accessed by message {}",
+            lock_msg_id,
+            lock_access_result.sent_message_id()
+        ),
+    );
+}
+
+fn init_fixture<'a>(system: &'a System) -> (Program<'a>, MessageId) {
+    system.init_logger_with_default_filter("");
+    let program = Program::current(system);
+    program.send_bytes(USER_ID, []);
+    let lock_result = program.send(USER_ID, Command::MxLock(MxLockContinuation::MoveToStatic));
+    (program, lock_result.sent_message_id())
+}
+
+#[track_caller]
+fn assert_paniced(result: &RunResult, panic_msg: &str) {
+    assert_eq!(result.log().len(), 1);
+    assert!(matches!(
+        result.log()[0].reply_code(),
+        Some(ReplyCode::Error(ErrorReplyReason::Execution(
+            SimpleExecutionError::UserspacePanic
+        )))
+    ));
+    let payload = String::from_utf8(result.log()[0].payload().into())
+        .expect("Unable to decode panic message")
+        .split(',')
+        .map(String::from)
+        .next()
+        .expect("Unable to split panic message");
+    assert_eq!(payload, format!("'{}'", panic_msg));
+}

--- a/examples/binaries/waiter/tests/mx_lock_access.rs
+++ b/examples/binaries/waiter/tests/mx_lock_access.rs
@@ -50,7 +50,7 @@ fn access_mx_lock_guard_from_different_msg_fails(
 }
 
 fn init_fixture(system: &System) -> (Program<'_>, MessageId) {
-    system.init_logger_with_default_filter("");
+    system.init_logger_with_fallback_filter("");
     let program = Program::current(system);
     program.send_bytes(USER_ID, []);
     let lock_result = program.send(

--- a/examples/binaries/waiter/tests/mx_lock_access.rs
+++ b/examples/binaries/waiter/tests/mx_lock_access.rs
@@ -1,101 +1,45 @@
 use demo_waiter::{Command, LockContinuation, LockStaticAccessSubcommand, MxLockContinuation};
 use gear_core::ids::MessageId;
 use gtest::{Program, System};
-use utils::{assert_paniced, USER_ID};
+use utils::{assert_panicked, USER_ID};
 
 mod utils;
 
 #[test]
 fn drop_mx_lock_guard_from_different_msg_fails() {
-    let system = System::new();
-    let (program, lock_msg_id) = init_fixture(&system);
-
-    let lock_access_result = program.send(
-        USER_ID,
-        Command::MxLockStaticAccess(LockStaticAccessSubcommand::Drop),
-    );
-
-    assert_paniced(
-        &lock_access_result,
-        &format!(
-            "Mutex guard held by message {} is being accessed by message {}",
-            lock_msg_id,
-            lock_access_result.sent_message_id()
-        ),
-    );
+    access_mx_lock_guard_from_different_msg_fails(LockStaticAccessSubcommand::Drop);
 }
 
 #[test]
 fn as_ref_mx_lock_guard_from_different_msg_fails() {
-    let system = System::new();
-    let (program, lock_msg_id) = init_fixture(&system);
-
-    let lock_access_result = program.send(
-        USER_ID,
-        Command::MxLockStaticAccess(LockStaticAccessSubcommand::AsRef),
-    );
-
-    assert_paniced(
-        &lock_access_result,
-        &format!(
-            "Mutex guard held by message {} is being accessed by message {}",
-            lock_msg_id,
-            lock_access_result.sent_message_id()
-        ),
-    );
+    access_mx_lock_guard_from_different_msg_fails(LockStaticAccessSubcommand::AsRef);
 }
 
 #[test]
 fn as_mut_mx_lock_guard_from_different_msg_fails() {
-    let system = System::new();
-    let (program, lock_msg_id) = init_fixture(&system);
-
-    let lock_access_result = program.send(
-        USER_ID,
-        Command::MxLockStaticAccess(LockStaticAccessSubcommand::AsMut),
-    );
-
-    assert_paniced(
-        &lock_access_result,
-        &format!(
-            "Mutex guard held by message {} is being accessed by message {}",
-            lock_msg_id,
-            lock_access_result.sent_message_id()
-        ),
-    );
+    access_mx_lock_guard_from_different_msg_fails(LockStaticAccessSubcommand::AsMut);
 }
 
 #[test]
 fn deref_mx_lock_guard_from_different_msg_fails() {
-    let system = System::new();
-    let (program, lock_msg_id) = init_fixture(&system);
-
-    let lock_access_result = program.send(
-        USER_ID,
-        Command::MxLockStaticAccess(LockStaticAccessSubcommand::Deref),
-    );
-
-    assert_paniced(
-        &lock_access_result,
-        &format!(
-            "Mutex guard held by message {} is being accessed by message {}",
-            lock_msg_id,
-            lock_access_result.sent_message_id()
-        ),
-    );
+    access_mx_lock_guard_from_different_msg_fails(LockStaticAccessSubcommand::Deref);
 }
 
 #[test]
 fn deref_mut_mx_lock_guard_from_different_msg_fails() {
+    access_mx_lock_guard_from_different_msg_fails(LockStaticAccessSubcommand::DerefMut);
+}
+
+fn access_mx_lock_guard_from_different_msg_fails(
+    lock_access_subcommand: LockStaticAccessSubcommand,
+) {
     let system = System::new();
     let (program, lock_msg_id) = init_fixture(&system);
 
-    let lock_access_result = program.send(
-        USER_ID,
-        Command::MxLockStaticAccess(LockStaticAccessSubcommand::DerefMut),
-    );
+    let lock_access_result =
+        program.send(USER_ID, Command::MxLockStaticAccess(lock_access_subcommand));
 
-    assert_paniced(
+    assert_panicked(
         &lock_access_result,
         &format!(
             "Mutex guard held by message {} is being accessed by message {}",

--- a/examples/binaries/waiter/tests/mx_lock_access.rs
+++ b/examples/binaries/waiter/tests/mx_lock_access.rs
@@ -105,7 +105,7 @@ fn deref_mut_mx_lock_guard_from_different_msg_fails() {
     );
 }
 
-fn init_fixture<'a>(system: &'a System) -> (Program<'a>, MessageId) {
+fn init_fixture(system: &System) -> (Program<'_>, MessageId) {
     system.init_logger_with_default_filter("");
     let program = Program::current(system);
     program.send_bytes(USER_ID, []);

--- a/examples/binaries/waiter/tests/rw_lock_access.rs
+++ b/examples/binaries/waiter/tests/rw_lock_access.rs
@@ -95,7 +95,7 @@ fn access_rw_lock_guard_from_different_msg_fails(
 }
 
 fn init_fixture(system: &System, lock_type: RwLockType) -> (Program<'_>, MessageId) {
-    system.init_logger_with_fallback_filter("");
+    system.init_logger_with_default_filter("");
     let program = Program::current(system);
     program.send_bytes(USER_ID, []);
     let lock_result = program.send(

--- a/examples/binaries/waiter/tests/rw_lock_access.rs
+++ b/examples/binaries/waiter/tests/rw_lock_access.rs
@@ -95,7 +95,7 @@ fn access_rw_lock_guard_from_different_msg_fails(
 }
 
 fn init_fixture(system: &System, lock_type: RwLockType) -> (Program<'_>, MessageId) {
-    system.init_logger_with_default_filter("");
+    system.init_logger_with_fallback_filter("");
     let program = Program::current(system);
     program.send_bytes(USER_ID, []);
     let lock_result = program.send(

--- a/examples/binaries/waiter/tests/rw_lock_access.rs
+++ b/examples/binaries/waiter/tests/rw_lock_access.rs
@@ -1,0 +1,182 @@
+use demo_waiter::{
+    Command, LockContinuation, LockStaticAccessSubcommand, RwLockContinuation, RwLockType,
+};
+use gear_core::ids::MessageId;
+use gtest::{Program, System};
+use utils::{assert_paniced, USER_ID};
+
+mod utils;
+
+#[test]
+fn drop_r_lock_guard_from_different_msg_fails() {
+    let system = System::new();
+    let (program, lock_msg_id) = init_fixture(&system, RwLockType::Read);
+
+    let lock_access_result = program.send(
+        USER_ID,
+        Command::RwLockStaticAccess(RwLockType::Read, LockStaticAccessSubcommand::Drop),
+    );
+
+    assert_paniced(
+        &lock_access_result,
+        &format!(
+            "Read lock guard held by message {} is being accessed by message {}",
+            lock_msg_id,
+            lock_access_result.sent_message_id()
+        ),
+    );
+}
+
+#[test]
+fn as_ref_r_lock_guard_from_different_msg_fails() {
+    let system = System::new();
+    let (program, lock_msg_id) = init_fixture(&system, RwLockType::Read);
+
+    let lock_access_result = program.send(
+        USER_ID,
+        Command::RwLockStaticAccess(RwLockType::Read, LockStaticAccessSubcommand::AsRef),
+    );
+
+    assert_paniced(
+        &lock_access_result,
+        &format!(
+            "Read lock guard held by message {} is being accessed by message {}",
+            lock_msg_id,
+            lock_access_result.sent_message_id()
+        ),
+    );
+}
+
+#[test]
+fn deref_r_lock_guard_from_different_msg_fails() {
+    let system = System::new();
+    let (program, lock_msg_id) = init_fixture(&system, RwLockType::Read);
+
+    let lock_access_result = program.send(
+        USER_ID,
+        Command::RwLockStaticAccess(RwLockType::Read, LockStaticAccessSubcommand::Deref),
+    );
+
+    assert_paniced(
+        &lock_access_result,
+        &format!(
+            "Read lock guard held by message {} is being accessed by message {}",
+            lock_msg_id,
+            lock_access_result.sent_message_id()
+        ),
+    );
+}
+
+#[test]
+fn drop_w_lock_guard_from_different_msg_fails() {
+    let system = System::new();
+    let (program, lock_msg_id) = init_fixture(&system, RwLockType::Write);
+
+    let lock_access_result = program.send(
+        USER_ID,
+        Command::RwLockStaticAccess(RwLockType::Write, LockStaticAccessSubcommand::Drop),
+    );
+
+    assert_paniced(
+        &lock_access_result,
+        &format!(
+            "Write lock guard held by message {} is being accessed by message {}",
+            lock_msg_id,
+            lock_access_result.sent_message_id()
+        ),
+    );
+}
+
+#[test]
+fn as_ref_w_lock_guard_from_different_msg_fails() {
+    let system = System::new();
+    let (program, lock_msg_id) = init_fixture(&system, RwLockType::Write);
+
+    let lock_access_result = program.send(
+        USER_ID,
+        Command::RwLockStaticAccess(RwLockType::Write, LockStaticAccessSubcommand::AsRef),
+    );
+
+    assert_paniced(
+        &lock_access_result,
+        &format!(
+            "Write lock guard held by message {} is being accessed by message {}",
+            lock_msg_id,
+            lock_access_result.sent_message_id()
+        ),
+    );
+}
+
+#[test]
+fn as_mut_w_lock_guard_from_different_msg_fails() {
+    let system = System::new();
+    let (program, lock_msg_id) = init_fixture(&system, RwLockType::Write);
+
+    let lock_access_result = program.send(
+        USER_ID,
+        Command::RwLockStaticAccess(RwLockType::Write, LockStaticAccessSubcommand::AsMut),
+    );
+
+    assert_paniced(
+        &lock_access_result,
+        &format!(
+            "Write lock guard held by message {} is being accessed by message {}",
+            lock_msg_id,
+            lock_access_result.sent_message_id()
+        ),
+    );
+}
+
+#[test]
+fn deref_w_lock_guard_from_different_msg_fails() {
+    let system = System::new();
+    let (program, lock_msg_id) = init_fixture(&system, RwLockType::Write);
+
+    let lock_access_result = program.send(
+        USER_ID,
+        Command::RwLockStaticAccess(RwLockType::Write, LockStaticAccessSubcommand::Deref),
+    );
+
+    assert_paniced(
+        &lock_access_result,
+        &format!(
+            "Write lock guard held by message {} is being accessed by message {}",
+            lock_msg_id,
+            lock_access_result.sent_message_id()
+        ),
+    );
+}
+
+#[test]
+fn deref_mut_w_lock_guard_from_different_msg_fails() {
+    let system = System::new();
+    let (program, lock_msg_id) = init_fixture(&system, RwLockType::Write);
+
+    let lock_access_result = program.send(
+        USER_ID,
+        Command::RwLockStaticAccess(RwLockType::Write, LockStaticAccessSubcommand::DerefMut),
+    );
+
+    assert_paniced(
+        &lock_access_result,
+        &format!(
+            "Write lock guard held by message {} is being accessed by message {}",
+            lock_msg_id,
+            lock_access_result.sent_message_id()
+        ),
+    );
+}
+
+fn init_fixture(system: &System, lock_type: RwLockType) -> (Program<'_>, MessageId) {
+    system.init_logger_with_default_filter("");
+    let program = Program::current(system);
+    program.send_bytes(USER_ID, []);
+    let lock_result = program.send(
+        USER_ID,
+        Command::RwLock(
+            lock_type,
+            RwLockContinuation::General(LockContinuation::MoveToStatic),
+        ),
+    );
+    (program, lock_result.sent_message_id())
+}

--- a/examples/binaries/waiter/tests/rw_lock_access.rs
+++ b/examples/binaries/waiter/tests/rw_lock_access.rs
@@ -3,164 +3,91 @@ use demo_waiter::{
 };
 use gear_core::ids::MessageId;
 use gtest::{Program, System};
-use utils::{assert_paniced, USER_ID};
+use utils::{assert_panicked, USER_ID};
 
 mod utils;
 
 #[test]
 fn drop_r_lock_guard_from_different_msg_fails() {
-    let system = System::new();
-    let (program, lock_msg_id) = init_fixture(&system, RwLockType::Read);
-
-    let lock_access_result = program.send(
-        USER_ID,
-        Command::RwLockStaticAccess(RwLockType::Read, LockStaticAccessSubcommand::Drop),
-    );
-
-    assert_paniced(
-        &lock_access_result,
-        &format!(
-            "Read lock guard held by message {} is being accessed by message {}",
-            lock_msg_id,
-            lock_access_result.sent_message_id()
-        ),
+    access_rw_lock_guard_from_different_msg_fails(
+        RwLockType::Read,
+        LockStaticAccessSubcommand::Drop,
     );
 }
 
 #[test]
 fn as_ref_r_lock_guard_from_different_msg_fails() {
-    let system = System::new();
-    let (program, lock_msg_id) = init_fixture(&system, RwLockType::Read);
-
-    let lock_access_result = program.send(
-        USER_ID,
-        Command::RwLockStaticAccess(RwLockType::Read, LockStaticAccessSubcommand::AsRef),
-    );
-
-    assert_paniced(
-        &lock_access_result,
-        &format!(
-            "Read lock guard held by message {} is being accessed by message {}",
-            lock_msg_id,
-            lock_access_result.sent_message_id()
-        ),
+    access_rw_lock_guard_from_different_msg_fails(
+        RwLockType::Read,
+        LockStaticAccessSubcommand::AsRef,
     );
 }
 
 #[test]
 fn deref_r_lock_guard_from_different_msg_fails() {
-    let system = System::new();
-    let (program, lock_msg_id) = init_fixture(&system, RwLockType::Read);
-
-    let lock_access_result = program.send(
-        USER_ID,
-        Command::RwLockStaticAccess(RwLockType::Read, LockStaticAccessSubcommand::Deref),
-    );
-
-    assert_paniced(
-        &lock_access_result,
-        &format!(
-            "Read lock guard held by message {} is being accessed by message {}",
-            lock_msg_id,
-            lock_access_result.sent_message_id()
-        ),
+    access_rw_lock_guard_from_different_msg_fails(
+        RwLockType::Read,
+        LockStaticAccessSubcommand::Deref,
     );
 }
 
 #[test]
 fn drop_w_lock_guard_from_different_msg_fails() {
-    let system = System::new();
-    let (program, lock_msg_id) = init_fixture(&system, RwLockType::Write);
-
-    let lock_access_result = program.send(
-        USER_ID,
-        Command::RwLockStaticAccess(RwLockType::Write, LockStaticAccessSubcommand::Drop),
-    );
-
-    assert_paniced(
-        &lock_access_result,
-        &format!(
-            "Write lock guard held by message {} is being accessed by message {}",
-            lock_msg_id,
-            lock_access_result.sent_message_id()
-        ),
+    access_rw_lock_guard_from_different_msg_fails(
+        RwLockType::Write,
+        LockStaticAccessSubcommand::Drop,
     );
 }
 
 #[test]
 fn as_ref_w_lock_guard_from_different_msg_fails() {
-    let system = System::new();
-    let (program, lock_msg_id) = init_fixture(&system, RwLockType::Write);
-
-    let lock_access_result = program.send(
-        USER_ID,
-        Command::RwLockStaticAccess(RwLockType::Write, LockStaticAccessSubcommand::AsRef),
-    );
-
-    assert_paniced(
-        &lock_access_result,
-        &format!(
-            "Write lock guard held by message {} is being accessed by message {}",
-            lock_msg_id,
-            lock_access_result.sent_message_id()
-        ),
+    access_rw_lock_guard_from_different_msg_fails(
+        RwLockType::Write,
+        LockStaticAccessSubcommand::AsRef,
     );
 }
 
 #[test]
 fn as_mut_w_lock_guard_from_different_msg_fails() {
-    let system = System::new();
-    let (program, lock_msg_id) = init_fixture(&system, RwLockType::Write);
-
-    let lock_access_result = program.send(
-        USER_ID,
-        Command::RwLockStaticAccess(RwLockType::Write, LockStaticAccessSubcommand::AsMut),
-    );
-
-    assert_paniced(
-        &lock_access_result,
-        &format!(
-            "Write lock guard held by message {} is being accessed by message {}",
-            lock_msg_id,
-            lock_access_result.sent_message_id()
-        ),
+    access_rw_lock_guard_from_different_msg_fails(
+        RwLockType::Write,
+        LockStaticAccessSubcommand::AsMut,
     );
 }
 
 #[test]
 fn deref_w_lock_guard_from_different_msg_fails() {
-    let system = System::new();
-    let (program, lock_msg_id) = init_fixture(&system, RwLockType::Write);
-
-    let lock_access_result = program.send(
-        USER_ID,
-        Command::RwLockStaticAccess(RwLockType::Write, LockStaticAccessSubcommand::Deref),
-    );
-
-    assert_paniced(
-        &lock_access_result,
-        &format!(
-            "Write lock guard held by message {} is being accessed by message {}",
-            lock_msg_id,
-            lock_access_result.sent_message_id()
-        ),
+    access_rw_lock_guard_from_different_msg_fails(
+        RwLockType::Write,
+        LockStaticAccessSubcommand::Deref,
     );
 }
 
 #[test]
 fn deref_mut_w_lock_guard_from_different_msg_fails() {
+    access_rw_lock_guard_from_different_msg_fails(
+        RwLockType::Write,
+        LockStaticAccessSubcommand::DerefMut,
+    );
+}
+
+fn access_rw_lock_guard_from_different_msg_fails(
+    lock_type: RwLockType,
+    lock_access_subcommand: LockStaticAccessSubcommand,
+) {
     let system = System::new();
-    let (program, lock_msg_id) = init_fixture(&system, RwLockType::Write);
+    let (program, lock_msg_id) = init_fixture(&system, lock_type);
 
     let lock_access_result = program.send(
         USER_ID,
-        Command::RwLockStaticAccess(RwLockType::Write, LockStaticAccessSubcommand::DerefMut),
+        Command::RwLockStaticAccess(lock_type, lock_access_subcommand),
     );
 
-    assert_paniced(
+    assert_panicked(
         &lock_access_result,
         &format!(
-            "Write lock guard held by message {} is being accessed by message {}",
+            "{:?} lock guard held by message {} is being accessed by message {}",
+            lock_type,
             lock_msg_id,
             lock_access_result.sent_message_id()
         ),

--- a/examples/binaries/waiter/tests/utils.rs
+++ b/examples/binaries/waiter/tests/utils.rs
@@ -1,0 +1,22 @@
+use gstd::errors::{ErrorReplyReason, ReplyCode, SimpleExecutionError};
+use gtest::RunResult;
+
+pub const USER_ID: u64 = 10;
+
+#[track_caller]
+pub fn assert_paniced(result: &RunResult, panic_msg: &str) {
+    assert_eq!(result.log().len(), 1);
+    assert!(matches!(
+        result.log()[0].reply_code(),
+        Some(ReplyCode::Error(ErrorReplyReason::Execution(
+            SimpleExecutionError::UserspacePanic
+        )))
+    ));
+    let payload = String::from_utf8(result.log()[0].payload().into())
+        .expect("Unable to decode panic message")
+        .split(',')
+        .map(String::from)
+        .next()
+        .expect("Unable to split panic message");
+    assert_eq!(payload, format!("'{}'", panic_msg));
+}

--- a/examples/binaries/waiter/tests/utils.rs
+++ b/examples/binaries/waiter/tests/utils.rs
@@ -4,7 +4,7 @@ use gtest::RunResult;
 pub const USER_ID: u64 = 10;
 
 #[track_caller]
-pub fn assert_paniced(result: &RunResult, panic_msg: &str) {
+pub fn assert_panicked(result: &RunResult, panic_msg: &str) {
     assert_eq!(result.log().len(), 1);
     assert!(matches!(
         result.log()[0].reply_code(),

--- a/gstd/src/lock/mutex.rs
+++ b/gstd/src/lock/mutex.rs
@@ -16,7 +16,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::MessageId;
+use super::access::AccessQueue;
+use crate::{exec, msg, MessageId};
 use core::{
     cell::UnsafeCell,
     future::Future,
@@ -24,8 +25,6 @@ use core::{
     pin::Pin,
     task::{Context, Poll},
 };
-
-use super::access::AccessQueue;
 
 /// A mutual exclusion primitive useful for protecting shared data.
 ///
@@ -117,14 +116,44 @@ impl<T> Mutex<T> {
 /// [`lock`](Mutex::lock) method on [`Mutex`].
 pub struct MutexGuard<'a, T> {
     mutex: &'a Mutex<T>,
+    holder_msg_id: MessageId,
+}
+
+impl<'a, T> MutexGuard<'a, T> {
+    fn ensure_access_by_holder(&self) {
+        let current_msg_id = msg::id();
+        if self.holder_msg_id != current_msg_id {
+            panic!(
+                "Mutex guard held by message 0x{} is being accessed by message 0x{}",
+                hex::encode(self.holder_msg_id),
+                hex::encode(current_msg_id)
+            );
+        }
+    }
 }
 
 impl<'a, T> Drop for MutexGuard<'a, T> {
     fn drop(&mut self) {
+        self.ensure_access_by_holder();
         unsafe {
-            *self.mutex.locked.get() = None;
-            if let Some(message_id) = self.mutex.queue.dequeue() {
-                crate::exec::wake(message_id).expect("Failed to wake the message");
+            let locked_by = &mut *self.mutex.locked.get();
+            if let Some(owner_msg_id) = *locked_by {
+                if owner_msg_id != self.holder_msg_id {
+                    panic!(
+                        "Mutex guard held by message 0x{} does not match lock owner message 0x{}",
+                        hex::encode(self.holder_msg_id),
+                        hex::encode(owner_msg_id),
+                    );
+                }
+                *locked_by = None;
+                if let Some(message_id) = self.mutex.queue.dequeue() {
+                    exec::wake(message_id).expect("Failed to wake the message");
+                }
+            } else {
+                panic!(
+                    "Mutex guard held by message 0x{} is being dropped for non-existing lock",
+                    hex::encode(self.holder_msg_id),
+                );
             }
         }
     }
@@ -132,12 +161,14 @@ impl<'a, T> Drop for MutexGuard<'a, T> {
 
 impl<'a, T> AsRef<T> for MutexGuard<'a, T> {
     fn as_ref(&self) -> &'a T {
+        self.ensure_access_by_holder();
         unsafe { &*self.mutex.value.get() }
     }
 }
 
 impl<'a, T> AsMut<T> for MutexGuard<'a, T> {
     fn as_mut(&mut self) -> &'a mut T {
+        self.ensure_access_by_holder();
         unsafe { &mut *self.mutex.value.get() }
     }
 }
@@ -146,12 +177,14 @@ impl<T> Deref for MutexGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
+        self.ensure_access_by_holder();
         unsafe { &*self.mutex.value.get() }
     }
 }
 
 impl<T> DerefMut for MutexGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
+        self.ensure_access_by_holder();
         unsafe { &mut *self.mutex.value.get() }
     }
 }
@@ -193,18 +226,21 @@ impl<'a, T> Future for MutexLockFuture<'a, T> {
     // In case of locked mutex and an `.await`, function `poll` checks if the
     // mutex can be taken, else it waits (goes into *waiting queue*).
     fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let current_msg_id = crate::msg::id();
+        let current_msg_id = msg::id();
         let lock = unsafe { &mut *self.mutex.locked.get() };
         if lock.is_none() {
             *lock = Some(current_msg_id);
-            Poll::Ready(MutexGuard { mutex: self.mutex })
+            Poll::Ready(MutexGuard {
+                mutex: self.mutex,
+                holder_msg_id: current_msg_id,
+            })
         } else {
             // If the message is already in the access queue, and we come here,
             // it means the message has just been woken up from the waitlist.
             // In that case we do not want to register yet another access attempt
             // and just go back to the waitlist.
             if !self.mutex.queue.contains(&current_msg_id) {
-                self.mutex.queue.enqueue(crate::msg::id());
+                self.mutex.queue.enqueue(current_msg_id);
             }
             Poll::Pending
         }

--- a/gstd/src/lock/rwlock.rs
+++ b/gstd/src/lock/rwlock.rs
@@ -17,7 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::access::AccessQueue;
-use crate::MessageId;
+use crate::{exec, msg, MessageId};
 use core::{
     cell::{Cell, UnsafeCell},
     future::Future,
@@ -167,10 +167,25 @@ unsafe impl<T> Sync for RwLock<T> {}
 /// [`read`](RwLock::read) method on [`RwLock`].
 pub struct RwLockReadGuard<'a, T> {
     lock: &'a RwLock<T>,
+    holder_msg_id: MessageId,
+}
+
+impl<'a, T> RwLockReadGuard<'a, T> {
+    fn ensure_access_by_holder(&self) {
+        let current_msg_id = msg::id();
+        if self.holder_msg_id != current_msg_id {
+            panic!(
+                "Read lock guard held by message 0x{} is being accessed by message 0x{}",
+                hex::encode(self.holder_msg_id),
+                hex::encode(current_msg_id)
+            );
+        }
+    }
 }
 
 impl<'a, T> Drop for RwLockReadGuard<'a, T> {
     fn drop(&mut self) {
+        self.ensure_access_by_holder();
         unsafe {
             let readers = &self.lock.readers;
             let readers_count = readers.get().saturating_sub(1);
@@ -181,7 +196,7 @@ impl<'a, T> Drop for RwLockReadGuard<'a, T> {
                 *self.lock.locked.get() = None;
 
                 if let Some(message_id) = self.lock.queue.dequeue() {
-                    crate::exec::wake(message_id).expect("Failed to wake the message");
+                    exec::wake(message_id).expect("Failed to wake the message");
                 }
             }
         }
@@ -190,6 +205,7 @@ impl<'a, T> Drop for RwLockReadGuard<'a, T> {
 
 impl<'a, T> AsRef<T> for RwLockReadGuard<'a, T> {
     fn as_ref(&self) -> &'a T {
+        self.ensure_access_by_holder();
         unsafe { &*self.lock.value.get() }
     }
 }
@@ -198,21 +214,8 @@ impl<T> Deref for RwLockReadGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
+        self.ensure_access_by_holder();
         unsafe { &*self.lock.value.get() }
-    }
-}
-
-impl<T> Deref for RwLockWriteGuard<'_, T> {
-    type Target = T;
-
-    fn deref(&self) -> &T {
-        unsafe { &*self.lock.value.get() }
-    }
-}
-
-impl<T> DerefMut for RwLockWriteGuard<'_, T> {
-    fn deref_mut(&mut self) -> &mut T {
-        unsafe { &mut *self.lock.value.get() }
     }
 }
 
@@ -223,14 +226,44 @@ impl<T> DerefMut for RwLockWriteGuard<'_, T> {
 /// [`write`](RwLock::write) method on [`RwLock`].
 pub struct RwLockWriteGuard<'a, T> {
     lock: &'a RwLock<T>,
+    holder_msg_id: MessageId,
+}
+
+impl<'a, T> RwLockWriteGuard<'a, T> {
+    fn ensure_access_by_holder(&self) {
+        let current_msg_id = msg::id();
+        if self.holder_msg_id != current_msg_id {
+            panic!(
+                "Write lock guard held by message 0x{} is being accessed by message 0x{}",
+                hex::encode(self.holder_msg_id),
+                hex::encode(current_msg_id)
+            );
+        }
+    }
 }
 
 impl<'a, T> Drop for RwLockWriteGuard<'a, T> {
     fn drop(&mut self) {
+        self.ensure_access_by_holder();
         unsafe {
-            *self.lock.locked.get() = None;
-            if let Some(message_id) = self.lock.queue.dequeue() {
-                crate::exec::wake(message_id).expect("Failed to wake the message");
+            let locked_by = &mut *self.lock.locked.get();
+            if let Some(owner_msg_id) = *locked_by {
+                if owner_msg_id != self.holder_msg_id {
+                    panic!(
+                        "Write lock guard held by message 0x{} does not match lock owner message 0x{}",
+                        hex::encode(self.holder_msg_id),
+                        hex::encode(owner_msg_id),
+                    );
+                }
+                *locked_by = None;
+                if let Some(message_id) = self.lock.queue.dequeue() {
+                    exec::wake(message_id).expect("Failed to wake the message");
+                }
+            } else {
+                panic!(
+                    "Write lock guard held by message 0x{} is being dropped for non-existing lock",
+                    hex::encode(self.holder_msg_id),
+                );
             }
         }
     }
@@ -238,12 +271,30 @@ impl<'a, T> Drop for RwLockWriteGuard<'a, T> {
 
 impl<'a, T> AsRef<T> for RwLockWriteGuard<'a, T> {
     fn as_ref(&self) -> &'a T {
+        self.ensure_access_by_holder();
         unsafe { &*self.lock.value.get() }
     }
 }
 
 impl<'a, T> AsMut<T> for RwLockWriteGuard<'a, T> {
     fn as_mut(&mut self) -> &'a mut T {
+        self.ensure_access_by_holder();
+        unsafe { &mut *self.lock.value.get() }
+    }
+}
+
+impl<T> Deref for RwLockWriteGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        self.ensure_access_by_holder();
+        unsafe { &*self.lock.value.get() }
+    }
+}
+
+impl<T> DerefMut for RwLockWriteGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        self.ensure_access_by_holder();
         unsafe { &mut *self.lock.value.get() }
     }
 }
@@ -309,11 +360,14 @@ impl<'a, T> Future for RwLockReadFuture<'a, T> {
         let readers = &self.lock.readers;
         let readers_count = readers.get().saturating_add(1);
 
-        let current_msg_id = crate::msg::id();
+        let current_msg_id = msg::id();
         let lock = unsafe { &mut *self.lock.locked.get() };
         if lock.is_none() && readers_count <= READERS_LIMIT {
             readers.replace(readers_count);
-            Poll::Ready(RwLockReadGuard { lock: self.lock })
+            Poll::Ready(RwLockReadGuard {
+                lock: self.lock,
+                holder_msg_id: current_msg_id,
+            })
         } else {
             // If the message is already in the access queue, and we come here,
             // it means the message has just been woken up from the waitlist.
@@ -331,11 +385,14 @@ impl<'a, T> Future for RwLockWriteFuture<'a, T> {
     type Output = RwLockWriteGuard<'a, T>;
 
     fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let current_msg_id = crate::msg::id();
+        let current_msg_id = msg::id();
         let lock = unsafe { &mut *self.lock.locked.get() };
         if lock.is_none() && self.lock.readers.get() == 0 {
             *lock = Some(current_msg_id);
-            Poll::Ready(RwLockWriteGuard { lock: self.lock })
+            Poll::Ready(RwLockWriteGuard {
+                lock: self.lock,
+                holder_msg_id: current_msg_id,
+            })
         } else {
             // If the message is already in the access queue, and we come here,
             // it means the message has just been woken up from the waitlist.

--- a/gstd/src/lock/rwlock.rs
+++ b/gstd/src/lock/rwlock.rs
@@ -247,23 +247,22 @@ impl<'a, T> Drop for RwLockWriteGuard<'a, T> {
         self.ensure_access_by_holder();
         unsafe {
             let locked_by = &mut *self.lock.locked.get();
-            if let Some(owner_msg_id) = *locked_by {
-                if owner_msg_id != self.holder_msg_id {
-                    panic!(
-                        "Write lock guard held by message 0x{} does not match lock owner message 0x{}",
-                        hex::encode(self.holder_msg_id),
-                        hex::encode(owner_msg_id),
-                    );
-                }
-                *locked_by = None;
-                if let Some(message_id) = self.lock.queue.dequeue() {
-                    exec::wake(message_id).expect("Failed to wake the message");
-                }
-            } else {
+            let owner_msg_id = locked_by.unwrap_or_else(|| {
                 panic!(
                     "Write lock guard held by message 0x{} is being dropped for non-existing lock",
                     hex::encode(self.holder_msg_id),
                 );
+            });
+            if owner_msg_id != self.holder_msg_id {
+                panic!(
+                    "Write lock guard held by message 0x{} does not match lock owner message 0x{}",
+                    hex::encode(self.holder_msg_id),
+                    hex::encode(owner_msg_id),
+                );
+            }
+            *locked_by = None;
+            if let Some(message_id) = self.lock.queue.dequeue() {
+                exec::wake(message_id).expect("Failed to wake the message");
             }
         }
     }

--- a/gtest/src/system.rs
+++ b/gtest/src/system.rs
@@ -42,11 +42,11 @@ impl System {
     }
 
     pub fn init_logger(&self) {
-        self.init_logger_with_default_filter("gwasm=debug")
+        self.init_logger_with_fallback_filter("gwasm=debug")
     }
 
-    pub fn init_logger_with_default_filter<'a>(&self, default_filter: impl Into<Cow<'a, str>>) {
-        let _ = Builder::from_env(Env::default().default_filter_or(default_filter))
+    pub fn init_logger_with_fallback_filter<'a>(&self, fallback_filter: impl Into<Cow<'a, str>>) {
+        let _ = Builder::from_env(Env::default().default_filter_or(fallback_filter))
             .format(|buf, record| {
                 let lvl = record.level().to_string().to_uppercase();
                 let target = record.target().to_string();

--- a/gtest/src/system.rs
+++ b/gtest/src/system.rs
@@ -26,7 +26,7 @@ use colored::Colorize;
 use env_logger::{Builder, Env};
 use gear_core::{ids::CodeId, message::Dispatch};
 use path_clean::PathClean;
-use std::{cell::RefCell, env, fs, io::Write, path::Path, thread};
+use std::{borrow::Cow, cell::RefCell, env, fs, io::Write, path::Path, thread};
 
 pub struct System(pub(crate) RefCell<ExtManager>);
 
@@ -42,7 +42,11 @@ impl System {
     }
 
     pub fn init_logger(&self) {
-        let _ = Builder::from_env(Env::default().default_filter_or("gwasm=debug"))
+        self.init_logger_with_default_filter("gwasm=debug")
+    }
+
+    pub fn init_logger_with_default_filter<'a>(&self, default_filter: impl Into<Cow<'a, str>>) {
+        let _ = Builder::from_env(Env::default().default_filter_or(default_filter))
             .format(|buf, record| {
                 let lvl = record.level().to_string().to_uppercase();
                 let target = record.target().to_string();

--- a/gtest/src/system.rs
+++ b/gtest/src/system.rs
@@ -42,11 +42,11 @@ impl System {
     }
 
     pub fn init_logger(&self) {
-        self.init_logger_with_fallback_filter("gwasm=debug")
+        self.init_logger_with_default_filter("gwasm=debug")
     }
 
-    pub fn init_logger_with_fallback_filter<'a>(&self, fallback_filter: impl Into<Cow<'a, str>>) {
-        let _ = Builder::from_env(Env::default().default_filter_or(fallback_filter))
+    pub fn init_logger_with_default_filter<'a>(&self, default_filter: impl Into<Cow<'a, str>>) {
+        let _ = Builder::from_env(Env::default().default_filter_or(default_filter))
             .format(|buf, record| {
                 let lvl = record.level().to_string().to_uppercase();
                 let target = record.target().to_string();

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -8557,7 +8557,9 @@ fn call_forbidden_function() {
 
 #[test]
 fn waking_message_waiting_for_mx_lock_does_not_lead_to_deadlock() {
-    use demo_waiter::{Command as WaiterCommand, MxLockContinuation, WASM_BINARY as WAITER_WASM};
+    use demo_waiter::{
+        Command as WaiterCommand, LockContinuation, MxLockContinuation, WASM_BINARY as WAITER_WASM,
+    };
 
     let execution = || {
         System::reset_events();
@@ -8590,16 +8592,19 @@ fn waking_message_waiting_for_mx_lock_does_not_lead_to_deadlock() {
             (msg_id, msg_block_number)
         };
 
-        let (lock_owner_msg_id, _lock_owner_msg_block_number) =
-            send_command_to_waiter(WaiterCommand::MxLock(MxLockContinuation::SleepFor(4)));
+        let (lock_owner_msg_id, _lock_owner_msg_block_number) = send_command_to_waiter(
+            WaiterCommand::MxLock(MxLockContinuation::General(LockContinuation::SleepFor(4))),
+        );
 
-        let (lock_rival_1_msg_id, _) =
-            send_command_to_waiter(WaiterCommand::MxLock(MxLockContinuation::Nothing));
+        let (lock_rival_1_msg_id, _) = send_command_to_waiter(WaiterCommand::MxLock(
+            MxLockContinuation::General(LockContinuation::Nothing),
+        ));
 
         send_command_to_waiter(WaiterCommand::WakeUp(lock_rival_1_msg_id.into()));
 
-        let (lock_rival_2_msg_id, _) =
-            send_command_to_waiter(WaiterCommand::MxLock(MxLockContinuation::Nothing));
+        let (lock_rival_2_msg_id, _) = send_command_to_waiter(WaiterCommand::MxLock(
+            MxLockContinuation::General(LockContinuation::Nothing),
+        ));
 
         assert!(WaitlistOf::<Test>::contains(
             &waiter_prog_id,
@@ -8631,7 +8636,8 @@ fn waking_message_waiting_for_mx_lock_does_not_lead_to_deadlock() {
 #[test]
 fn waking_message_waiting_for_rw_lock_does_not_lead_to_deadlock() {
     use demo_waiter::{
-        Command as WaiterCommand, RwLockContinuation, RwLockType, WASM_BINARY as WAITER_WASM,
+        Command as WaiterCommand, LockContinuation, RwLockContinuation, RwLockType,
+        WASM_BINARY as WAITER_WASM,
     };
 
     let execution = || {
@@ -8667,20 +8673,22 @@ fn waking_message_waiting_for_rw_lock_does_not_lead_to_deadlock() {
 
         // For write lock
         {
-            let (lock_owner_msg_id, _lock_owner_msg_block_number) = send_command_to_waiter(
-                WaiterCommand::RwLock(RwLockType::Read, RwLockContinuation::SleepFor(4)),
-            );
+            let (lock_owner_msg_id, _lock_owner_msg_block_number) =
+                send_command_to_waiter(WaiterCommand::RwLock(
+                    RwLockType::Read,
+                    RwLockContinuation::General(LockContinuation::SleepFor(4)),
+                ));
 
             let (lock_rival_1_msg_id, _) = send_command_to_waiter(WaiterCommand::RwLock(
                 RwLockType::Write,
-                RwLockContinuation::Nothing,
+                RwLockContinuation::General(LockContinuation::Nothing),
             ));
 
             send_command_to_waiter(WaiterCommand::WakeUp(lock_rival_1_msg_id.into()));
 
             let (lock_rival_2_msg_id, _) = send_command_to_waiter(WaiterCommand::RwLock(
                 RwLockType::Write,
-                RwLockContinuation::Nothing,
+                RwLockContinuation::General(LockContinuation::Nothing),
             ));
 
             assert!(WaitlistOf::<Test>::contains(
@@ -8708,20 +8716,22 @@ fn waking_message_waiting_for_rw_lock_does_not_lead_to_deadlock() {
 
         // For read lock
         {
-            let (lock_owner_msg_id, _lock_owner_msg_block_number) = send_command_to_waiter(
-                WaiterCommand::RwLock(RwLockType::Write, RwLockContinuation::SleepFor(4)),
-            );
+            let (lock_owner_msg_id, _lock_owner_msg_block_number) =
+                send_command_to_waiter(WaiterCommand::RwLock(
+                    RwLockType::Write,
+                    RwLockContinuation::General(LockContinuation::SleepFor(4)),
+                ));
 
             let (lock_rival_1_msg_id, _) = send_command_to_waiter(WaiterCommand::RwLock(
                 RwLockType::Read,
-                RwLockContinuation::Nothing,
+                RwLockContinuation::General(LockContinuation::Nothing),
             ));
 
             send_command_to_waiter(WaiterCommand::WakeUp(lock_rival_1_msg_id.into()));
 
             let (lock_rival_2_msg_id, _) = send_command_to_waiter(WaiterCommand::RwLock(
                 RwLockType::Write,
-                RwLockContinuation::Nothing,
+                RwLockContinuation::General(LockContinuation::Nothing),
             ));
 
             assert!(WaitlistOf::<Test>::contains(


### PR DESCRIPTION
At the moment it is allowed to obtain mx/read/write lock guard in the context of one message and use it in the context of another which is wrong. This PR fixes this issue.

@reviewer-or-team
