### PR TITLE
fix(gtest): make block duration 3 secs

### DIFF
--- a/gtest/src/lib.rs
+++ b/gtest/src/lib.rs
@@ -351,6 +351,8 @@ pub mod constants {
     pub const EXISTENTIAL_DEPOSIT: Value = 10 * UNITS;
     /// Value per gas.
     pub const VALUE_PER_GAS: Value = 25;
+    /// Duration of one block in msecs.
+    pub const BLOCK_DURATION_IN_MSECS: u64 = 3000;
     /// Duration of one epoch.
     pub const EPOCH_DURATION_IN_BLOCKS: Block = 600;
 

--- a/gtest/src/system.rs
+++ b/gtest/src/system.rs
@@ -21,6 +21,7 @@ use crate::{
     mailbox::Mailbox,
     manager::{Actors, Balance, ExtManager},
     program::{Program, ProgramIdWrapper},
+    BLOCK_DURATION_IN_MSECS,
 };
 use codec::{Decode, DecodeAll};
 use colored::Colorize;
@@ -174,7 +175,10 @@ impl System {
 
                 let next_block_number = manager.block_info.height + 1;
                 manager.block_info.height = next_block_number;
-                manager.block_info.timestamp += 1000;
+                manager.block_info.timestamp = manager
+                    .block_info
+                    .timestamp
+                    .saturating_add(BLOCK_DURATION_IN_MSECS);
                 manager.process_delayed_dispatches(next_block_number)
             })
             .collect::<Vec<Vec<_>>>()


### PR DESCRIPTION
Resolves #3514 

- Fixed block duration when incrementing in `System::spend_blocks`.

@gear-tech/dev 
