### PR TITLE
feat(pallet-gear-rpc): read states in batch

### DIFF
--- a/pallets/gear/rpc/src/lib.rs
+++ b/pallets/gear/rpc/src/lib.rs
@@ -37,6 +37,8 @@ use sp_core::{Bytes, H256};
 use sp_runtime::traits::Block as BlockT;
 use std::sync::Arc;
 
+const MAX_BATCH_SIZE: usize = 256;
+
 /// Converts a runtime trap into a [`CallError`].
 fn runtime_error_into_rpc_error(err: impl std::fmt::Debug) -> JsonRpseeError {
     CallError::Custom(ErrorObject::owned(
@@ -358,6 +360,15 @@ where
         batch_id_payload: Vec<(H256, Bytes)>,
         at: Option<<Block as BlockT>::Hash>,
     ) -> RpcResult<Vec<Bytes>> {
+        if batch_id_payload.len() > MAX_BATCH_SIZE {
+            return Err(CallError::Custom(ErrorObject::owned(
+                8000,
+                "Runtime error",
+                Some(format!("Batch size must be lower than {MAX_BATCH_SIZE:?}")),
+            ))
+            .into());
+        }
+
         let at_hash = at.unwrap_or_else(|| self.client.info().best_hash);
 
         batch_id_payload
@@ -401,6 +412,15 @@ where
         argument: Option<Bytes>,
         at: Option<<Block as BlockT>::Hash>,
     ) -> RpcResult<Vec<Bytes>> {
+        if batch_id_payload.len() > MAX_BATCH_SIZE {
+            return Err(CallError::Custom(ErrorObject::owned(
+                8000,
+                "Runtime error",
+                Some(format!("Batch size must be lower than {MAX_BATCH_SIZE:?}")),
+            ))
+            .into());
+        }
+
         let at_hash = at.unwrap_or_else(|| self.client.info().best_hash);
 
         batch_id_payload


### PR DESCRIPTION
By this call rpc users can avoid network bottleneck by reading states in one iteration.

This is useful for indexers or for example to fetch all nft contracts.

Usage:
```bash
❯ curl -s -H "Content-Type: application/json" -d '{
   "id":1,
   "jsonrpc":"2.0",
   "method":"gear_readStateBatch",
   "params":[
      [
         [
            "0x6f3abd2d1c8d71812eefdda68228bdf80053ca6549d8b13897a671a8580e9d64",
            "0x00"
         ],
         [
            "0x93ad566cbf9c10f33a0f63026379177b983bbab86e8a0529dfa38837d8f42487",
            "0x00"
         ]
      ]
   ]
} http://127.0.0.1:9944

{
   "jsonrpc":"2.0",
   "result":[
      "0x0026c7026331ed7e90eb5a6fad656c910839182d8fabd77a4bcd6a62b7b0fb967a00000c616161107777777700000000000000000000000000000000000000000000000000000000000000000426c7026331ed7e90eb5a6fad656c910839182d8fabd77a4bcd6a62b7b0fb967a000000",
      "0x0026c7026331ed7e90eb5a6fad656c910839182d8fabd77a4bcd6a62b7b0fb967a00001c50505050505050184f4f4f4f4f4f00000000000000000000000000000000000000000000000000000000000000000426c7026331ed7e90eb5a6fad656c910839182d8fabd77a4bcd6a62b7b0fb967a000000"
   ],
   "id":1
}
```

todo:

- [ ] find a way to run it in one copy (collect results)

@reviewer-or-team
