### PR TITLE
fix(runtime-fuzzer): reduce the range of pages num for free syscall

### DIFF
--- a/utils/runtime-fuzzer/src/gear_calls.rs
+++ b/utils/runtime-fuzzer/src/gear_calls.rs
@@ -426,7 +426,7 @@ fn config(
 
     let mut params_config = SysCallsParamsConfig::default();
     params_config.add_rule(ParamType::Alloc, (10..=20).into());
-    params_config.add_rule(ParamType::Free, (initial_pages..=initial_pages + 35).into());
+    params_config.add_rule(ParamType::Free, (initial_pages..=initial_pages + 1).into());
 
     let existing_addresses = NonEmpty::collect(
         programs


### PR DESCRIPTION
```rust
let initial_pages = 2;
// ...
params_config.add_rule(ParamType::Free, (initial_pages..=initial_pages + 35).into());
// range with `initial_pages + 35` causes `free` syscall with page_no > initial_pages
// (leads to frequent falls)
```