### PR TITLE
refactor(wasm-gen): add new approach of processing syscall parameters

### DIFF
--- a/utils/wasm-instrument/src/syscalls.rs
+++ b/utils/wasm-instrument/src/syscalls.rs
@@ -299,7 +299,6 @@ impl SysCallName {
                 Ptr(PtrInfo::new_mutable(PtrType::BufferStart {
                     length_param_idx: 1,
                 })),
-                Ptr(PtrInfo::new_mutable(PtrType::BlockNumber)),
                 Ptr(PtrInfo::new_mutable(PtrType::ErrorCode)),
             ]),
             Self::Reply => SysCallSignature::gr([

--- a/utils/wasm-instrument/src/syscalls.rs
+++ b/utils/wasm-instrument/src/syscalls.rs
@@ -296,11 +296,9 @@ impl SysCallName {
             Self::Read => SysCallSignature::gr([
                 MessagePosition,
                 Size,
-                // TODO #3375, the PtrType::BlockNumber is incorrect here.
-                // Should be:
-                // Ptr(PtrInfo::new_mutable(PtrType::BufferStart {
-                //     length_param_idx: 1,
-                // }))
+                Ptr(PtrInfo::new_mutable(PtrType::BufferStart {
+                    length_param_idx: 1,
+                })),
                 Ptr(PtrInfo::new_mutable(PtrType::BlockNumber)),
                 Ptr(PtrInfo::new_mutable(PtrType::ErrorCode)),
             ]),


### PR DESCRIPTION
Resolves #3375

Instead of skipping the parameter, we will first push the parameter with `value=0` and then mutate it by `length_param_idx`. 
