### PR TITLE
fix(wasm-gen): Include value into argument of invocable syscalls with destination param

### DIFF
--- a/utils/wasm-gen/src/generator/syscalls.rs
+++ b/utils/wasm-gen/src/generator/syscalls.rs
@@ -193,8 +193,8 @@ impl InvocableSysCall {
         })
     }
 
-    /// Returns the index of the destination param.
-    fn has_destination_param(&self) -> Option<usize> {
+    /// Returns the index of the destination param if a syscall has it.
+    fn destination_param_idx(&self) -> Option<usize> {
         use InvocableSysCall::*;
         use SysCallName::*;
 
@@ -204,6 +204,13 @@ impl InvocableSysCall {
             Loose(SendCommit | SendCommitWGas) => Some(1),
             _ => None,
         }
+    }
+
+    /// Returns `true` for every syscall which has a destination param idx and that is not `gr_exit` syscall,
+    /// as it only has destination param.
+    fn has_destination_param_with_value(&self) -> bool {
+        self.destination_param_idx().is_some()
+            && !matches!(self, InvocableSysCall::Loose(SysCallName::Exit))
     }
 
     // If syscall changes from fallible into infallible or vice versa in future,

--- a/utils/wasm-gen/src/generator/syscalls/invocator.rs
+++ b/utils/wasm-gen/src/generator/syscalls/invocator.rs
@@ -31,9 +31,10 @@ use gear_wasm_instrument::{
     parity_wasm::elements::{BlockType, Instruction, Internal, ValueType},
     syscalls::{ParamType, PtrInfo, PtrType, SysCallName, SysCallSignature},
 };
+use gsys::Hash;
 use std::{
     collections::{btree_map::Entry, BTreeMap, BinaryHeap, HashSet},
-    iter,
+    iter, mem,
     num::NonZeroU32,
 };
 
@@ -321,7 +322,7 @@ impl<'a, 'b> SysCallsInvocator<'a, 'b> {
             self.unstructured.len()
         );
 
-        if let Some(argument_index) = invocable.has_destination_param() {
+        if let Some(argument_index) = invocable.destination_param_idx() {
             log::trace!(
                 " -- Building call instructions for a `{}` syscall with destination",
                 invocable.to_str()
@@ -376,13 +377,36 @@ impl<'a, 'b> SysCallsInvocator<'a, 'b> {
             let upper_limit = mem_size.saturating_sub(100);
             let offset = self.unstructured.int_in_range(0..=upper_limit)?;
 
-            vec![
-                // call `gsys::gr_source` with a memory offset
+            let mut ret = {
+                // 3 instructions for invoking `gsys::gr_source` and possibly 3 more
+                // for defining value param so HashWithValue will be constructed.
+                let capacity = 3 + invocable
+                    .has_destination_param_with_value()
+                    .then_some(3)
+                    .unwrap_or_default();
+                Vec::with_capacity(capacity)
+            };
+            ret.extend_from_slice(&[
+                // call `gsys::gr_source` storing actor id and some `offset` pointer
                 Instruction::I32Const(offset as i32),
                 Instruction::Call(gr_source_call_indexes_handle),
-                // pass the offset as the first argument to the send-call
                 Instruction::I32Const(offset as i32),
-            ]
+            ]);
+
+            if invocable.has_destination_param_with_value() {
+                // We have to skip actor id bytes to define the following value param.
+                let skip_bytes = mem::size_of::<Hash>();
+                ret.extend_from_slice(&[
+                    // Define 0 value for HashWithValue
+                    Instruction::I32Const(0),
+                    // Store value on the offset + skip_bytes. That will form HashWithValue.
+                    Instruction::I32Store(2, skip_bytes as u32),
+                    // Pass the offset as the first argument to the syscall with destination
+                    Instruction::I32Const(offset as i32),
+                ]);
+            }
+
+            ret
         } else {
             let address_offset = match self.offsets.as_mut() {
                 Some(offsets) => {

--- a/utils/wasm-gen/src/generator/syscalls/invocator.rs
+++ b/utils/wasm-gen/src/generator/syscalls/invocator.rs
@@ -387,7 +387,7 @@ impl<'a, 'b> SysCallsInvocator<'a, 'b> {
                 Vec::with_capacity(capacity)
             };
             ret.extend_from_slice(&[
-                // call `gsys::gr_source` storing actor id and some `offset` pointer
+                // call `gsys::gr_source` storing actor id and some `offset` pointer.
                 Instruction::I32Const(offset as i32),
                 Instruction::Call(gr_source_call_indexes_handle),
                 Instruction::I32Const(offset as i32),
@@ -401,7 +401,7 @@ impl<'a, 'b> SysCallsInvocator<'a, 'b> {
                     Instruction::I32Const(0),
                     // Store value on the offset + skip_bytes. That will form HashWithValue.
                     Instruction::I32Store(2, skip_bytes as u32),
-                    // Pass the offset as the first argument to the syscall with destination
+                    // Pass the offset as the first argument to the syscall with destination.
                     Instruction::I32Const(offset as i32),
                 ]);
             }

--- a/utils/wasm-gen/src/generator/syscalls/invocator.rs
+++ b/utils/wasm-gen/src/generator/syscalls/invocator.rs
@@ -377,15 +377,9 @@ impl<'a, 'b> SysCallsInvocator<'a, 'b> {
             let upper_limit = mem_size.saturating_sub(100);
             let offset = self.unstructured.int_in_range(0..=upper_limit)?;
 
-            let mut ret = {
-                // 3 instructions for invoking `gsys::gr_source` and possibly 3 more
-                // for defining value param so HashWithValue will be constructed.
-                let capacity = 3 + invocable
-                    .has_destination_param_with_value()
-                    .then_some(3)
-                    .unwrap_or_default();
-                Vec::with_capacity(capacity)
-            };
+            // 3 instructions for invoking `gsys::gr_source` and possibly 3 more
+            // for defining value param so HashWithValue will be constructed.
+            let mut ret = Vec::with_capacity(6);
             ret.extend_from_slice(&[
                 // call `gsys::gr_source` storing actor id and some `offset` pointer.
                 Instruction::I32Const(offset as i32),


### PR DESCRIPTION
Loose and precise syscalls with destination param received only destination (`gsys::Hash`) instead of destination with value (`gsys::HashWithValue`) when their invocation instructions were generated in `wasm-gen`.