### PR TITLE
fix(runtime-fuzzer): Fix fuzzer coverage script

### DIFF
--- a/docker/runtime-fuzzer/Dockerfile
+++ b/docker/runtime-fuzzer/Dockerfile
@@ -18,7 +18,7 @@ RUN apt update -y && \
     rustup target add wasm32-unknown-unknown --toolchain nightly; \
     rustup default nightly; \
     # Install cargo-fuzz \
-    cargo install --git https://github.com/rust-fuzz/cargo-fuzz; \
+    cargo install --version 0.11.2 cargo-fuzz; \
     # Set rights \
     chmod +x ./scripts/gear.sh && \
     # Create dir for corpus \

--- a/docker/runtime-fuzzer/scripts/fuzzer.sh
+++ b/docker/runtime-fuzzer/scripts/fuzzer.sh
@@ -67,7 +67,8 @@ function start_container_post {
      	-c "cargo install cargo-binutils && \
 		rustup component add llvm-tools-preview && \
 		rustup component add --toolchain nightly llvm-tools-preview && \
-		cargo fuzz coverage --release --sanitizer=none main /corpus/main && \
+		cargo fuzz coverage --release --sanitizer=none main /corpus/main -- \
+        -rss_limit_mb=8192 -max_len=35000000 -len_control=0 && \
 		cargo cov -- show target/x86_64-unknown-linux-gnu/coverage/x86_64-unknown-linux-gnu/release/main \
         --format=text \
         --show-line-counts \

--- a/utils/runtime-fuzzer/README.md
+++ b/utils/runtime-fuzzer/README.md
@@ -19,7 +19,7 @@ cd utils/runtime-fuzzer
 # Fuzzer expects a minimal input size of 25 MiB. Without providing a corpus of the same or larger
 # size fuzzer will stuck for a long time with trying to test the target using 0..100 bytes.
 mkdir -p fuzz/corpus/main
-dd if=/dev/urandom of=fuzz/corpus/main/check-fuzzer-bytes bs=1 count=27000000
+dd if=/dev/urandom of=fuzz/corpus/main/fuzzer-seed-corpus bs=1 count=27000000
 
 # Run fuzzer for at least 20 minutes and then press Ctrl-C to stop fuzzing.
 # You can also remove RUST_LOG to avoid printing tons of logs on terminal.


### PR DESCRIPTION
When installing `cargo-fuzz` from github it requires additional params used when fuzzing for creating a proper coverage report

@gear-tech/dev 
