### PR TITLE
fix(authorship): Forward-fix a test that will require the gear-bank account to exist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3677,6 +3677,7 @@ dependencies = [
  "gear-node-testing",
  "gear-runtime-primitives",
  "log",
+ "pallet-balances",
  "pallet-gear",
  "pallet-gear-messenger",
  "pallet-gear-rpc-runtime-api",

--- a/node/authorship/Cargo.toml
+++ b/node/authorship/Cargo.toml
@@ -52,6 +52,7 @@ sp-consensus-babe = { workspace = true, features = ["std"] }
 sp-state-machine = { workspace = true, features = ["std"] }
 pallet-sudo  = { workspace = true, features = ["std"] }
 pallet-timestamp = { workspace = true, features = ["std"] }
+pallet-balances  = { workspace = true, features = ["std"] }
 pallet-gear = { workspace = true, features = ["std"] }
 pallet-gear-messenger  = { workspace = true, features = ["std"] }
 testing.workspace = true


### PR DESCRIPTION
The `pallet-bank` that is about to be merged introduces the bank account and requires the latter exists at the time an `init_package` is created. This would make one of the tests fail.
The current PR forward-fixes that.