### PR TITLE
feat(cli): Add node CLI arg to set max block gas value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3686,6 +3686,7 @@ name = "gear-authorship"
 version = "0.1.0"
 dependencies = [
  "demo-mul-by-const",
+ "env_logger",
  "frame-support",
  "frame-system",
  "futures",

--- a/gsdk/src/metadata/generated.rs
+++ b/gsdk/src/metadata/generated.rs
@@ -1881,7 +1881,9 @@ pub mod runtime_types {
                     },
                     #[codec(index = 6)]
                     #[doc = "Process message queue"]
-                    run,
+                    run {
+                        max_gas: ::core::option::Option<::core::primitive::u64>,
+                    },
                     #[codec(index = 7)]
                     #[doc = "Sets `ExecuteInherent` flag."]
                     #[doc = ""]

--- a/node/authorship/Cargo.toml
+++ b/node/authorship/Cargo.toml
@@ -57,3 +57,4 @@ pallet-gear-messenger  = { workspace = true, features = ["std"] }
 testing.workspace = true
 vara-runtime  = { workspace = true, features = ["std"] }
 demo-mul-by-const.workspace = true
+env_logger.workspace = true

--- a/node/authorship/src/authorship.rs
+++ b/node/authorship/src/authorship.rs
@@ -97,6 +97,7 @@ impl<A, B, C> ProposerFactory<A, B, C, DisableProofRecording> {
         transaction_pool: Arc<A>,
         prometheus: Option<&PrometheusRegistry>,
         telemetry: Option<TelemetryHandle>,
+        max_gas: Option<u64>,
     ) -> Self {
         ProposerFactory {
             spawn_handle: Box::new(spawn_handle),
@@ -107,7 +108,7 @@ impl<A, B, C> ProposerFactory<A, B, C, DisableProofRecording> {
             telemetry,
             client,
             include_proof_in_block_size_estimation: false,
-            max_gas: None,
+            max_gas,
             _phantom: PhantomData,
         }
     }
@@ -173,11 +174,6 @@ impl<A, B, C, PR> ProposerFactory<A, B, C, PR> {
     /// are being tried with no success, hence block producer ends up creating an empty block.
     pub fn set_soft_deadline(&mut self, percent: Percent) {
         self.soft_deadline_percent = percent;
-    }
-
-    /// Set the hard limit for the block gas
-    pub fn set_block_max_gas(&mut self, max_gas: u64) {
-        self.max_gas = Some(max_gas);
     }
 }
 

--- a/node/authorship/src/block_builder.rs
+++ b/node/authorship/src/block_builder.rs
@@ -75,13 +75,17 @@ where
         self.block_builder.estimate_block_size(include_proof)
     }
 
-    pub fn create_terminal_extrinsic(&mut self) -> Result<Block::Extrinsic, Error> {
+    pub fn create_terminal_extrinsic(
+        &mut self,
+        max_gas: Option<u64>,
+    ) -> Result<Block::Extrinsic, Error> {
         let block_hash = self.parent_hash;
         self.api
             .execute_in_transaction(move |api| {
                 TransactionOutcome::Rollback(api.gear_run_extrinsic_with_context(
                     block_hash,
                     ExecutionContext::BlockConstruction,
+                    max_gas,
                 ))
             })
             .map_err(|e| Error::Application(Box::new(e)))

--- a/node/authorship/src/tests.rs
+++ b/node/authorship/src/tests.rs
@@ -158,7 +158,8 @@ fn custom_extrinsic_is_placed_in_each_block() {
     );
     assert_eq!(txpool.ready().count(), 1);
 
-    let mut proposer_factory = ProposerFactory::new(spawner, client.clone(), txpool, None, None);
+    let mut proposer_factory =
+        ProposerFactory::new(spawner, client.clone(), txpool, None, None, None);
     let timestamp_provider = sp_timestamp::InherentDataProvider::from_system_time();
     let time_slot = sp_timestamp::Timestamp::current().as_millis() / SLOT_DURATION;
 
@@ -243,7 +244,8 @@ fn proposed_storage_changes_match_execute_block_storage_changes() {
         )),
     );
 
-    let mut proposer_factory = ProposerFactory::new(spawner, client.clone(), txpool, None, None);
+    let mut proposer_factory =
+        ProposerFactory::new(spawner, client.clone(), txpool, None, None, None);
     let timestamp_provider = sp_timestamp::InherentDataProvider::from_system_time();
     let time_slot = sp_timestamp::Timestamp::current().as_millis() / SLOT_DURATION;
 
@@ -362,7 +364,7 @@ fn queue_remains_intact_if_processing_fails() {
     );
 
     let mut proposer_factory =
-        ProposerFactory::new(spawner, client.clone(), txpool.clone(), None, None);
+        ProposerFactory::new(spawner, client.clone(), txpool.clone(), None, None, None);
     let timestamp_provider = sp_timestamp::InherentDataProvider::from_system_time();
 
     let proposer = block_on(
@@ -547,9 +549,8 @@ fn block_max_gas_works() {
         )),
     );
 
-    let mut proposer_factory = ProposerFactory::new(spawner, client.clone(), txpool, None, None);
-    // Enforce a hard limit for the block gas
-    proposer_factory.set_block_max_gas(MAX_GAS);
+    let mut proposer_factory =
+        ProposerFactory::new(spawner, client.clone(), txpool, None, None, Some(MAX_GAS));
 
     let timestamp_provider = sp_timestamp::InherentDataProvider::from_system_time();
 

--- a/node/authorship/src/tests.rs
+++ b/node/authorship/src/tests.rs
@@ -91,7 +91,7 @@ fn checked_extrinsics(n: u32, signer: AccountId, nonce: &mut u32) -> Vec<Checked
                     code: WASM_BINARY.to_vec(),
                     salt: salt.as_bytes().to_vec(),
                     init_payload: (i as u64).encode(),
-                    gas_limit: 10_000_000,
+                    gas_limit: 500_000_000,
                     value: 0,
                 }),
             };
@@ -101,8 +101,17 @@ fn checked_extrinsics(n: u32, signer: AccountId, nonce: &mut u32) -> Vec<Checked
         .collect()
 }
 
+pub(crate) fn init_logger() {
+    let _ = env_logger::Builder::from_default_env()
+        .format_module_path(false)
+        .format_level(true)
+        .try_init();
+}
+
 #[test]
 fn custom_extrinsic_is_placed_in_each_block() {
+    init_logger();
+
     let client = Arc::new(
         TestClientBuilder::new()
             .set_execution_strategy(sc_client_api::ExecutionStrategy::NativeWhenPossible)
@@ -187,6 +196,8 @@ fn custom_extrinsic_is_placed_in_each_block() {
 
 #[test]
 fn proposed_storage_changes_match_execute_block_storage_changes() {
+    init_logger();
+
     let client_builder = TestClientBuilder::new()
         .set_execution_strategy(sc_client_api::ExecutionStrategy::NativeWhenPossible);
     let backend = client_builder.backend();
@@ -292,6 +303,8 @@ fn proposed_storage_changes_match_execute_block_storage_changes() {
 #[ignore = "Unstable due time timestamp inconsistency"]
 fn queue_remains_intact_if_processing_fails() {
     use sp_state_machine::IterArgs;
+
+    init_logger();
 
     let client_builder = TestClientBuilder::new()
         .set_execution_strategy(sc_client_api::ExecutionStrategy::NativeWhenPossible);
@@ -477,4 +490,121 @@ fn queue_remains_intact_if_processing_fails() {
         .unwrap()
         .for_each(|_k| queue_len += 1);
     assert_eq!(queue_len, 8);
+}
+
+#[test]
+fn block_max_gas_works() {
+    use sp_state_machine::IterArgs;
+
+    init_logger();
+
+    const INIT_MSG_GAS_LIMIT: u64 = 500_000_000;
+    const MAX_GAS: u64 = 2 * INIT_MSG_GAS_LIMIT + 25_000_100; // Enough to fit 2 messages
+
+    let client_builder = TestClientBuilder::new()
+        .set_execution_strategy(sc_client_api::ExecutionStrategy::NativeWhenPossible);
+    let backend = client_builder.backend();
+    let mut client = Arc::new(client_builder.build());
+    let spawner = sp_core::testing::TaskExecutor::new();
+    let txpool = BasicPool::new_full(
+        Default::default(),
+        true.into(),
+        None,
+        spawner.clone(),
+        client.clone(),
+    );
+
+    let genesis_hash =
+        <[u8; 32]>::try_from(&client.info().best_hash[..]).expect("H256 is a 32 byte type");
+    let mut nonce = 0_u32;
+    // Creating 5 extrinsics
+    let extrinsics = checked_extrinsics(5, bob(), &mut nonce)
+        .iter()
+        .map(|x| {
+            sign(
+                x.clone(),
+                VERSION.spec_version,
+                VERSION.transaction_version,
+                genesis_hash,
+            )
+            .into()
+        })
+        .collect::<Vec<_>>();
+
+    block_on(txpool.submit_at(&BlockId::number(0), SOURCE, extrinsics)).unwrap();
+
+    block_on(
+        txpool.maintain(chain_event(
+            client
+                .header(
+                    client
+                        .block_hash_from_id(&BlockId::Number(0_u32))
+                        .unwrap()
+                        .unwrap(),
+                )
+                .expect("header get error")
+                .expect("there should be header"),
+        )),
+    );
+
+    let mut proposer_factory = ProposerFactory::new(spawner, client.clone(), txpool, None, None);
+    // Enforce a hard limit for the block gas
+    proposer_factory.set_block_max_gas(MAX_GAS);
+
+    let timestamp_provider = sp_timestamp::InherentDataProvider::from_system_time();
+
+    let proposer = block_on(
+        proposer_factory.init(
+            &client
+                .header(
+                    client
+                        .block_hash_from_id(&BlockId::number(0))
+                        .unwrap()
+                        .unwrap(),
+                )
+                .expect("Database error querying block #0")
+                .expect("Block #0 should exist"),
+        ),
+    )
+    .expect("Proposer initialization failed");
+
+    let inherent_data =
+        block_on(timestamp_provider.create_inherent_data()).expect("Create inherent data failed");
+    let time_slot = sp_timestamp::Timestamp::current().as_millis() / SLOT_DURATION;
+
+    let proposal = block_on(proposer.propose(
+        inherent_data,
+        pre_digest(time_slot, 0),
+        time::Duration::from_secs(20),
+        None,
+    ))
+    .unwrap();
+
+    // All extrinsics have been included in the block: 1 inherent + 5 normal + 1 terminal
+    assert_eq!(proposal.block.extrinsics().len(), 7);
+
+    // Importing block #1
+    block_on(client.import(BlockOrigin::Own, proposal.block.clone())).unwrap();
+
+    let best_hash = client.info().best_hash;
+    assert_eq!(best_hash, proposal.block.hash());
+
+    let state = backend.state_at(best_hash).unwrap();
+    // Ensure message queue still has 5 messages as none of the messages fit into the gas allownce
+    let queue_entry_prefix = storage_prefix(
+        pallet_gear_messenger::Pallet::<Runtime>::name().as_bytes(),
+        "Dispatches".as_bytes(),
+    );
+    let mut queue_entry_args = IterArgs::default();
+    queue_entry_args.prefix = Some(&queue_entry_prefix);
+
+    let mut queue_len = 0_u32;
+
+    state
+        .keys(queue_entry_args)
+        .unwrap()
+        .for_each(|_k| queue_len += 1);
+
+    // 2 out of 5 messages have been processed, 3 remain in the queue
+    assert_eq!(queue_len, 3);
 }

--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -29,6 +29,10 @@ pub struct RunCmd {
     /// Force using Vara native runtime.
     #[arg(long = "force-vara")]
     pub force_vara: bool,
+
+    /// The upper limit for the amount of gas a validator can burn in one block.
+    #[arg(long, short = 'g')]
+    pub max_gas: Option<u64>,
 }
 
 #[derive(Debug, Parser)]

--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -31,7 +31,7 @@ pub struct RunCmd {
     pub force_vara: bool,
 
     /// The upper limit for the amount of gas a validator can burn in one block.
-    #[arg(long, short = 'g')]
+    #[arg(long)]
     pub max_gas: Option<u64>,
 }
 

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -362,7 +362,7 @@ pub fn run() -> sc_cli::Result<()> {
             };
 
             runner.run_node_until_exit(|config| async move {
-                service::new_full(config, cli.no_hardware_benchmarks)
+                service::new_full(config, cli.no_hardware_benchmarks, cli.run.max_gas)
                     .map_err(sc_cli::Error::Service)
             })
         }

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -485,16 +485,14 @@ where
     (with_startup_data)(&block_import, &babe_link);
 
     if let sc_service::config::Role::Authority { .. } = &role {
-        let mut proposer = authorship::ProposerFactory::new(
+        let proposer = authorship::ProposerFactory::new(
             task_manager.spawn_handle(),
             client.clone(),
             transaction_pool.clone(),
             prometheus_registry.as_ref(),
             telemetry.as_ref().map(|x| x.handle()),
+            max_gas,
         );
-        if let Some(max_gas) = max_gas {
-            proposer.set_block_max_gas(max_gas);
-        };
 
         let client_clone = client.clone();
         let slot_duration = babe_link.config().slot_duration();

--- a/pallets/gear-debug/src/mock.rs
+++ b/pallets/gear-debug/src/mock.rs
@@ -250,7 +250,7 @@ pub fn run_to_block(n: u64, remaining_weight: Option<u64>) {
             );
         }
 
-        Gear::run(frame_support::dispatch::RawOrigin::None.into()).unwrap();
+        Gear::run(frame_support::dispatch::RawOrigin::None.into(), None).unwrap();
         Gear::on_finalize(System::block_number());
 
         assert!(!System::events().iter().any(|e| {

--- a/pallets/gear-scheduler/src/mock.rs
+++ b/pallets/gear-scheduler/src/mock.rs
@@ -250,7 +250,7 @@ pub fn run_to_block(n: u64, remaining_weight: Option<u64>) {
             );
         }
 
-        Gear::run(frame_support::dispatch::RawOrigin::None.into()).unwrap();
+        Gear::run(frame_support::dispatch::RawOrigin::None.into(), None).unwrap();
         Gear::on_finalize(System::block_number());
 
         assert!(!System::events().iter().any(|e| {

--- a/pallets/gear/rpc/runtime-api/src/lib.rs
+++ b/pallets/gear/rpc/runtime-api/src/lib.rs
@@ -29,7 +29,7 @@ sp_api::decl_runtime_apis! {
         fn calculate_gas_info(source: H256, kind: HandleKind, payload: Vec<u8>, value: u128, allow_other_panics: bool, initial_gas: Option<u64>,) -> Result<GasInfo, Vec<u8>>;
 
         /// Generate inherent-like extrinsic that runs message queue processing.
-        fn gear_run_extrinsic() -> <Block as BlockT>::Extrinsic;
+        fn gear_run_extrinsic(max_gas: Option<u64>) -> <Block as BlockT>::Extrinsic;
 
         fn read_state(program_id: H256) -> Result<Vec<u8>, Vec<u8>>;
 

--- a/pallets/gear/src/benchmarking/tests/utils.rs
+++ b/pallets/gear/src/benchmarking/tests/utils.rs
@@ -76,7 +76,7 @@ where
             );
         }
 
-        Gear::<T>::run(frame_support::dispatch::RawOrigin::None.into()).unwrap();
+        Gear::<T>::run(frame_support::dispatch::RawOrigin::None.into(), None).unwrap();
         Gear::<T>::on_finalize(SystemPallet::<T>::block_number());
     }
 }

--- a/pallets/gear/src/manager/journal.rs
+++ b/pallets/gear/src/manager/journal.rs
@@ -490,6 +490,7 @@ where
         );
 
         GasAllowanceOf::<T>::decrease(gas_burned);
+        // TODO: #3112. Rework requeueing logic to avoid blocked queue.
         QueueOf::<T>::requeue(dispatch)
             .unwrap_or_else(|e| unreachable!("Message queue corrupted! {:?}", e));
     }

--- a/pallets/gear/src/mock.rs
+++ b/pallets/gear/src/mock.rs
@@ -369,7 +369,7 @@ pub fn run_to_block_maybe_with_queue(
                 QueueProcessingOf::<Test>::deny();
             }
 
-            Gear::run(frame_support::dispatch::RawOrigin::None.into()).unwrap();
+            Gear::run(frame_support::dispatch::RawOrigin::None.into(), None).unwrap();
         }
 
         Gear::on_finalize(System::block_number());

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -161,8 +161,10 @@ macro_rules! impl_runtime_apis_plus_common {
 					Gear::calculate_gas_info(account_id, kind, payload, value, allow_other_panics, initial_gas)
 				}
 
-				fn gear_run_extrinsic() -> <Block as BlockT>::Extrinsic {
-					UncheckedExtrinsic::new_unsigned(Gear::run_call().into()).into()
+				fn gear_run_extrinsic(max_gas: Option<u64>) -> <Block as BlockT>::Extrinsic {
+					UncheckedExtrinsic::new_unsigned(
+						Gear::run_call(max_gas).into()
+					).into()
 				}
 
 				fn read_state(program_id: H256) -> Result<Vec<u8>, Vec<u8>> {

--- a/runtime/vara/src/integration_tests.rs
+++ b/runtime/vara/src/integration_tests.rs
@@ -66,7 +66,7 @@ pub(crate) fn on_initialize(new_block_number: BlockNumberFor<Runtime>) {
 
 // Run on_finalize hooks (in pallets reverse order, as they appear in AllPalletsWithSystem)
 pub(crate) fn on_finalize(current_blk: BlockNumberFor<Runtime>) {
-    Gear::run(frame_support::dispatch::RawOrigin::None.into()).unwrap();
+    Gear::run(frame_support::dispatch::RawOrigin::None.into(), None).unwrap();
     GearPayment::on_finalize(current_blk);
     GearGas::on_finalize(current_blk);
     Gear::on_finalize(current_blk);


### PR DESCRIPTION
Enables `--max-gas` command line argument to set a hard limit for the amount of gas a validator can spend in one block for the message queue processing.

Useful to reduce pressure on validators in case of the network congestion (DDoS attack or whatnot) to keep producing blocks at constant rate and not disable the queue processing completely.

Implementation wise, this value, if set, is propagated to the block authorship module in the client and then passed as a parameter to the `Gear::run()` extrinsic through a `runtime-api`, which will from now on take an `Option<u64>` as an argument.