### PR TITLE
chore(workspace): fix warnings from dapp template, add gstd as dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,6 +2075,7 @@ name = "demo-calc-hash"
 version = "0.1.0"
 dependencies = [
  "gear-wasm-builder",
+ "gstd",
  "parity-scale-codec",
  "sha2 0.10.8",
 ]
@@ -2239,6 +2240,7 @@ name = "demo-meta-io"
 version = "0.1.0"
 dependencies = [
  "gmeta",
+ "gstd",
  "parity-scale-codec",
  "scale-info",
 ]

--- a/core/src/ids.rs
+++ b/core/src/ids.rs
@@ -105,7 +105,7 @@ macro_rules! declare_id {
         }
 
         impl core::fmt::Display for $name {
-            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 let len = self.0.len();
                 let median = (len + 1) / 2;
 
@@ -132,7 +132,7 @@ macro_rules! declare_id {
         }
 
         impl core::fmt::Debug for $name {
-            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 core::fmt::Display::fmt(self, f)
             }
         }

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -130,7 +130,7 @@ impl Decode for PageBuf {
 impl EncodeLike for PageBuf {}
 
 impl Debug for PageBuf {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "PageBuf({:?}..{:?})",

--- a/examples/calc-hash/Cargo.toml
+++ b/examples/calc-hash/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+gstd.workspace = true
 parity-scale-codec.workspace = true
 sha2 = { version = "0.10.8", default-features = false }
 

--- a/examples/new-meta/io/Cargo.toml
+++ b/examples/new-meta/io/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+gstd.workspace = true
 gmeta.workspace = true
 scale-info.workspace = true
 parity-scale-codec.workspace = true

--- a/gcore/src/errors.rs
+++ b/gcore/src/errors.rs
@@ -35,7 +35,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::SyscallUsage => write!(f, "syscall usage error"),
             Error::Ext(e) => write!(f, "{}", e),

--- a/gcore/src/lib.rs
+++ b/gcore/src/lib.rs
@@ -69,8 +69,6 @@
 #![doc(html_favicon_url = "https://gear-tech.io/favicons/favicon.ico")]
 #![doc(test(attr(deny(warnings), allow(unused_variables, unused_assignments))))]
 
-extern crate alloc;
-
 pub mod errors;
 pub mod exec;
 pub mod msg;

--- a/gstd/codegen/src/lib.rs
+++ b/gstd/codegen/src/lib.rs
@@ -18,8 +18,6 @@
 
 //! Provides macros for async runtime of Gear contracts.
 
-extern crate proc_macro;
-
 use core::fmt::Display;
 use proc_macro::TokenStream;
 use proc_macro2::Ident;
@@ -77,7 +75,7 @@ impl MainAttrs {
 }
 
 impl Parse for MainAttrs {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let punctuated: Punctuated<MainAttr, Token![,]> = Punctuated::parse_terminated(input)?;
         let mut attrs = MainAttrs {
             handle_reply: None,
@@ -114,7 +112,7 @@ struct MainAttr {
 }
 
 impl Parse for MainAttr {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let name: Ident = input.parse()?;
         let _: Token![=] = input.parse()?;
         let path: Path = input.parse()?;

--- a/gstd/src/common/errors.rs
+++ b/gstd/src/common/errors.rs
@@ -63,7 +63,7 @@ impl Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::Core(e) => fmt::Display::fmt(e, f),
             Error::Timeout(expected, now) => {

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -211,7 +211,7 @@ impl WasmProject {
         // Copy original `Cargo.lock` if any
         let from_lock = self.original_dir.join("Cargo.lock");
         let to_lock = self.out_dir.join("Cargo.lock");
-        let _ = fs::copy(from_lock, to_lock);
+        drop(fs::copy(from_lock, to_lock));
 
         let mut source_code = "#![no_std] pub use orig_project::*;\n".to_owned();
 


### PR DESCRIPTION
dapp-template throws some additional warnings during build: https://github.com/gear-foundation/dapp-template/blob/master/.cargo/config.toml#L5
pr also fixes `cargo build -p {demo-calc-hash, demo-meta-io}`
@gear-tech/dev
