### PR TITLE
feat(wasm-gen): Introduce `unreachable_enabled` in `wasm-gen`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13751,7 +13751,7 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 [[package]]
 name = "wasm-encoder"
 version = "0.16.0"
-source = "git+https://github.com/gear-tech/wasm-tools.git?branch=gear-stable#2db6004e21aa014f411f8b575a99969284cff702"
+source = "git+https://github.com/gear-tech/wasm-tools.git?branch=gear-stable#9942645b3891607e13f11f6444ca320ba36a6a1f"
 dependencies = [
  "leb128",
 ]
@@ -13838,7 +13838,7 @@ dependencies = [
 [[package]]
 name = "wasm-smith"
 version = "0.11.4"
-source = "git+https://github.com/gear-tech/wasm-tools.git?branch=gear-stable#2db6004e21aa014f411f8b575a99969284cff702"
+source = "git+https://github.com/gear-tech/wasm-tools.git?branch=gear-stable#9942645b3891607e13f11f6444ca320ba36a6a1f"
 dependencies = [
  "arbitrary",
  "flagset",
@@ -14220,7 +14220,7 @@ checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 [[package]]
 name = "wasmparser"
 version = "0.90.0"
-source = "git+https://github.com/gear-tech/wasm-tools.git?branch=gear-stable#2db6004e21aa014f411f8b575a99969284cff702"
+source = "git+https://github.com/gear-tech/wasm-tools.git?branch=gear-stable#9942645b3891607e13f11f6444ca320ba36a6a1f"
 dependencies = [
  "indexmap 1.9.3",
 ]

--- a/utils/node-loader/src/utils.rs
+++ b/utils/node-loader/src/utils.rs
@@ -239,6 +239,7 @@ pub fn get_wasm_gen_config(
         injection_amounts,
         params_config,
         initial_pages: initial_pages as u32,
+        unreachable_enabled: false,
         ..Default::default()
     }
 }

--- a/utils/runtime-fuzzer/src/arbitrary_call.rs
+++ b/utils/runtime-fuzzer/src/arbitrary_call.rs
@@ -233,6 +233,7 @@ fn config(
         log_info,
         params_config,
         initial_pages: initial_pages as u32,
+        unreachable_enabled: false,
         ..Default::default()
     }
 }

--- a/utils/wasm-gen/src/config.rs
+++ b/utils/wasm-gen/src/config.rs
@@ -140,7 +140,7 @@ pub struct StandardGearWasmConfigsBundle<T = [u8; 32]> {
     pub existing_addresses: Option<NonEmpty<T>>,
     /// Flag which signals whether recursions must be removed.
     pub remove_recursion: bool,
-    /// Flag which signals whether `call_indirect` instruction must not be used
+    /// Flag which signals whether `call_indirect` instruction must be used
     /// during wasm generation.
     pub call_indirect_enabled: bool,
     /// Injection amount ranges for each sys-call.
@@ -153,6 +153,9 @@ pub struct StandardGearWasmConfigsBundle<T = [u8; 32]> {
     pub stack_end_page: Option<u32>,
     /// Sys-calls params config
     pub params_config: SysCallsParamsConfig,
+    /// Flag which signals whether `unreachable` instruction must be used
+    /// during wasm generation.
+    pub unreachable_enabled: bool,
 }
 
 impl<T> Default for StandardGearWasmConfigsBundle<T> {
@@ -167,6 +170,7 @@ impl<T> Default for StandardGearWasmConfigsBundle<T> {
             initial_pages: DEFAULT_INITIAL_SIZE,
             stack_end_page: None,
             params_config: SysCallsParamsConfig::default(),
+            unreachable_enabled: true,
         }
     }
 }
@@ -183,10 +187,12 @@ impl<T: Into<Hash>> ConfigsBundle for StandardGearWasmConfigsBundle<T> {
             initial_pages,
             stack_end_page,
             params_config,
+            unreachable_enabled,
         } = self;
 
         let selectable_params = SelectableParams {
             call_indirect_enabled,
+            unreachable_enabled,
             ..SelectableParams::default()
         };
 

--- a/utils/wasm-gen/src/config.rs
+++ b/utils/wasm-gen/src/config.rs
@@ -39,7 +39,8 @@
 //!         ],
 //!         max_instructions: 100_000,
 //!         min_funcs: 15,
-//!         max_funcs: 30
+//!         max_funcs: 30,
+//!         unreachable_enabled: true,
 //!     };
 //!     let arbitrary = ArbitraryParams::arbitrary(u)?;
 //!     Ok((selectable_params, arbitrary).into())

--- a/utils/wasm-gen/src/config/module.rs
+++ b/utils/wasm-gen/src/config/module.rs
@@ -85,6 +85,7 @@ impl From<(SelectableParams, ArbitraryParams)> for WasmModuleConfig {
             max_instructions,
             min_funcs,
             max_funcs,
+            unreachable_enabled,
         } = selectable_params;
 
         let ArbitraryParams {
@@ -173,6 +174,7 @@ impl From<(SelectableParams, ArbitraryParams)> for WasmModuleConfig {
             table_max_size_required,
             memory_grow_enabled,
             call_indirect_enabled,
+            unreachable_instruction_enabled: unreachable_enabled,
         })
     }
 }
@@ -354,6 +356,9 @@ pub struct SelectableParams {
     /// Maximum amount of functions `wasm-gen` will insert
     /// into generated wasm.
     pub max_funcs: usize,
+    /// Flag signalizing whether `unreachable` instruction
+    /// must be used or not.
+    pub unreachable_enabled: bool,
 }
 
 impl Default for SelectableParams {
@@ -366,6 +371,7 @@ impl Default for SelectableParams {
             max_instructions: 100_000,
             min_funcs: 15,
             max_funcs: 30,
+            unreachable_enabled: true,
         }
     }
 }

--- a/utils/wasm-gen/src/tests.rs
+++ b/utils/wasm-gen/src/tests.rs
@@ -286,6 +286,7 @@ fn execute_wasm_with_syscall_injected(
             max_instructions: 0,
             min_funcs: 1,
             max_funcs: 1,
+            unreachable_enabled: true,
         },
     );
 


### PR DESCRIPTION
Picks up these changes https://github.com/gear-tech/wasm-tools/commit/9942645b3891607e13f11f6444ca320ba36a6a1f by introducing `unreachable_enabled` selectable option for module generation config in `wasm-gen`.

Also this PR disables the intruction in fuzzer and loader, because in accordance to coverage data reports most of executions end up reaching `unreachable`, testing which isn't the main priority. 