### PR TITLE
feat(tests, cli): Add subcommand to `gear-replay-cli` tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4035,6 +4035,7 @@ dependencies = [
  "gear-runtime-interface",
  "gear-runtime-primitives",
  "gear-service",
+ "hex",
  "log",
  "parity-scale-codec",
  "sc-cli",

--- a/utils/gear-replay-cli/Cargo.toml
+++ b/utils/gear-replay-cli/Cargo.toml
@@ -35,6 +35,7 @@ substrate-rpc-client.workspace = true
 # third-party
 codec.workspace = true
 clap = { workspace = true, features = ["derive"] }
+hex.workspace = true
 log.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 

--- a/utils/gear-replay-cli/Cargo.toml
+++ b/utils/gear-replay-cli/Cargo.toml
@@ -7,10 +7,10 @@ license.workspace = true
 
 [dependencies]
 # Internal
-vara-runtime = { workspace = true, optional = true }
-gear-runtime = { workspace = true, optional = true }
-gear-runtime-interface = { workspace = true, features = ["std"], optional = true }
+gear-runtime-interface.workspace = true
 runtime-primitives.workspace = true
+gear-runtime = { workspace = true, optional = true }
+vara-runtime = { workspace = true, optional = true }
 service = { workspace = true, optional = true }
 
 # Substrate Primitives
@@ -53,12 +53,11 @@ std = [
     "sp-externalities/std",
     "sc-executor/std",
     "frame-system/std",
+    "gear-runtime-interface/std",
     "gear-runtime?/std",
     "vara-runtime?/std",
 ]
-always-wasm = [
-    "gear-runtime-interface",
-]
+always-wasm = []
 vara-native = [
     "service/vara-native",
     "vara-runtime",

--- a/utils/gear-replay-cli/README.md
+++ b/utils/gear-replay-cli/README.md
@@ -108,7 +108,7 @@ General command format and available subcommand are:
 
 ```bash
     gear-replay-cli -h 
-    Commands of `gear-reply` CLI
+    Commands of `gear-replay` CLI
 
     Usage: gear-replay-cli [OPTIONS] <COMMAND>
 

--- a/utils/gear-replay-cli/README.md
+++ b/utils/gear-replay-cli/README.md
@@ -104,12 +104,33 @@ Another difference from the `try-runtime` API is that in `gear-replay-cli` the b
 
 In order to use the native runtime build make sure the node is built with the Runtime spec version that matches the one currently uploaded on chain.
 
-- Replay a block on Vara live chain
+General command format and available subcommand are:
+
+```bash
+    gear-replay-cli -h 
+    Commands of `gear-reply` CLI
+
+    Usage: gear-replay-cli [OPTIONS] <COMMAND>
+
+    Commands:
+    replay-block  Replay block subcommand
+    gear-run      GearRun subcommand
+    help          Print this message or the help of the given subcommand(s)
+
+    Options:
+    -u, --uri <URI>            The RPC url [default: wss://archive-rpc.vara-network.io:443]
+    -l, --log [<NODE_LOG>...]  Sets a custom logging filter. Syntax is `<target>=<level>`, e.g. -lsync=debug
+    -h, --help                 Print help (see more with '--help')
+```
+
+Currently supported cases include:
+
+- Replaying a block on a live chain
 
   - current latest finalized block on Vara chain
 
     ```bash
-    gear-replay-cli --uri wss://archive-rpc.vara-network.io:443 -lgear::runtime=debug -lpallet_gear,gear_common,pallet_gear_scheduler=debug
+    gear-replay-cli --uri wss://archive-rpc.vara-network.io:443 -lgear::runtime,pallet_gear,gear_common,pallet_gear_scheduler=debug replay-block
     ```
 
   - block with `$HASH` or `$BLOCK_NUM`
@@ -118,8 +139,8 @@ In order to use the native runtime build make sure the node is built with the Ru
     export HASH=0x8dc1e32576c1ad4e28dc141769576efdbc19d0170d427b69edb2261cfc36e905
     export BLOCK_NUM=2000000
 
-    gear-replay-cli --uri wss://archive-rpc.vara-network.io:443 --block "$HASH" -lgear::runtime=debug -lpallet_gear,gear_common=debug
-    gear-replay-cli --uri wss://archive-rpc.vara-network.io:443 --block "$BLOCK_NUM" -lgear::runtime=debug -lpallet_gear,gear_common=debug
+    gear-replay-cli --uri wss://archive-rpc.vara-network.io:443 -lgear::runtime,pallet_gear,gear_common=debug replay-block --block "$HASH"
+    gear-replay-cli --uri wss://archive-rpc.vara-network.io:443 -lgear::runtime,pallet_gear,gear_common=debug replay-block --block "$BLOCK_NUM"
     ```
 
 <br/>

--- a/utils/gear-replay-cli/src/cmd/gear_run.rs
+++ b/utils/gear-replay-cli/src/cmd/gear_run.rs
@@ -1,6 +1,6 @@
 // This file is part of Gear.
 
-// Copyright (C) 2021-2022 Gear Technologies Inc.
+// Copyright (C) 2021-2023 Gear Technologies Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/utils/gear-replay-cli/src/cmd/gear_run.rs
+++ b/utils/gear-replay-cli/src/cmd/gear_run.rs
@@ -1,0 +1,165 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Replaying a block against the live chain state
+
+use crate::{parse, util::*, BlockHashOrNumber, SharedParams, LOG_TARGET};
+use clap::Parser;
+use codec::{Decode, Joiner};
+#[cfg(feature = "always-wasm")]
+use sc_executor::sp_wasm_interface::ExtendedHostFunctions;
+#[cfg(all(not(feature = "always-wasm"), feature = "gear-native"))]
+use service::GearExecutorDispatch;
+#[cfg(all(not(feature = "always-wasm"), feature = "vara-native"))]
+use service::VaraExecutorDispatch;
+use sp_runtime::{
+    generic::SignedBlock,
+    traits::{Block as BlockT, Header as HeaderT, One},
+    ApplyExtrinsicResult, DeserializeOwned, Saturating,
+};
+use sp_state_machine::ExecutionStrategy;
+use std::{fmt::Debug, str::FromStr};
+use substrate_rpc_client::{ws_client, ChainApi};
+
+/// GearRun subcommand
+#[derive(Clone, Debug, Parser)]
+pub struct GearRunCmd<Block: BlockT> {
+    /// The block hash or number as of which the state (including the runtime) is fetched.
+    /// If omitted, the latest finalized block is used.
+    #[arg(
+		short,
+		long,
+		value_parser = parse::block,
+	)]
+    block: Option<BlockHashOrNumber<Block>>,
+}
+
+pub(crate) async fn gear_run<Block>(
+    shared: SharedParams,
+    command: GearRunCmd<Block>,
+) -> sc_cli::Result<()>
+where
+    Block: BlockT + DeserializeOwned,
+    Block::Header: DeserializeOwned,
+    Block::Hash: FromStr,
+    <Block::Hash as FromStr>::Err: Debug,
+{
+    // Initialize the RPC client.
+    // get the block number associated with this block.
+    let block_ws_uri = shared.uri.clone();
+    let rpc = ws_client(&block_ws_uri).await?;
+
+    let block_hash_or_num = match command.block.clone() {
+        Some(b) => b,
+        None => {
+            let height = ChainApi::<
+                (),
+                <Block as BlockT>::Hash,
+                <Block as BlockT>::Header,
+                SignedBlock<Block>,
+            >::finalized_head(&rpc)
+            .await
+            .map_err(rpc_err_handler)?;
+
+            log::info!(
+                target: LOG_TARGET,
+                "Block is not provided, setting it to the latest finalized head: {:?}",
+                height
+            );
+
+            BlockHashOrNumber::Hash(height)
+        }
+    };
+
+    let (block_number, block_hash) = match block_hash_or_num {
+        BlockHashOrNumber::Number(n) => (n, block_number_to_hash::<Block>(&rpc, n).await?),
+        BlockHashOrNumber::Hash(hash) => (block_hash_to_number::<Block>(&rpc, hash).await?, hash),
+    };
+
+    // Get the state at the height corresponging to the requested block.
+    log::info!(
+        target: LOG_TARGET,
+        "Fetching state from {:?} at {:?}",
+        shared.uri,
+        block_hash,
+    );
+    let ext =
+        build_externalities::<Block>(shared.uri.clone(), Some(block_hash), vec![], true).await?;
+
+    let next_hash =
+        block_number_to_hash::<Block>(&rpc, block_number.saturating_add(One::one())).await?;
+    log::info!(target: LOG_TARGET, "Fetching block {:?} ", next_hash);
+    let block = fetch_block::<Block>(&rpc, next_hash).await?;
+
+    // A digest item gets added when the runtime is processing the block, so we need to pop
+    // the last one to be consistent with what a gossiped block would contain.
+    let (mut header, extrinsics) = block.deconstruct();
+    header.digest_mut().pop();
+    let block = Block::new(header, extrinsics);
+
+    // Create executor, suitable for usage in conjunction with the preferred execution strategy.
+    #[cfg(all(not(feature = "always-wasm"), feature = "vara-native"))]
+    let executor = build_executor::<VaraExecutorDispatch>();
+    #[cfg(all(not(feature = "always-wasm"), feature = "gear-native"))]
+    let executor = build_executor::<GearExecutorDispatch>();
+    #[cfg(feature = "always-wasm")]
+    let executor = build_executor::<
+        ExtendedHostFunctions<
+            sp_io::SubstrateHostFunctions,
+            (
+                gear_runtime_interface::gear_ri::HostFunctions,
+                gear_runtime_interface::sandbox::HostFunctions,
+            ),
+        >,
+    >();
+
+    #[cfg(not(feature = "always-wasm"))]
+    let strategy = ExecutionStrategy::NativeElseWasm;
+    #[cfg(feature = "always-wasm")]
+    let strategy = ExecutionStrategy::AlwaysWasm;
+
+    let (_changes, _enc_res) = state_machine_call(
+        &ext,
+        &executor,
+        "Core_initialize_block",
+        &vec![].and(block.header()),
+        full_extensions(),
+        strategy,
+    )?;
+    log::info!(target: LOG_TARGET, "Core_initialize_block completed");
+
+    // Encoded Gear::run() extrinsic
+    let tx = vec![4_u8, 104, 6];
+
+    let (_changes, enc_res) = state_machine_call(
+        &ext,
+        &executor,
+        "BlockBuilder_apply_extrinsic",
+        &vec![].and(&tx),
+        full_extensions(),
+        strategy,
+    )?;
+    let r = ApplyExtrinsicResult::decode(&mut &enc_res[..]).unwrap();
+    log::info!(
+        target: LOG_TARGET,
+        "BlockBuilder_apply_extrinsic done with result {:?}",
+        r
+    );
+
+    Ok(())
+}

--- a/utils/gear-replay-cli/src/cmd/gear_run.rs
+++ b/utils/gear-replay-cli/src/cmd/gear_run.rs
@@ -91,7 +91,7 @@ where
         BlockHashOrNumber::Hash(hash) => (block_hash_to_number::<Block>(&rpc, hash).await?, hash),
     };
 
-    // Get the state at the height corresponging to previous block.
+    // Get the state at the height corresponding to previous block.
     let previous_hash =
         block_number_to_hash::<Block>(&rpc, current_number.saturating_sub(One::one())).await?;
     log::info!(

--- a/utils/gear-replay-cli/src/cmd/mod.rs
+++ b/utils/gear-replay-cli/src/cmd/mod.rs
@@ -1,6 +1,6 @@
 // This file is part of Gear.
 
-// Copyright (C) 2021-2022 Gear Technologies Inc.
+// Copyright (C) 2021-2023 Gear Technologies Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/utils/gear-replay-cli/src/cmd/mod.rs
+++ b/utils/gear-replay-cli/src/cmd/mod.rs
@@ -1,6 +1,6 @@
 // This file is part of Gear.
 
-// Copyright (C) 2021-2023 Gear Technologies Inc.
+// Copyright (C) 2021-2022 Gear Technologies Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,5 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#[tokio::main]
-async fn main() -> sc_cli::Result<()> {
-    gear_replay_cli::run().await
-}
+pub mod gear_run;
+pub mod replay_block;

--- a/utils/gear-replay-cli/src/cmd/replay_block.rs
+++ b/utils/gear-replay-cli/src/cmd/replay_block.rs
@@ -1,6 +1,6 @@
 // This file is part of Gear.
 
-// Copyright (C) 2021-2022 Gear Technologies Inc.
+// Copyright (C) 2021-2023 Gear Technologies Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/utils/gear-replay-cli/src/cmd/replay_block.rs
+++ b/utils/gear-replay-cli/src/cmd/replay_block.rs
@@ -1,0 +1,179 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Replaying a block against the live chain state
+
+use crate::{parse, util::*, BlockHashOrNumber, SharedParams, LOG_TARGET};
+use clap::Parser;
+use codec::Encode;
+#[cfg(feature = "always-wasm")]
+use sc_executor::sp_wasm_interface::ExtendedHostFunctions;
+#[cfg(all(not(feature = "always-wasm"), feature = "gear-native"))]
+use service::GearExecutorDispatch;
+#[cfg(all(not(feature = "always-wasm"), feature = "vara-native"))]
+use service::VaraExecutorDispatch;
+use sp_runtime::{
+    generic::SignedBlock,
+    traits::{Block as BlockT, Header as HeaderT, One},
+    DeserializeOwned, Saturating,
+};
+use sp_state_machine::ExecutionStrategy;
+use std::{fmt::Debug, str::FromStr};
+use substrate_rpc_client::{ws_client, ChainApi};
+
+/// Replay block subcommand
+#[derive(Clone, Debug, Parser)]
+pub struct ReplayBlockCmd<Block: BlockT> {
+    /// The block hash or number we want to replay. If omitted, the latest finalized block is used.
+    /// The blockchain state at previous block with respect to this parameter will be scraped.
+    #[arg(
+		short,
+		long,
+		value_parser = parse::block,
+	)]
+    block: Option<BlockHashOrNumber<Block>>,
+
+    /// Pallet(s) to scrape. Comma-separated multiple items are also accepted.
+    /// If empty, entire chain state will be scraped.
+    #[arg(short, long, num_args = 1..)]
+    pallet: Vec<String>,
+
+    /// Fetch the child-keys as well.
+    ///
+    /// Default is `false`, if specific `--pallets` are specified, `true` otherwise. In other
+    /// words, if you scrape the whole state the child tree data is included out of the box.
+    /// Otherwise, it must be enabled explicitly using this flag.
+    #[arg(long)]
+    child_tree: bool,
+}
+
+pub(crate) async fn replay_block<Block>(
+    shared: SharedParams,
+    command: ReplayBlockCmd<Block>,
+) -> sc_cli::Result<()>
+where
+    Block: BlockT + DeserializeOwned,
+    Block::Header: DeserializeOwned,
+    Block::Hash: FromStr,
+    <Block::Hash as FromStr>::Err: Debug,
+{
+    // Initialize the RPC client.
+    // get the block number associated with this block.
+    let block_ws_uri = shared.uri.clone();
+    let rpc = ws_client(&block_ws_uri).await?;
+
+    let block_hash_or_num = match command.block.clone() {
+        Some(b) => b,
+        None => {
+            let height = ChainApi::<
+                (),
+                <Block as BlockT>::Hash,
+                <Block as BlockT>::Header,
+                SignedBlock<Block>,
+            >::finalized_head(&rpc)
+            .await
+            .map_err(rpc_err_handler)?;
+
+            log::info!(
+                target: LOG_TARGET,
+                "Block is not provided, setting it to the latest finalized head: {:?}",
+                height
+            );
+
+            BlockHashOrNumber::Hash(height)
+        }
+    };
+
+    let (current_number, current_hash) = match block_hash_or_num {
+        BlockHashOrNumber::Number(n) => (n, block_number_to_hash::<Block>(&rpc, n).await?),
+        BlockHashOrNumber::Hash(hash) => (block_hash_to_number::<Block>(&rpc, hash).await?, hash),
+    };
+
+    // Get the state at the height corresponging to previous block.
+    let previous_hash =
+        block_number_to_hash::<Block>(&rpc, current_number.saturating_sub(One::one())).await?;
+    log::info!(
+        target: LOG_TARGET,
+        "Fetching state from {:?} at {:?}",
+        shared.uri,
+        previous_hash,
+    );
+    let ext = build_externalities::<Block>(
+        shared.uri.clone(),
+        Some(previous_hash),
+        command.pallet.clone(),
+        command.child_tree,
+    )
+    .await?;
+
+    log::info!(target: LOG_TARGET, "Fetching block {:?} ", current_hash);
+    let block = fetch_block::<Block>(&rpc, current_hash).await?;
+
+    // A digest item gets added when the runtime is processing the block, so we need to pop
+    // the last one to be consistent with what a gossiped block would contain.
+    let (mut header, extrinsics) = block.deconstruct();
+    header.digest_mut().pop();
+    let block = Block::new(header, extrinsics);
+
+    // Create executor, suitable for usage in conjunction with the preferred execution strategy.
+    #[cfg(all(not(feature = "always-wasm"), feature = "vara-native"))]
+    let executor = build_executor::<VaraExecutorDispatch>();
+    #[cfg(all(not(feature = "always-wasm"), feature = "gear-native"))]
+    let executor = build_executor::<GearExecutorDispatch>();
+    #[cfg(feature = "always-wasm")]
+    let executor = build_executor::<
+        ExtendedHostFunctions<
+            sp_io::SubstrateHostFunctions,
+            (
+                gear_runtime_interface::gear_ri::HostFunctions,
+                gear_runtime_interface::sandbox::HostFunctions,
+            ),
+        >,
+    >();
+
+    // for now, hardcoded for the sake of simplicity. We might customize them one day.
+    #[cfg(not(feature = "try-runtime"))]
+    let payload = block.encode();
+    #[cfg(feature = "try-runtime")]
+    let payload = (block, false, false, "none").encode();
+    #[cfg(not(feature = "try-runtime"))]
+    let method = "Core_execute_block";
+    #[cfg(feature = "try-runtime")]
+    let method = "TryRuntime_execute_block";
+
+    #[cfg(not(feature = "always-wasm"))]
+    let strategy = ExecutionStrategy::NativeElseWasm;
+    #[cfg(feature = "always-wasm")]
+    let strategy = ExecutionStrategy::AlwaysWasm;
+
+    let (_changes, _enc_res) = state_machine_call(
+        &ext,
+        &executor,
+        method,
+        &payload,
+        full_extensions(),
+        strategy,
+    )?;
+    log::info!(
+        target: LOG_TARGET,
+        "Core_execute_block for block {} completed",
+        current_number
+    );
+
+    Ok(())
+}

--- a/utils/gear-replay-cli/src/cmd/replay_block.rs
+++ b/utils/gear-replay-cli/src/cmd/replay_block.rs
@@ -112,7 +112,7 @@ where
         BlockHashOrNumber::Hash(hash) => (block_hash_to_number::<Block>(&rpc, hash).await?, hash),
     };
 
-    // Get the state at the height corresponging to previous block.
+    // Get the state at the height corresponding to previous block.
     let previous_hash =
         block_number_to_hash::<Block>(&rpc, current_number.saturating_sub(One::one())).await?;
     log::info!(
@@ -139,7 +139,7 @@ where
     header.digest_mut().pop();
 
     // In case the `Gear::run()` extrinsic has been dropped due to panic, we re-insert it here.
-    // Timestamp inherent is alwasy present hence `extrinsics` vector is not empty
+    // Timestamp inherent is always present hence `extrinsics` vector is not empty
     assert!(!extrinsics.is_empty());
 
     if command.force_run {

--- a/utils/gear-replay-cli/src/lib.rs
+++ b/utils/gear-replay-cli/src/lib.rs
@@ -43,7 +43,7 @@ pub(crate) enum BlockHashOrNumber<B: BlockT> {
     Number(NumberFor<B>),
 }
 
-/// Commands of `gear-reply` CLI
+/// Commands of `gear-replay` CLI
 #[derive(Debug, Subcommand)]
 pub enum Command {
     ReplayBlock(replay_block::ReplayBlockCmd<Block>),

--- a/utils/gear-replay-cli/src/lib.rs
+++ b/utils/gear-replay-cli/src/lib.rs
@@ -1,6 +1,6 @@
 // This file is part of Gear.
 
-// Copyright (C) 2021-2022 Gear Technologies Inc.
+// Copyright (C) 2021-2023 Gear Technologies Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/utils/gear-replay-cli/src/lib.rs
+++ b/utils/gear-replay-cli/src/lib.rs
@@ -1,0 +1,116 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2022 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Replaying a block against the live chain state
+
+use clap::{Parser, Subcommand};
+use cmd::*;
+use runtime_primitives::Block;
+use sc_tracing::logging::LoggerBuilder;
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
+use std::fmt::Debug;
+
+pub(crate) const LOG_TARGET: &str = "gear_replay";
+
+mod cmd;
+mod parse;
+mod util;
+
+const VARA_SS58_PREFIX: u8 = 137;
+const GEAR_SS58_PREFIX: u8 = 42;
+
+pub(crate) type HashFor<B> = <B as BlockT>::Hash;
+pub(crate) type NumberFor<B> = <<B as BlockT>::Header as HeaderT>::Number;
+
+#[derive(Clone, Debug)]
+pub(crate) enum BlockHashOrNumber<B: BlockT> {
+    Hash(HashFor<B>),
+    Number(NumberFor<B>),
+}
+
+/// Commands of `gear-reply` CLI
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    ReplayBlock(replay_block::ReplayBlockCmd<Block>),
+    GearRun(gear_run::GearRunCmd<Block>),
+}
+
+/// Parameters shared across the subcommands
+#[derive(Clone, Debug, Parser)]
+#[group(skip)]
+pub struct SharedParams {
+    /// The RPC url.
+    #[arg(
+		short,
+		long,
+		value_parser = parse::url,
+		default_value = "wss://archive-rpc.vara-network.io:443"
+	)]
+    uri: String,
+
+    /// Sets a custom logging filter. Syntax is `<target>=<level>`, e.g. -lsync=debug.
+    ///
+    /// Log levels (least to most verbose) are error, warn, info, debug, and trace.
+    /// By default, all targets log `info`. The global log level can be set with `-l<level>`.
+    #[arg(short = 'l', long, value_name = "NODE_LOG", num_args = 0..)]
+    pub log: Vec<String>,
+}
+
+#[derive(Debug, Parser)]
+struct ReplayCli {
+    #[clap(flatten)]
+    pub shared: SharedParams,
+
+    /// Commands.
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+impl ReplayCli {
+    fn log_filters(&self) -> sc_cli::Result<String> {
+        Ok(self.shared.log.join(","))
+    }
+
+    fn init_logger(&self) -> sc_cli::Result<()> {
+        let logger = LoggerBuilder::new(self.log_filters()?);
+        Ok(logger.init()?)
+    }
+}
+
+pub async fn run() -> sc_cli::Result<()> {
+    let options = ReplayCli::parse();
+
+    options.init_logger()?;
+
+    let ss58_prefix = match options.shared.uri.contains("vara") {
+        true => VARA_SS58_PREFIX,
+        false => GEAR_SS58_PREFIX,
+    };
+    sp_core::crypto::set_default_ss58_version(ss58_prefix.try_into().unwrap());
+
+    match &options.command {
+        Command::ReplayBlock(cmd) => {
+            cmd::replay_block::replay_block::<Block>(options.shared.clone(), cmd.clone()).await?
+        }
+        Command::GearRun(cmd) => {
+            cmd::gear_run::gear_run::<Block>(options.shared.clone(), cmd.clone()).await?
+        }
+    }
+
+    Ok(())
+}

--- a/utils/gear-replay-cli/src/lib.rs
+++ b/utils/gear-replay-cli/src/lib.rs
@@ -93,6 +93,8 @@ impl ReplayCli {
 }
 
 pub async fn run() -> sc_cli::Result<()> {
+    gear_runtime_interface::sandbox_init();
+
     let options = ReplayCli::parse();
 
     options.init_logger()?;

--- a/utils/gear-replay-cli/src/parse.rs
+++ b/utils/gear-replay-cli/src/parse.rs
@@ -1,6 +1,6 @@
 // This file is part of Gear.
 
-// Copyright (C) 2021-2022 Gear Technologies Inc.
+// Copyright (C) 2021-2023 Gear Technologies Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/utils/gear-replay-cli/src/util.rs
+++ b/utils/gear-replay-cli/src/util.rs
@@ -1,6 +1,6 @@
 // This file is part of Gear.
 
-// Copyright (C) 2021-2022 Gear Technologies Inc.
+// Copyright (C) 2021-2023 Gear Technologies Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/utils/gear-replay-cli/src/util.rs
+++ b/utils/gear-replay-cli/src/util.rs
@@ -23,11 +23,11 @@ use crate::{HashFor, NumberFor, LOG_TARGET};
 use frame_remote_externalities::{
     Builder, Mode, OnlineConfig, RemoteExternalities, TestExternalities,
 };
-use sc_executor::WasmExecutor;
 #[cfg(feature = "always-wasm")]
-use sc_executor::{sp_wasm_interface::HostFunctions, WasmtimeInstantiationStrategy};
+use sc_executor::sp_wasm_interface::HostFunctions;
 #[cfg(not(feature = "always-wasm"))]
 use sc_executor::{NativeElseWasmExecutor, NativeExecutionDispatch};
+use sc_executor::{WasmExecutor, WasmtimeInstantiationStrategy};
 use sp_core::{
     offchain::{
         testing::{TestOffchainExt, TestTransactionPoolExt},
@@ -59,7 +59,9 @@ pub(crate) fn build_executor<D: NativeExecutionDispatch>() -> NativeElseWasmExec
     let runtime_cache_size = 2;
 
     NativeElseWasmExecutor::<D>::new_with_wasm_executor(WasmExecutor::new(
-        sc_executor::WasmExecutionMethod::Interpreted,
+        sc_executor::WasmExecutionMethod::Compiled {
+            instantiation_strategy: WasmtimeInstantiationStrategy::RecreateInstanceCopyOnWrite,
+        },
         heap_pages,
         max_runtime_instances,
         None,


### PR DESCRIPTION
Existing CLI replays blocks that have already been finalized. However, if an extrinsic panicked at the time of block creation, it would have been dropped and not included in a block, thereby destroying the whole purpose of attempting to get some meaningful information about the root cause of the panic.

To circumvent that, a subcommand is being introduced that would mimic the steps of a block producer (not validator): initialize a block and apply extrinsic through calling the `BlockBuilder_apply_extrinsic` runtime api. Current implementation only supports the `Gear::run()` extrinsic, mainly because it is where the message queue is processed, but also because it doesn't have any arguments, therefore the known encoded version of it can be supplied to the runtime api call (without a need of creating an `UncheckedExtrinsic` by hand and then encoding it - that would require having the `Runtime` as an explicit dependency, which we want to avoid).