### PR TITLE
Put `*.meta.txt`s in the `target` directory along with WASMs

### DIFF
--- a/gcli/tests/cmd/program.rs
+++ b/gcli/tests/cmd/program.rs
@@ -94,7 +94,7 @@ Metadata {
 
 #[test]
 fn test_command_program_metadata_works() -> Result<()> {
-    let meta = env::example_path("new-meta/demo_new_meta.meta.txt");
+    let meta = env::wasm_bin("demo_new_meta.meta.txt");
     let args = Args::new("program").action("meta").meta(meta);
     let result = common::gcli(Vec::<String>::from(args)).expect("run gcli failed");
 
@@ -109,7 +109,7 @@ fn test_command_program_metadata_works() -> Result<()> {
 
 #[test]
 fn test_command_program_metadata_derive_works() -> Result<()> {
-    let meta = env::example_path("new-meta/demo_new_meta.meta.txt");
+    let meta = env::wasm_bin("demo_new_meta.meta.txt");
     let args = Args::new("program")
         .action("meta")
         .meta(meta)

--- a/gcli/tests/common/env.rs
+++ b/gcli/tests/common/env.rs
@@ -53,8 +53,3 @@ pub fn bin(name: &str) -> String {
 pub fn wasm_bin(name: &str) -> String {
     bin_path(name, true)
 }
-
-/// path of `example/binaries` folders
-pub fn example_path(name: &str) -> String {
-    ROOT.clone() + "/examples/" + name
-}

--- a/gcli/tests/gear.rs
+++ b/gcli/tests/gear.rs
@@ -37,7 +37,7 @@ fn paths() {
         env::bin("gear"),
         env::bin("gcli"),
         env::wasm_bin("demo_new_meta.opt.wasm"),
-        env::example_path("new-meta/demo_new_meta.meta.txt"),
+        env::wasm_bin("demo_new_meta.meta.txt"),
     ]
     .into_iter()
     .for_each(|path| {

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -218,6 +218,8 @@ impl WasmProject {
                 .as_ref()
                 .expect("Run `WasmProject::create_project()` first");
 
+            fs::create_dir_all(&self.wasm_target_dir)?;
+
             let wasm_meta_path = self
                 .wasm_target_dir
                 .join([file_base_name, ".meta.txt"].concat());
@@ -394,7 +396,6 @@ extern "C" fn metahash() {{
             .join(format!("{}.wasm", &file_base_name));
 
         fs::create_dir_all(&self.target_dir)?;
-        fs::create_dir_all(&self.wasm_target_dir)?;
 
         if self.project_type.is_metawasm() {
             self.postprocess_meta(&original_wasm_path, file_base_name)?;

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -211,14 +211,14 @@ impl WasmProject {
 
         let mut source_code = "#![no_std] pub use orig_project::*;\n".to_owned();
 
+        fs::create_dir_all(&self.wasm_target_dir)?;
+
         // Write metadata
         if let Some(metadata) = &self.project_type.metadata() {
             let file_base_name = self
                 .file_base_name
                 .as_ref()
                 .expect("Run `WasmProject::create_project()` first");
-
-            fs::create_dir_all(&self.wasm_target_dir)?;
 
             let wasm_meta_path = self
                 .wasm_target_dir

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -219,7 +219,7 @@ impl WasmProject {
                 .expect("Run `WasmProject::create_project()` first");
 
             let wasm_meta_path = self
-                .original_dir
+                .wasm_target_dir
                 .join([file_base_name, ".meta.txt"].concat());
 
             smart_fs::write_metadata(wasm_meta_path, metadata)


### PR DESCRIPTION
The current location of `*.meta.txt`s is inconvenient. It's not a problem in a workspace with a single contract but becomes cumbersome in a workspace with a large number of contracts as a developer needs to open each contract folder to access multiple `*.meta.txt`s. Also this makes a CI setup more complicated since we distribute contract binaries paired with their `*.meta.txt` file and have to find the latter across all the workspace.