### PR TITLE
feat!(runtime): Add ability to align total supply

### DIFF
--- a/gsdk/src/metadata/generated.rs
+++ b/gsdk/src/metadata/generated.rs
@@ -3250,6 +3250,8 @@ pub mod runtime_types {
                         to: ::subxt::utils::MultiAddress<::subxt::utils::AccountId32, ()>,
                         value: ::core::primitive::u128,
                     },
+                    #[codec(index = 3)]
+                    align_supply { target: ::core::primitive::u128 },
                 }
                 #[derive(Debug, crate::gp::Decode, crate::gp::DecodeAsType, crate::gp::Encode)]
                 #[doc = "Error for the staking rewards pallet."]
@@ -3273,6 +3275,9 @@ pub mod runtime_types {
                     #[codec(index = 2)]
                     #[doc = "Burned from the pool."]
                     Burned { amount: ::core::primitive::u128 },
+                    #[codec(index = 3)]
+                    #[doc = "Minted to the pool."]
+                    Minted { amount: ::core::primitive::u128 },
                 }
             }
         }
@@ -9792,6 +9797,7 @@ pub mod calls {
         Refill,
         ForceRefill,
         Withdraw,
+        AlignSupply,
     }
     impl CallInfo for StakingRewardsCall {
         const PALLET: &'static str = "StakingRewards";
@@ -9800,6 +9806,7 @@ pub mod calls {
                 Self::Refill => "refill",
                 Self::ForceRefill => "force_refill",
                 Self::Withdraw => "withdraw",
+                Self::AlignSupply => "align_supply",
             }
         }
     }

--- a/pallets/staking-rewards/src/weights.rs
+++ b/pallets/staking-rewards/src/weights.rs
@@ -31,6 +31,7 @@ pub trait WeightInfo {
 	fn refill() -> Weight;
 	fn force_refill() -> Weight;
 	fn withdraw() -> Weight;
+	fn align_supply() -> Weight;
 }
 
 /// Weights for pallet_treasury using the Substrate node and recommended hardware.
@@ -58,6 +59,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             .saturating_add(T::DbWeight::get().reads(2_u64))
             .saturating_add(T::DbWeight::get().writes(3_u64))
 	}
+
+	fn align_supply() -> Weight {
+		Weight::from_parts(55_241_000_u64, 0)
+            .saturating_add(T::DbWeight::get().reads(1_u64))
+            .saturating_add(T::DbWeight::get().writes(2_u64))
+	}
 }
 
 // For backwards compatibility and tests
@@ -78,5 +85,11 @@ impl WeightInfo for () {
 		Weight::from_parts(54_529_000_u64, 0)
             .saturating_add(RocksDbWeight::get().reads(2_u64))
             .saturating_add(RocksDbWeight::get().writes(3_u64))
+	}
+
+	fn align_supply() -> Weight {
+		Weight::from_parts(55_241_000_u64, 0)
+            .saturating_add(RocksDbWeight::get().reads(1_u64))
+            .saturating_add(RocksDbWeight::get().writes(2_u64))
 	}
 }


### PR DESCRIPTION
This PR brings new extrinsic supposed to be called only once by governance voting on minting/burning some tokens from offset pool in order to align total issuance to 10kkk tokens, because network ran into imbalance here due to previous runtime bugs (see PRs related to dust removal and staking rewards)