### PR TITLE
feat(weights-diff): Add memory weights

### DIFF
--- a/scripts/weight-diff.sh
+++ b/scripts/weight-diff.sh
@@ -53,3 +53,4 @@ git checkout "$current_branch"
 
 cargo run --package gear-weight-diff --release -- diff "$dump_path1" "$dump_path2" "$runtime" "instruction" $flag
 cargo run --package gear-weight-diff --release -- diff "$dump_path1" "$dump_path2" "$runtime" "host-fn" $flag
+cargo run --package gear-weight-diff --release -- diff "$dump_path1" "$dump_path2" "$runtime" "memory" $flag

--- a/utils/weight-diff/src/main.rs
+++ b/utils/weight-diff/src/main.rs
@@ -76,6 +76,7 @@ enum Runtime {
 enum WeightsKind {
     Instruction,
     HostFn,
+    Memory,
 }
 
 #[derive(Debug, Serialize)]
@@ -97,6 +98,7 @@ struct DeserializableDump {
 struct DeserializableSchedule {
     instruction_weights: IndexMap<String, serde_json::Value>,
     host_fn_weights: IndexMap<String, serde_json::Value>,
+    memory_weights: IndexMap<String, serde_json::Value>,
 }
 
 impl DeserializableSchedule {
@@ -120,6 +122,18 @@ impl DeserializableSchedule {
         let mut map = IndexMap::new();
 
         for (k, v) in self.host_fn_weights.clone() {
+            if let Ok(v) = serde_json::from_value::<Weight>(v) {
+                map.insert(k, v.ref_time());
+            }
+        }
+
+        map
+    }
+
+    fn memory_weights(&self) -> IndexMap<String, u64> {
+        let mut map = IndexMap::new();
+
+        for (k, v) in self.memory_weights.clone() {
             if let Ok(v) = serde_json::from_value::<Weight>(v) {
                 map.insert(k, v.ref_time());
             }
@@ -214,6 +228,7 @@ fn main() {
                     schedule2.instruction_weights(),
                 ),
                 WeightsKind::HostFn => (schedule1.host_fn_weights(), schedule2.host_fn_weights()),
+                WeightsKind::Memory => (schedule1.memory_weights(), schedule2.memory_weights()),
             };
 
             let mut result_map = IndexMap::new();


### PR DESCRIPTION
Add comparison for memory weights.

```bash
cargo run --package gear-weight-diff --release -- diff ./weight-dumps/master.json  ./weight-dumps/vs-refine-runtime-interface.json "gear" "memory" --display-units
```
For example:

Comparison table for Gear runtime

| name                                  | master   | vs/refine-runtime-interface | diff    |
|---------------------------------------|----------|-----------------------------|---------|
| lazy_pages_signal_read                | 28.1 µs  | 28.1 µs                     | -0.17%  |
| lazy_pages_signal_write               | 33.9 µs  | 34.9 µs                     | -2.75%  |
| lazy_pages_signal_write_after_read    | 9.1 µs   | 9.7 µs                      | -5.54%  |
| lazy_pages_host_func_read             | 29.1 µs  | 29.0 µs                     | +0.15%  |
| lazy_pages_host_func_write            | 32.3 µs  | 34.8 µs                     | -7.16%  |
| lazy_pages_host_func_write_after_read | 7.6 µs   | 10.4 µs                     | -26.92% |
| load_page_data                        | 8.9 µs   | 9.1 µs                      | -1.87%  |
| upload_page_data                      | 103.9 µs | 103.9 µs                    | -0.03%  |
| static_page                           | 100 ps   | 100 ps                      | +0.00%  |
| mem_grow                              | 299.7 ns | 298.0 ns                    | +0.58%  |
| parachain_read_heuristic              | 0 ps     | 0 ps                        | N/A     |

@reviewer-or-team
