### PR TITLE
fix(vara): Update MAXIMUM_BLOCK_WEIGHT to 1 sec

### DIFF
--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -157,16 +157,22 @@ pub const BABE_GENESIS_EPOCH_CONFIG: sp_consensus_babe::BabeEpochConfiguration =
         allowed_slots: sp_consensus_babe::AllowedSlots::PrimaryAndSecondaryPlainSlots,
     };
 
-// We'll verify that WEIGHT_REF_TIME_PER_SECOND does not overflow, allowing us to use
+// We'll verify that WEIGHT_REF_TIME_PER_MILLIS does not overflow, allowing us to use
 // simple multiply and divide operators instead of saturating or checked ones.
-const_assert!(WEIGHT_REF_TIME_PER_SECOND.checked_div(3).is_some());
-const_assert!((WEIGHT_REF_TIME_PER_SECOND / 3).checked_mul(2).is_some());
+const_assert!(WEIGHT_REF_TIME_PER_MILLIS
+    .checked_div(MILLISECS_PER_BLOCK)
+    .is_some());
+const_assert!((WEIGHT_REF_TIME_PER_MILLIS / MILLISECS_PER_BLOCK)
+    .checked_mul(2)
+    .is_some());
 
 /// We allow for 1/3 of block time for computations, with maximum proof size.
 ///
-/// It's 2/3 sec for vara runtime with 2 second block duration.
-const MAXIMUM_BLOCK_WEIGHT: Weight =
-    Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND * 2 / 3, u64::MAX);
+/// It's 3/3 sec for vara runtime with 3 second block duration.
+const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
+    WEIGHT_REF_TIME_PER_MILLIS * MILLISECS_PER_BLOCK / 3,
+    u64::MAX,
+);
 
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -157,14 +157,10 @@ pub const BABE_GENESIS_EPOCH_CONFIG: sp_consensus_babe::BabeEpochConfiguration =
         allowed_slots: sp_consensus_babe::AllowedSlots::PrimaryAndSecondaryPlainSlots,
     };
 
-// We'll verify that WEIGHT_REF_TIME_PER_MILLIS does not overflow, allowing us to use
+// We'll verify that WEIGHT_REF_TIME_PER_SECOND does not overflow, allowing us to use
 // simple multiply and divide operators instead of saturating or checked ones.
-const_assert!(WEIGHT_REF_TIME_PER_MILLIS
-    .checked_div(MILLISECS_PER_BLOCK)
-    .is_some());
-const_assert!((WEIGHT_REF_TIME_PER_MILLIS / MILLISECS_PER_BLOCK)
-    .checked_mul(2)
-    .is_some());
+const_assert!(WEIGHT_REF_TIME_PER_SECOND.checked_div(3).is_some());
+const_assert!((WEIGHT_REF_TIME_PER_SECOND / 3).checked_mul(2).is_some());
 
 /// We allow for 1/3 of block time for computations, with maximum proof size.
 ///


### PR DESCRIPTION
3 sec block was introduced in https://github.com/gear-tech/gear/pull/2436 but MAXIMUM_BLOCK_WEIGHT wasn't changed.

This PR updates MAXIMUM_BLOCK_WEIGHT calculation using block time from constants.

@reviewer-or-team
