### PR TITLE
feat(gstd): add the missing `dbg!` macro

### DIFF
--- a/gstd/src/macros/debug.rs
+++ b/gstd/src/macros/debug.rs
@@ -59,3 +59,39 @@ macro_rules! debug {
 macro_rules! debug {
     ($($arg:tt)*) => {};
 }
+
+/// Prints and returns the value of a given expression for quick and dirty
+/// debugging.
+///
+/// Similar to the standard library's
+/// [`dbg!`](https://doc.rust-lang.org/std/macro.dbg.html) macro.
+#[cfg(any(feature = "debug", debug_assertions))]
+#[macro_export]
+macro_rules! dbg {
+    () => {
+        $crate::debug!("[{}:{}]", $crate::prelude::file!(), $crate::prelude::line!())
+    };
+    ($val:expr $(,)?) => {
+        match $val {
+            tmp => {
+                $crate::debug!("[{}:{}] {} = {:#?}",
+                    $crate::prelude::file!(),
+                    $crate::prelude::line!(),
+                    $crate::prelude::stringify!($val),
+                    &tmp,
+                );
+                tmp
+            }
+        }
+    };
+    ($($val:expr),+ $(,)?) => {
+        ($($crate::dbg!($val)),+,)
+    };
+}
+
+#[cfg(not(any(feature = "debug", debug_assertions)))]
+#[allow(missing_docs)]
+#[macro_export]
+macro_rules! dbg {
+    ($($arg:tt)*) => {};
+}

--- a/gstd/src/prelude.rs
+++ b/gstd/src/prelude.rs
@@ -21,6 +21,7 @@
 
 // Reexports from Rust's libraries
 
+pub use crate::dbg;
 pub use ::alloc::{
     borrow,
     borrow::ToOwned,

--- a/gstd/tests/debug.rs
+++ b/gstd/tests/debug.rs
@@ -1,0 +1,33 @@
+use gstd::{debug, prelude::*};
+
+static mut DEBUG_MSG: Vec<u8> = Vec::new();
+
+mod sys {
+    use super::*;
+
+    #[no_mangle]
+    unsafe extern "C" fn gr_debug(payload: *const u8, len: u32) {
+        DEBUG_MSG.resize(len as _, 0);
+        ptr::copy(payload, DEBUG_MSG.as_mut_ptr(), len as _);
+    }
+}
+
+#[test]
+fn test_debug() {
+    let value = 42;
+
+    debug!("{value}");
+    assert!(unsafe { DEBUG_MSG == b"42" });
+
+    debug!("Formatted: value = {value}");
+    assert_eq!(unsafe { &DEBUG_MSG }, b"Formatted: value = 42");
+
+    debug!("String literal");
+    assert_eq!(unsafe { &DEBUG_MSG }, b"String literal");
+
+    crate::dbg!(value);
+    assert_eq!(
+        unsafe { &DEBUG_MSG },
+        b"[gstd/tests/debug.rs:28] value = 42"
+    );
+}

--- a/gstd/tests/debug.rs
+++ b/gstd/tests/debug.rs
@@ -17,7 +17,7 @@ fn test_debug() {
     let value = 42;
 
     debug!("{value}");
-    assert!(unsafe { DEBUG_MSG == b"42" });
+    assert_eq!(unsafe { &DEBUG_MSG }, b"42");
 
     debug!("Formatted: value = {value}");
     assert_eq!(unsafe { &DEBUG_MSG }, b"Formatted: value = 42");


### PR DESCRIPTION
- Added `dbg!` macro to `gstd` prelude similar to the standard library's one (https://doc.rust-lang.org/std/macro.dbg.html).

@gear-tech/dev 
