### PR TITLE
refactor(pallet-airdrop): Add tests and benchmarks

### DIFF
--- a/pallets/airdrop/Cargo.toml
+++ b/pallets/airdrop/Cargo.toml
@@ -45,7 +45,7 @@ pallet-gear-gas = { workspace = true, features = ["std"] }
 frame-support-test = { workspace = true, features = ["std"] }
 
 [features]
-default = ['std']
+default = ["std"]
 std = [
 	"common/std",
 	"parity-scale-codec/std",

--- a/pallets/airdrop/src/benchmarking.rs
+++ b/pallets/airdrop/src/benchmarking.rs
@@ -37,7 +37,7 @@ benchmarks! {
         <T as pallet_gear::Config>::Currency::deposit_creating(&source, (1u128 << 60).unique_saturated_into());
         let recipient: T::AccountId = benchmarking::account("recipient", 0, 0);
         // Keeping in mind the existential deposit
-        let amount = 100_000_u128.saturating_add(10_u128.saturating_mul(q.into()));
+        let amount = 10_000_000_000_000_u128.saturating_add(10_u128.saturating_mul(q.into()));
 
     }: _(RawOrigin::Root, source, recipient.clone(), amount.unique_saturated_into())
     verify {

--- a/pallets/airdrop/src/benchmarking.rs
+++ b/pallets/airdrop/src/benchmarking.rs
@@ -59,10 +59,10 @@ benchmarks! {
         let vesting_schedule = VestingInfo::new(vested_amount.unique_saturated_into(), 10u128.unique_saturated_into(),  1000u32.into());
         pallet_vesting::Pallet::<T>::vested_transfer(RawOrigin::Signed(source.clone()).into(), source_lookup, vesting_schedule)?;
 
-    }: _(RawOrigin::Root, source.clone(), recipient.clone(), 0, Some(amount.into()))
+    }: _(RawOrigin::Root, source.clone(), recipient.clone(), 0, Some(amount))
     verify {
         // check that the total vested amount is halved between the source and the recipient
-        assert_eq!(pallet_vesting::Pallet::<T>::vesting_balance(&source), Some(amount.into()));
+        assert_eq!(pallet_vesting::Pallet::<T>::vesting_balance(&source), Some(amount));
         assert_eq!(<T as pallet_vesting::Config>::Currency::free_balance(&recipient), amount);
     }
 }

--- a/pallets/airdrop/src/benchmarking.rs
+++ b/pallets/airdrop/src/benchmarking.rs
@@ -23,7 +23,8 @@ use common::{benchmarking, Origin};
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
 use frame_support::traits::Currency;
 use frame_system::RawOrigin;
-use sp_runtime::traits::UniqueSaturatedInto;
+use pallet_vesting::VestingInfo;
+use sp_runtime::traits::{StaticLookup, UniqueSaturatedInto};
 
 benchmarks! {
     where_clause { where
@@ -42,6 +43,27 @@ benchmarks! {
     }: _(RawOrigin::Root, source, recipient.clone(), amount.unique_saturated_into())
     verify {
         assert_eq!(pallet_balances::Pallet::<T>::total_balance(&recipient), amount.unique_saturated_into());
+    }
+
+    transfer_vested {
+        let q in 1 .. 256;
+
+        let source: T::AccountId = benchmarking::account("source", 0, 0);
+        let source_lookup = T::Lookup::unlookup(source.clone());
+        <T as pallet_gear::Config>::Currency::deposit_creating(&source, (1u128 << 60).unique_saturated_into());
+        let recipient: T::AccountId = benchmarking::account("recipient", 0, 0);
+        let amount = <T as pallet_vesting::Config>::MinVestedTransfer::get().saturating_mul(q.into());
+
+        // create vesting schedule amount * 2
+        let vested_amount = amount.saturating_mul(2u128.unique_saturated_into());
+        let vesting_schedule = VestingInfo::new(vested_amount.unique_saturated_into(), 10u128.unique_saturated_into(),  1000u32.into());
+        pallet_vesting::Pallet::<T>::vested_transfer(RawOrigin::Signed(source.clone()).into(), source_lookup, vesting_schedule)?;
+
+    }: _(RawOrigin::Root, source.clone(), recipient.clone(), 0, Some(amount.into()))
+    verify {
+        // check that the total vested amount is halved between the source and the recipient
+        assert_eq!(pallet_vesting::Pallet::<T>::vesting_balance(&source), Some(amount.into()));
+        assert_eq!(<T as pallet_vesting::Config>::Currency::free_balance(&recipient), amount);
     }
 }
 

--- a/pallets/airdrop/src/lib.rs
+++ b/pallets/airdrop/src/lib.rs
@@ -109,7 +109,7 @@ pub mod pallet {
         /// Emits the following events:
         /// - `TokensDeposited{ dest, amount }`
         #[pallet::call_index(0)]
-        #[pallet::weight(<T as Config>::WeightInfo::transfer())]
+        #[pallet::weight(<T as Config>::WeightInfo::transfer(1))]
         pub fn transfer(
             origin: OriginFor<T>,
             source: T::AccountId,
@@ -146,7 +146,7 @@ pub mod pallet {
         /// Emits the following events:
         /// - `VestingScheduleRemoved{ who, schedule_index }`
         #[pallet::call_index(1)]
-        #[pallet::weight(<T as Config>::WeightInfo::transfer())]
+        #[pallet::weight(<T as Config>::WeightInfo::transfer_vested(1))]
         pub fn transfer_vested(
             origin: OriginFor<T>,
             source: T::AccountId,

--- a/pallets/airdrop/src/mock.rs
+++ b/pallets/airdrop/src/mock.rs
@@ -203,6 +203,8 @@ impl pallet_vesting::Config for Test {
     const MAX_VESTING_SCHEDULES: u32 = 28;
 }
 
+pub type VestingError = pallet_vesting::Error<Test>;
+
 impl pallet_airdrop::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type WeightInfo = ();

--- a/pallets/airdrop/src/tests.rs
+++ b/pallets/airdrop/src/tests.rs
@@ -19,7 +19,7 @@
 use super::*;
 use crate::mock::{
     new_test_ext, Airdrop, AirdropCall, AirdropError, Balances, RuntimeCall, RuntimeOrigin, Sudo,
-    Test, Vesting, ALICE, BOB, ROOT,
+    Test, Vesting, VestingError, ALICE, BOB, ROOT,
 };
 use frame_support::{assert_err, assert_noop, assert_ok};
 use frame_system::Config;
@@ -76,6 +76,18 @@ fn vesting_transfer_works() {
         assert_eq!(Balances::total_balance(&BOB), 100_000_000);
         assert_eq!(Balances::total_balance(&ROOT), 100_000_000);
         assert_eq!(Balances::total_issuance(), 200_000_000);
+
+        // Vesting must exist on the source account
+        assert_err!(
+            Airdrop::transfer_vested(RuntimeOrigin::root(), ALICE, BOB, 1, Some(200_000_000)),
+            VestingError::NotVesting
+        );
+
+        // Schedule must exist on the source account
+        assert_err!(
+            Airdrop::transfer_vested(RuntimeOrigin::root(), BOB, ALICE, 1, Some(200_000_000)),
+            VestingError::ScheduleIndexOutOfBounds
+        );
 
         // Amount can't be bigger than locked funds
         assert_err!(

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -816,7 +816,7 @@ impl pallet_gear_messenger::Config for Runtime {
 
 impl pallet_airdrop::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type WeightInfo = pallet_airdrop::weights::AirdropWeight<Runtime>;
+    type WeightInfo = weights::pallet_airdrop::SubstrateWeight<Runtime>;
     type VestingSchedule = Vesting;
 }
 

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -1070,6 +1070,7 @@ mod benches {
         [pallet_timestamp, Timestamp]
         [pallet_utility, Utility]
         // Gear pallets
+        [pallet_airdrop, Airdrop]
         [pallet_gear, Gear]
         [pallet_gear_voucher, GearVoucher]
     );

--- a/runtime/vara/src/weights/mod.rs
+++ b/runtime/vara/src/weights/mod.rs
@@ -19,6 +19,7 @@
 //! A list of the different weight modules for our runtime.
 
 pub mod frame_system;
+pub mod pallet_airdrop;
 pub mod pallet_balances;
 pub mod pallet_gear;
 pub mod pallet_gear_voucher;

--- a/runtime/vara/src/weights/pallet_airdrop.rs
+++ b/runtime/vara/src/weights/pallet_airdrop.rs
@@ -43,7 +43,7 @@ pub trait WeightInfo {
 
 /// Weights for pallet_airdrop using the Gear node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
-impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+impl<T: frame_system::Config> pallet_airdrop::WeightInfo for SubstrateWeight<T> {
     /// The range of component `q` is `[1, 256]`.
     fn transfer(_q: u32, ) -> Weight {
         // Proof Size summary in bytes:


### PR DESCRIPTION
Resolves #2949  .

- Add tests for `Notvesting` and `ScheduleIndexOutOfBounds` errors
- Fix `transfer` benchmark
- Add `transfer_vested` benchmark
- Add benchmarks to runtime
- Update pallet weights

But no fee will be paid anyway as these calls are only allowed for sudo


@gear-tech/dev 
