### PR TITLE
feat(gcli): clean imports for metadata executor

### DIFF
--- a/utils/wasm-builder/src/optimize.rs
+++ b/utils/wasm-builder/src/optimize.rs
@@ -6,7 +6,7 @@ use gear_core::code::{Code, TryNewCodeConfig};
 use gear_wasm_instrument::{rules::CustomConstantCostRules, STACK_END_EXPORT_NAME};
 use pwasm_utils::{
     parity_wasm,
-    parity_wasm::elements::{Internal, Module, Section, Serialize},
+    parity_wasm::elements::{Module, Section, Serialize},
 };
 #[cfg(not(feature = "wasm-opt"))]
 use std::process::Command;
@@ -30,6 +30,8 @@ const OPTIMIZED_EXPORTS: [&str; 7] = [
     "metahash",
     STACK_END_EXPORT_NAME,
 ];
+
+const OPTIMIZED_META_EXPORTS: [&str; 1] = ["metadata"];
 
 /// Type of the output wasm.
 #[derive(PartialEq, Eq)]
@@ -88,20 +90,7 @@ impl Optimizer {
         let exports = if ty == OptType::Opt {
             OPTIMIZED_EXPORTS.to_vec()
         } else {
-            self.module
-                .export_section()
-                .ok_or_else(|| anyhow::anyhow!("Export section not found"))?
-                .entries()
-                .iter()
-                .flat_map(|entry| {
-                    if let Internal::Function(_) = entry.internal() {
-                        let entry = entry.field();
-                        (!OPTIMIZED_EXPORTS.contains(&entry)).then_some(entry)
-                    } else {
-                        None
-                    }
-                })
-                .collect()
+            OPTIMIZED_META_EXPORTS.to_vec()
         };
 
         pwasm_utils::optimize(&mut module, exports)

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -286,6 +286,8 @@ extern "C" fn metahash() {{
             )?;
         }
 
+        optimize::optimize_wasm(meta_wasm_path.clone(), meta_wasm_path.clone(), "4", false)?;
+
         smart_fs::write(
             self.out_dir.join("wasm_binary.rs"),
             format!(


### PR DESCRIPTION
Resolves #3416 

- [x] ~~clean imports of `*.meta.wasm`~~
- [x] trim imports of metadata executor of `gcli`

@gear-tech/dev 
