### PR TITLE
chore(dep): upgrade cargo-metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,6 +1026,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.18",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cargo_toml"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,7 +1629,7 @@ name = "crates-io-manager"
 version = "1.0.3"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.18.1",
  "cargo_toml",
  "crates-io",
  "curl",
@@ -4554,7 +4568,7 @@ name = "gear-wasm-builder"
 version = "0.1.2"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.18.1",
  "chrono",
  "colored",
  "dirs",
@@ -12649,7 +12663,7 @@ source = "git+https://github.com/gear-tech/substrate.git?branch=gear-polkadot-v0
 dependencies = [
  "ansi_term",
  "build-helper",
- "cargo_metadata",
+ "cargo_metadata 0.15.3",
  "filetime",
  "sp-maybe-compressed-blob",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,22 +146,9 @@ serde_json = "^1"
 serde_yaml = "0.8.26"
 sha-1 = "0.10.1"
 static_assertions = "1"
-# # NOTE
-#
-# 1. subxt v0.29.0 breaks the logging in gsdk, our fork is based on the
-# unpublished v0.29.0 from the main repo with fixes.
-#
-# 2. subxt v0.29.0 upgrades the substrate dependencies which are not
-# compatible with our current dependencies.
-#
-# 3. changing but patching the source here for making these work out of
-# workspace.
-#
-# 4. subxt-metadata and subxt-codegen are just used by gsdk-codegen for now
-# gathering them here for easy management.
-subxt = { version = "0.32.1" }
-subxt-metadata = { version = "0.32.1" }
-subxt-codegen = { version = "0.32.1" }
+subxt = "0.32.1"
+subxt-metadata = "0.32.1"
+subxt-codegen = "0.32.1"
 syn = "2.0.39"
 thiserror = "1.0.50"
 tokio = { version = "1.34.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,8 +101,7 @@ base64 = "0.21.5"
 byteorder = { version = "1.5.0", default-features = false }
 blake2-rfc = { version = "0.2.18", default-features = false }
 bs58 = { version = "0.5.0", default-features = false }
-# TODO: upgrade this package ( issue #2694 )
-cargo_metadata = "=0.15.3"
+cargo_metadata = "0.18.1"
 clap = { version = "4.4.8" }
 codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false }
 color-eyre = "0.6.2"

--- a/utils/wasm-builder/src/crate_info.rs
+++ b/utils/wasm-builder/src/crate_info.rs
@@ -18,7 +18,7 @@
 
 use anyhow::{Context, Result};
 use cargo_metadata::{Metadata, MetadataCommand, Package};
-use std::{collections::HashMap, path::Path};
+use std::{collections::BTreeMap, path::Path};
 
 use crate::builder_error::BuilderError;
 
@@ -32,7 +32,7 @@ pub struct CrateInfo {
     /// Crate version.
     pub version: String,
     /// Crate features.
-    pub features: HashMap<String, Vec<String>>,
+    pub features: BTreeMap<String, Vec<String>>,
 }
 
 impl CrateInfo {


### PR DESCRIPTION
Resolves #2694

`cargo-metadata` is pinned to `0.15.3` is caused by `substrate-wasm-builder` is using `v0.15.3`, however we don't have to follow some of the outdated substrate deps' versions forever

@gear-tech/dev 
