### PR TITLE
feat(wasm-builder): Set optimisation params

### DIFF
--- a/utils/wasm-builder/src/optimize.rs
+++ b/utils/wasm-builder/src/optimize.rs
@@ -277,6 +277,7 @@ pub fn do_optimization(
         "z" => OptimizationOptions::new_optimize_for_size_aggressively(),
         _ => panic!("Invalid optimization level {}", optimization_level),
     }
+    .shrink_level(wasm_opt::ShrinkLevel::Level2)
     .add_pass(Pass::Dae)
     .add_pass(Pass::Vacuum)
     // the memory in our module is imported, `wasm-opt` needs to be told that

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -161,8 +161,9 @@ impl WasmProject {
         dev_profile.insert("opt-level".into(), "s".into());
 
         let mut release_profile = Table::new();
-        release_profile.insert("lto".into(), true.into());
-        release_profile.insert("opt-level".into(), "s".into());
+        release_profile.insert("lto".into(), "fat".into());
+        release_profile.insert("opt-level".into(), "z".into());
+        release_profile.insert("codegen-units".into(), 1.into());
 
         let mut production_profile = Table::new();
         production_profile.insert("inherits".into(), "release".into());
@@ -316,7 +317,7 @@ extern "C" fn metahash() {{
             let path = optimize::optimize_wasm(
                 original_copy_wasm_path.clone(),
                 opt_wasm_path.clone(),
-                "s",
+                "z",
                 true,
             )
             .map(|res| {

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -31,6 +31,8 @@ use std::{
 };
 use toml::value::Table;
 
+const OPT_LEVEL: &str = "z";
+
 /// Enum defining type of binary compiling: production program or metawasm.
 pub enum ProjectType {
     Program(Option<MetadataRepr>),
@@ -158,11 +160,11 @@ impl WasmProject {
         lib.insert("crate-type".into(), vec!["cdylib".to_string()].into());
 
         let mut dev_profile = Table::new();
-        dev_profile.insert("opt-level".into(), "s".into());
+        dev_profile.insert("opt-level".into(), OPT_LEVEL.into());
 
         let mut release_profile = Table::new();
         release_profile.insert("lto".into(), "fat".into());
-        release_profile.insert("opt-level".into(), "z".into());
+        release_profile.insert("opt-level".into(), OPT_LEVEL.into());
         release_profile.insert("codegen-units".into(), 1.into());
 
         let mut production_profile = Table::new();
@@ -317,7 +319,7 @@ extern "C" fn metahash() {{
             let path = optimize::optimize_wasm(
                 original_copy_wasm_path.clone(),
                 opt_wasm_path.clone(),
-                "z",
+                "4",
                 true,
             )
             .map(|res| {


### PR DESCRIPTION
Resolves # .

- update `fungible-token` changes from https://github.com/gear-foundation/dapps-fungible-token/pull/52.
- set `opt-level = z` in toml
- set `wasm-opt` level to 4 and shrink 2
- set `codegen-units = 1`
- set `lto = "fat"`, which is the same as `true`

These changes reduce the size of wasm artifacts and speed up programs.

`stress_transfer` benchmark (updated):
```
before: Gas burned for one transfer operation = 0.9770345439034853 * 10^9. Calculated as geometric mean from 100 transfer operations.
after:  Gas burned for one transfer operation = 0.9441607030742862 * 10^9. Calculated as geometric mean from 100 transfer operations.
```

Artifact size:

```
fungible-token upload fees

before:
4.254320105 unit
after:
3.609106373 unit
```

Before | After | program |
---|---|---
 | 54 Ki|  46 Ki | demo_async.opt.wasm | 
 | 35 Ki | 32 Ki | demo_async_custom_entry.opt.wasm | 
 | 53 Ki | 44 Ki | demo_async_init.opt.wasm | 
 | 50 Ki | 42 Ki | demo_async_recursion.opt.wasm | 
 | 51 Ki | 42 Ki | demo_async_signal_entry.opt.wasm | 
 | 55 Ki | 45 Ki | demo_async_tester.opt.wasm | 
 | 19 Ki | 18 Ki | demo_btree.opt.wasm | 
 | 18 Ki | 14 Ki | demo_calc_hash_in_one_block.opt.wasm | 
 | 37 Ki | 21 Ki | demo_calc_hash_over_blocks.opt.wasm | 
 | 51 Ki | 43 Ki | demo_compose.opt.wasm | 
 | 48 Ki | 30 Ki | demo_constructor.opt.wasm | 
 | 56 Ki | 48 Ki | demo_distributor.opt.wasm | 
 | 41 Ki | 28 Ki | demo_fungible_token.opt.wasm | 
 | 58 Ki | 48 Ki | demo_futures_unordered.opt.wasm | 
 | 51 Ki | 42 Ki | demo_incomplete_async_payloads.opt.wasm | 
 | 50 Ki | 40 Ki | demo_init_fail_sender.opt.wasm | 
 | 48 Ki | 39 Ki | demo_init_wait_reply_exit.opt.wasm | 
 | 51 Ki | 43 Ki | demo_ncompose.opt.wasm | 
 | 17 Ki | 16 Ki | demo_node.opt.wasm | 
 | 5.9 Ki |6.7 Ki | demo_piggy_bank.opt.wasm | 
 | 5.9 Ki | 5.9 Ki | demo_ping.opt.wasm | 
 | 71 Ki | 62 Ki | demo_rwlock.opt.wasm | 
 | 13 Ki | 14 Ki | demo_send_from_reservation.opt.wasm | 
 | 27 Ki | 27 Ki | demo_signal_entry.opt.wasm | 
 | 27 Ki | 13 Ki | demo_stack_allocations.opt.wasm | 
 | 50 Ki | 41 Ki | demo_sync_duplicate.opt.wasm | 
 | 56 Ki | 46 Ki | demo_wait_timeout.opt.wasm | 
 | 72 Ki | 60 Ki | demo_waiter.opt.wasm | 
 | 49 Ki | 40 Ki | demo_waiting_proxy.opt.wasm | 
 | 61 Ki | 58 Ki | test_syscalls.opt.wasm | 

@gear-tech/dev 
