### PR TITLE
refactor(wasm-gen, runtime-fuzzer): Increase successful messages execution rate in `runtime-fuzzer`.

### DIFF
--- a/scripts/src/test.sh
+++ b/scripts/src/test.sh
@@ -88,7 +88,7 @@ run_fuzzer() {
   cd $ROOT_DIR/utils/runtime-fuzzer
 
   if [ "$3" = "wlogs" ]; then
-    LOG_TARGETS="debug,syscalls,gear_wasm_gen=trace,runtime_fuzzer=trace,gear_backend_common=trace"
+    LOG_TARGETS="debug,syscalls,gear_wasm_gen=trace,runtime_fuzzer=trace,gear_core_backend=trace"
   else
     LOG_TARGETS="off"
   fi

--- a/utils/node-loader/src/utils.rs
+++ b/utils/node-loader/src/utils.rs
@@ -219,10 +219,10 @@ pub fn get_wasm_gen_config(
             (SysCallName::Leave, 0..=0),
             (SysCallName::Panic, 0..=0),
             (SysCallName::OomPanic, 0..=0),
-            (SysCallName::Send, 2..=3),
+            (SysCallName::Send, 10..=15),
             (SysCallName::Exit, 0..=1),
-            (SysCallName::Alloc, 1..=3),
-            (SysCallName::Free, 1..=3),
+            (SysCallName::Alloc, 3..=6),
+            (SysCallName::Free, 3..=6),
         ]
         .map(|(sys_call, range)| (InvocableSysCall::Loose(sys_call), range))
         .into_iter(),

--- a/utils/node-loader/src/utils.rs
+++ b/utils/node-loader/src/utils.rs
@@ -219,10 +219,10 @@ pub fn get_wasm_gen_config(
             (SysCallName::Leave, 0..=0),
             (SysCallName::Panic, 0..=0),
             (SysCallName::OomPanic, 0..=0),
-            (SysCallName::Send, 20..=30),
+            (SysCallName::Send, 2..=3),
             (SysCallName::Exit, 0..=1),
-            (SysCallName::Alloc, 5..=10),
-            (SysCallName::Free, 5..=10),
+            (SysCallName::Alloc, 1..=3),
+            (SysCallName::Free, 1..=3),
         ]
         .map(|(sys_call, range)| (InvocableSysCall::Loose(sys_call), range))
         .into_iter(),
@@ -230,7 +230,7 @@ pub fn get_wasm_gen_config(
 
     let mut params_config = SysCallsParamsConfig::default();
     params_config.add_rule(ParamType::Alloc, (1..=10).into());
-    params_config.add_rule(ParamType::Free, (initial_pages..=initial_pages + 25).into());
+    params_config.add_rule(ParamType::Free, (initial_pages..=initial_pages + 50).into());
 
     StandardGearWasmConfigsBundle {
         log_info: Some(format!("Gear program seed = '{seed}'")),

--- a/utils/runtime-fuzzer/README.md
+++ b/utils/runtime-fuzzer/README.md
@@ -23,7 +23,7 @@ dd if=/dev/urandom of=fuzz/corpus/main/fuzzer-seed-corpus bs=1 count=27000000
 
 # Run fuzzer for at least 20 minutes and then press Ctrl-C to stop fuzzing.
 # You can also remove RUST_LOG to avoid printing tons of logs on terminal.
-RUST_LOG=debug,syscalls,gear_wasm_gen=trace,runtime_fuzzer=trace,gear_backend_common=trace \
+RUST_LOG=debug,syscalls,gear_wasm_gen=trace,runtime_fuzzer=trace,gear_core_backend=trace \
 cargo fuzz run \
     --release \
     --sanitizer=none \

--- a/utils/runtime-fuzzer/src/gear_calls.rs
+++ b/utils/runtime-fuzzer/src/gear_calls.rs
@@ -43,6 +43,14 @@ use gear_wasm_gen::{
 const MAX_PAYLOAD_SIZE: usize = 512 * 1024;
 static_assertions::const_assert!(MAX_PAYLOAD_SIZE <= gear_core::message::MAX_PAYLOAD_SIZE);
 
+/// Maximum salt size for the fuzzer - 512 bytes.
+///
+/// There's no need in large salts as we have only 35 extrinsics
+/// for one run. Also small salt will make overall size of the
+/// corpus smaller.
+const MAX_SALT_SIZE: usize = 512;
+static_assertions::const_assert!(MAX_SALT_SIZE <= gear_core::message::MAX_PAYLOAD_SIZE);
+
 /// This trait provides ability for [`ExtrinsicGenerator`]s to fetch messages
 /// from mailbox, for example [`UploadProgramGenerator`] and
 /// [`ClaimValueGenerator`] use it.
@@ -238,8 +246,8 @@ impl UploadProgramGenerator {
     }
 
     const fn unstructured_size_hint(&self) -> usize {
-        // 1024 KiB for payload and salt and 50 KiB for code.
-        1080 * 1024
+        // 512 KiB for payload, 50 KiB for code and 512 bytes for salt.
+        572 * 1024 + 512
     }
 }
 
@@ -377,7 +385,7 @@ fn arbitrary_message_id_from_mailbox(
 }
 
 fn arbitrary_salt(u: &mut Unstructured) -> Result<Vec<u8>> {
-    arbitrary_limited_bytes(u, MAX_PAYLOAD_SIZE)
+    arbitrary_limited_bytes(u, MAX_SALT_SIZE)
 }
 
 fn arbitrary_payload(u: &mut Unstructured) -> Result<Vec<u8>> {
@@ -400,10 +408,10 @@ fn config(
             (SysCallName::Leave, 0..=0),
             (SysCallName::Panic, 0..=0),
             (SysCallName::OomPanic, 0..=0),
-            (SysCallName::Send, 20..=30),
+            (SysCallName::Send, 3..=4),
             (SysCallName::Exit, 0..=1),
-            (SysCallName::Alloc, 20..=30),
-            (SysCallName::Free, 20..=30),
+            (SysCallName::Alloc, 1..=3),
+            (SysCallName::Free, 1..=3),
         ]
         .map(|(sys_call, range)| (InvocableSysCall::Loose(sys_call), range))
         .into_iter(),
@@ -411,10 +419,7 @@ fn config(
 
     let mut params_config = SysCallsParamsConfig::default();
     params_config.add_rule(ParamType::Alloc, (10..=20).into());
-    params_config.add_rule(
-        ParamType::Free,
-        (initial_pages..=initial_pages + 250).into(),
-    );
+    params_config.add_rule(ParamType::Free, (initial_pages..=initial_pages + 35).into());
 
     let existing_addresses = NonEmpty::collect(
         programs

--- a/utils/runtime-fuzzer/src/gear_calls.rs
+++ b/utils/runtime-fuzzer/src/gear_calls.rs
@@ -246,8 +246,11 @@ impl UploadProgramGenerator {
     }
 
     const fn unstructured_size_hint(&self) -> usize {
-        // 512 KiB for payload, 50 KiB for code and 512 bytes for salt.
-        572 * 1024 + 512
+        // Max code size - 50 KiB.
+        const MAX_CODE_SIZE: usize = 50 * 1024;
+        const AUXILIARY_SIZE: usize = 512;
+
+        MAX_CODE_SIZE + MAX_PAYLOAD_SIZE + MAX_SALT_SIZE + AUXILIARY_SIZE
     }
 }
 

--- a/utils/runtime-fuzzer/src/gear_calls.rs
+++ b/utils/runtime-fuzzer/src/gear_calls.rs
@@ -411,10 +411,10 @@ fn config(
             (SysCallName::Leave, 0..=0),
             (SysCallName::Panic, 0..=0),
             (SysCallName::OomPanic, 0..=0),
-            (SysCallName::Send, 3..=4),
+            (SysCallName::Send, 10..=15),
             (SysCallName::Exit, 0..=1),
-            (SysCallName::Alloc, 1..=3),
-            (SysCallName::Free, 1..=3),
+            (SysCallName::Alloc, 3..=6),
+            (SysCallName::Free, 3..=6),
         ]
         .map(|(sys_call, range)| (InvocableSysCall::Loose(sys_call), range))
         .into_iter(),

--- a/utils/wasm-gen/src/config/module.rs
+++ b/utils/wasm-gen/src/config/module.rs
@@ -368,9 +368,9 @@ impl Default for SelectableParams {
             allowed_instructions: vec![
                 Numeric, Reference, Parametric, Variable, Table, Memory, Control,
             ],
-            max_instructions: 100_000,
-            min_funcs: 15,
-            max_funcs: 30,
+            max_instructions: 500,
+            min_funcs: 3,
+            max_funcs: 5,
             unreachable_enabled: true,
         }
     }


### PR DESCRIPTION
This task was a hot one from the beginning of `runtime-fuzzer` launch when first production coverages were available. The issue was that there were too many traps, which caused a very weak coverage for messaging logic in the `pallet_gear`.

After researching it thoroughly, I have found out that there were 2 many trap reasons: `Possibly 'unreachable' instruction reached` and `Not enough gas to continue execution`. 
The former trap reason was caused not only by `unreachable` instruction occurrences, but there were some other internal wasmi errors causing that termination reason. I have turned off `unreachable` instructions here https://github.com/gear-tech/gear/pull/3307.
The latter one was mainly due to large loops in wasm - each function body consisted of about 100_000 instructions and these instructions could call other functions with the same size in a loop. Turning off `Control` instructions can be a solution to that, but it brings some other problems described here https://github.com/gear-tech/gear/issues/3382. This seems to be the best solution to the problem - https://github.com/gear-tech/gear/issues/3313.

Basically, there are 3 available params that have a significant effect on execution:
1. Turning off `Control` (`if`, `loop`, `try`, `catch` and etc.)  instructions. This makes the execution of the ~8gb corpus directory really fast (3 minutes), there are no `Not enough gas to continue execution` errors, but it there is a still a huge number of traps.
2. Instructions number in the function body.
3. Amount of internal functions generated by `wasm-smith`.

After running 2 corpuses sets each about 8 gb with different values for these params, I have found out that amount of instructions doesn't have a huge effect on execution time or execution results. In theory, less instructions make less gas errors and more frequent syscalls invocations. In practice, this has a very weak effect when amount of functions is large. The third  param caused the most effect on increasing the corpus execution speed and amount of successfull executions. Even if there are 100_000 instructions, but less functions, it empirically shows great results. 

 
