### PR TITLE
feat(gstd): Introduce packages for gstd framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4778,6 +4778,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "gstd-framework-macros"
+version = "1.0.1"
+dependencies = [
+ "gstd-framework-macros-core",
+ "proc-macro-error",
+]
+
+[[package]]
+name = "gstd-framework-macros-core"
+version = "1.0.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "gsys"
 version = "1.0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,8 @@ members = [
     "gsdk/codegen",
     "gsdk/api-gen",
     "gstd",
+    "gstd/framework/macros",
+    "gstd/framework/macros/core",
     "gsys",
     "gtest",
     "node/cli",
@@ -86,7 +88,7 @@ members = [
     "pallets/*",
     "runtime/*",
     "utils/*",
-    "utils/runtime-fuzzer/fuzz"
+    "utils/runtime-fuzzer/fuzz",
 ]
 
 [workspace.dependencies]
@@ -127,6 +129,7 @@ parking_lot = "0.12.1"
 path-clean = "1.0.1"
 primitive-types = { version = "0.12.1", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
+proc-macro-error = "1.0"
 proptest = "1.1.0"
 quick-xml = "0.28"
 quote = { version = "1.0.33", default-features = false }

--- a/gstd/framework/macros/Cargo.toml
+++ b/gstd/framework/macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "gstd-framework-macros"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+gstd-framework-macros-core = { path = "./core" }
+proc-macro-error.workspace = true

--- a/gstd/framework/macros/core/Cargo.toml
+++ b/gstd/framework/macros/core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "gstd-framework-macros-core"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+proc-macro2.workspace = true
+quote.workspace = true

--- a/gstd/framework/macros/core/src/lib.rs
+++ b/gstd/framework/macros/core/src/lib.rs
@@ -1,0 +1,30 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2023 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use proc_macro2::TokenStream as TokenStream2;
+
+pub fn command_handlers_core(tokens: TokenStream2) -> TokenStream2 {
+    tokens
+}
+
+pub fn query_handlers_core(tokens: TokenStream2) -> TokenStream2 {
+    tokens
+}
+
+#[cfg(test)]
+mod tests;

--- a/gstd/framework/macros/core/src/tests.rs
+++ b/gstd/framework/macros/core/src/tests.rs
@@ -1,0 +1,45 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2023 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+use quote::quote;
+
+#[test]
+fn command_handlers_works() {
+    let input = quote! {
+        fn do_this() {}
+    };
+    let expected = quote! {
+        fn do_this() {}
+    };
+    assert_eq!(
+        expected.to_string(),
+        command_handlers_core(input).to_string()
+    );
+}
+
+#[test]
+fn query_handlers_works() {
+    let input = quote! {
+        fn this() {}
+    };
+    let expected = quote! {
+        fn this() {}
+    };
+    assert_eq!(expected.to_string(), query_handlers_core(input).to_string());
+}

--- a/gstd/framework/macros/src/lib.rs
+++ b/gstd/framework/macros/src/lib.rs
@@ -1,0 +1,33 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2023 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use gstd_framework_macros_core::{command_handlers_core, query_handlers_core};
+use proc_macro::TokenStream;
+use proc_macro_error::proc_macro_error;
+
+#[proc_macro_error]
+#[proc_macro]
+pub fn command_handlers(tokens: TokenStream) -> TokenStream {
+    command_handlers_core(tokens.into()).into()
+}
+
+#[proc_macro_error]
+#[proc_macro]
+pub fn query_handlers(tokens: TokenStream) -> TokenStream {
+    query_handlers_core(tokens.into()).into()
+}


### PR DESCRIPTION
This is a very first PR in the series devoted to sort of framework built on top of gstd. The framework aims to simplification of smart contract development and showcasing best practices. This particular PR introduces initial structure for framework packages. The idea is that all framework related packages will be sitting under the `gstd/framework` folder. The very first top-level package of the framework is the one with proc macros. The sub-package is intended for testable functionality for the latter.
@NikVolf , @breathx, @shamilsan  I am happy to hear your feedback