### PR TITLE
feat(docs): generate link to definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ test-syscalls-integrity-release:
 # Misc section
 .PHONY: doc
 doc:
-	@ RUSTDOCFLAGS="--enable-index-page -Zunstable-options -D warnings" cargo doc --no-deps \
+	@ RUSTDOCFLAGS="--enable-index-page --generate-link-to-definition -Zunstable-options -D warnings" cargo doc --no-deps \
 		-p galloc -p gclient -p gcore -p gear-backend-common -p gear-backend-sandbox \
 		-p gear-core -p gear-core-processor -p gear-lazy-pages -p gear-core-errors \
 		-p gmeta -p gstd -p gtest -p gear-wasm-builder -p gear-common \


### PR DESCRIPTION
This PR makes the documentation more user friendly because you can jump to any func, struct, enum variant, etc. Also we can enable the same for gear-foundation.
![image](https://github.com/gear-tech/gear/assets/109800286/9bec167f-5cf8-4b69-b826-5f241bcf0abd)

Running `make doc` on the local machine:
- before: `1 m 57 s`
- after: `2 m 9 s`

@gear-tech/dev
