### PR TITLE
chore(tests): Adjust `block_max_gas_works` test of gear-authorship

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3752,6 +3752,7 @@ dependencies = [
  "pallet-balances",
  "pallet-gear",
  "pallet-gear-messenger",
+ "pallet-gear-program",
  "pallet-gear-rpc-runtime-api",
  "pallet-sudo",
  "pallet-timestamp",

--- a/node/authorship/Cargo.toml
+++ b/node/authorship/Cargo.toml
@@ -58,6 +58,6 @@ pallet-gear-messenger  = { workspace = true, features = ["std"] }
 pallet-gear-program = { workspace = true, features = ["std"] }
 testing = {workspace = true, features = ["vara-native"] }
 vara-runtime  = { workspace = true, features = ["std", "dev"] }
-demo-mul-by-const.workspace = true
+demo-mul-by-const = { workspace = true, features = ["debug"] }
 env_logger.workspace = true
 service = { workspace = true, features = ["dev", "vara-native"] }

--- a/node/authorship/Cargo.toml
+++ b/node/authorship/Cargo.toml
@@ -42,6 +42,7 @@ frame-system = { workspace = true, features = ["std"] }
 prometheus-endpoint.workspace = true
 
 [dev-dependencies]
+common = { workspace = true, features = ["std"] }
 sc-transaction-pool.workspace = true
 frame-support = { workspace = true, features = ["std"] }
 sp-io = { workspace = true, features = ["std"] }
@@ -54,6 +55,7 @@ pallet-timestamp = { workspace = true, features = ["std"] }
 pallet-balances  = { workspace = true, features = ["std"] }
 pallet-gear = { workspace = true, features = ["std"] }
 pallet-gear-messenger  = { workspace = true, features = ["std"] }
+pallet-gear-program = { workspace = true, features = ["std"] }
 testing = {workspace = true, features = ["vara-native"] }
 vara-runtime  = { workspace = true, features = ["std", "dev"] }
 demo-mul-by-const.workspace = true

--- a/node/authorship/src/tests.rs
+++ b/node/authorship/src/tests.rs
@@ -55,7 +55,7 @@ use vara_runtime::{AccountId, Runtime, RuntimeCall, UncheckedExtrinsic, SLOT_DUR
 use runtime_primitives::BlockNumber;
 
 const SOURCE: TransactionSource = TransactionSource::External;
-const DEFAULT_GAS_LIMIT: u64 = 550_000_000;
+const DEFAULT_GAS_LIMIT: u64 = 865_000_000;
 
 fn chain_event<B: BlockT>(header: B::Header) -> ChainEvent<B>
 where


### PR DESCRIPTION
Recently the debug feature of `demo-waiter` crate in pallet-gear has been enabled for specific reasons. However this leads to propagation of `debug` feature for `gstd` to all crates when the workspace are being built. It is the reason of `block_max_gas_works` test failure in `make pre-commit` locally since the required gas limit changed.

@gear-tech/dev 
