### PR TITLE
ci(dispatch): skip label dispatching on PRs of dependabot

### DIFF
--- a/.github/actions/label/build.js
+++ b/.github/actions/label/build.js
@@ -20,8 +20,12 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 /**
  *  If skipping this action.
+ *
+ * @returns {Promise<[boolean, string]>} [skip, String(check_runs)]
  **/
-const skip = async ({ core, github }) => {
+const skip = async ({ github }) => {
+  if (TITLE.includes("[depbot]")) return [true, ""]
+
   const {
     data: { check_runs },
   } = await github.rest.checks.listForRef({
@@ -142,7 +146,8 @@ const listJobs = async ({ github, core, run_id }) => {
  *  The main function.
  **/
 module.exports = async ({ github, core }) => {
-  const [skipAction, check_runs] = await skip({ core, github });
+  const [skipAction, check_runs] = await skip({ github });
+
   if (skipAction) {
     core.info("Build has already been processed, check runs: " + check_runs);
     return;

--- a/.github/actions/label/build.js
+++ b/.github/actions/label/build.js
@@ -3,7 +3,7 @@
  */
 
 const [owner, repo] = ["gear-tech", "gear"];
-const { LABEL, REF, HEAD_SHA, TITLE, NUMBER } = process.env;
+const { LABEL, REF, HEAD_SHA, TITLE, NUMBER, IS_FORK, REF_NAME } = process.env;
 const linux =
   LABEL === "A0-pleasereview" ||
   LABEL === "A4-insubstantial" ||
@@ -24,7 +24,7 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
  * @returns {Promise<[boolean, string]>} [skip, String(check_runs)]
  **/
 const skip = async ({ github }) => {
-  if (TITLE.includes("[depbot]")) return [true, ""]
+  if (!IS_FORK && REF_NAME.startsWith("dependabot")) return [true, ""]
 
   const {
     data: { check_runs },

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -74,8 +74,10 @@ jobs:
     if: >-
       needs.status.outputs.skip-ci != '1'
       && (
-        contains(github.event.pull_request.title, '[depbot]')
-        || (
+        (
+          github.event.pull_request.head.repo.full_name == 'gear-tech/gear'
+          && contains(github.event.pull_request.title, '[depbot]')
+        ) || (
           contains(github.event.pull_request.labels.*.name, 'A0-pleasereview')
           || contains(github.event.pull_request.labels.*.name, 'A4-insubstantial')
           || contains(github.event.pull_request.labels.*.name, 'A2-mergeoncegreen')

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -22,8 +22,10 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           LABEL: ${{ github.event.label.name }}
           REF: ${{ github.head_ref || github.ref_name }}
+          REF_NAME: ${{ github.ref_name }}
           TITLE: ${{ github.event.pull_request.title }}
           NUMBER: ${{ github.event.number }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.full_name != 'gear-tech/gear' }}
         with:
           script: |
             const script = require('./.github/actions/label/build.js');


### PR DESCRIPTION
Resolves #3577 

skip label dispatching on PRs of dependabot, because dependabot doesn't have accesses for dispatching workflows


@gear-tech/dev 
