### PR TITLE
fix(scripts): rewrite `install.sh` in POSIX way 

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -127,10 +127,10 @@ curl --proto '=https' --tlsv1.2 -SfL "$archive_url" -o "$archive_tmp" || err "fa
 tar -C "$td" -xf "$archive_tmp" || err "failed to extract $archive_name"
 
 for f in "$td"/*; do
-  [ -x "$td/$f" ] || continue
+  [ -x "$f" ] || continue
 
   mkdir -p "$dest"
-  sudo install -m 755 "$td"/"$f" "$dest"
+  sudo install -m 755 "$f" "$dest"
 
 done
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@ if [ -n "${GITHUB_ACTIONS-}" ]; then
 fi
 
 help() {
-  cat <<EOF
+  cat << EOF
 Install a binary release of gear hosted on get.gear.rs
 
 USAGE:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -72,11 +72,13 @@ while [ $# -gt 0 ]; do
 done
 
 # Dependencies
+need sudo
 need curl
 need install
 need mkdir
 need mktemp
 need tar
+need xz
 
 # Optional dependencies
 if [ -z "${tag-}" ]; then


### PR DESCRIPTION
Resolves #3336

This PR fixes the `install.sh` script to work with `/bin/sh`. I also checked the script using [shellcheck](https://www.shellcheck.net) and in the ubuntu docker container.
