### PR TITLE
feat(gsdk): Expose `GearConfig` and `PairSigner`

### DIFF
--- a/gsdk/src/lib.rs
+++ b/gsdk/src/lib.rs
@@ -17,10 +17,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Gear api
-use crate::metadata::runtime_types::gear_common::{
-    gas_provider::node::{GasNode, GasNodeId},
-    ActiveProgram,
-};
 pub use crate::{
     api::Api,
     config::GearConfig,
@@ -30,11 +26,16 @@ pub use crate::{
     subscription::{Blocks, Events},
 };
 pub use gear_core::gas::GasInfo;
+pub use subxt::dynamic::Value;
+
+use crate::metadata::runtime_types::gear_common::{
+    gas_provider::node::{GasNode, GasNodeId},
+    ActiveProgram,
+};
 use gear_core::ids::{MessageId, ReservationId};
 use parity_scale_codec::Decode;
 use sp_runtime::AccountId32;
 use std::collections::HashMap;
-pub use subxt::dynamic::Value;
 use subxt::{
     tx::{TxInBlock as SubxtTxInBlock, TxStatus as SubxtTxStatus},
     OnlineClient,

--- a/gsdk/src/lib.rs
+++ b/gsdk/src/lib.rs
@@ -17,19 +17,17 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Gear api
+use crate::metadata::runtime_types::gear_common::{
+    gas_provider::node::{GasNode, GasNodeId},
+    ActiveProgram,
+};
 pub use crate::{
     api::Api,
+    config::GearConfig,
     metadata::Event,
     result::{Error, Result},
     signer::PairSigner,
     subscription::{Blocks, Events},
-};
-use crate::{
-    config::GearConfig,
-    metadata::runtime_types::gear_common::{
-        gas_provider::node::{GasNode, GasNodeId},
-        ActiveProgram,
-    },
 };
 pub use gear_core::gas::GasInfo;
 use gear_core::ids::{MessageId, ReservationId};

--- a/gsdk/src/signer/mod.rs
+++ b/gsdk/src/signer/mod.rs
@@ -150,6 +150,10 @@ impl Inner {
     pub fn api(&self) -> &Api {
         &self.api
     }
+
+    pub fn signer(&self) -> &PairSigner<GearConfig, Pair> {
+        &self.signer
+    }
 }
 
 impl From<(Api, PairSigner<GearConfig, Pair>)> for Signer {


### PR DESCRIPTION
If we want to use subxt in external crates with gsdk we need access to subxt Signer and Config

@gear-tech/dev 
