### PR TITLE
chore: downgrade rust version to nightly-2023-09-05

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-09-18"
+channel = "nightly-2023-09-05"
 components = [ "llvm-tools" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "default"


### PR DESCRIPTION
Resolves #3533 (see details about regression)
fixes `cargo fuzz coverage`
