### PR TITLE
fix(node-loader): Fix anoying error with too large RPC data

### DIFF
--- a/gsdk/src/client.rs
+++ b/gsdk/src/client.rs
@@ -37,6 +37,7 @@ use subxt::{
 
 const DEFAULT_GEAR_ENDPOINT: &str = "wss://rpc-node.gear-tech.io:443";
 const DEFAULT_TIMEOUT: u64 = 60_000;
+const ONE_HUNDRED_MEGA_BYTES: u32 = 100 * 1024 * 1024;
 
 struct Params(Option<Box<RawValue>>);
 
@@ -67,7 +68,7 @@ impl RpcClient {
                     // *WARNING*:
                     // After updating jsonrpsee to 0.20.0 and higher
                     // use another method created only for that.
-                    .max_request_body_size(100 * 1024 * 1024)
+                    .max_request_body_size(ONE_HUNDRED_MEGA_BYTES)
                     .connection_timeout(Duration::from_millis(timeout))
                     .request_timeout(Duration::from_millis(timeout))
                     .build(url)

--- a/gsdk/src/client.rs
+++ b/gsdk/src/client.rs
@@ -63,6 +63,11 @@ impl RpcClient {
         if url.starts_with("ws") {
             Ok(Self::Ws(
                 WsClientBuilder::default()
+                    // Actually that stand for the response too.
+                    // *WARNING*:
+                    // After updating jsonrpsee to 0.20.0 and higher
+                    // use another method created only for that.
+                    .max_request_body_size(100 * 1024 * 1024)
                     .connection_timeout(Duration::from_millis(timeout))
                     .request_timeout(Duration::from_millis(timeout))
                     .build(url)


### PR DESCRIPTION
Pretty frequently we receive an RPC error, which tell us that RPC payload is too big. This fixes the client side of that error.

Server side is "fixed" with running the node (loaded by `gear-node-loader`) with  `--rpc-max-response-size 100` cli param.

@gear-tech/dev 
