### PR TITLE
refactor(gsdk): Remove abiguity in `Api::blocks()` functions

### DIFF
--- a/gclient/src/api/mod.rs
+++ b/gclient/src/api/mod.rs
@@ -120,7 +120,7 @@ impl GearApi {
     /// Create an [`EventListener`] to subscribe and handle continuously
     /// incoming events.
     pub async fn subscribe(&self) -> Result<EventListener> {
-        let events = self.0.api().finalized_blocks().await?;
+        let events = self.0.api().subscribe_finalized_blocks().await?;
         Ok(EventListener(events))
     }
 

--- a/gsdk/src/api.rs
+++ b/gsdk/src/api.rs
@@ -71,14 +71,14 @@ impl Api {
     ///   // ...
     /// }
     /// ```
-    pub async fn blocks(&self) -> Result<Blocks> {
+    pub async fn subscribe_blocks(&self) -> Result<Blocks> {
         Ok(self.client.blocks().subscribe_all().await?.into())
     }
 
     /// Subscribe finalized blocks
     ///
     /// Same as `blocks` but only finalized blocks.
-    pub async fn finalized_blocks(&self) -> Result<Blocks> {
+    pub async fn subscribe_finalized_blocks(&self) -> Result<Blocks> {
         Ok(self.client.blocks().subscribe_finalized().await?.into())
     }
 

--- a/gsdk/src/api.rs
+++ b/gsdk/src/api.rs
@@ -77,7 +77,7 @@ impl Api {
 
     /// Subscribe finalized blocks
     ///
-    /// Same as `blocks` but only finalized blocks.
+    /// Same as [`subscribe_blocks`] but only finalized blocks.
     pub async fn subscribe_finalized_blocks(&self) -> Result<Blocks> {
         Ok(self.client.blocks().subscribe_finalized().await?.into())
     }

--- a/gsdk/src/api.rs
+++ b/gsdk/src/api.rs
@@ -65,7 +65,7 @@ impl Api {
     ///
     /// ```ignore
     /// let api = Api::new(None).await?;
-    /// let blocks = api.blocks().await?;
+    /// let blocks = api.subscribe_blocks().await?;
     ///
     /// while let Ok(block) = blocks.next().await {
     ///   // ...

--- a/gsdk/src/api.rs
+++ b/gsdk/src/api.rs
@@ -77,7 +77,7 @@ impl Api {
 
     /// Subscribe finalized blocks
     ///
-    /// Same as [`subscribe_blocks`] but only finalized blocks.
+    /// Same as `subscribe_blocks` but only finalized blocks.
     pub async fn subscribe_finalized_blocks(&self) -> Result<Blocks> {
         Ok(self.client.blocks().subscribe_finalized().await?.into())
     }

--- a/gsdk/tests/rpc.rs
+++ b/gsdk/tests/rpc.rs
@@ -209,7 +209,7 @@ async fn test_runtime_wasm_blob_version() -> Result<()> {
 
     let node = dev_node();
     let api = Api::new(Some(&node_uri(&node))).await?;
-    let mut finalized_blocks = api.finalized_blocks().await?;
+    let mut finalized_blocks = api.subscribe_finalized_blocks().await?;
 
     let wasm_blob_version_1 = api.runtime_wasm_blob_version(None).await?;
     assert!(

--- a/utils/node-loader/src/main.rs
+++ b/utils/node-loader/src/main.rs
@@ -38,7 +38,7 @@ async fn run(params: Params) -> Result<()> {
 /// Broadcast new events to receivers.
 async fn listen_events(tx: Sender<subxt::events::Events<GearConfig>>, node: String) -> Result<()> {
     let api = gsdk::Api::new(Some(&node)).await?;
-    let mut event_listener = api.finalized_blocks().await?;
+    let mut event_listener = api.subscribe_finalized_blocks().await?;
 
     while let Some(events) = event_listener.next_events().await {
         tx.send(events?)?;

--- a/utils/validator-checks/src/listener.rs
+++ b/utils/validator-checks/src/listener.rs
@@ -33,7 +33,7 @@ impl Listener {
 
     /// Listen to finalized blocks.
     pub async fn listen_finalized(&self) -> Result<Blocks> {
-        self.api.finalized_blocks().await.map_err(Into::into)
+        self.api.subscribe_finalized_blocks().await.map_err(Into::into)
     }
 
     /// Run validator checks.

--- a/utils/validator-checks/src/listener.rs
+++ b/utils/validator-checks/src/listener.rs
@@ -33,7 +33,10 @@ impl Listener {
 
     /// Listen to finalized blocks.
     pub async fn listen_finalized(&self) -> Result<Blocks> {
-        self.api.subscribe_finalized_blocks().await.map_err(Into::into)
+        self.api
+            .subscribe_finalized_blocks()
+            .await
+            .map_err(Into::into)
     }
 
     /// Run validator checks.


### PR DESCRIPTION
Resolves #3453 

@reviewer-or-team
