### PR TITLE
feat(node): don't set logger hook if custom log is present

### DIFF
--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -352,7 +352,7 @@ pub fn run() -> sc_cli::Result<()> {
             Ok(())
         }
         None => {
-            let runner = if cli.run.base.validator {
+            let runner = if cli.run.base.validator && cli.run.base.shared_params.log.is_empty() {
                 cli.create_runner_with_logger_hook(&cli.run.base, |logger, _| {
                     logger.with_detailed_output(false);
                     logger.with_max_level(log::LevelFilter::Info);


### PR DESCRIPTION
Currently we can't override log filter if `--validator` flag is enabled.

@reviewer-or-team
