### PR TITLE
Test sending message to terminated program from program

### DIFF
--- a/examples/constructor/src/builder.rs
+++ b/examples/constructor/src/builder.rs
@@ -77,7 +77,7 @@ impl Calls {
     }
 
     pub fn reply_code(self, key: impl AsRef<str>) -> Self {
-        self.add_call(Call::ReplyCode).store(key)
+        self.add_call(Call::ReplyCode).store_vec(key)
     }
 
     pub fn value(self, key: impl AsRef<str>) -> Self {

--- a/pallets/gear/src/queue.rs
+++ b/pallets/gear/src/queue.rs
@@ -292,7 +292,9 @@ where
             _ => {
                 // Reaching this branch is possible when init message was processed with failure,
                 // while other kind of messages were already in the queue/were added to the queue
-                // (for example. moved from wait list in case of async init)
+                // (for example. moved from wait list in case of async init).
+                // Also this branch is reachable when progam sends a message to a terminated
+                // program.
                 log::debug!("Program '{program_id:?}' is not active");
                 return ActorResult::Data(None);
             }

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -13170,8 +13170,8 @@ fn test_gas_allowance_exceed_with_context() {
     })
 }
 
-/// Test that if a message is addressed to the terminated program (sent from program)
-/// This case is handled properly - no panic occur, the message is not executed.
+/// Test that if a message is addressed to a terminated program (sent from program),
+/// then no panic occurs and the message is not executed.
 #[test]
 fn test_send_to_terminated_from_program() {
     use demo_constructor::{Arg, Calls, Scheme, WASM_BINARY as DEMO_CONSTRUCTOR_WASM_BINARY};

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -13174,7 +13174,7 @@ fn test_gas_allowance_exceed_with_context() {
 /// then no panic occurs and the message is not executed.
 #[test]
 fn test_send_to_terminated_from_program() {
-    use demo_constructor::{Arg, Calls, Scheme, WASM_BINARY as DEMO_CONSTRUCTOR_WASM_BINARY};
+    use demo_constructor::{Calls, Scheme};
 
     init_logger();
     new_test_ext().execute_with(|| {
@@ -13187,7 +13187,7 @@ fn test_send_to_terminated_from_program() {
         let (_, pid_dead) = utils::submit_constructor_with_args(
             // Using `USER_2` not to pollute `USER_1` mailbox to make test easier.
             USER_2,
-            b"salt1".to_vec(),
+            b"salt1",
             Scheme::predefined(init_dead, handle_dead, Calls::default()),
             0,
         );
@@ -13201,7 +13201,7 @@ fn test_send_to_terminated_from_program() {
         let (_, proxy_pid) = utils::submit_constructor_with_args(
             // Using `USER_2` not to pollute `USER_1` mailbox to make test easier.
             USER_2,
-            b"salt2".to_vec(),
+            b"salt2",
             Scheme::predefined(Calls::default(), handle_proxy, handle_reply_proxy),
             0,
         );


### PR DESCRIPTION
We don't allow sending message to terminated program from extrinsic (by user). But checking destination "activeness" is quite hard from the wasm execution level, i.e. when program sends message to some other terminated program.

Here we test this do not cause a panic and returns expected errors.

@gear-tech/dev 