### PR TITLE
feat(runtime): make transaction cost multiplier smoother

### DIFF
--- a/pallets/payment/src/lib.rs
+++ b/pallets/payment/src/lib.rs
@@ -217,10 +217,8 @@ where
         let len_step = S::get().max(1); // Avoiding division by 0.
 
         let queue_len: u128 = QueueOf::<T>::len().saturated_into();
-        // min(30) in order to not goes into negative multiplier or UB.
-        // 30 is the last not negative bit in i32.
-        let pow = queue_len.saturating_div(len_step).min(30);
-        Multiplier::saturating_from_integer(1 << pow)
+        let multiplier = queue_len.saturating_div(len_step).saturating_add(1);
+        Multiplier::saturating_from_integer(multiplier)
     }
 }
 

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -278,7 +278,7 @@ impl pallet_balances::Config for Runtime {
 
 parameter_types! {
     pub const TransactionByteFee: Balance = 1;
-    pub const QueueLengthStep: u128 = 10;
+    pub const QueueLengthStep: u128 = 1000;
     pub const OperationalFeeMultiplier: u8 = 5;
 }
 

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -346,7 +346,7 @@ impl pallet_balances::Config for Runtime {
 
 parameter_types! {
     pub const TransactionByteFee: Balance = 1;
-    pub const QueueLengthStep: u128 = 10;
+    pub const QueueLengthStep: u128 = 1000;
     pub const OperationalFeeMultiplier: u8 = 5;
 }
 


### PR DESCRIPTION
- Change transaction cost multipler from `2^(QUEUE_LEN/10)` to `QUEUE_LEN/1000 + 1`.

@gear-tech/dev 
