### PR TITLE
chore(versioning): Update runtime version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,14 +3633,14 @@ dependencies = [
 
 [[package]]
 name = "galloc"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dlmalloc",
 ]
 
 [[package]]
 name = "gcli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "base64 0.21.3",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "gclient"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3725,7 +3725,7 @@ dependencies = [
 
 [[package]]
 name = "gcore"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "galloc",
  "gear-core-errors",
@@ -3738,7 +3738,7 @@ dependencies = [
 
 [[package]]
 name = "gear-authorship"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "demo-mul-by-const",
  "env_logger",
@@ -3782,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "gear-backend-codegen"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3791,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "gear-backend-common"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "actor-system-error",
  "blake2-rfc",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "gear-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "clap 4.4.2",
  "frame-benchmarking",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "gear-common"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "derive_more",
  "enum-iterator 1.4.1",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "gear-common-codegen"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "quote",
  "syn 2.0.31",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "gear-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "gear-core-errors"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "derive_more",
  "enum-iterator 1.4.1",
@@ -3952,7 +3952,7 @@ dependencies = [
 
 [[package]]
 name = "gear-core-processor"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "actor-system-error",
  "derive_more",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "gear-lazy-pages"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cfg-if",
  "derive_more",
@@ -4010,7 +4010,7 @@ dependencies = [
 
 [[package]]
 name = "gear-node-loader"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4042,7 +4042,7 @@ dependencies = [
 
 [[package]]
 name = "gear-node-testing"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "gear-runtime"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "const-str",
  "frame-benchmarking",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "gear-runtime-common"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "gear-runtime-interface"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "byteorder",
  "derive_more",
@@ -4221,7 +4221,7 @@ dependencies = [
 
 [[package]]
 name = "gear-runtime-primitives"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "sp-core 7.0.0 (git+https://github.com/gear-tech/substrate.git?branch=gear-polkadot-v0.9.41-canary-no-sandbox)",
  "sp-runtime 7.0.0 (git+https://github.com/gear-tech/substrate.git?branch=gear-polkadot-v0.9.41-canary-no-sandbox)",
@@ -4274,7 +4274,7 @@ dependencies = [
 
 [[package]]
 name = "gear-service"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -4355,7 +4355,7 @@ dependencies = [
 
 [[package]]
 name = "gear-stack-buffer"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cc",
 ]
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "gear-wasm-instrument"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "enum-iterator 1.4.1",
  "gear-backend-common",
@@ -4619,7 +4619,7 @@ dependencies = [
 
 [[package]]
 name = "gmeta"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "blake2-rfc",
  "derive_more",
@@ -4633,7 +4633,7 @@ dependencies = [
 
 [[package]]
 name = "gmeta-codegen"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "gmeta",
  "gstd",
@@ -4657,7 +4657,7 @@ dependencies = [
 
 [[package]]
 name = "gsdk"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "base64 0.21.3",
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "gsdk-codegen"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4717,7 +4717,7 @@ dependencies = [
 
 [[package]]
 name = "gstd"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bs58",
  "futures",
@@ -4746,7 +4746,7 @@ dependencies = [
 
 [[package]]
 name = "gsys"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 name = "gtest"
@@ -7314,7 +7314,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "blake2-rfc",
  "demo-async",
@@ -7412,7 +7412,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-bank"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7430,7 +7430,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-debug"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "demo-vec",
  "env_logger",
@@ -7467,7 +7467,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-gas"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "env_logger",
  "frame-benchmarking",
@@ -7496,7 +7496,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-messenger"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "env_logger",
  "frame-benchmarking",
@@ -7520,7 +7520,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-payment"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "env_logger",
  "frame-benchmarking",
@@ -7554,7 +7554,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-proc-macro"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7563,7 +7563,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-program"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7588,7 +7588,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-rpc"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "gear-common",
  "gear-core",
@@ -7604,7 +7604,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-rpc-runtime-api"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "pallet-gear",
  "sp-api",
@@ -7615,7 +7615,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-scheduler"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "env_logger",
  "frame-benchmarking",
@@ -7646,7 +7646,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-staking-rewards"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "env_logger",
  "frame-benchmarking",
@@ -7698,7 +7698,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-voucher"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "env_logger",
  "frame-benchmarking",
@@ -13495,7 +13495,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vara-runtime"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "const-str",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Gear Technologies"]
 edition = "2021"
 license = "GPL-3.0"

--- a/runtime/gear/src/lib.rs
+++ b/runtime/gear/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("gear"),
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
-    spec_version: 1000,
+    spec_version: 1010,
     impl_version: 1,
     transaction_version: 1,
     state_version: 1,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -142,7 +142,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1000,
+    spec_version: 1010,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
To avoid nightly builds running in native, for example 

(should also be a rule)