### PR TITLE
fix(backport)!: Move nightly features behind feature gates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2741,6 +2741,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e493c573fce17f00dcab13b6ac057994f3ce17d1af4dc39bfd482b83c6eb6157"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4770,6 +4779,7 @@ name = "gstd"
 version = "1.0.2"
 dependencies = [
  "bs58 0.5.0",
+ "document-features",
  "futures",
  "galloc",
  "gcore",
@@ -6376,6 +6386,12 @@ name = "linux-raw-sys"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+
+[[package]]
+name = "litrs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9275e0933cf8bb20f008924c0cb07a0692fe54d8064996520bf998de9eb79aa"
 
 [[package]]
 name = "lock_api"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ gcore = { path = "gcore" }
 gcli = { path = "gcli" }
 gclient = { path = "gclient" }
 gsdk = { path = "gsdk" }
-gstd = { path = "gstd" }
+gstd = { path = "gstd", features = [ "nightly" ] }
 gsys = { path = "gsys" }
 gtest = { path = "gtest" }
 gmeta = { path = "gmeta" }

--- a/gstd/Cargo.toml
+++ b/gstd/Cargo.toml
@@ -24,9 +24,7 @@ static_assertions.workspace = true
 [features]
 #! ## Default features
 
-default = ["default-stable", "nightly"]
-## Stable subset of default features.
-default-stable = ["panic-handler"]
+default = ["panic-handler"]
 ## When enabled, a panic handler is provided by this crate.
 panic-handler = []
 

--- a/gstd/Cargo.toml
+++ b/gstd/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+document-features = { version = "0.2.7", optional = true }
 galloc.workspace = true
 gcore = { workspace = true, features = ["codec"] }
 gstd-codegen = { path = "codegen" }
@@ -13,7 +14,7 @@ gear-core-errors.workspace = true
 hashbrown.workspace = true
 bs58 = { workspace = true, features = ["alloc"] }
 hex = { workspace = true, features = ["alloc"] }
-parity-scale-codec = { workspace = true, features = [ "derive" ] }
+parity-scale-codec = { workspace = true, features = ["derive"] }
 primitive-types = { workspace = true, features = ["scale-info"] }
 scale-info = { workspace = true, features = ["derive"] }
 futures = { workspace = true, features = ["alloc"] }
@@ -21,10 +22,34 @@ futures = { workspace = true, features = ["alloc"] }
 static_assertions.workspace = true
 
 [features]
+#! ## Default features
+
 default = ["default-stable", "nightly"]
+## Stable subset of default features.
 default-stable = ["panic-handler"]
-nightly = ["panic-messages", "oom-handler"]
+## When enabled, a panic handler is provided by this crate.
 panic-handler = []
-debug = ["galloc/debug", "gcore/debug"]
+
+#! ## Nightly features
+
+## Enables all features below.
+## These features depend on unstable Rust API and require nightly toolchain.
+nightly = ["panic-messages", "oom-handler"]
+## When enabled, additional context information is available from
+## panic messages in debug mode. Relies on [`panic_info_message`][rust-66745].
 panic-messages = []
+## When enabled, an OOM error handler is provided.
+## Relies on [`alloc_error_handler`][rust-51540],
 oom-handler = []
+
+#! ## Additional features
+
+## Enables debug logging; this heavily impacts gas cost 
+## and is therefore disabled by default.
+debug = ["galloc/debug", "gcore/debug"]
+
+#! [rust-66745]: https://github.com/rust-lang/rust/issues/66745
+#! [rust-51540]: https://github.com/rust-lang/rust/issues/51540
+
+[package.metadata.docs.rs]
+all-features = true

--- a/gstd/Cargo.toml
+++ b/gstd/Cargo.toml
@@ -21,6 +21,10 @@ futures = { workspace = true, features = ["alloc"] }
 static_assertions.workspace = true
 
 [features]
-default = ["panic-handler"]
+default = ["default-stable", "nightly"]
+default-stable = ["panic-handler"]
+nightly = ["panic-messages", "oom-handler"]
 panic-handler = []
 debug = ["galloc/debug", "gcore/debug"]
+panic-messages = []
+oom-handler = []

--- a/gstd/src/common/handlers.rs
+++ b/gstd/src/common/handlers.rs
@@ -25,26 +25,29 @@
 //! debug and non-debug mode, for programs built in `wasm32` architecture.
 //! For `debug` mode it provides more extensive logging.
 
+#[cfg(target_arch = "wasm32")]
+use crate::ext;
+#[cfg(target_arch = "wasm32")]
+use core::panic::PanicInfo;
+
 #[cfg(feature = "oom-handler")]
 #[cfg(target_arch = "wasm32")]
 #[alloc_error_handler]
 pub fn oom(_: core::alloc::Layout) -> ! {
-    crate::ext::oom_panic()
+    ext::oom_panic()
 }
 
 #[cfg(not(all(feature = "panic-message", feature = "debug")))]
 #[cfg(target_arch = "wasm32")]
 #[panic_handler]
 pub fn panic(_: &PanicInfo) -> ! {
-    crate::ext::panic("no info")
+    ext::panic("no info")
 }
 
 #[cfg(all(feature = "panic-message", feature = "debug"))]
 #[cfg(target_arch = "wasm32")]
 #[panic_handler]
-pub fn panic(panic_info: &core::panic::PanicInfo) -> ! {
-    use crate::{ext, prelude::format};
-
+pub fn panic(panic_info: &PanicInfo) -> ! {
     let msg = match (panic_info.message(), panic_info.location()) {
         (Some(msg), Some(loc)) => format!(
             "'{:?}', {}:{}:{}",

--- a/gstd/src/common/handlers.rs
+++ b/gstd/src/common/handlers.rs
@@ -32,15 +32,14 @@ pub fn oom(_: core::alloc::Layout) -> ! {
     crate::ext::oom_panic()
 }
 
-#[cfg(not(any(feature = "debug", debug_assertions)))]
+#[cfg(not(all(feature = "panic-message", feature = "debug")))]
 #[cfg(target_arch = "wasm32")]
 #[panic_handler]
 pub fn panic(_: &PanicInfo) -> ! {
     crate::ext::panic("no info")
 }
 
-#[cfg(feature = "panic-message")]
-#[cfg(any(feature = "debug", debug_assertions))]
+#[cfg(all(feature = "panic-message", feature = "debug"))]
 #[cfg(target_arch = "wasm32")]
 #[panic_handler]
 pub fn panic(panic_info: &core::panic::PanicInfo) -> ! {

--- a/gstd/src/common/handlers.rs
+++ b/gstd/src/common/handlers.rs
@@ -25,27 +25,27 @@
 //! debug and non-debug mode, for programs built in `wasm32` architecture.
 //! For `debug` mode it provides more extensive logging.
 
-#[cfg(target_arch = "wasm32")]
-use {crate::ext, core::alloc::Layout, core::panic::PanicInfo};
-
+#[cfg(feature = "oom-handler")]
 #[cfg(target_arch = "wasm32")]
 #[alloc_error_handler]
-pub fn oom(_: Layout) -> ! {
-    ext::oom_panic()
+pub fn oom(_: core::alloc::Layout) -> ! {
+    crate::ext::oom_panic()
 }
 
 #[cfg(not(any(feature = "debug", debug_assertions)))]
 #[cfg(target_arch = "wasm32")]
 #[panic_handler]
 pub fn panic(_: &PanicInfo) -> ! {
-    ext::panic("no info")
+    crate::ext::panic("no info")
 }
 
+#[cfg(feature = "panic-message")]
 #[cfg(any(feature = "debug", debug_assertions))]
 #[cfg(target_arch = "wasm32")]
 #[panic_handler]
-pub fn panic(panic_info: &PanicInfo) -> ! {
+pub fn panic(panic_info: &core::panic::PanicInfo) -> ! {
     use crate::prelude::format;
+    use crate::ext;
 
     let msg = match (panic_info.message(), panic_info.location()) {
         (Some(msg), Some(loc)) => format!(

--- a/gstd/src/common/handlers.rs
+++ b/gstd/src/common/handlers.rs
@@ -24,28 +24,24 @@
 //! Panic handlers are available in two implementations -
 //! debug and non-debug mode, for programs built in `wasm32` architecture.
 //! For `debug` mode it provides more extensive logging.
+#![cfg(target_arch = "wasm32")]
 
-#[cfg(target_arch = "wasm32")]
 use crate::ext;
-#[cfg(target_arch = "wasm32")]
 use core::panic::PanicInfo;
 
 #[cfg(feature = "oom-handler")]
-#[cfg(target_arch = "wasm32")]
 #[alloc_error_handler]
 pub fn oom(_: core::alloc::Layout) -> ! {
     ext::oom_panic()
 }
 
 #[cfg(not(all(feature = "panic-message", feature = "debug")))]
-#[cfg(target_arch = "wasm32")]
 #[panic_handler]
 pub fn panic(_: &PanicInfo) -> ! {
     ext::panic("no info")
 }
 
 #[cfg(all(feature = "panic-message", feature = "debug"))]
-#[cfg(target_arch = "wasm32")]
 #[panic_handler]
 pub fn panic(panic_info: &PanicInfo) -> ! {
     let msg = match (panic_info.message(), panic_info.location()) {

--- a/gstd/src/common/handlers.rs
+++ b/gstd/src/common/handlers.rs
@@ -44,7 +44,7 @@ mod panic_handler {
 
     #[cfg(feature = "debug")]
     #[panic_handler]
-    pub fn panic(_: &PanicInfo) -> ! {
+    pub fn panic(panic_info: &PanicInfo) -> ! {
         use crate::prelude::format;
         #[cfg(not(feature = "panic-messages"))]
         let message = None::<&core::fmt::Arguments<'_>>;

--- a/gstd/src/common/handlers.rs
+++ b/gstd/src/common/handlers.rs
@@ -36,15 +36,16 @@ mod panic_handler {
     use crate::ext;
     use core::panic::PanicInfo;
 
-    #[cfg(not(all(feature = "panic-message", feature = "debug")))]
+    #[cfg(not(all(feature = "panic-messages", feature = "debug")))]
     #[panic_handler]
     pub fn panic(_: &PanicInfo) -> ! {
         ext::panic("no info")
     }
 
-    #[cfg(all(feature = "panic-message", feature = "debug"))]
+    #[cfg(all(feature = "panic-messages", feature = "debug"))]
     #[panic_handler]
     pub fn panic(panic_info: &PanicInfo) -> ! {
+        use crate::prelude::format;
         let msg = match (panic_info.message(), panic_info.location()) {
             (Some(msg), Some(loc)) => format!(
                 "'{:?}', {}:{}:{}",

--- a/gstd/src/common/handlers.rs
+++ b/gstd/src/common/handlers.rs
@@ -26,12 +26,9 @@
 //! For `debug` mode it provides more extensive logging.
 
 #[cfg(feature = "oom-handler")]
-use crate::ext;
-
-#[cfg(feature = "oom-handler")]
 #[alloc_error_handler]
 pub fn oom(_: core::alloc::Layout) -> ! {
-    ext::oom_panic()
+    crate::ext::oom_panic()
 }
 
 #[cfg(feature = "panic-handler")]

--- a/gstd/src/common/handlers.rs
+++ b/gstd/src/common/handlers.rs
@@ -44,8 +44,7 @@ pub fn panic(_: &PanicInfo) -> ! {
 #[cfg(target_arch = "wasm32")]
 #[panic_handler]
 pub fn panic(panic_info: &core::panic::PanicInfo) -> ! {
-    use crate::prelude::format;
-    use crate::ext;
+    use crate::{ext, prelude::format};
 
     let msg = match (panic_info.message(), panic_info.location()) {
         (Some(msg), Some(loc)) => format!(

--- a/gstd/src/common/mod.rs
+++ b/gstd/src/common/mod.rs
@@ -19,6 +19,6 @@
 //! Common modules for each Gear smart contract.
 
 pub mod errors;
-#[cfg(feature = "panic-handler")]
+#[cfg(target_arch = "wasm32")]
 mod handlers;
 pub mod primitives;

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -34,10 +34,10 @@
 //!   impacts gas cost and is thus disabled by default.
 //! - **default** - Includes all default features.
 //!   - **default-stable** - Includes default stable features
-//!     - **panic-handler** - When enabled, a panic handler is provided
-//!       by this crate.
-//!   - **nightly** - Includes default nightly features.
-//!     These features depend on unstable Rust API and require nightly toolchain.
+//!     - **panic-handler** - When enabled, a panic handler is provided by this
+//!       crate.
+//!   - **nightly** - Includes default nightly features. These features depend
+//!     on unstable Rust API and require nightly toolchain.
 //!     - **panic-messages** - When enabled, additional context information is
 //!       available from panic messages in debug mode. Relies on
 //!       [`panic_info_message`][rust-66745].

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -124,10 +124,10 @@
 #![no_std]
 #![warn(missing_docs)]
 #![cfg_attr(
-    all(target_arch = "wasm32", any(feature = "debug", debug_assertions)),
+    all(target_arch = "wasm32", any(feature = "debug", debug_assertions), feature = "panic-messages"),
     feature(panic_info_message)
 )]
-#![cfg_attr(target_arch = "wasm32", feature(alloc_error_handler))]
+#![cfg_attr(all(target_arch = "wasm32", feature = "oom-handler"), feature(alloc_error_handler))]
 #![cfg_attr(feature = "strict", deny(warnings))]
 #![doc(html_logo_url = "https://docs.gear.rs/logo.svg")]
 #![doc(test(attr(deny(warnings), allow(unused_variables, unused_assignments))))]

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -28,6 +28,25 @@
 //! asynchronous programming primitives, arbitrary types encoding/decoding,
 //! providing convenient instruments for creating programs from programs, etc.
 //!
+//! # Crate features
+//!
+//! - **debug** - When enabled, logging becomes more verbose; this heavily
+//!   impacts gas cost and is thus disabled by default.
+//! - **default** - Includes all default features.
+//!   - **default-stable** - Includes default stable features
+//!     - **panic-handler** - When enabled, a panic handler is provided
+//!       by this crate.
+//!   - **nightly** - Includes default nightly features.
+//!     These features depend on unstable Rust API and require nightly toolchain.
+//!     - **panic-messages** - When enabled, additional context information is
+//!       available from panic messages in debug mode. Relies on
+//!       [`panic_info_message`][rust-66745].
+//!     - **oom-handler** - When enabled, an OOM error handler is provided.
+//!       Relies on [`alloc_error_handler`][rust-51540]
+//!
+//! [rust-66745]: https://github.com/rust-lang/rust/issues/66745
+//! [rust-51540]: https://github.com/rust-lang/rust/issues/51540
+//!
 //! # Examples
 //!
 //! Decode input payload using a custom type:

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -29,7 +29,6 @@
 //! providing convenient instruments for creating programs from programs, etc.
 //!
 //! # Crate features
-//!
 #![cfg_attr(
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! # Crate features
 //!
-//! - **debug** - When enabled, logging becomes more verbose; this heavily
+//! - **debug** - Enables debug logging; this heavily
 //!   impacts gas cost and is thus disabled by default.
 //! - **default** - Includes all default features.
 //!   - **default-stable** - Includes default stable features

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -30,23 +30,10 @@
 //!
 //! # Crate features
 //!
-//! - **debug** - Enables debug logging; this heavily
-//!   impacts gas cost and is thus disabled by default.
-//! - **default** - Includes all default features.
-//!   - **default-stable** - Includes default stable features
-//!     - **panic-handler** - When enabled, a panic handler is provided by this
-//!       crate.
-//!   - **nightly** - Includes default nightly features. These features depend
-//!     on unstable Rust API and require nightly toolchain.
-//!     - **panic-messages** - When enabled, additional context information is
-//!       available from panic messages in debug mode. Relies on
-//!       [`panic_info_message`][rust-66745].
-//!     - **oom-handler** - When enabled, an OOM error handler is provided.
-//!       Relies on [`alloc_error_handler`][rust-51540]
-//!
-//! [rust-66745]: https://github.com/rust-lang/rust/issues/66745
-//! [rust-51540]: https://github.com/rust-lang/rust/issues/51540
-//!
+#![cfg_attr(
+    feature = "document-features",
+    cfg_attr(doc, doc = ::document_features::document_features!())
+)]
 //! # Examples
 //!
 //! Decode input payload using a custom type:

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -124,11 +124,7 @@
 #![no_std]
 #![warn(missing_docs)]
 #![cfg_attr(
-    all(
-        target_arch = "wasm32",
-        any(feature = "debug", debug_assertions),
-        feature = "panic-messages"
-    ),
+    all(target_arch = "wasm32", feature = "panic-messages",),
     feature(panic_info_message)
 )]
 #![cfg_attr(

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -124,10 +124,17 @@
 #![no_std]
 #![warn(missing_docs)]
 #![cfg_attr(
-    all(target_arch = "wasm32", any(feature = "debug", debug_assertions), feature = "panic-messages"),
+    all(
+        target_arch = "wasm32",
+        any(feature = "debug", debug_assertions),
+        feature = "panic-messages"
+    ),
     feature(panic_info_message)
 )]
-#![cfg_attr(all(target_arch = "wasm32", feature = "oom-handler"), feature(alloc_error_handler))]
+#![cfg_attr(
+    all(target_arch = "wasm32", feature = "oom-handler"),
+    feature(alloc_error_handler)
+)]
 #![cfg_attr(feature = "strict", deny(warnings))]
 #![doc(html_logo_url = "https://docs.gear.rs/logo.svg")]
 #![doc(test(attr(deny(warnings), allow(unused_variables, unused_assignments))))]


### PR DESCRIPTION
- `default` now compiles on stable
- `alloc_error_handler` is behind `oom-handler`
- `panic_info_message` is behind `panic-messages`
- Both can be activated with `nightly`

## TODO
- [ ] Cover stable toolchain compiling with tests