### PR TITLE
fix(gtest): catch panic reply in RunResult

### DIFF
--- a/gtest/src/log.rs
+++ b/gtest/src/log.rs
@@ -266,11 +266,9 @@ impl PartialEq<CoreLog> for Log {
             }
         }
 
-        if matches!(self.reply_code, Some(c) if c.is_success()) {
-            if let Some(payload) = &self.payload {
-                if payload.inner() != other.payload.inner() {
-                    return false;
-                }
+        if let Some(payload) = &self.payload {
+            if payload.inner() != other.payload.inner() {
+                return false;
             }
         }
 


### PR DESCRIPTION
Resolves #3023 

@gear-tech/dev 

## Release Notes

- **Fixed bug related to missing panic replies when using the `RunResult::contains` function in `gtest`**
- There was a bug when dealing with the [`RunResult`](https://docs.gear.rs/gtest/struct.RunResult.html) containing a panic reply. Calling the [`RunResult::contains`](https://docs.gear.rs/gtest/struct.RunResult.html#method.contains) function with any payload returned `true` in case of panic result inside it.