### PR TITLE
fix(gstd): log the panic message for the debugging convenience

### DIFF
--- a/gstd/src/common/handlers.rs
+++ b/gstd/src/common/handlers.rs
@@ -76,5 +76,6 @@ pub fn panic(panic_info: &PanicInfo) -> ! {
         _ => ext::panic("no info"),
     };
 
+    crate::debug!("panic occurred: {msg}");
     ext::panic(&msg)
 }


### PR DESCRIPTION
#2200 broke the the printing of panic messages in `gtest` tests due to removing a log function to do so. This PR adds it back for debug builds just before calling `gr_panic`.