### PR TITLE
chore(gcli): move vara-runtime to dev-dependencies

### DIFF
--- a/gcli/Cargo.toml
+++ b/gcli/Cargo.toml
@@ -46,7 +46,6 @@ reqwest = { workspace = true, default-features = false, features = [ "json", "ru
 etc.workspace = true
 sp-io = { workspace = true, features = [ "std" ] }
 sp-core = { workspace = true, features = [ "std" ] }
-vara-runtime = { workspace = true, features = [ "std", "dev" ] }
 
 [dev-dependencies]
 rand.workspace = true
@@ -54,6 +53,7 @@ demo-messager.workspace = true
 demo-new-meta.workspace = true
 demo-waiter.workspace = true
 gsdk = { workspace = true, features = ["testing"] }
+vara-runtime = { workspace = true, features = [ "std", "dev" ] }
 
 [build-dependencies]
 which.workspace = true

--- a/gcli/bin/gcli.rs
+++ b/gcli/bin/gcli.rs
@@ -23,7 +23,7 @@ use color_eyre::eyre::Result;
 async fn main() -> Result<()> {
     color_eyre::install()?;
 
-    sp_core::crypto::set_default_ss58_version(vara_runtime::SS58Prefix::get().try_into().unwrap());
+    sp_core::crypto::set_default_ss58_version(gcli::VARA_SS58_PREFIX.into());
 
     if let Err(e) = gcli::cmd::Opt::run().await {
         log::error!("{}", e);

--- a/gcli/src/lib.rs
+++ b/gcli/src/lib.rs
@@ -128,3 +128,6 @@ pub mod meta;
 pub mod result;
 pub mod template;
 pub mod utils;
+
+/// SS58 prefix for vara network.
+pub const VARA_SS58_PREFIX: u8 = 137;

--- a/gcli/tests/gear.rs
+++ b/gcli/tests/gear.rs
@@ -46,3 +46,11 @@ fn paths() {
         }
     })
 }
+
+#[test]
+fn ss58_prefix() {
+    assert_eq!(
+        gcli::VARA_SS58_PREFIX,
+        vara_runtime::SS58Prefix::get().try_into().unwrap()
+    );
+}


### PR DESCRIPTION
Resolves #3427 

-
-
-

@reviewer-or-team
