### PR TITLE
[skip-ci] ci(skip): skip CI with green spot

### DIFF
--- a/.github/actions/label/skip.js
+++ b/.github/actions/label/skip.js
@@ -4,7 +4,7 @@
 
 const SKIP_CI = "[skip-ci]";
 const { TITLE, HEAD_SHA } = process.env;
-const CHECKS = ["linux", "win-cross"]
+const CHECKS = ["check", "build"]
 const [owner, repo] = ["gear-tech", "gear"];
 
 module.exports = async ({ github, core }) => {
@@ -16,7 +16,7 @@ module.exports = async ({ github, core }) => {
     const { data: res } = await github.rest.checks.create({
       owner,
       repo,
-      name: `build / ${check}`,
+      name: `${check} / linux`,
       head_sha: HEAD_SHA,
       status: "completed",
       conclusion: "success",

--- a/.github/actions/label/skip.js
+++ b/.github/actions/label/skip.js
@@ -1,0 +1,28 @@
+/**
+ * Javascript module for skipping CI
+ */
+
+const SKIP_CI = "[skip-ci]";
+const { TITLE, HEAD_SHA } = process.env;
+const CHECKS = ["linux", "win-cross"]
+const [owner, repo] = ["gear-tech", "gear"];
+
+module.exports = async ({ github, core }) => {
+  if (!TITLE.includes(SKIP_CI)) return;
+
+  core.info(`Skipping CI for ${TITLE}`);
+
+  for (check of CHECKS) {
+    const { data: res } = await github.rest.checks.create({
+      owner,
+      repo,
+      name: `build / ${check}`,
+      head_sha: HEAD_SHA,
+      status: "completed",
+      conclusion: "success",
+    });
+
+    core.info(`Created check ${check}`);
+    core.info(JSON.stringify(res, null, 2));
+  }
+}

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -25,6 +25,15 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - uses: actions/github-script@v6
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          TITLE: ${{ github.event.pull_request.title }}
+        with:
+          script: |
+            const script = require('./.github/actions/label/skip.js');
+            await script({ github, core });
+
       - name: Check Commit Message
         id: check-commit-message
         run: |

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -54,6 +54,7 @@ jobs:
 
   check:
     needs: status
+    if: ${{ !contains(github.event.pull_request.title, '[skip-ci]') }}
     uses: ./.github/workflows/check.yml
     with:
       cache: ${{ needs.status.outputs.cache }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTUP_HOME: /tmp/rustup_home
-    if: github.actor != 'dependabot[bot]' && ${{ !contains(github.event.pull_request.title, '[skip-ci]') }}
+    if: ${{ !contains(github.event.pull_request.title, '[skip-ci]') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTUP_HOME: /tmp/rustup_home
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && ${{ !contains(github.event.pull_request.title, '[skip-ci]') }}
     steps:
       - uses: actions/checkout@v4
 
@@ -39,8 +39,8 @@ jobs:
           publish_dir: ./target/doc
           cname: docs.gear.rs
           force_orphan: true
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
+          user_name: "github-actions[bot]"
+          user_email: "github-actions[bot]@users.noreply.github.com"
 
       - name: Deploy PR
         if: github.event_name == 'pull_request'

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -14,7 +14,6 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.title, '[skip-ci]') }}
     steps:
       - uses: actions/checkout@v4
       - name: typos-action

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -14,6 +14,7 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, '[skip-ci]') }}
     steps:
       - uses: actions/checkout@v4
       - name: typos-action

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,9 @@
+# Development Guidelines
+
+## CI
+
+Since we have required checks in our PR flow, simply `[skip ci]` will leave PRs
+with expected build checks, hangs with yellow spot in the UI of github. Here we
+have introduced `[skip-ci]` in this repo for providing green spots.
+
+Reference: [Skipping workflow runs](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs)


### PR DESCRIPTION
Resolves #3309 

we can not process this hack with `[skip ci]` because [it will skip everything][skip-ci]..., so here in this PR we check the title of PRs, if contains `[skip-ci]`, we simply skip heavy CIs

Leaving one `typos` is that the [create checks API][create-checks] of github requires one more workflow excepting the workflow it belongs to most of the time ( this API is originally designed for github APPs, so it could be buggy we calling it from github actions directly), for example, see the CI of [de52c97](https://github.com/gear-tech/gear/pull/3324/commits/de52c97b9aecfda22953ced1e350b8a26e543f6e), this may also related to #3316 

[create-checks]: https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#create-a-check-run
[skip-ci]: https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs

@gear-tech/dev 
