### PR TITLE
bugfix(runtime): Correctly distribute resources for gasless delayed sending

### DIFF
--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -519,14 +519,6 @@ impl Ext {
             .limit_of(reservation_id)
             .ok_or(ReservationError::InvalidReservationId)?;
 
-        // Almost unreachable since reservation couldn't be created
-        // with gas less than mailbox_threshold.
-        //
-        // TODO: review this place once more in #1828.
-        let limit = limit
-            .checked_sub(self.context.mailbox_threshold)
-            .ok_or(MessageError::InsufficientGasLimit)?;
-
         // Checking that reservation could be charged for
         // dispatch stash with given delay.
         if delay != 0 {
@@ -863,6 +855,8 @@ impl Externalities for Ext {
     ) -> Result<MessageId, Self::FallibleError> {
         self.check_forbidden_destination(msg.destination())?;
         self.check_message_value(msg.value())?;
+        // TODO: unify logic around different source of gas (may be origin msg,
+        // or reservation) in order to implement #1828.
         self.check_reservation_gas_limit(&id, delay)?;
         // TODO: gasful sending (#1828)
         self.charge_message_value(msg.value())?;

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -505,23 +505,20 @@ impl Ext {
         }
     }
 
-    // TODO: gasful sending (#1828).
-    /// Check reservation gas for gasless sending.
-    /// Gas of reservation for sending should be [mailbox_threshold + delay price; +inf).
-    fn check_reservation_gas_limit(
+    /// Checking that reservation could be charged for
+    /// dispatch stash with given delay.
+    fn check_reservation_gas_limit_for_delayed_sending(
         &mut self,
         reservation_id: &ReservationId,
         delay: u32,
     ) -> Result<(), FallibleExtError> {
-        let limit = self
-            .context
-            .gas_reserver
-            .limit_of(reservation_id)
-            .ok_or(ReservationError::InvalidReservationId)?;
-
-        // Checking that reservation could be charged for
-        // dispatch stash with given delay.
         if delay != 0 {
+            let limit = self
+                .context
+                .gas_reserver
+                .limit_of(reservation_id)
+                .ok_or(ReservationError::InvalidReservationId)?;
+
             // Take delay and get cost of block.
             // reserve = wait_cost * (delay + reserve_for).
             let cost_per_block = self.context.dispatch_hold_cost;
@@ -554,9 +551,30 @@ impl Ext {
     }
 
     // It's temporary fn, used to solve `core-audit/issue#22`.
-    fn safe_gasfull_sends<T: Packet>(&mut self, packet: &T) -> Result<(), FallibleExtError> {
-        match packet.gas_limit() {
-            Some(x) if x != 0 => {
+    fn safe_gasfull_sends<T: Packet>(
+        &mut self,
+        packet: &T,
+        delay: u32,
+    ) -> Result<(), FallibleExtError> {
+        // In case of delayed sending from origin message we keep some gas
+        // for it while processing outgoing sending notes so gas for
+        // previously gasless sends should appear to prevent their
+        // invasion for gas for storing delayed message.
+        match (packet.gas_limit(), delay != 0) {
+            // Zero gasfull instant.
+            //
+            // In this case there is nothing to do.
+            (Some(0), false) => {}
+
+            // Any non-zero gasfull or zero gasfull with delay.
+            //
+            // In case of zero gasfull with delay it's pretty similar to
+            // gasless with delay case.
+            //
+            // In case of any non-zero gasfull we prevent stealing for any
+            // previous gasless-es's thresholds from gas supposed to be
+            // sent with this `packet`.
+            (Some(_), _) => {
                 let prev_gasless_fee = self
                     .outgoing_gasless
                     .saturating_mul(self.context.mailbox_threshold);
@@ -565,8 +583,29 @@ impl Ext {
 
                 self.outgoing_gasless = 0;
             }
-            None => self.outgoing_gasless = self.outgoing_gasless.saturating_add(1),
-            _ => {}
+
+            // Gasless with delay.
+            //
+            // In this case we must give threshold for each uncovered gasless-es
+            // sent, otherwise they will steal gas from this `packet` that was
+            // supposed to pay for delay.
+            //
+            // It doesn't guarantee threshold for itself.
+            (None, true) => {
+                let prev_gasless_fee = self
+                    .outgoing_gasless
+                    .saturating_mul(self.context.mailbox_threshold);
+
+                self.reduce_gas(prev_gasless_fee)?;
+
+                self.outgoing_gasless = 1;
+            }
+
+            // Gasless instant.
+            //
+            // In this case there is no need to give any thresholds for previous
+            // gasless-es: only counter should be increased.
+            (None, false) => self.outgoing_gasless = self.outgoing_gasless.saturating_add(1),
         };
 
         Ok(())
@@ -610,54 +649,8 @@ impl Ext {
         }
     }
 
-    fn charge_for_dispatch_stash_hold<T: Packet>(
-        &mut self,
-        packet: &T,
-        delay: u32,
-    ) -> Result<(), FallibleExtError> {
+    fn charge_for_dispatch_stash_hold(&mut self, delay: u32) -> Result<(), FallibleExtError> {
         if delay != 0 {
-            // In case of delayed sending from origin message we keep some gas
-            // for it while processing outgoing sending notes so gas for
-            // previously gasless sends should appear to prevent their
-            // invasion for gas for storing delayed message.
-            //
-            // In case of sending delayed gasfull message with non-zero gas
-            // it's already charged in `safe_gasful_sending`.
-            match packet.gas_limit() {
-                // Giving threshold for all previous gasless-es.
-                Some(0) => {
-                    let prev_gasless_fee = self
-                        .outgoing_gasless
-                        .saturating_mul(self.context.mailbox_threshold);
-
-                    self.reduce_gas(prev_gasless_fee)?;
-
-                    self.outgoing_gasless = 0;
-                }
-                // Giving threshold for all previous gasless-es, except current.
-                None => {
-                    // This gasless sending isn't guaranteed to be provided
-                    // with gas, but previously sent gasless - must be.
-                    let prev_gasless_fee = self
-                        .outgoing_gasless
-                        .saturating_sub(1)
-                        .saturating_mul(self.context.mailbox_threshold);
-
-                    self.reduce_gas(prev_gasless_fee)?;
-
-                    // Current message sent is gasless so there is no guarantee for
-                    // it to be added in mailbox, and any future gasfull or delayed
-                    // will guarantee + pay for that.
-                    self.outgoing_gasless = 1;
-                }
-                // Check that threshold is given for all previous gasless-es.
-                _ => {
-                    if self.outgoing_gasless != 0 {
-                        unreachable!("`safe_gasfull_send` must be called before charging for dispatch stash hold!");
-                    }
-                }
-            }
-
             // Take delay and get cost of block.
             // reserve = wait_cost * (delay + reserve_for).
             let cost_per_block = self.context.dispatch_hold_cost;
@@ -670,6 +663,7 @@ impl Ext {
                 return Err(MessageError::InsufficientGasForDelayedSending.into());
             }
         }
+
         Ok(())
     }
 
@@ -858,11 +852,10 @@ impl Externalities for Ext {
         delay: u32,
     ) -> Result<MessageId, Self::FallibleError> {
         self.check_forbidden_destination(msg.destination())?;
-        self.safe_gasfull_sends(&msg)?;
+        self.safe_gasfull_sends(&msg, delay)?;
         self.charge_expiring_resources(&msg, true)?;
         self.charge_sending_fee(delay)?;
-
-        self.charge_for_dispatch_stash_hold(&msg, delay)?;
+        self.charge_for_dispatch_stash_hold(delay)?;
 
         let msg_id = self
             .context
@@ -883,7 +876,7 @@ impl Externalities for Ext {
         self.check_message_value(msg.value())?;
         // TODO: unify logic around different source of gas (may be origin msg,
         // or reservation) in order to implement #1828.
-        self.check_reservation_gas_limit(&id, delay)?;
+        self.check_reservation_gas_limit_for_delayed_sending(&id, delay)?;
         // TODO: gasful sending (#1828)
         self.charge_message_value(msg.value())?;
         self.charge_sending_fee(delay)?;
@@ -905,7 +898,7 @@ impl Externalities for Ext {
     // TODO: Consider per byte charge (issue #2255).
     fn reply_commit(&mut self, msg: ReplyPacket) -> Result<MessageId, Self::FallibleError> {
         self.check_forbidden_destination(self.context.message_context.reply_destination())?;
-        self.safe_gasfull_sends(&msg)?;
+        self.safe_gasfull_sends(&msg, 0)?;
         self.charge_expiring_resources(&msg, false)?;
         self.charge_sending_fee(0)?;
 
@@ -920,7 +913,6 @@ impl Externalities for Ext {
     ) -> Result<MessageId, Self::FallibleError> {
         self.check_forbidden_destination(self.context.message_context.reply_destination())?;
         self.check_message_value(msg.value())?;
-        self.check_reservation_gas_limit(&id, 0)?;
         // TODO: gasful sending (#1828)
         self.charge_message_value(msg.value())?;
         self.charge_sending_fee(0)?;
@@ -1198,12 +1190,10 @@ impl Externalities for Ext {
         delay: u32,
     ) -> Result<(MessageId, ProgramId), Self::FallibleError> {
         // We don't check for forbidden destination here, since dest is always unique and almost impossible to match SYSTEM_ID
-
-        self.safe_gasfull_sends(&packet)?;
+        self.safe_gasfull_sends(&packet, delay)?;
         self.charge_expiring_resources(&packet, true)?;
         self.charge_sending_fee(delay)?;
-
-        self.charge_for_dispatch_stash_hold(&packet, delay)?;
+        self.charge_for_dispatch_stash_hold(delay)?;
 
         let code_hash = packet.code_id();
 

--- a/examples/delayed-sender/src/lib.rs
+++ b/examples/delayed-sender/src/lib.rs
@@ -26,5 +26,7 @@ mod code {
 #[cfg(feature = "wasm-wrapper")]
 pub use code::WASM_BINARY_OPT as WASM_BINARY;
 
+pub const DELAY: u32 = 100;
+
 #[cfg(not(feature = "wasm-wrapper"))]
 mod wasm;

--- a/examples/delayed-sender/src/wasm.rs
+++ b/examples/delayed-sender/src/wasm.rs
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::DELAY;
 use gstd::{exec, msg, MessageId};
 
 static mut MID: Option<MessageId> = None;
@@ -30,6 +31,19 @@ extern "C" fn init() {
 
 #[no_mangle]
 extern "C" fn handle() {
+    let size = msg::size();
+
+    if size == 0 {
+        // Other case of delayed sending, representing possible panic case of
+        // sending delayed gasless messages.
+        msg::send_bytes_delayed(msg::source(), [], 0, DELAY).expect("Failed to send msg");
+
+        msg::send_bytes_delayed(msg::source(), [], 0, DELAY).expect("Failed to send msg");
+
+        return;
+    }
+
+    // Common delayed sender case.
     if let Some(message_id) = unsafe { MID.take() } {
         let delay: u32 = msg::load().unwrap();
 

--- a/examples/delayed-sender/src/wasm.rs
+++ b/examples/delayed-sender/src/wasm.rs
@@ -34,7 +34,7 @@ extern "C" fn handle() {
     let size = msg::size();
 
     if size == 0 {
-        // Other case of delayed sending, representing possible panic case of
+        // Another case of delayed sending, representing possible panic case of
         // sending delayed gasless messages.
         msg::send_bytes_delayed(msg::source(), [], 0, DELAY).expect("Failed to send msg");
 

--- a/pallets/gear/src/internal.rs
+++ b/pallets/gear/src/internal.rs
@@ -556,6 +556,10 @@ where
 
                     // If available gas is greater then threshold,
                     // than threshold can be used.
+                    //
+                    // Here we subtract gas for delay from gas limit to prevent
+                    // case when gasless message steal threshold from gas for
+                    // delay payment and delay payment becomes insufficient.
                     (gas_limit.saturating_sub(gas_for_delay) >= threshold).then_some(threshold)
                 })
                 .unwrap_or_default();

--- a/pallets/gear/src/internal.rs
+++ b/pallets/gear/src/internal.rs
@@ -557,7 +557,7 @@ where
 
                     // If available gas is greater then threshold,
                     // than threshold can be used.
-                    (gas_limit >= threshold).then_some(threshold)
+                    (gas_limit.saturating_sub(gas_for_delay) >= threshold).then_some(threshold)
                 })
                 .unwrap_or_default();
 

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -45,10 +45,10 @@ use crate::{
     },
     pallet,
     runtime_api::RUNTIME_API_BLOCK_LIMITS_COUNT,
-    BlockGasLimitOf, Config, CostsPerBlockOf, CurrencyOf, DbWeightOf, Error, Event, GasAllowanceOf,
-    GasBalanceOf, GasHandlerOf, GasInfo, GearBank, MailboxOf, ProgramStorageOf, QueueOf,
-    RentCostPerBlockOf, RentFreePeriodOf, ResumeMinimalPeriodOf, ResumeSessionDurationOf, Schedule,
-    TaskPoolOf, WaitlistOf,
+    BlockGasLimitOf, Config, CostsPerBlockOf, CurrencyOf, DbWeightOf, DispatchStashOf, Error,
+    Event, GasAllowanceOf, GasBalanceOf, GasHandlerOf, GasInfo, GearBank, MailboxOf,
+    ProgramStorageOf, QueueOf, RentCostPerBlockOf, RentFreePeriodOf, ResumeMinimalPeriodOf,
+    ResumeSessionDurationOf, Schedule, TaskPoolOf, WaitlistOf,
 };
 use common::{
     event::*, scheduler::*, storage::*, ActiveProgram, CodeStorage, GasTree, LockId, LockableTree,
@@ -82,6 +82,61 @@ pub use utils::init_logger;
 use utils::*;
 
 type Gas = <<Test as Config>::GasProvider as common::GasProvider>::GasTree;
+
+#[test]
+fn delayed_send_from_reservation_not_for_mailbox() {
+    use demo_delayed_reservation_sender::{ReservationSendingShowcase, WASM_BINARY};
+
+    init_logger();
+    new_test_ext().execute_with(|| {
+        assert_ok!(Gear::upload_program(
+            RuntimeOrigin::signed(USER_1),
+            WASM_BINARY.to_vec(),
+            DEFAULT_SALT.to_vec(),
+            EMPTY_PAYLOAD.to_vec(),
+            10_000_000_000u64,
+            0,
+            false,
+        ));
+
+        let pid = get_last_program_id();
+
+        run_to_next_block(None);
+        assert!(Gear::is_initialized(pid));
+
+        assert_ok!(Gear::send_message(
+            RuntimeOrigin::signed(USER_1),
+            pid,
+            ReservationSendingShowcase::ToSourceInPlace {
+                reservation_amount: <Test as Config>::MailboxThreshold::get(),
+                reservation_delay: 1_000,
+                sending_delay: 1,
+            }
+            .encode(),
+            BlockGasLimitOf::<Test>::get(),
+            0,
+            false,
+        ));
+
+        let mid = utils::get_last_message_id();
+
+        run_to_next_block(None);
+        assert_succeed(mid);
+
+        let outgoing = MessageId::generate_outgoing(mid, 0);
+
+        assert!(DispatchStashOf::<Test>::contains_key(&outgoing));
+
+        run_to_next_block(None);
+
+        assert!(!DispatchStashOf::<Test>::contains_key(&outgoing));
+        assert!(!MailboxOf::<Test>::contains(&USER_1, &outgoing));
+
+        let message = maybe_any_last_message().expect("Should be");
+        assert_eq!(message.id(), outgoing);
+        assert_eq!(message.destination(), USER_1.into());
+    });
+}
 
 #[test]
 fn cascading_delayed_gasless_send_work() {

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -159,6 +159,26 @@ fn cascading_delayed_gasless_send_work() {
         run_for_blocks(DELAY, None);
         assert!(MailboxOf::<Test>::contains(&USER_1, &first_outgoing));
         assert!(MailboxOf::<Test>::contains(&USER_1, &second_outgoing));
+
+        // Similar case when none of them goes into mailbox
+        // (impossible because delayed sent after gasless).
+        assert_ok!(Gear::send_message(
+            RuntimeOrigin::signed(USER_1),
+            pid,
+            EMPTY_PAYLOAD.to_vec(),
+            min_limit - 2 * <Test as Config>::MailboxThreshold::get(),
+            0,
+            false,
+        ));
+
+        let mid = get_last_message_id();
+
+        run_to_next_block(None);
+
+        assert_failed(
+            mid,
+            ActorExecutionErrorReplyReason::Trap(TrapExplanation::GasLimitExceeded),
+        );
     });
 }
 


### PR DESCRIPTION
This one is pretty similar to #2211 in way of solving the panic, but appeared after #2053.