### PR TITLE
fix(rpc-fns): Fix bug with `calculate_gas` returning block gas limit

### DIFF
--- a/common/src/gas_provider/internal.rs
+++ b/common/src/gas_provider/internal.rs
@@ -407,6 +407,27 @@ where
 
         Ok(())
     }
+
+    // Get limit node fn that may work with both: consumed and not, depending on `validate` argument.
+    fn get_limit_node_impl(
+        key: impl Into<NodeId>,
+        validate: impl FnOnce(&GasNode<ExternalId, NodeId, Balance>) -> Result<(), Error>,
+    ) -> Result<(Balance, NodeId), Error> {
+        let key = key.into();
+
+        let node = Self::get_node(key).ok_or_else(InternalError::node_not_found)?;
+
+        validate(&node)?;
+
+        let (node_with_value, maybe_key) = Self::node_with_value(node)?;
+
+        // The node here is external, specified or reserved hence has the inner value
+        let v = node_with_value
+            .value()
+            .ok_or_else(InternalError::unexpected_node_type)?;
+
+        Ok((v, maybe_key.unwrap_or(key)))
+    }
 }
 
 impl<TotalValue, Balance, InternalError, Error, ExternalId, NodeId, StorageMap> Tree
@@ -487,20 +508,13 @@ where
     ) -> Result<(Self::Balance, Self::NodeId), Self::Error> {
         let key = key.into();
 
-        let node = Self::get_node(key).ok_or_else(InternalError::node_not_found)?;
-
-        if node.is_consumed() {
-            return Err(InternalError::node_was_consumed().into());
-        }
-
-        let (node_with_value, maybe_key) = Self::node_with_value(node)?;
-
-        // The node here is external, specified or reserved hence has the inner value
-        let v = node_with_value
-            .value()
-            .ok_or_else(InternalError::unexpected_node_type)?;
-
-        Ok((v, maybe_key.unwrap_or(key)))
+        Self::get_limit_node_impl(key, |node| {
+            if node.is_consumed() {
+                Err(InternalError::node_was_consumed().into())
+            } else {
+                Ok(())
+            }
+        })
     }
 
     fn get_limit_node_consumed(
@@ -508,20 +522,13 @@ where
     ) -> Result<(Self::Balance, Self::NodeId), Self::Error> {
         let key = key.into();
 
-        let node = Self::get_node(key).ok_or_else(InternalError::node_not_found)?;
-
-        if !node.is_consumed() {
-            return Err(InternalError::forbidden().into());
-        }
-
-        let (node_with_value, maybe_key) = Self::node_with_value(node)?;
-
-        // The node here is external, specified or reserved hence has the inner value
-        let v = node_with_value
-            .value()
-            .ok_or_else(InternalError::unexpected_node_type)?;
-
-        Ok((v, maybe_key.unwrap_or(key)))
+        Self::get_limit_node_impl(key, |node| {
+            if !node.is_consumed() {
+                Err(InternalError::forbidden().into())
+            } else {
+                Ok(())
+            }
+        })
     }
 
     /// Marks a node with `key` as consumed, if possible, and tries to return

--- a/common/src/gas_provider/internal.rs
+++ b/common/src/gas_provider/internal.rs
@@ -503,6 +503,27 @@ where
         Ok((v, maybe_key.unwrap_or(key)))
     }
 
+    fn get_limit_node_consumed(
+        key: impl Into<Self::NodeId>,
+    ) -> Result<(Self::Balance, Self::NodeId), Self::Error> {
+        let key = key.into();
+
+        let node = Self::get_node(key).ok_or_else(InternalError::node_not_found)?;
+
+        if !node.is_consumed() {
+            return Err(InternalError::forbidden().into());
+        }
+
+        let (node_with_value, maybe_key) = Self::node_with_value(node)?;
+
+        // The node here is external, specified or reserved hence has the inner value
+        let v = node_with_value
+            .value()
+            .ok_or_else(InternalError::unexpected_node_type)?;
+
+        Ok((v, maybe_key.unwrap_or(key)))
+    }
+
     /// Marks a node with `key` as consumed, if possible, and tries to return
     /// it's value and delete it. The function performs same procedure with all
     /// the nodes on the path from it to the root, if possible.

--- a/common/src/gas_provider/internal.rs
+++ b/common/src/gas_provider/internal.rs
@@ -489,6 +489,10 @@ where
 
         let node = Self::get_node(key).ok_or_else(InternalError::node_not_found)?;
 
+        if node.is_consumed() {
+            return Err(InternalError::node_was_consumed().into());
+        }
+
         let (node_with_value, maybe_key) = Self::node_with_value(node)?;
 
         // The node here is external, specified or reserved hence has the inner value

--- a/common/src/gas_provider/internal.rs
+++ b/common/src/gas_provider/internal.rs
@@ -523,10 +523,10 @@ where
         let key = key.into();
 
         Self::get_limit_node_impl(key, |node| {
-            if !node.is_consumed() {
-                Err(InternalError::forbidden().into())
-            } else {
+            if node.is_consumed() {
                 Ok(())
+            } else {
+                Err(InternalError::forbidden().into())
             }
         })
     }

--- a/common/src/gas_provider/mod.rs
+++ b/common/src/gas_provider/mod.rs
@@ -126,11 +126,28 @@ pub trait Tree {
         key: impl Into<Self::NodeId>,
     ) -> Result<(Self::Balance, Self::NodeId), Self::Error>;
 
+    /// Get value associated with given id and the key of an consumed ancestor,
+    /// that keeps this value.
+    ///
+    /// Error occurs if the tree is invalidated (has "orphan" nodes), and the
+    /// node identified by the `key` belongs to a subtree originating at
+    /// such "orphan" node, or in case of inexistent key.
+    fn get_limit_node_consumed(
+        key: impl Into<Self::NodeId>,
+    ) -> Result<(Self::Balance, Self::NodeId), Self::Error>;
+
     /// Get value associated with given id.
     ///
     /// See [`get_limit_node`](Self::get_limit_node) for details.
     fn get_limit(key: impl Into<Self::NodeId>) -> Result<Self::Balance, Self::Error> {
         Self::get_limit_node(key).map(|(balance, _key)| balance)
+    }
+
+    /// Get value associated with given id within consumed node.
+    ///
+    /// See [`get_limit_node_consumed`](Self::get_limit_node_consumed) for details.
+    fn get_limit_consumed(key: impl Into<Self::NodeId>) -> Result<Self::Balance, Self::Error> {
+        Self::get_limit_node_consumed(key).map(|(balance, _key)| balance)
     }
 
     /// Consume underlying value.

--- a/pallets/gear/src/runtime_api.rs
+++ b/pallets/gear/src/runtime_api.rs
@@ -151,12 +151,22 @@ where
             let journal = step.execute().unwrap_or_else(|e| unreachable!("{e:?}"));
 
             let get_main_limit = || {
+                // For case when node is not consumed and has any (even zero) balance
+                // it means that it burned/sent all the funds and we must return it.
+                //
+                // For case when node is consumed and has zero balance it means that
+                // node moved its funds upstream to its ancestor. So this shouldn't
+                // be returned.
+                //
+                // For case when node is consumed and has non zero balance it means
+                // that it has gasless child that will consume gas further. So we
+                // handle this value as well.
                 GasHandlerOf::<T>::get_limit(main_message_id)
                     .ok()
                     .or_else(|| {
                         GasHandlerOf::<T>::get_limit_consumed(main_message_id)
                             .ok()
-                            .and_then(|limit| (!limit.is_zero()).then_some(limit))
+                            .filter(|limit| !limit.is_zero())
                     })
             };
 

--- a/pallets/gear/src/runtime_api.rs
+++ b/pallets/gear/src/runtime_api.rs
@@ -150,7 +150,15 @@ where
             };
             let journal = step.execute().unwrap_or_else(|e| unreachable!("{e:?}"));
 
-            let get_main_limit = || GasHandlerOf::<T>::get_limit(main_message_id).ok();
+            let get_main_limit = || {
+                GasHandlerOf::<T>::get_limit(main_message_id)
+                    .ok()
+                    .or_else(|| {
+                        GasHandlerOf::<T>::get_limit_consumed(main_message_id)
+                            .ok()
+                            .and_then(|limit| (!limit.is_zero()).then_some(limit))
+                    })
+            };
 
             let get_origin_msg_of = |msg_id| {
                 GasHandlerOf::<T>::get_origin_key(msg_id)

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -9162,11 +9162,23 @@ fn program_generator_works() {
 
         assert!(Gear::is_active(generator_id));
 
+        let GasInfo { min_limit, .. } = Gear::calculate_gas_info(
+            USER_1.into_origin(),
+            HandleKind::Handle(generator_id),
+            EMPTY_PAYLOAD.to_vec(),
+            0,
+            true,
+            true,
+        )
+        .expect("calculate_gas_info failed");
+
+        assert_ne!(min_limit, BlockGasLimitOf::<Test>::get());
+
         assert_ok!(Gear::send_message(
             RuntimeOrigin::signed(USER_1),
             generator_id,
-            vec![],
-            BlockGasLimitOf::<Test>::get(),
+            EMPTY_PAYLOAD.to_vec(),
+            min_limit,
             0
         ));
 

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -72,6 +72,7 @@ use gear_core::{
 };
 use gear_core_errors::*;
 use gear_wasm_instrument::STACK_END_EXPORT_NAME;
+use gstd::errors::Error as GstdError;
 use sp_runtime::{traits::UniqueSaturatedInto, SaturatedConversion};
 use sp_std::convert::TryFrom;
 pub use utils::init_logger;
@@ -6653,8 +6654,8 @@ fn pay_program_rent_syscall_works() {
 
         let error_text = if cfg!(any(feature = "debug", debug_assertions)) {
             format!(
-                "{PAY_PROGRAM_RENT_EXPECT}: Ext({:?})",
-                ExtError::Execution(ExecutionError::NotEnoughValue)
+                "{PAY_PROGRAM_RENT_EXPECT}: {:?}",
+                GstdError::Core(ExtError::Execution(ExecutionError::NotEnoughValue).into())
             )
         } else {
             String::from("no info")
@@ -6698,8 +6699,10 @@ fn pay_program_rent_syscall_works() {
 
         let error_text = if cfg!(any(feature = "debug", debug_assertions)) {
             format!(
-                "{PAY_PROGRAM_RENT_EXPECT}: Ext({:?})",
-                ExtError::ProgramRent(ProgramRentError::MaximumBlockCountPaid)
+                "{PAY_PROGRAM_RENT_EXPECT}: {:?}",
+                GstdError::Core(
+                    ExtError::ProgramRent(ProgramRentError::MaximumBlockCountPaid).into()
+                )
             )
         } else {
             String::from("no info")
@@ -7814,8 +7817,8 @@ fn test_create_program_with_value_lt_ed() {
 
         let error_text = if cfg!(any(feature = "debug", debug_assertions)) {
             format!(
-                "Failed to create program: Ext({:?})",
-                ExtError::Message(MessageError::InsufficientValue)
+                "Failed to create program: {:?}",
+                GstdError::Core(ExtError::Message(MessageError::InsufficientValue).into())
             )
         } else {
             String::from("no info")
@@ -7867,8 +7870,8 @@ fn test_create_program_with_exceeding_value() {
 
         let error_text = if cfg!(any(feature = "debug", debug_assertions)) {
             format!(
-                "Failed to create program: Ext({:?})",
-                ExtError::Execution(ExecutionError::NotEnoughValue)
+                "Failed to create program: {:?}",
+                GstdError::Core(ExtError::Execution(ExecutionError::NotEnoughValue).into())
             )
         } else {
             String::from("no info")


### PR DESCRIPTION
While calculating gas there is getter for current gas limit of the main node, that will be none if some error occurs in gas tree (e.g. node not found). Same should be for query of its balance (even in other functionality).
That affected calculating that way: we check balance of already consumed node that has 0 balance, so calculator means that execution burned all gas from the node, which initially equals block gas limit.