### PR TITLE
chore(ci): remove missing label in `combined-dependabot.yml`

### DIFF
--- a/.github/workflows/combined-dependabot.yml
+++ b/.github/workflows/combined-dependabot.yml
@@ -137,7 +137,7 @@ jobs:
                 mergeFailedPRs.push(prString);
               }
             }
-            
+
             console.log('Creating combined PR');
             const combinedPRsString = combinedPRs.join('\n');
             let body = '✅ This PR was created by the Combine PRs action by combining the following PRs:\n' + combinedPRsString;
@@ -161,7 +161,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pull.number,
-                labels: [ "A4-insubstantial", "E1-forcewindows", "E2-forcemacos" ]
+                labels: [ "A4-insubstantial", "E2-forcemacos" ]
               });
             } catch (e) {
               console.log("Failed to add labels:", e);


### PR DESCRIPTION
We no longer have the E1-forcewindows label. This throws an error in the workflow: https://github.com/gear-tech/gear/actions/runs/5840328530/job/15839453525#step:2:208