### PR TITLE
chore: downgrade rust version to nightly-2023-09-18

### DIFF
--- a/examples/constructor/src/builder.rs
+++ b/examples/constructor/src/builder.rs
@@ -46,6 +46,8 @@ impl Calls {
         self
     }
 
+    // TODO #3452: remove this on next rust update
+    #[allow(clippy::useless_conversion)]
     pub fn add_from_iter(mut self, calls: impl Iterator<Item = Call>) -> Self {
         self.0.extend(calls.into_iter());
         self

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-10-14"
+channel = "nightly-2023-09-18"
 components = [ "llvm-tools" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "default"

--- a/scripts/src/clippy.sh
+++ b/scripts/src/clippy.sh
@@ -20,13 +20,14 @@ EOF
 }
 
 gear_clippy() {
+  # TODO #3452: remove `-A clippy::needless_pass_by_ref_mut` on next rust update
   EXCLUDE_PACKAGES="--exclude vara-runtime --exclude runtime-fuzzer --exclude runtime-fuzzer-fuzz"
   INCLUDE_PACKAGES="-p vara-runtime -p runtime-fuzzer -p runtime-fuzzer-fuzz"
 
-  __GEAR_WASM_BUILDER_NO_BUILD=1 SKIP_WASM_BUILD=1 SKIP_VARA_RUNTIME_WASM_BUILD=1 cargo clippy --workspace "$@" $EXCLUDE_PACKAGES -- --no-deps -D warnings
-  __GEAR_WASM_BUILDER_NO_BUILD=1 SKIP_WASM_BUILD=1 SKIP_VARA_RUNTIME_WASM_BUILD=1 cargo clippy $INCLUDE_PACKAGES --all-features -- --no-deps -D warnings
+  __GEAR_WASM_BUILDER_NO_BUILD=1 SKIP_WASM_BUILD=1 SKIP_VARA_RUNTIME_WASM_BUILD=1 cargo clippy --workspace "$@" $EXCLUDE_PACKAGES -- --no-deps -D warnings -A clippy::needless_pass_by_ref_mut
+  __GEAR_WASM_BUILDER_NO_BUILD=1 SKIP_WASM_BUILD=1 SKIP_VARA_RUNTIME_WASM_BUILD=1 cargo clippy $INCLUDE_PACKAGES --all-features -- --no-deps -D warnings -A clippy::needless_pass_by_ref_mut
 }
 
 examples_clippy() {
-  __GEAR_WASM_BUILDER_NO_BUILD=1 SKIP_WASM_BUILD=1 SKIP_VARA_RUNTIME_WASM_BUILD=1 cargo clippy -p "demo-*" -p test-syscalls --no-default-features "$@" -- --no-deps -D warnings
+  __GEAR_WASM_BUILDER_NO_BUILD=1 SKIP_WASM_BUILD=1 SKIP_VARA_RUNTIME_WASM_BUILD=1 cargo clippy -p "demo-*" -p test-syscalls --no-default-features "$@" -- --no-deps -D warnings -A clippy::needless_pass_by_ref_mut
 }


### PR DESCRIPTION
it should fix fuzzer & CI

disadvantages: `needless_pass_by_ref_mut` warnings (#3452)