### PR TITLE
chore(runtime-interface): handle std for sp-io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7279,6 +7279,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.41",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7279,7 +7279,6 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
- "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.41",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ gear-core-backend = { path = "core-backend", default-features = false }
 gear-call-gen = { path = "utils/call-gen" }
 gear-common = { path = "common", default-features = false }
 gear-common-codegen = { path = "common/codegen" }
-gear-core = { path = "core" }
+gear-core = { path = "core", default-features = false }
 gear-core-errors = { path = "core-errors" }
 gear-core-processor = { path = "core-processor", default-features = false }
 gear-lazy-pages = { path = "lazy-pages" }

--- a/runtime-interface/Cargo.toml
+++ b/runtime-interface/Cargo.toml
@@ -14,14 +14,16 @@ gear-lazy-pages-common.workspace = true
 gear-lazy-pages = { workspace = true, optional = true }
 gear-sandbox-host = { workspace = true, optional = true }
 
-log = { workspace = true, optional = true }
+sp-io.workspace = true
 sp-runtime-interface.workspace = true
 sp-std.workspace = true
 sp-wasm-interface.workspace = true
-sp-io.workspace = true
-codec = { workspace = true }
-static_assertions.workspace = true
+
 byteorder.workspace = true
+codec = { workspace = true }
+log = { workspace = true, optional = true }
+static_assertions.workspace = true
+
 
 [target.'cfg(windows)'.dependencies]
 winapi = { workspace = true, features = ["memoryapi"] }
@@ -30,13 +32,15 @@ winapi = { workspace = true, features = ["memoryapi"] }
 default = ["std"]
 std = [
 	"gear-core/std",
-	"sp-runtime-interface/std",
-	"sp-std/std",
+	"gear-lazy-pages",
+	"gear-sandbox-host",
+
 	"sp-io/std",
+	"sp-std/std",
+	"sp-runtime-interface/std",
 	"sp-wasm-interface/std",
+
 	"byteorder/std",
 	"codec/std",
 	"log",
-	"gear-lazy-pages",
-	"gear-sandbox-host",
 ]

--- a/runtime-interface/Cargo.toml
+++ b/runtime-interface/Cargo.toml
@@ -29,8 +29,10 @@ winapi = { workspace = true, features = ["memoryapi"] }
 [features]
 default = ["std"]
 std = [
+	"gear-core/std",
 	"sp-runtime-interface/std",
 	"sp-std/std",
+	"sp-io/std",
 	"sp-wasm-interface/std",
 	"byteorder/std",
 	"codec/std",


### PR DESCRIPTION
Resolves #3622 

`sp-io` is missed in `gear-runtime-interface`

### review the problem

- `gear-sandbox`
- `core-backend` 
 
can not be built with feature `std` directly


@gear-tech/dev 
