### PR TITLE
feat(wasm-gen): customize logic on reaching stack limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4827,8 +4827,7 @@ dependencies = [
 [[package]]
 name = "gwasm-instrument"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcb127cb43d375de7cdacffd0e4e1c746e52381d11a0465909ae6fbecb99c6c3"
+source = "git+https://github.com/StackOverflowExcept1on/wasm-instrument?branch=v0.2.1-sign-ext-stack-height#595872d8a52a8cc850ac771e3ba67ed20916f119"
 dependencies = [
  "gear-wasm",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -485,6 +485,7 @@ debug = true
 parity-wasm = { version = "0.45.0", git = "https://github.com/gear-tech/parity-wasm", branch = "v0.45.0-sign-ext" }
 wasmi-validation = { version = "0.5.0", git = "https://github.com/gear-tech/wasmi", branch = "v0.13.2-sign-ext" }
 wasm-instrument = { version = "0.3.0", git = "https://github.com/gear-tech/wasm-instrument", branch = "v0.3.0-sign-ext" }
+gwasm-instrument = { version = "0.2.1", git = "https://github.com/StackOverflowExcept1on/wasm-instrument", branch = "v0.2.1-sign-ext-stack-height" }
 
 # TODO: remove after https://github.com/BLAKE3-team/BLAKE3/pull/230
 blake3 = { git = "https://github.com/gear-tech/BLAKE3", branch = "fix-clang-cl-cross" }

--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -740,8 +740,7 @@ impl Default for Limits {
             // To avoid potential stack overflow problems we have a panic in sandbox in case,
             // execution is ended with stack overflow error. So, process queue execution will be
             // stopped and we will be able to investigate the problem and decrease this constant if needed.
-            // TODO #3435. Disabled stack height is a temp solution.
-            stack_height: cfg!(not(feature = "fuzz")).then_some(20_000),
+            stack_height: Some(20_000),
             globals: 256,
             locals: 1024,
             parameters: 128,

--- a/utils/runtime-fuzzer/README.md
+++ b/utils/runtime-fuzzer/README.md
@@ -23,7 +23,7 @@ dd if=/dev/urandom of=fuzz/corpus/main/fuzzer-seed-corpus bs=1 count=350000
 
 # Run fuzzer for at least 20 minutes and then press Ctrl-C to stop fuzzing.
 # You can also remove RUST_LOG to avoid printing tons of logs on terminal.
-RUST_LOG=debug,syscalls,gear_wasm_gen=trace,runtime_fuzzer=trace,gear_core_backend=trace \
+RUST_LOG=debug,syscalls,runtime::sandbox=trace,gear_wasm_gen=trace,runtime_fuzzer=trace,gear_core_backend=trace \
 cargo fuzz run \
     --release \
     --sanitizer=none \

--- a/utils/wasm-gen/src/generator.rs
+++ b/utils/wasm-gen/src/generator.rs
@@ -139,6 +139,8 @@ impl<'a, 'b> GearWasmGenerator<'a, 'b> {
             .into_wasm_module()
             .into_inner();
 
+        let module = utils::inject_stack_limiter(module);
+
         Ok(if config.remove_recursions {
             log::trace!("Removing recursions");
             utils::remove_recursion(module)


### PR DESCRIPTION
Resolves #3435

This PR inserts the stack limit to `15_000` instead of `20_000` (in the gear pallet).

TODO:
- [ ] review https://github.com/gear-tech/wasm-instrument/pull/5
- [ ] publish new version of `gwasm-instrument`, e.g. `0.2.2`

