### PR TITLE
refactor(gstd-codegen): use fully qualified paths

### DIFF
--- a/gstd/codegen/src/lib.rs
+++ b/gstd/codegen/src/lib.rs
@@ -455,7 +455,7 @@ pub fn wait_for_reply(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
 
             // Registering signal.
-            signals().register_signal(waiting_reply_to);
+            crate::async_runtime::signals().register_signal(waiting_reply_to);
 
             Ok(MessageFuture { waiting_reply_to })
         }
@@ -471,7 +471,7 @@ pub fn wait_for_reply(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
 
             // Registering signal.
-            signals().register_signal(waiting_reply_to);
+            crate::async_runtime::signals().register_signal(waiting_reply_to);
 
             Ok(CodecMessageFuture::<D> { waiting_reply_to, _marker: Default::default() })
         }
@@ -538,7 +538,7 @@ pub fn wait_create_program_for_reply(attr: TokenStream, item: TokenStream) -> To
         #function
 
         #[doc = #for_reply_docs]
-        pub fn #for_reply #for_reply_generics ( #inputs #variadic ) -> Result<CreateProgramFuture> {
+        pub fn #for_reply #for_reply_generics ( #inputs #variadic ) -> Result<crate::msg::CreateProgramFuture> {
             // Function call.
             let (waiting_reply_to, program_id) = #ident #args ?;
 
@@ -548,13 +548,13 @@ pub fn wait_create_program_for_reply(attr: TokenStream, item: TokenStream) -> To
             }
 
             // Registering signal.
-            signals().register_signal(waiting_reply_to);
+            crate::async_runtime::signals().register_signal(waiting_reply_to);
 
-            Ok(CreateProgramFuture { waiting_reply_to, program_id })
+            Ok(crate::msg::CreateProgramFuture { waiting_reply_to, program_id })
         }
 
         #[doc = #for_reply_as_docs]
-        pub fn #for_reply_as #for_reply_as_generics ( #inputs #variadic ) -> Result<CodecCreateProgramFuture<D>> {
+        pub fn #for_reply_as #for_reply_as_generics ( #inputs #variadic ) -> Result<crate::msg::CodecCreateProgramFuture<D>> {
             // Function call.
             let (waiting_reply_to, program_id) = #ident #args ?;
 
@@ -564,9 +564,9 @@ pub fn wait_create_program_for_reply(attr: TokenStream, item: TokenStream) -> To
             }
 
             // Registering signal.
-            signals().register_signal(waiting_reply_to);
+            crate::async_runtime::signals().register_signal(waiting_reply_to);
 
-            Ok(CodecCreateProgramFuture::<D> { waiting_reply_to, program_id, _marker: Default::default() })
+            Ok(crate::msg::CodecCreateProgramFuture::<D> { waiting_reply_to, program_id, _marker: Default::default() })
         }
     }
     .into()

--- a/gstd/codegen/src/lib.rs
+++ b/gstd/codegen/src/lib.rs
@@ -445,7 +445,7 @@ pub fn wait_for_reply(attr: TokenStream, item: TokenStream) -> TokenStream {
         #function
 
         #[doc = #for_reply_docs]
-        pub fn #for_reply #for_reply_generics ( #inputs #variadic ) -> Result<MessageFuture> {
+        pub fn #for_reply #for_reply_generics ( #inputs #variadic ) -> Result<crate::msg::MessageFuture> {
             // Function call.
             let waiting_reply_to = #ident #args ?;
 
@@ -457,11 +457,11 @@ pub fn wait_for_reply(attr: TokenStream, item: TokenStream) -> TokenStream {
             // Registering signal.
             crate::async_runtime::signals().register_signal(waiting_reply_to);
 
-            Ok(MessageFuture { waiting_reply_to })
+            Ok(crate::msg::MessageFuture { waiting_reply_to })
         }
 
         #[doc = #for_reply_as_docs]
-        pub fn #for_reply_as #for_reply_as_generics ( #inputs #variadic ) -> Result<CodecMessageFuture<D>> {
+        pub fn #for_reply_as #for_reply_as_generics ( #inputs #variadic ) -> Result<crate::msg::CodecMessageFuture<D>> {
             // Function call.
             let waiting_reply_to = #ident #args ?;
 
@@ -473,7 +473,7 @@ pub fn wait_for_reply(attr: TokenStream, item: TokenStream) -> TokenStream {
             // Registering signal.
             crate::async_runtime::signals().register_signal(waiting_reply_to);
 
-            Ok(CodecMessageFuture::<D> { waiting_reply_to, _marker: Default::default() })
+            Ok(crate::msg::CodecMessageFuture::<D> { waiting_reply_to, _marker: Default::default() })
         }
     }
     .into()

--- a/gstd/codegen/src/lib.rs
+++ b/gstd/codegen/src/lib.rs
@@ -419,7 +419,7 @@ pub fn wait_for_reply(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     // Generate generics.
     let decodable_ty = utils::ident("D");
-    let decodable_traits = vec![utils::ident("Decode")];
+    let decodable_traits = vec![syn::parse_quote!(crate::codec::Decode)];
     let (for_reply_generics, for_reply_as_generics) = (
         function.sig.generics.clone(),
         utils::append_generic(
@@ -524,7 +524,7 @@ pub fn wait_create_program_for_reply(attr: TokenStream, item: TokenStream) -> To
 
     // Generate generics.
     let decodable_ty = utils::ident("D");
-    let decodable_traits = vec![utils::ident("Decode")];
+    let decodable_traits = vec![syn::parse_quote!(crate::codec::Decode)];
     let (for_reply_generics, for_reply_as_generics) = (
         function.sig.generics.clone(),
         utils::append_generic(

--- a/gstd/codegen/src/lib.rs
+++ b/gstd/codegen/src/lib.rs
@@ -340,7 +340,7 @@ pub fn async_init(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     payload: T,
 ///     value: u128,
 ///     reply_deposit: u64
-/// ) -> Result<MessageFuture> {
+/// ) -> Result<crate::msg::MessageFuture> {
 ///     // Function call.
 ///     let waiting_reply_to = send_bytes(program, payload, value)?;
 ///
@@ -350,9 +350,9 @@ pub fn async_init(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     }
 ///
 ///     // Registering signal.
-///     signals().register_signal(waiting_reply_to);
+///     crate::async_runtime::signals().register_signal(waiting_reply_to);
 ///
-///     Ok(MessageFuture { waiting_reply_to })
+///     Ok(crate::msg::MessageFuture { waiting_reply_to })
 /// }
 ///
 /// /// Same as [`send_bytes`](self::send_bytes), but the program
@@ -372,7 +372,7 @@ pub fn async_init(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     payload: T,
 ///     value: u128,
 ///     reply_deposit: u64,
-/// ) -> Result<CodecMessageFuture<D>> {
+/// ) -> Result<crate::msg::CodecMessageFuture<D>> {
 ///     // Function call.
 ///     let waiting_reply_to = send_bytes(program, payload, value)?;
 ///
@@ -382,9 +382,9 @@ pub fn async_init(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     }
 ///
 ///     // Registering signal.
-///     signals().register_signal(waiting_reply_to);
+///     crate::async_runtime::signals().register_signal(waiting_reply_to);
 ///
-///     Ok(CodecMessageFuture::<D> {
+///     Ok(crate::msg::CodecMessageFuture::<D> {
 ///         waiting_reply_to,
 ///         _marker: Default::default(),
 ///     })

--- a/gstd/codegen/src/lib.rs
+++ b/gstd/codegen/src/lib.rs
@@ -367,7 +367,7 @@ pub fn async_init(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// ///
 /// /// - [`send_bytes_for_reply`](self::send_bytes_for_reply)
 /// /// - <https://docs.substrate.io/reference/scale-codec>
-/// pub fn send_bytes_for_reply_as<T: AsRef<[u8]>, D: Decode>(
+/// pub fn send_bytes_for_reply_as<T: AsRef<[u8]>, D: crate::codec::Decode>(
 ///     program: ActorId,
 ///     payload: T,
 ///     value: u128,

--- a/gstd/codegen/src/utils.rs
+++ b/gstd/codegen/src/utils.rs
@@ -20,8 +20,7 @@ use syn::{
     parse_quote,
     punctuated::Punctuated,
     token::{Comma, Plus},
-    Expr, Generics, Ident, Path, Token, TraitBound, TraitBoundModifier,
-    TypeParam, TypeParamBound,
+    Expr, Generics, Ident, Path, Token, TraitBound, TraitBoundModifier, TypeParam, TypeParamBound,
 };
 
 /// Describes how to output documentation for `_for_reply_(as)`

--- a/gstd/codegen/src/utils.rs
+++ b/gstd/codegen/src/utils.rs
@@ -20,7 +20,7 @@ use syn::{
     parse_quote,
     punctuated::Punctuated,
     token::{Comma, Plus},
-    Expr, Generics, Ident, PathArguments, PathSegment, Token, TraitBound, TraitBoundModifier,
+    Expr, Generics, Ident, Path, Token, TraitBound, TraitBoundModifier,
     TypeParam, TypeParamBound,
 };
 
@@ -119,19 +119,15 @@ pub fn wait_for_reply_docs(name: String, style: DocumentationStyle) -> (String, 
 /// # Note
 ///
 /// Only supports `TraitBound` for now.
-pub fn append_generic(mut generics: Generics, ident: Ident, traits: Vec<Ident>) -> Generics {
+pub fn append_generic(mut generics: Generics, ident: Ident, traits: Vec<Path>) -> Generics {
     let mut bounds: Punctuated<TypeParamBound, Plus> = Punctuated::new();
-    for t in traits {
+    for path in traits {
         bounds.push_value(
             TraitBound {
                 paren_token: None,
                 modifier: TraitBoundModifier::None,
                 lifetimes: None,
-                path: PathSegment {
-                    ident: t,
-                    arguments: PathArguments::None,
-                }
-                .into(),
+                path,
             }
             .into(),
         )

--- a/gstd/src/msg/async.rs
+++ b/gstd/src/msg/async.rs
@@ -20,7 +20,7 @@ use crate::{
     async_runtime::{self, signals, Lock, ReplyPoll},
     errors::{Error, Result},
     msg::macros::impl_futures,
-    prelude::{convert::AsRef, Vec},
+    prelude::Vec,
     ActorId, Config, MessageId,
 };
 use core::{

--- a/gstd/src/msg/basic.rs
+++ b/gstd/src/msg/basic.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use gear_core_errors::{ReplyCode, SignalCode};
 use gstd_codegen::wait_for_reply;
-use scale_info::scale::{Decode, Output};
+use scale_info::scale::Output;
 
 /// Message handle.
 ///

--- a/gstd/src/msg/basic.rs
+++ b/gstd/src/msg/basic.rs
@@ -18,7 +18,7 @@
 
 use crate::{
     errors::{Error, IntoResult, Result},
-    msg::{utils, CodecMessageFuture, MessageFuture},
+    msg::utils,
     prelude::{ops::RangeBounds, vec, Vec},
     ActorId, MessageId, ReservationId,
 };

--- a/gstd/src/msg/basic.rs
+++ b/gstd/src/msg/basic.rs
@@ -17,10 +17,9 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    async_runtime::signals,
     errors::{Error, IntoResult, Result},
     msg::{utils, CodecMessageFuture, MessageFuture},
-    prelude::{convert::AsRef, ops::RangeBounds, vec, Vec},
+    prelude::{ops::RangeBounds, vec, Vec},
     ActorId, MessageId, ReservationId,
 };
 use gear_core_errors::{ReplyCode, SignalCode};

--- a/gstd/src/msg/encoded.rs
+++ b/gstd/src/msg/encoded.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     errors::{Error, IntoResult, Result},
-    msg::{utils, CodecMessageFuture, MessageFuture},
+    msg::utils,
     prelude::ops::RangeBounds,
     util::with_optimized_encode,
     ActorId, MessageId, ReservationId,

--- a/gstd/src/msg/encoded.rs
+++ b/gstd/src/msg/encoded.rs
@@ -21,7 +21,6 @@
 //! decoded/encoded via SCALE Codec (<https://docs.substrate.io/v3/advanced/scale-codec/>).
 
 use crate::{
-    async_runtime::signals,
     errors::{Error, IntoResult, Result},
     msg::{utils, CodecMessageFuture, MessageFuture},
     prelude::ops::RangeBounds,

--- a/gstd/src/prog/basic.rs
+++ b/gstd/src/prog/basic.rs
@@ -18,7 +18,6 @@
 
 use crate::{common::errors::Result, ActorId, CodeId, MessageId};
 use gstd_codegen::wait_create_program_for_reply;
-use scale_info::scale::Decode;
 
 /// Create a new program from the already existing on-chain code identified by
 /// [`CodeId`].

--- a/gstd/src/prog/basic.rs
+++ b/gstd/src/prog/basic.rs
@@ -16,13 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{
-    async_runtime::signals,
-    common::errors::Result,
-    msg::{CodecCreateProgramFuture, CreateProgramFuture},
-    prelude::convert::AsRef,
-    ActorId, CodeId, MessageId,
-};
+use crate::{common::errors::Result, ActorId, CodeId, MessageId};
 use gstd_codegen::wait_create_program_for_reply;
 use scale_info::scale::Decode;
 

--- a/gstd/src/prog/encoded.rs
+++ b/gstd/src/prog/encoded.rs
@@ -16,14 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{
-    async_runtime::signals,
-    common::errors::Result,
-    msg::{CodecCreateProgramFuture, CreateProgramFuture},
-    prelude::convert::AsRef,
-    util::with_optimized_encode,
-    ActorId, CodeId, MessageId,
-};
+use crate::{common::errors::Result, util::with_optimized_encode, ActorId, CodeId, MessageId};
 use gstd_codegen::wait_create_program_for_reply;
 use scale_info::scale::{Decode, Encode};
 

--- a/gstd/src/prog/encoded.rs
+++ b/gstd/src/prog/encoded.rs
@@ -18,7 +18,7 @@
 
 use crate::{common::errors::Result, util::with_optimized_encode, ActorId, CodeId, MessageId};
 use gstd_codegen::wait_create_program_for_reply;
-use scale_info::scale::{Decode, Encode};
+use scale_info::scale::Encode;
 
 /// Same as [`create_program_bytes`](super::create_program_bytes), but allows
 /// initialize program with the encodable payload.

--- a/gstd/src/prog/generator.rs
+++ b/gstd/src/prog/generator.rs
@@ -22,7 +22,7 @@ use crate::{
     common::errors::Result, prog, util::with_optimized_encode, ActorId, CodeId, MessageId,
 };
 use gstd_codegen::wait_create_program_for_reply;
-use scale_info::scale::{alloc::vec::Vec, Decode, Encode};
+use scale_info::scale::{alloc::vec::Vec, Encode};
 
 /// Helper to create programs without setting the salt manually.
 pub struct ProgramGenerator(u64);

--- a/gstd/src/prog/generator.rs
+++ b/gstd/src/prog/generator.rs
@@ -19,13 +19,7 @@
 //! Program generation module
 
 use crate::{
-    async_runtime::signals,
-    common::errors::Result,
-    msg::{CodecCreateProgramFuture, CreateProgramFuture},
-    prelude::convert::AsRef,
-    prog,
-    util::with_optimized_encode,
-    ActorId, CodeId, MessageId,
+    common::errors::Result, prog, util::with_optimized_encode, ActorId, CodeId, MessageId,
 };
 use gstd_codegen::wait_create_program_for_reply;
 use scale_info::scale::{alloc::vec::Vec, Decode, Encode};


### PR DESCRIPTION
Resolves #3051

Changes:
- [x] remove `AsRef` from imports
- [x] rewrite `gstd-codegen` to reduce imports
- [x] use  fully qualified paths for `D: Decode`
- [x] update docs in `gstd-codegen`

@gear-tech/dev
