### PR TITLE
fix(node-loader): Handle tx not found errors

### DIFF
--- a/utils/node-loader/src/batch_pool/api/nonce.rs
+++ b/utils/node-loader/src/batch_pool/api/nonce.rs
@@ -66,6 +66,7 @@ fn is_missed_nonce_err(err: &GClientError) -> bool {
     err_str.contains(&utils::SUBXT_RPC_CALL_ERR_STR.to_lowercase())
         || err_str.contains(&utils::TRANSACTION_INVALID.to_lowercase())
         || err_str.contains(&utils::TRANSACTION_DROPPED.to_lowercase())
+        || err_str.contains(&utils::TRANSACTION_WASNT_FOUND.to_lowercase())
 }
 
 #[test]

--- a/utils/node-loader/src/utils.rs
+++ b/utils/node-loader/src/utils.rs
@@ -31,6 +31,7 @@ pub const SUBXT_RPC_CALL_ERR_STR: &str = "Transaction would exhaust the block li
 pub const EVENTS_TIMEOUT_ERR_STR: &str = "Block events timeout";
 pub const TRANSACTION_INVALID: &str = "Transaction Invalid";
 pub const TRANSACTION_DROPPED: &str = "Transaction Dropped";
+pub const TRANSACTION_WASNT_FOUND: &str = "Transaction wasn't found";
 pub const WAITING_TX_FINALIZED_TIMEOUT_ERR_STR: &str =
     "Transaction finalization wait timeout is reached";
 


### PR DESCRIPTION
When Tx not found error occurres, all following batches end up with an error `Rpc error: RPC error: The background task been terminated because: Invalid request ID; restart required`. That's very hard to reproduce and pretty obscure situation, but from error string it seems that we need not to re-instantiate client (`GearApi` instance).

This PR is a try to solve the issue with a little blood.

@gear-tech/dev 
