### PR TITLE
chore(wasm-instrument): move syscall table test to core-backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4505,7 +4505,6 @@ version = "1.0.2"
 dependencies = [
  "enum-iterator 1.4.1",
  "gear-core",
- "gear-core-backend",
  "gwasm-instrument",
  "wasmparser-nostd 0.100.1",
  "wat",

--- a/utils/wasm-instrument/Cargo.toml
+++ b/utils/wasm-instrument/Cargo.toml
@@ -17,12 +17,10 @@ enum-iterator.workspace = true
 [dev-dependencies]
 wasmparser.workspace = true
 wat.workspace = true
-gear-core-backend = { workspace = true, features = ["mock"] }
 gear-core.workspace = true
 
 [features]
 default = ["std"]
 std = [
-    "gear-core-backend/std",
     "gwasm-instrument/std",
 ]

--- a/utils/wasm-instrument/src/lib.rs
+++ b/utils/wasm-instrument/src/lib.rs
@@ -24,15 +24,15 @@ extern crate alloc;
 use alloc::vec;
 
 use gwasm_instrument::{
-    gas_metering::{self, Rules},
+    gas_metering::Rules,
     parity_wasm::{
         builder,
         elements::{self, BlockType, ImportCountType, Instruction, Instructions, Local, ValueType},
     },
 };
 
-use crate::syscalls::SysCallName;
-pub use gwasm_instrument::{self as wasm_instrument, parity_wasm};
+pub use crate::syscalls::SysCallName;
+pub use gwasm_instrument::{self as wasm_instrument, gas_metering, parity_wasm};
 
 #[cfg(test)]
 mod tests;

--- a/utils/wasm-instrument/src/tests.rs
+++ b/utils/wasm-instrument/src/tests.rs
@@ -618,61 +618,6 @@ test_gas_counter_injection! {
     "#
 }
 
-/// Check that all sys calls are supported by backend.
-#[test]
-fn test_sys_calls_table() {
-    use gas_metering::ConstantCostRules;
-    use gear_core::message::DispatchKind;
-    use gear_core_backend::{
-        env::{BackendReport, Environment},
-        error::ActorTerminationReason,
-        mock::MockExt,
-    };
-    use parity_wasm::builder;
-
-    // Make module with one empty function.
-    let mut module = builder::module()
-        .function()
-        .signature()
-        .build()
-        .build()
-        .build();
-
-    // Insert syscalls imports.
-    for name in SysCallName::instrumentable() {
-        let sign = name.signature();
-        let types = module.type_section_mut().unwrap().types_mut();
-        let type_no = types.len() as u32;
-        types.push(parity_wasm::elements::Type::Function(sign.func_type()));
-
-        module = builder::from_module(module)
-            .import()
-            .module("env")
-            .external()
-            .func(type_no)
-            .field(name.to_str())
-            .build()
-            .build();
-    }
-
-    let module = inject(module, &ConstantCostRules::default(), "env").unwrap();
-    let code = module.into_bytes().unwrap();
-
-    // Execute wasm and check success.
-    let ext = MockExt::default();
-    let env =
-        Environment::new(ext, &code, DispatchKind::Init, Default::default(), 0.into()).unwrap();
-    let report = env
-        .execute(|_, _, _| -> Result<(), u32> { Ok(()) })
-        .unwrap();
-
-    let BackendReport {
-        termination_reason, ..
-    } = report;
-
-    assert_eq!(termination_reason, ActorTerminationReason::Success.into());
-}
-
 #[test]
 fn check_memory_array_pointers_definition_correctness() {
     let sys_calls = SysCallName::instrumentable();


### PR DESCRIPTION
Resolves # .

- `core-backend` already has dependency `gear-wasm-instrument`
- `core-backend` as dependency of `gear-wasm-instrument` makes it bigger and blocks uploading it to `crates-io`

blocks #3103 

@gear-tech/dev 
