### PR TITLE
ci(win-native): Remove cachepot as rustc_wrapper for build-win-native

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -159,7 +159,7 @@ jobs:
       - name: "ACTIONS: Setup environment variable"
         if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'E0-forcecoverage')
         run: echo "RUSTFLAGS=-Cinstrument-coverage" >> $GITHUB_ENV
-        
+
       - name: "Buid: Init"
         run: ./scripts/gear.sh init cargo
 
@@ -295,7 +295,6 @@ jobs:
       run:
         shell: msys2 {0}
     env:
-      RUSTC_WRAPPER: "cachepot"
       CARGO_INCREMENTAL: 0
     steps:
       - name: Cancel Previous Runs


### PR DESCRIPTION
Resolves #2970 .

Apparently, `cachepot` does not follow environment variables set via build scripts and prefers the ones it cached

@reviewer-or-team
