### PR TITLE
refactor(pallet-gear): Allow `calculate_gas_info` on terminated program.

### DIFF
--- a/pallets/gear/src/runtime_api.rs
+++ b/pallets/gear/src/runtime_api.rs
@@ -127,10 +127,6 @@ where
                 break;
             };
 
-            //let actor = ext_manager
-            //    .get_actor(actor_id)
-            //    .ok_or_else(|| b"Program not found in the storage".to_vec())?;
-
             let actor_id = queued_dispatch.destination();
             let dispatch_id = queued_dispatch.id();
             let dispatch_reply = queued_dispatch.reply_details().is_some();

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -14320,6 +14320,45 @@ fn gear_block_number_math_adds_up() {
     })
 }
 
+#[test]
+fn test_gas_info_of_terminated_program() {
+    use demo_constructor::{Calls, Scheme};
+
+    init_logger();
+    new_test_ext().execute_with(|| {
+        // Dies in init
+        let init_dead = Calls::builder().panic("Die in init");
+        let handle_dead = Calls::builder().panic("Called after being terminated!");
+        let (_, pid_dead) = utils::submit_constructor_with_args(
+            USER_1,
+            b"salt1",
+            Scheme::predefined(init_dead, handle_dead, Calls::default()),
+            0,
+        );
+
+        // Sends in handle message do dead program
+        let handle_proxy = Calls::builder().send(pid_dead.into_bytes(), []);
+        let (_, proxy_pid) = utils::submit_constructor_with_args(
+            USER_1,
+            b"salt2",
+            Scheme::predefined(Calls::default(), handle_proxy, Calls::default()),
+            0,
+        );
+
+        run_to_next_block(None);
+
+        let _gas_info = Gear::calculate_gas_info(
+            USER_1.into_origin(),
+            HandleKind::Handle(proxy_pid),
+            EMPTY_PAYLOAD.to_vec(),
+            0,
+            true,
+            true,
+        )
+        .expect("failed getting gas info");
+    })
+}
+
 mod utils {
     #![allow(unused)]
 
@@ -15250,43 +15289,4 @@ mod utils {
     pub(super) fn gas_price(gas: u64) -> u128 {
         <Test as pallet_gear_bank::Config>::GasMultiplier::get().gas_to_value(gas)
     }
-}
-
-#[test]
-fn test_gas_info_of_terminated_program() {
-    use demo_constructor::{Calls, Scheme};
-
-    init_logger();
-    new_test_ext().execute_with(|| {
-        // Dies in init
-        let init_dead = Calls::builder().panic("Die in init");
-        let handle_dead = Calls::builder().panic("Called after being terminated!");
-        let (_, pid_dead) = utils::submit_constructor_with_args(
-            USER_1,
-            b"salt1",
-            Scheme::predefined(init_dead, handle_dead, Calls::default()),
-            0,
-        );
-
-        // Sends in handle message do dead program
-        let handle_proxy = Calls::builder().send(pid_dead.into_bytes(), []);
-        let (_, proxy_pid) = utils::submit_constructor_with_args(
-            USER_1,
-            b"salt2",
-            Scheme::predefined(Calls::default(), handle_proxy, Calls::default()),
-            0,
-        );
-
-        run_to_next_block(None);
-
-        let _gas_info = Gear::calculate_gas_info(
-            USER_1.into_origin(),
-            HandleKind::Handle(proxy_pid),
-            EMPTY_PAYLOAD.to_vec(),
-            0,
-            true,
-            true,
-        )
-        .expect("failed getting gas info");
-    })
 }

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -15287,6 +15287,6 @@ fn test_gas_info_of_terminated_program() {
             true,
             true,
         )
-        .expect("failed getting gas info"); // panics here as `pid_dead` is terminated and rpc call wasn't able to get code.
+        .expect("failed getting gas info");
     })
 }

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -15263,7 +15263,7 @@ fn test_gas_info_of_terminated_program() {
         let handle_dead = Calls::builder().panic("Called after being terminated!");
         let (_, pid_dead) = utils::submit_constructor_with_args(
             USER_1,
-            b"salt1".to_vec(),
+            b"salt1",
             Scheme::predefined(init_dead, handle_dead, Calls::default()),
             0,
         );
@@ -15272,7 +15272,7 @@ fn test_gas_info_of_terminated_program() {
         let handle_proxy = Calls::builder().send(pid_dead.into_bytes(), []);
         let (_, proxy_pid) = utils::submit_constructor_with_args(
             USER_1,
-            b"salt2".to_vec(),
+            b"salt2",
             Scheme::predefined(Calls::default(), handle_proxy, Calls::default()),
             0,
         );

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -15251,3 +15251,42 @@ mod utils {
         <Test as pallet_gear_bank::Config>::GasMultiplier::get().gas_to_value(gas)
     }
 }
+
+#[test]
+fn test_gas_info_of_terminated_program() {
+    use demo_constructor::{Calls, Scheme};
+
+    init_logger();
+    new_test_ext().execute_with(|| {
+        // Dies in init
+        let init_dead = Calls::builder().panic("Die in init");
+        let handle_dead = Calls::builder().panic("Called after being terminated!");
+        let (_, pid_dead) = utils::submit_constructor_with_args(
+            USER_1,
+            b"salt1".to_vec(),
+            Scheme::predefined(init_dead, handle_dead, Calls::default()),
+            0,
+        );
+
+        // Sends in handle message do dead program
+        let handle_proxy = Calls::builder().send(pid_dead.into_bytes(), []);
+        let (_, proxy_pid) = utils::submit_constructor_with_args(
+            USER_1,
+            b"salt2".to_vec(),
+            Scheme::predefined(Calls::default(), handle_proxy, Calls::default()),
+            0,
+        );
+
+        run_to_next_block(None);
+
+        let _gas_info = Gear::calculate_gas_info(
+            USER_1.into_origin(),
+            HandleKind::Handle(proxy_pid),
+            EMPTY_PAYLOAD.to_vec(),
+            0,
+            true,
+            true,
+        )
+        .expect("failed getting gas info"); // panics here as `pid_dead` is terminated and rpc call wasn't able to get code.
+    })
+}


### PR DESCRIPTION
Resolves #3008.

@reviewer-or-team
