### PR TITLE
refactor(common): move LockId to gear-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3870,6 +3870,7 @@ version = "0.1.0"
 dependencies = [
  "blake2-rfc",
  "derive_more",
+ "enum-iterator 1.4.1",
  "env_logger",
  "gear-core-errors",
  "gear-wasm-instrument",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3642,7 +3642,6 @@ dependencies = [
  "env_logger",
  "futures",
  "futures-timer",
- "gear-common",
  "gear-core",
  "gear-core-errors",
  "gear-utils",

--- a/common/src/gas_provider/lockable.rs
+++ b/common/src/gas_provider/lockable.rs
@@ -17,16 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::{scheduler::StorageType, *};
-use enum_iterator::Sequence;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Sequence)]
-#[repr(u8)]
-pub enum LockId {
-    Mailbox,
-    Waitlist,
-    Reservation,
-    DispatchStash,
-}
+pub use gear_core::gas::LockId;
 
 /// An error indicating there is no corresponding enum variant to the one provided
 #[derive(Debug)]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,7 @@ hex = { workspace = true, features = ["alloc"] }
 hashbrown.workspace = true
 static_assertions.workspace = true
 paste = { workspace = true }
+enum-iterator.workspace = true
 
 [dev-dependencies]
 wabt.workspace = true

--- a/core/src/gas.rs
+++ b/core/src/gas.rs
@@ -19,7 +19,22 @@
 //! Gas module.
 
 use crate::costs::RuntimeCosts;
+use enum_iterator::Sequence;
 use scale_info::scale::{Decode, Encode};
+
+/// The id of the gas lock.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Sequence)]
+#[repr(u8)]
+pub enum LockId {
+    /// The gas lock is provided by the mailbox.
+    Mailbox,
+    /// The gas lock is provided by the waitlist.
+    Waitlist,
+    /// The gas lock is provided by reservation.
+    Reservation,
+    /// The gas lock is provided by dispatch stash.
+    DispatchStash,
+}
 
 /// This trait represents a token that can be used for charging `GasCounter`.
 ///

--- a/gclient/Cargo.toml
+++ b/gclient/Cargo.toml
@@ -10,7 +10,6 @@ gear-utils.workspace = true
 gsdk = { workspace = true, features = ["testing"] }
 gear-core.workspace = true
 gear-core-errors.workspace = true
-gear-common = { workspace = true, features = ["std"] }
 
 futures.workspace = true
 anyhow.workspace = true

--- a/gclient/src/api/calls.rs
+++ b/gclient/src/api/calls.rs
@@ -18,8 +18,8 @@
 
 use super::{GearApi, Result};
 use crate::{api::storage::account_id::IntoAccountId32, utils, Error};
-use gear_common::LockId;
 use gear_core::{
+    gas::LockId,
     ids::*,
     memory::PageBuf,
     pages::{GearPage, PageNumber, PageU32Size, GEAR_PAGE_SIZE, WASM_PAGE_SIZE},


### PR DESCRIPTION
Resolves #2965 

- [x] move `LockId` to `gear-core`

@gear-tech/dev 
