### PR TITLE
refactor(node, core): Forbid uninited programs to pay rent, increase waitlist duration for init-messages

### DIFF
--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -13260,6 +13260,112 @@ fn test_send_to_terminated_from_program() {
     })
 }
 
+#[test]
+fn pause_waited_uninited_program() {
+    use demo_init_wait::WASM_BINARY;
+
+    init_logger();
+
+    // closure to get corresponding block numbers
+    let get_remove_block = |current_gas: u64| {
+        assert_ok!(Gear::upload_program(
+            RuntimeOrigin::signed(USER_1),
+            WASM_BINARY.to_vec(),
+            current_gas.to_le_bytes().to_vec(),
+            Vec::new(),
+            current_gas,
+            0u128
+        ));
+
+        let program_id = utils::get_last_program_id();
+
+        assert!(!Gear::is_initialized(program_id));
+        assert!(Gear::is_active(program_id));
+
+        run_to_next_block(None);
+
+        let (_, remove_from_waitlist_block) = get_last_message_waited();
+
+        let program = ProgramStorageOf::<Test>::get_program(program_id)
+            .and_then(|p| ActiveProgram::try_from(p).ok())
+            .expect("program should exist");
+
+        (remove_from_waitlist_block, program.expiration_block)
+    };
+
+    // determine such gas value that init message will be removed
+    // before an execution of the PauseProgram task
+    let gas = new_test_ext().execute_with(|| {
+        let GasInfo {
+            waited: init_waited,
+            burned,
+            ..
+        } = Gear::calculate_gas_info(
+            USER_1.into_origin(),
+            HandleKind::Init(WASM_BINARY.to_vec()),
+            vec![],
+            0,
+            true,
+            true,
+        )
+        .expect("calculate_gas_info failed");
+
+        assert!(init_waited);
+
+        let mut current_gas = 2 * burned;
+
+        let (mut remove_from_waitlist_block, mut expiration_block) = get_remove_block(current_gas);
+
+        while remove_from_waitlist_block >= expiration_block {
+            current_gas = (current_gas + burned) / 2;
+
+            (remove_from_waitlist_block, expiration_block) = get_remove_block(current_gas);
+        }
+
+        current_gas
+    });
+
+    new_test_ext().execute_with(|| {
+        assert_ok!(Gear::upload_program(
+            RuntimeOrigin::signed(USER_1),
+            WASM_BINARY.to_vec(),
+            vec![],
+            Vec::new(),
+            gas,
+            0u128
+        ));
+
+        let program_id = utils::get_last_program_id();
+
+        assert!(!Gear::is_initialized(program_id));
+        assert!(Gear::is_active(program_id));
+
+        run_to_next_block(None);
+
+        let (_, remove_from_waitlist_block) = get_last_message_waited();
+
+        assert!(!Gear::is_initialized(program_id));
+        assert!(Gear::is_active(program_id));
+
+        run_to_next_block(None);
+
+        System::set_block_number(remove_from_waitlist_block - 1);
+        Gear::set_block_number(remove_from_waitlist_block - 1);
+
+        run_to_next_block(None);
+
+        let program = ProgramStorageOf::<Test>::get_program(program_id)
+            .and_then(|p| ActiveProgram::try_from(p).ok())
+            .expect("program should exist");
+        let expiration_block = program.expiration_block;
+
+        System::set_block_number(expiration_block - 1);
+        Gear::set_block_number(expiration_block - 1);
+
+        run_to_next_block(None);
+    })
+}
+
 mod utils {
     #![allow(unused)]
 


### PR DESCRIPTION
Resolves #3073 

- test pause_waited_uninited_program
-
-

@gear-tech/dev 
