### PR TITLE
chore: bump gear-dlmalloc for free_range support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4158,9 +4158,9 @@ dependencies = [
 
 [[package]]
 name = "gear-dlmalloc"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5c1d3d820d57acd0c4129b3551f5fe5b01e61c8cb2863bad2b183a4b32dc978"
+checksum = "6b88fcd5524e7ab9f156c17b14e754d6ba122ef9b00586d632d2ae3dbc7bfadb"
 dependencies = [
  "libc",
  "libc-print",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,8 +166,8 @@ tempfile = "3.8.1"
 
 # Published deps
 #
-# https://github.com/gear-tech/dlmalloc-rust/tree/v0.1.4
-dlmalloc = { package = "gear-dlmalloc", version = "0.1.4" }
+# https://github.com/gear-tech/gear-dlmalloc/tree/0.2.0
+dlmalloc = { package = "gear-dlmalloc", version = "0.2.0" }
 # https://github.com/gear-tech/wasm-instrument/tree/gear-stable-v0.3.0
 gwasm-instrument = { version = "0.3.0", default-features = false }
 # https://github.com/gear-tech/wasm-utils/tree/v0.19.0


### PR DESCRIPTION
Bump allocator to version that uses new `free_range` call.

@gear-tech/dev