### PR TITLE
test(core-processor): Add tests for send message limit

### DIFF
--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -1036,7 +1036,7 @@ mod tests {
     use super::*;
     use alloc::vec;
     use gear_core::{
-        message::{ContextSettings, IncomingDispatch, Payload, MAX_PAYLOAD_SIZE},
+        message::{ContextSettings, IncomingDispatch, MAX_PAYLOAD_SIZE},
         pages::PageNumber,
     };
 
@@ -1279,6 +1279,8 @@ mod tests {
                 .build(),
         );
 
+        let data = HandlePacket::default();
+
         let fake_handle = 0;
 
         let msg = ext.send_commit(fake_handle, data, 0);
@@ -1286,8 +1288,6 @@ mod tests {
             msg.unwrap_err(),
             FallibleExtError::Core(FallibleExtErrorCore::Message(MessageError::OutOfBounds))
         );
-
-        let data = HandlePacket::default();
 
         let handle = ext.send_init().unwrap();
 

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -1271,7 +1271,6 @@ mod tests {
     /// - `send_commit` on invalid handle
     /// - `send_commit` on used handle
     /// - `send_init` after limit is exceeded
-    ///
     fn test_send_commit() {
         let mut ext = Ext::new(
             ProcessorContextBuilder::new()
@@ -1289,7 +1288,7 @@ mod tests {
             FallibleExtError::Core(FallibleExtErrorCore::Message(MessageError::OutOfBounds))
         );
 
-        let handle = ext.send_init().unwrap();
+        let handle = ext.send_init().expect("Outgoing limit is 1");
 
         let msg = ext.send_commit(handle, data.clone(), 0);
         assert!(msg.is_ok());
@@ -1317,7 +1316,6 @@ mod tests {
     /// - `send_push` on used handle
     /// - `send_push` with too large payload
     /// - `send_push` data is added to buffer
-    ///
     fn test_send_push() {
         let mut ext = Ext::new(
             ProcessorContextBuilder::new()
@@ -1339,8 +1337,8 @@ mod tests {
             FallibleExtError::Core(FallibleExtErrorCore::Message(MessageError::OutOfBounds))
         );
 
-        let handle = ext.send_init().unwrap();
-
+        let handle = ext.send_init().expect("Outgoing limit is u32::MAX");
+        
         let res = ext.send_push(handle, &[1, 2, 3]);
         assert!(res.is_ok());
 
@@ -1386,7 +1384,6 @@ mod tests {
     /// - `send_push_input` on valid handle
     /// - `send_push_input` on used handle
     /// - `send_push_input` data is added to buffer
-    ///
     fn test_send_push_input() {
         let mut ext = Ext::new(
             ProcessorContextBuilder::new()
@@ -1408,7 +1405,7 @@ mod tests {
             FallibleExtError::Core(FallibleExtErrorCore::Message(MessageError::OutOfBounds))
         );
 
-        let handle = ext.send_init().unwrap();
+        let handle = ext.send_init().expect("Outgoing limit is u32::MAX");
 
         let res = ext
             .context
@@ -1418,6 +1415,9 @@ mod tests {
         assert!(res.is_ok());
 
         let res = ext.send_push_input(handle, 2, 3);
+        assert!(res.is_ok());
+
+        let res = ext.send_push_input(handle, 8, 10);
         assert!(res.is_ok());
 
         let msg = ext.send_commit(handle, data, 0);

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -1490,7 +1490,7 @@ mod tests {
     // - `reply_push` with too much data
     // - `reply_push` after `reply_commit`
     // - `reply_push` data is added to buffer
-    fn test_reply_commit() {
+    fn test_reply_push() {
         let mut ext = Ext::new(
             ProcessorContextBuilder::new()
                 .with_gas(GasCounter::new(u64::MAX))
@@ -1546,7 +1546,7 @@ mod tests {
     // - `reply_push_input` with valid data
     // - `reply_push_input` after `reply_commit`
     // - `reply_push_input` data is added to buffer
-    fn test_send_push_input() {
+    fn test_reply_push_input() {
         let mut ext = Ext::new(
             ProcessorContextBuilder::new()
                 .with_message_context(

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -1265,12 +1265,12 @@ mod tests {
     }
 
     #[test]
-    /// This function tests:
-    ///
-    /// - `send_commit` on valid handle
-    /// - `send_commit` on invalid handle
-    /// - `send_commit` on used handle
-    /// - `send_init` after limit is exceeded
+    // This function tests:
+    //
+    // - `send_commit` on valid handle
+    // - `send_commit` on invalid handle
+    // - `send_commit` on used handle
+    // - `send_init` after limit is exceeded
     fn test_send_commit() {
         let mut ext = Ext::new(
             ProcessorContextBuilder::new()
@@ -1309,13 +1309,13 @@ mod tests {
     }
 
     #[test]
-    /// This function tests:
-    ///
-    /// - `send_push` on non-existent handle
-    /// - `send_push` on valid handle
-    /// - `send_push` on used handle
-    /// - `send_push` with too large payload
-    /// - `send_push` data is added to buffer
+    // This function tests:
+    //
+    // - `send_push` on non-existent handle
+    // - `send_push` on valid handle
+    // - `send_push` on used handle
+    // - `send_push` with too large payload
+    // - `send_push` data is added to buffer
     fn test_send_push() {
         let mut ext = Ext::new(
             ProcessorContextBuilder::new()
@@ -1378,12 +1378,12 @@ mod tests {
     }
 
     #[test]
-    /// This function tests:
-    ///
-    /// - `send_push_input` on non-existent handle
-    /// - `send_push_input` on valid handle
-    /// - `send_push_input` on used handle
-    /// - `send_push_input` data is added to buffer
+    // This function tests:
+    //
+    // - `send_push_input` on non-existent handle
+    // - `send_push_input` on valid handle
+    // - `send_push_input` on used handle
+    // - `send_push_input` data is added to buffer
     fn test_send_push_input() {
         let mut ext = Ext::new(
             ProcessorContextBuilder::new()

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -1338,7 +1338,7 @@ mod tests {
         );
 
         let handle = ext.send_init().expect("Outgoing limit is u32::MAX");
-        
+
         let res = ext.send_push(handle, &[1, 2, 3]);
         assert!(res.is_ok());
 

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -1283,7 +1283,7 @@ mod tests {
 
         let fake_handle = 0;
 
-        let msg = ext.send_commit(fake_handle, data, 0);
+        let msg = ext.send_commit(fake_handle, data.clone(), 0);
         assert_eq!(
             msg.unwrap_err(),
             FallibleExtError::Core(FallibleExtErrorCore::Message(MessageError::OutOfBounds))
@@ -1294,7 +1294,7 @@ mod tests {
         let msg = ext.send_commit(handle, data.clone(), 0);
         assert!(msg.is_ok());
 
-        let msg = ext.send_commit(handle, data.clone(), 0);
+        let msg = ext.send_commit(handle, data, 0);
         assert_eq!(
             msg.unwrap_err(),
             FallibleExtError::Core(FallibleExtErrorCore::Message(MessageError::LateAccess))

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -1033,13 +1033,12 @@ impl Ext {
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
     use super::*;
+    use alloc::vec;
     use gear_core::{
-        message::{ContextSettings, IncomingDispatch},
+        message::{ContextSettings, IncomingDispatch, Payload, MAX_PAYLOAD_SIZE},
         pages::PageNumber,
     };
-    use gear_core::message::{MAX_PAYLOAD_SIZE, Payload};
 
     struct ProcessorContextBuilder(ProcessorContext);
 
@@ -1220,10 +1219,10 @@ mod tests {
     #[test]
     fn test_send_limit() {
         let mut ext = Ext::new(
-            ProcessorContextBuilder::new_with_context_settings(
-                ContextSettings::new(0, 0, 0, 0, 0, 2)
-            )
-            .build()
+            ProcessorContextBuilder::new_with_context_settings(ContextSettings::new(
+                0, 0, 0, 0, 0, 2,
+            ))
+            .build(),
         );
 
         let handle = ext.send_init().unwrap();
@@ -1246,10 +1245,15 @@ mod tests {
     #[test]
     fn test_handle_validity() {
         let mut ext = Ext::new(
-            ProcessorContextBuilder::new_with_context_settings(
-                ContextSettings::new(0, 0, 0, 0, 0, u32::MAX)
-            )
-            .build()
+            ProcessorContextBuilder::new_with_context_settings(ContextSettings::new(
+                0,
+                0,
+                0,
+                0,
+                0,
+                u32::MAX,
+            ))
+            .build(),
         );
 
         let fake_handle = 0;
@@ -1272,10 +1276,15 @@ mod tests {
     #[test]
     fn test_send_push() {
         let mut ext = Ext::new(
-            ProcessorContextBuilder::new_with_context_settings(
-                ContextSettings::new(0, 0, 0, 0, 0, u32::MAX)
-            )
-            .build()
+            ProcessorContextBuilder::new_with_context_settings(ContextSettings::new(
+                0,
+                0,
+                0,
+                0,
+                0,
+                u32::MAX,
+            ))
+            .build(),
         );
 
         let data = HandlePacket::default();
@@ -1290,7 +1299,9 @@ mod tests {
             Ok(_) => {}
             //If it is a "late access", it can be ignored, since it means the message was already
             // sent and cannot be changed, but the handle was valid
-            Err(FallibleExtError::Core(FallibleExtErrorCore::Message(MessageError::LateAccess))) => {}
+            Err(FallibleExtError::Core(FallibleExtErrorCore::Message(
+                MessageError::LateAccess,
+            ))) => {}
             Err(e) => {
                 panic!("{:?}", e);
             }
@@ -1300,10 +1311,15 @@ mod tests {
     #[test]
     fn test_payload_size() {
         let mut ext = Ext::new(
-            ProcessorContextBuilder::new_with_context_settings(
-                ContextSettings::new(0, 0, 0, 0, 0, u32::MAX)
-            )
-                .build()
+            ProcessorContextBuilder::new_with_context_settings(ContextSettings::new(
+                0,
+                0,
+                0,
+                0,
+                0,
+                u32::MAX,
+            ))
+            .build(),
         );
 
         let data = HandlePacket::new(ProgramId::default(), Payload::filled_with(0), 0);
@@ -1319,9 +1335,13 @@ mod tests {
         let data = vec![0u8; MAX_PAYLOAD_SIZE + 1];
 
         let msg = ext.send_push(handle, &data);
-        assert_eq!(msg.unwrap_err(), FallibleExtError::Core(FallibleExtErrorCore::Message(MessageError::MaxMessageSizeExceed)));
+        assert_eq!(
+            msg.unwrap_err(),
+            FallibleExtError::Core(FallibleExtErrorCore::Message(
+                MessageError::MaxMessageSizeExceed
+            ))
+        );
     }
-
 
     mod property_tests {
         use super::*;

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -1282,7 +1282,10 @@ mod tests {
         let fake_handle = 0;
 
         let msg = ext.send_commit(fake_handle, data, 0);
-        assert_eq!(msg.unwrap_err(), FallibleExtError::Core(FallibleExtErrorCore::Message(MessageError::OutOfBounds)));
+        assert_eq!(
+            msg.unwrap_err(),
+            FallibleExtError::Core(FallibleExtErrorCore::Message(MessageError::OutOfBounds))
+        );
 
         let data = HandlePacket::default();
 
@@ -1292,10 +1295,18 @@ mod tests {
         assert!(msg.is_ok());
 
         let msg = ext.send_commit(handle, data.clone(), 0);
-        assert_eq!(msg.unwrap_err(), FallibleExtError::Core(FallibleExtErrorCore::Message(MessageError::LateAccess)));
+        assert_eq!(
+            msg.unwrap_err(),
+            FallibleExtError::Core(FallibleExtErrorCore::Message(MessageError::LateAccess))
+        );
 
         let handle = ext.send_init();
-        assert_eq!(handle.unwrap_err(), FallibleExtError::Core(FallibleExtErrorCore::Message(MessageError::OutgoingMessagesAmountLimitExceeded)));
+        assert_eq!(
+            handle.unwrap_err(),
+            FallibleExtError::Core(FallibleExtErrorCore::Message(
+                MessageError::OutgoingMessagesAmountLimitExceeded
+            ))
+        );
     }
 
     #[test]
@@ -1323,7 +1334,10 @@ mod tests {
         let fake_handle = 0;
 
         let res = ext.send_push(fake_handle, &[0, 0, 0]);
-        assert_eq!(res.unwrap_err(), FallibleExtError::Core(FallibleExtErrorCore::Message(MessageError::OutOfBounds)));
+        assert_eq!(
+            res.unwrap_err(),
+            FallibleExtError::Core(FallibleExtErrorCore::Message(MessageError::OutOfBounds))
+        );
 
         let handle = ext.send_init().unwrap();
 
@@ -1347,11 +1361,20 @@ mod tests {
         assert!(msg.is_ok());
 
         let res = ext.send_push(handle, &[7, 8, 9]);
-        assert_eq!(res.unwrap_err(), FallibleExtError::Core(FallibleExtErrorCore::Message(MessageError::LateAccess)));
+        assert_eq!(
+            res.unwrap_err(),
+            FallibleExtError::Core(FallibleExtErrorCore::Message(MessageError::LateAccess))
+        );
 
         let (outcome, _) = ext.context.message_context.drain();
-        let ContextOutcomeDrain { mut outgoing_dispatches, .. } = outcome.drain();
-        let dispatch = outgoing_dispatches.pop().map(|(dispatch, _, _)| dispatch).expect("Send commit was ok");
+        let ContextOutcomeDrain {
+            mut outgoing_dispatches,
+            ..
+        } = outcome.drain();
+        let dispatch = outgoing_dispatches
+            .pop()
+            .map(|(dispatch, _, _)| dispatch)
+            .expect("Send commit was ok");
 
         assert_eq!(dispatch.message().payload_bytes(), &[1, 2, 3, 4, 5, 6]);
     }

--- a/core/src/message/context.rs
+++ b/core/src/message/context.rs
@@ -78,19 +78,9 @@ impl ContextSettings {
         self.sending_fee
     }
 
-    /// Setter for inner sending fee field.
-    pub fn set_sending_fee(&mut self, fee: u64) {
-        self.sending_fee = fee;
-    }
-
     /// Getter for inner scheduled sending fee field.
     pub fn scheduled_sending_fee(&self) -> u64 {
         self.scheduled_sending_fee
-    }
-
-    /// Setter for inner scheduled sending fee field.
-    pub fn set_scheduled_sending_fee(&mut self, fee: u64) {
-        self.scheduled_sending_fee = fee;
     }
 
     /// Getter for inner waiting fee field.
@@ -98,19 +88,9 @@ impl ContextSettings {
         self.waiting_fee
     }
 
-    /// Setter for inner waiting fee field.
-    pub fn set_waiting_fee(&mut self, fee: u64) {
-        self.waiting_fee = fee;
-    }
-
     /// Getter for inner waking fee field.
     pub fn waking_fee(&self) -> u64 {
         self.waking_fee
-    }
-
-    /// Setter for inner waking fee field.
-    pub fn set_waking_fee(&mut self, fee: u64) {
-        self.waking_fee = fee;
     }
 
     /// Getter for inner reservation fee field.
@@ -118,20 +98,9 @@ impl ContextSettings {
         self.reservation_fee
     }
 
-    /// Setter for inner reservation fee field.
-
-    pub fn set_reservation_fee(&mut self, fee: u64) {
-        self.reservation_fee = fee;
-    }
-
     /// Getter for inner outgoing limit field.
     pub fn outgoing_limit(&self) -> u32 {
         self.outgoing_limit
-    }
-
-    /// Setter for inner outgoing limit field.
-    pub fn set_outgoing_limit(&mut self, limit: u32) {
-        self.outgoing_limit = limit;
     }
 }
 
@@ -285,11 +254,6 @@ impl MessageContext {
     /// Getter for inner settings.
     pub fn settings(&self) -> &ContextSettings {
         &self.settings
-    }
-
-    /// Getter for mutable inner settings.
-    pub fn settings_mut(&mut self) -> &mut ContextSettings {
-        &mut self.settings
     }
 
     fn check_reply_availability(&self) -> Result<(), ExecutionError> {

--- a/core/src/message/context.rs
+++ b/core/src/message/context.rs
@@ -78,9 +78,19 @@ impl ContextSettings {
         self.sending_fee
     }
 
+    /// Setter for inner sending fee field.
+    pub fn set_sending_fee(&mut self, fee: u64) {
+        self.sending_fee = fee;
+    }
+
     /// Getter for inner scheduled sending fee field.
     pub fn scheduled_sending_fee(&self) -> u64 {
         self.scheduled_sending_fee
+    }
+
+    /// Setter for inner scheduled sending fee field.
+    pub fn set_scheduled_sending_fee(&mut self, fee: u64) {
+        self.scheduled_sending_fee = fee;
     }
 
     /// Getter for inner waiting fee field.
@@ -88,9 +98,19 @@ impl ContextSettings {
         self.waiting_fee
     }
 
+    /// Setter for inner waiting fee field.
+    pub fn set_waiting_fee(&mut self, fee: u64) {
+        self.waiting_fee = fee;
+    }
+
     /// Getter for inner waking fee field.
     pub fn waking_fee(&self) -> u64 {
         self.waking_fee
+    }
+
+    /// Setter for inner waking fee field.
+    pub fn set_waking_fee(&mut self, fee: u64) {
+        self.waking_fee = fee;
     }
 
     /// Getter for inner reservation fee field.
@@ -98,9 +118,20 @@ impl ContextSettings {
         self.reservation_fee
     }
 
+    /// Setter for inner reservation fee field.
+
+    pub fn set_reservation_fee(&mut self, fee: u64) {
+        self.reservation_fee = fee;
+    }
+
     /// Getter for inner outgoing limit field.
     pub fn outgoing_limit(&self) -> u32 {
         self.outgoing_limit
+    }
+
+    /// Setter for inner outgoing limit field.
+    pub fn set_outgoing_limit(&mut self, limit: u32) {
+        self.outgoing_limit = limit;
     }
 }
 
@@ -254,6 +285,11 @@ impl MessageContext {
     /// Getter for inner settings.
     pub fn settings(&self) -> &ContextSettings {
         &self.settings
+    }
+
+    /// Getter for mutable inner settings.
+    pub fn settings_mut(&mut self) -> &mut ContextSettings {
+        &mut self.settings
     }
 
     fn check_reply_availability(&self) -> Result<(), ExecutionError> {


### PR DESCRIPTION
- Added a test for the limit of message `send_init` calls.
- Also checks that the `send_commit`, `send_push` and `send_push_input` functions do not error.
- Added helper methods on `ProcessorContextBuilder` for message config.