### PR TITLE
refactor(core): Change Debug/Display implementation for Payload

### DIFF
--- a/core/src/buffer.rs
+++ b/core/src/buffer.rs
@@ -38,8 +38,8 @@ use scale_info::{
 pub struct LimitedVec<T, E, const N: usize>(Vec<T>, PhantomData<E>);
 
 impl<T: Clone + Default, E: Default, const N: usize> Display for LimitedVec<T, E, N>
-    where
-        [T]: AsRef<[u8]>,
+where
+    [T]: AsRef<[u8]>,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let len = self.0.len();

--- a/core/src/buffer.rs
+++ b/core/src/buffer.rs
@@ -53,11 +53,9 @@ where
                 e1 = precision;
                 s2 = len - precision;
             }
-        } else if !f.sign_plus() {
-            if median > 8 {
-                e1 = 8;
-                s2 = len - 8;
-            }
+        } else if !f.sign_plus() && median > 8 {
+            e1 = 8;
+            s2 = len - 8;
         }
 
         let p1 = hex::encode(&self.0[..e1]);

--- a/core/src/buffer.rs
+++ b/core/src/buffer.rs
@@ -53,6 +53,11 @@ where
                 e1 = precision;
                 s2 = len - precision;
             }
+        } else if !f.sign_plus() {
+            if median > 8 {
+                e1 = 8;
+                s2 = len - 8;
+            }
         }
 
         let p1 = hex::encode(&self.0[..e1]);
@@ -276,8 +281,13 @@ mod test {
 
         // `Debug`/`Display`.
         assert_eq!(
-            format!("{buffer:?}"),
+            format!("{buffer:+?}"),
             "0x6162636465666768696a6b6c6d6e6f707172737475767778797a303132333435"
+        );
+        // `Debug`/`Display` with default precision.
+        assert_eq!(
+            format!("{buffer:?}"),
+            "0x6162636465666768..797a303132333435"
         );
         // `Debug`/`Display` with precision 0.
         assert_eq!(format!("{buffer:.0?}"), "0x..");
@@ -292,14 +302,19 @@ mod test {
             format!("{buffer:.15?}"),
             "0x6162636465666768696a6b6c6d6e6f..72737475767778797a303132333435"
         );
-        // `Debug`/`Display` with precision 30 (the same for any case >= 16).
+        // `Debug`/`Display` with precision 30.
         assert_eq!(
             format!("{buffer:.30?}"),
             "0x6162636465666768696a6b6c6d6e6f707172737475767778797a303132333435"
         );
-        // Alternate formatter.
+        // Alternate formatter with default precision.
         assert_eq!(
             format!("{buffer:#}"),
+            "LimitedVec(0x6162636465666768..797a303132333435)"
+        );
+        // Alternate formatter with max precision.
+        assert_eq!(
+            format!("{buffer:+#}"),
             "LimitedVec(0x6162636465666768696a6b6c6d6e6f707172737475767778797a303132333435)"
         );
         // Alternate formatter with precision 2.

--- a/core/src/buffer.rs
+++ b/core/src/buffer.rs
@@ -37,6 +37,7 @@ use scale_info::{
 #[derive(Clone, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Decode, Encode, TypeInfo)]
 pub struct LimitedVec<T, E, const N: usize>(Vec<T>, PhantomData<E>);
 
+/// Formatter for [`LimitedVec`] will print to precision of 8 by default, to print the whole data, use `{:+}`.
 impl<T: Clone + Default, E: Default, const N: usize> Display for LimitedVec<T, E, N>
 where
     [T]: AsRef<[u8]>,


### PR DESCRIPTION
Changes the Display and Debug implementations for `LimitedVec`, reusing the code from `declare_id` macro. This allows the formatting of the Payload to be formatted without printing the entire payload, which can be up to 8MiB. This applies to Messages and Packets aswell.

@gear-tech/dev 
