### PR TITLE
feat(gsdk): allow transaction retracted

### DIFF
--- a/gsdk/src/signer/calls.rs
+++ b/gsdk/src/signer/calls.rs
@@ -343,16 +343,16 @@ impl Signer {
                 b.block_hash(),
                 b.extrinsic_hash()
             ),
-            TxStatus::Retracted(h) => log::info!("	Status: Retracted( {h} )"),
-            TxStatus::FinalityTimeout(h) => log::info!("	Status: FinalityTimeout( {h} )"),
+            TxStatus::Retracted(h) => log::warn!("	Status: Retracted( {h} )"),
+            TxStatus::FinalityTimeout(h) => log::warn!("	Status: FinalityTimeout( {h} )"),
             TxStatus::Finalized(b) => log::info!(
                 "	Status: Finalized( block hash: {}, extrinsic hash: {} )",
                 b.block_hash(),
                 b.extrinsic_hash()
             ),
-            TxStatus::Usurped(h) => log::info!("	Status: Usurped( {h} )"),
-            TxStatus::Dropped => log::info!("	Status: Dropped"),
-            TxStatus::Invalid => log::info!("	Status: Invalid"),
+            TxStatus::Usurped(h) => log::warn!("	Status: Usurped( {h} )"),
+            TxStatus::Dropped => log::warn!("	Status: Dropped"),
+            TxStatus::Invalid => log::warn!("	Status: Invalid"),
         }
     }
 
@@ -389,7 +389,7 @@ impl Signer {
             let status = status?;
             self.log_status(&status);
             match status {
-                Future | Ready | Broadcast(_) | InBlock(_) => (),
+                Future | Ready | Broadcast(_) | InBlock(_) | Retracted(_) => (),
                 Finalized(b) => {
                     log::info!(
                         "Successfully submitted call {}::{} {} at {}!",

--- a/gsdk/src/signer/calls.rs
+++ b/gsdk/src/signer/calls.rs
@@ -344,15 +344,15 @@ impl Signer {
                 b.extrinsic_hash()
             ),
             TxStatus::Retracted(h) => log::warn!("	Status: Retracted( {h} )"),
-            TxStatus::FinalityTimeout(h) => log::warn!("	Status: FinalityTimeout( {h} )"),
+            TxStatus::FinalityTimeout(h) => log::error!("	Status: FinalityTimeout( {h} )"),
             TxStatus::Finalized(b) => log::info!(
                 "	Status: Finalized( block hash: {}, extrinsic hash: {} )",
                 b.block_hash(),
                 b.extrinsic_hash()
             ),
-            TxStatus::Usurped(h) => log::warn!("	Status: Usurped( {h} )"),
-            TxStatus::Dropped => log::warn!("	Status: Dropped"),
-            TxStatus::Invalid => log::warn!("	Status: Invalid"),
+            TxStatus::Usurped(h) => log::error!("	Status: Usurped( {h} )"),
+            TxStatus::Dropped => log::error!("	Status: Dropped"),
+            TxStatus::Invalid => log::error!("	Status: Invalid"),
         }
     }
 

--- a/gsdk/src/signer/mod.rs
+++ b/gsdk/src/signer/mod.rs
@@ -52,16 +52,15 @@ impl Signer {
     }
 
     /// Change inner signer.
-    pub fn change(self, suri: &str, passwd: Option<&str>) -> Result<Self> {
-        Ok(Self {
-            api: self.api,
-            signer: PairSigner::new(
-                Pair::from_string(suri, passwd).map_err(|_| Error::InvalidSecret)?,
-            ),
-            nonce: None,
-        })
+    pub fn change(mut self, suri: &str, passwd: Option<&str>) -> Result<Self> {
+        let signer =
+            PairSigner::new(Pair::from_string(suri, passwd).map_err(|_| Error::InvalidSecret)?);
+        self.signer = signer;
+
+        Ok(self)
     }
 
+    /// Set nonce of the signer
     pub fn set_nonce(&mut self, nonce: u32) {
         self.nonce = Some(nonce)
     }


### PR DESCRIPTION
Resolves #2962 

As the context provided in #2962, it is possible to reach the retracted event of the transactions. here in this PR we just allow `Retracted` in our processor, it is safe because the watch logic will keep working on listening the events in futures blocks unless we drop it

for the `TxProcess::wait_for_finliazed` implementation in `subxt`:

https://github.com/paritytech/subxt/blob/master/subxt/src/tx/tx_progress.rs#L106


## How to reproduce the error and why?

```bash
git clone https://github.com/gear-foundation/dapps-dex.git
cd dapps-dex
git checkout cl/retracted-txs
cargo nextest run -Fbinary-vendor state_consistency  --release --no-capture 
```

```
       START             dex-pair::state_consistency state_consistency

running 1 test
Uploaded `../target/wasm32-unknown-unknown/debug/ft_storage.opt.wasm`.
Uploaded `../target/wasm32-unknown-unknown/debug/ft_logic.opt.wasm`.
Initialized `../target/wasm32-unknown-unknown/debug/ft_main.opt.wasm`.
Error: GearSDK(Tx(Retracted(0x3428ca21b777103f2ea8fa715c4cfa4f12fb2ff057d4e446853c380e742b9e70)))
test state_consistency ... FAILED

failures:

failures:
    state_consistency

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 52.08s

        FAIL [  52.097s] dex-pair::state_consistency state_consistency
   Canceling due to test failure: 0 tests still running
------------
     Summary [  52.098s] 1 tests run: 0 passed, 1 failed, 9 skipped
        FAIL [  52.097s] dex-pair::state_consistency state_consistency
error: test run failed
```

This test sends several transactions in a short time, the txs are included in closed blocks but the transaction pool
can not process all of them

## The fixes

```
# let's assume your gear repo is located at `../gear`
cd ../gear
git fetch master
git checkout cl/issue-2962
```

```bash
git checkout cl/fix-retracted-txs
rm -rf target
cargo nextest run -Fbinary-vendor state_consistency  --release --no-capture 
```

```bash
Uploaded `../target/wasm32-unknown-unknown/release/ft_storage.opt.wasm`.
Uploaded `../target/wasm32-unknown-unknown/release/ft_logic.opt.wasm`.
Initialized `../target/wasm32-unknown-unknown/release/ft_main.opt.wasm`.
Initialized `../target/wasm32-unknown-unknown/release/ft_main.opt.wasm`.
        SLOW [> 60.000s] dex-pair::state_consistency state_consistency
test state_consistency has been running for over 60 seconds
Sending a payload: `CreatePair(ActorId([202, 236, 147, 247, 50, 91, 176, 89, 228, 161, 46, 80, 32, 86, 83, 237, 223, 130, 121, 22, 163, 85, 60, 162, 193, 231, 162, 66, 139, 136, 72, 224]), ActorId([250, 229, 207, 66, 90, 116, 231, 209, 186, 221, 10, 224, 228, 149, 50, 170, 177, 127, 101, 77, 182, 132, 64, 42, 67, 36, 178, 45, 28, 40, 23, 76]))`.
Calculated gas limit: 5175640181.
Modified gas limit: 10351280362.
Sending completed.
Error: GearSDK(Subxt(Rpc(ClientError(Call(Custom(ErrorObject { code: ServerError(8000), message: "Runtime error", data: Some(RawValue("\"Program not found in the storage\"")) }))))))
test state_consistency ... FAILED

failures:

failures:
    state_consistency

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 110.06s

        FAIL [ 110.075s] dex-pair::state_consistency state_consistency
   Canceling due to test failure: 0 tests still running
------------
     Summary [ 110.075s] 1 tests run: 0 passed, 1 failed, 9 skipped
        FAIL [ 110.075s] dex-pair::state_consistency state_consistency
error: test run failed
```

the retracted transaction problem has been resolved

@gear-tech/dev 
