### PR TITLE
[dep] ci(dep): introduce label `[dep]`

### DIFF
--- a/.github/actions/label/skip.js
+++ b/.github/actions/label/skip.js
@@ -3,6 +3,7 @@
  */
 
 const SKIP_CI = "[skip-ci]";
+const DEP = "[dep]";
 const { TITLE, HEAD_SHA } = process.env;
 const CHECKS = ["check", "build"]
 const [owner, repo] = ["gear-tech", "gear"];
@@ -13,6 +14,8 @@ module.exports = async ({ github, core }) => {
   core.info(`Skipping CI for ${TITLE}`);
 
   for (check of CHECKS) {
+    if (TITLE.includes(DEP) && check === "check") continue;
+
     const { data: res } = await github.rest.checks.create({
       owner,
       repo,

--- a/.github/actions/label/skip.js
+++ b/.github/actions/label/skip.js
@@ -9,7 +9,7 @@ const CHECKS = ["check", "build"]
 const [owner, repo] = ["gear-tech", "gear"];
 
 module.exports = async ({ github, core }) => {
-  if (!TITLE.includes(SKIP_CI)) return;
+  if (!TITLE.includes(SKIP_CI) && !TITLE.includes(DEP)) return;
 
   core.info(`Skipping CI for ${TITLE}`);
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       interval: "weekly"
       day: "friday"
     commit-message:
-      prefix: "[skip-ci] "
+      prefix: "[dep] "
 
   - package-ecosystem: "cargo"
     directory: "/examples/"
@@ -16,7 +16,7 @@ updates:
       interval: "weekly"
       day: "friday"
     commit-message:
-      prefix: "[skip-ci] "
+      prefix: "[dep] "
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -25,4 +25,4 @@ updates:
       interval: "weekly"
       day: "friday"
     commit-message:
-      prefix: "[skip-ci] "
+      prefix: "[dep] "

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,27 +2,27 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
-    labels: ["A0-pleasereview", "A4-insubstantial", "E2-forcemacos"]
+    labels: ["A4-insubstantial", "E2-forcemacos"]
     schedule:
       interval: "weekly"
       day: "friday"
     commit-message:
-      prefix: "[depbot] "
+      prefix: "[skip-ci] "
 
   - package-ecosystem: "cargo"
     directory: "/examples/"
-    labels: ["A0-pleasereview", "A4-insubstantial"]
+    labels: ["A4-insubstantial"]
     schedule:
       interval: "weekly"
       day: "friday"
     commit-message:
-      prefix: "[depbot] "
+      prefix: "[skip-ci] "
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    labels: ["A0-pleasereview", "A4-insubstantial"]
+    labels: ["A4-insubstantial"]
     schedule:
       interval: "weekly"
       day: "friday"
     commit-message:
-      prefix: "[depbot] "
+      prefix: "[skip-ci] "


### PR DESCRIPTION
Introduce `[dep]` prefix for appending passed `build / linux` for dependabot's PRs, we should leave the `check / linux` with dependabot's PRs since we need to forbid merging them separately when there is sth wrong

@gear-tech/dev 
