### PR TITLE
feat(wasm-gen): Introduce value fuzzing abilities to `wasm-gen`

### DIFF
--- a/utils/node-loader/src/batch_pool/generators/batch.rs
+++ b/utils/node-loader/src/batch_pool/generators/batch.rs
@@ -10,7 +10,6 @@ use gear_call_gen::{
     CallArgs, CallGenRng, CallGenRngCore, ClaimValueArgs, CreateProgramArgs, SendMessageArgs,
     SendReplyArgs, UploadCodeArgs, UploadProgramArgs,
 };
-use gear_core::ids::ProgramId;
 use gear_utils::NonEmpty;
 use gear_wasm_gen::StandardGearWasmConfigsBundle;
 use std::iter;
@@ -206,7 +205,7 @@ impl<Rng: CallGenRng> BatchGenerator<Rng> {
     fn gen_batch<
         T: CallArgs,
         FuzzerArgsFn: FnMut(&mut Rng) -> T::FuzzerArgs,
-        ConstArgsFn: Fn() -> T::ConstArgs<StandardGearWasmConfigsBundle<ProgramId>>,
+        ConstArgsFn: Fn() -> T::ConstArgs<StandardGearWasmConfigsBundle>,
     >(
         batch_size: usize,
         seed: Seed,

--- a/utils/node-loader/src/utils.rs
+++ b/utils/node-loader/src/utils.rs
@@ -243,7 +243,7 @@ pub fn get_wasm_gen_config(
             .filter(|&pid| pid != ProgramId::default())
             .map(|pid| pid.into()),
     )
-    .map(|non_empty| SyscallDestination::ExistingAddresses(non_empty))
+    .map(SyscallDestination::ExistingAddresses)
     .unwrap_or(SyscallDestination::Source);
 
     params_config.set_ptr_rule(PtrParamAllowedValues::ActorId(syscall_destination.clone()));

--- a/utils/node-loader/src/utils.rs
+++ b/utils/node-loader/src/utils.rs
@@ -5,11 +5,9 @@ use gclient::{Event, GearApi, GearEvent, WSAddress};
 use gear_call_gen::Seed;
 use gear_core::ids::{MessageId, ProgramId};
 use gear_core_errors::ReplyCode;
-use gear_utils::NonEmpty;
 use gear_wasm_gen::{
-    EntryPointsSet, InvocableSyscall, PtrParamAllowedValues, RegularParamType,
-    StandardGearWasmConfigsBundle, SyscallDestination, SyscallName, SyscallsInjectionTypes,
-    SyscallsParamsConfig,
+    EntryPointsSet, InvocableSyscall, RegularParamType, StandardGearWasmConfigsBundle, SyscallName,
+    SyscallsInjectionTypes, SyscallsParamsConfig,
 };
 use gsdk::metadata::runtime_types::{
     gear_common::event::DispatchStatus as GenDispatchStatus,
@@ -211,7 +209,7 @@ pub fn err_waited_or_succeed_batch(
 /// Returns configs bundle with a gear wasm generator config, which logs `seed`.
 pub fn get_wasm_gen_config(
     seed: Seed,
-    existing_programs: impl Iterator<Item = ProgramId>,
+    _existing_programs: impl Iterator<Item = ProgramId>,
 ) -> StandardGearWasmConfigsBundle {
     let initial_pages = 2;
     let mut injection_types = SyscallsInjectionTypes::all_once();
@@ -236,21 +234,6 @@ pub fn get_wasm_gen_config(
         RegularParamType::Free,
         (initial_pages..=initial_pages + 50).into(),
     );
-    params_config.set_ptr_rule(PtrParamAllowedValues::Value(0..=0));
-
-    let syscall_destination = NonEmpty::collect(
-        existing_programs
-            .filter(|&pid| pid != ProgramId::default())
-            .map(|pid| pid.into()),
-    )
-    .map(SyscallDestination::ExistingAddresses)
-    .unwrap_or(SyscallDestination::Source);
-
-    params_config.set_ptr_rule(PtrParamAllowedValues::ActorId(syscall_destination.clone()));
-    params_config.set_ptr_rule(PtrParamAllowedValues::ActorIdWithValue {
-        actor: syscall_destination.clone(),
-        range: 0..=0,
-    });
 
     StandardGearWasmConfigsBundle {
         log_info: Some(format!("Gear program seed = '{seed}'")),

--- a/utils/node-loader/src/utils.rs
+++ b/utils/node-loader/src/utils.rs
@@ -228,12 +228,13 @@ pub fn get_wasm_gen_config(
         .into_iter(),
     );
 
-    let mut params_config = SyscallsParamsConfig::default_regular();
-    params_config.set_rule(RegularParamType::Alloc, (1..=10).into());
-    params_config.set_rule(
-        RegularParamType::Free,
-        (initial_pages..=initial_pages + 50).into(),
-    );
+    let params_config = SyscallsParamsConfig::new()
+        .with_default_regular_config()
+        .with_rule(RegularParamType::Alloc, (1..=10).into())
+        .with_rule(
+            RegularParamType::Free,
+            (initial_pages..=initial_pages + 50).into(),
+        );
 
     StandardGearWasmConfigsBundle {
         log_info: Some(format!("Gear program seed = '{seed}'")),

--- a/utils/runtime-fuzzer/src/gear_calls.rs
+++ b/utils/runtime-fuzzer/src/gear_calls.rs
@@ -35,9 +35,8 @@ use gear_call_gen::{ClaimValueArgs, SendReplyArgs};
 use gear_core::ids::{CodeId, MessageId, ProgramId};
 use gear_utils::NonEmpty;
 use gear_wasm_gen::{
-    EntryPointsSet, InvocableSyscall, PtrParamAllowedValues, RegularParamType,
-    StandardGearWasmConfigsBundle, SyscallDestination, SyscallName, SyscallsInjectionTypes,
-    SyscallsParamsConfig,
+    ActorKind, EntryPointsSet, InvocableSyscall, PtrParamAllowedValues, RegularParamType,
+    StandardGearWasmConfigsBundle, SyscallName, SyscallsInjectionTypes, SyscallsParamsConfig,
 };
 use std::mem;
 
@@ -437,14 +436,14 @@ fn config(programs: &[ProgramId], log_info: Option<String>) -> StandardGearWasmC
             .filter(|&pid| pid != ProgramId::default())
             .map(|pid| pid.into()),
     )
-    .map(SyscallDestination::ExistingAddresses)
-    .unwrap_or(SyscallDestination::Source);
+    .map(ActorKind::ExistingAddresses)
+    .unwrap_or(ActorKind::Source);
 
     log::trace!("Messages destination config: {:?}", syscall_destination);
 
     params_config.set_ptr_rule(PtrParamAllowedValues::ActorId(syscall_destination.clone()));
     params_config.set_ptr_rule(PtrParamAllowedValues::ActorIdWithValue {
-        actor: syscall_destination.clone(),
+        actor_kind: syscall_destination.clone(),
         range: 0..=0,
     });
 

--- a/utils/runtime-fuzzer/src/gear_calls.rs
+++ b/utils/runtime-fuzzer/src/gear_calls.rs
@@ -280,7 +280,7 @@ pub(crate) struct SendMessageGenerator {
 impl SendMessageGenerator {
     fn generate(
         &self,
-        intermediate_data: &mut TempData,
+        intermediate_data: &TempData,
         unstructured: &mut Unstructured,
     ) -> Result<Option<GearCall>> {
         let program_id = unstructured
@@ -437,7 +437,7 @@ fn config(programs: &[ProgramId], log_info: Option<String>) -> StandardGearWasmC
             .filter(|&pid| pid != ProgramId::default())
             .map(|pid| pid.into()),
     )
-    .map(|non_empty| SyscallDestination::ExistingAddresses(non_empty))
+    .map(SyscallDestination::ExistingAddresses)
     .unwrap_or(SyscallDestination::Source);
 
     log::trace!("Messages destination config: {:?}", syscall_destination);

--- a/utils/wasm-gen/src/config.rs
+++ b/utils/wasm-gen/src/config.rs
@@ -55,7 +55,6 @@
 //! };
 //! let entry_points_set = EntryPointsSet::InitHandle;
 //! let syscalls_config = SyscallsConfigBuilder::new(SyscallsInjectionTypes::all_once())
-//!     .with_source_msg_dest()
 //!     .with_log_info("I'm from wasm-gen".into())
 //!     .build();
 //!
@@ -102,9 +101,6 @@ pub use generator::*;
 pub use module::*;
 pub use syscalls::*;
 
-use gear_utils::NonEmpty;
-use gsys::Hash;
-
 /// Trait which describes a type that stores and manages data for generating
 /// [`GearWasmGeneratorConfig`] and [`SelectableParams`], which are both used
 /// by [`crate::generate_gear_program_code`] and [`crate::generate_gear_program_module`]
@@ -132,13 +128,9 @@ impl ConfigsBundle for (GearWasmGeneratorConfig, SelectableParams) {
 /// Standard set of configurational data which is used to generate always
 /// valid gear-wasm using generators of the current crate.
 #[derive(Debug, Clone)]
-pub struct StandardGearWasmConfigsBundle<T = [u8; 32]> {
+pub struct StandardGearWasmConfigsBundle {
     /// Externalities to be logged.
     pub log_info: Option<String>,
-    /// Set of existing addresses, which will be used as message destinations.
-    ///
-    /// If is `None`, then `gr_source` result will be used as a message destination.
-    pub existing_addresses: Option<NonEmpty<T>>,
     /// Flag which signals whether recursions must be removed.
     pub remove_recursion: bool,
     /// If the limit is set to `Some(_)`, programs will try to stop execution
@@ -160,11 +152,10 @@ pub struct StandardGearWasmConfigsBundle<T = [u8; 32]> {
     pub params_config: SyscallsParamsConfig,
 }
 
-impl<T> Default for StandardGearWasmConfigsBundle<T> {
+impl Default for StandardGearWasmConfigsBundle {
     fn default() -> Self {
         Self {
             log_info: Some("StandardGearWasmConfigsBundle".into()),
-            existing_addresses: None,
             remove_recursion: false,
             critical_gas_limit: Some(1_000_000),
             injection_types: SyscallsInjectionTypes::all_once(),
@@ -176,11 +167,10 @@ impl<T> Default for StandardGearWasmConfigsBundle<T> {
     }
 }
 
-impl<T: Into<Hash>> ConfigsBundle for StandardGearWasmConfigsBundle<T> {
+impl ConfigsBundle for StandardGearWasmConfigsBundle {
     fn into_parts(self) -> (GearWasmGeneratorConfig, SelectableParams) {
         let StandardGearWasmConfigsBundle {
             log_info,
-            existing_addresses,
             remove_recursion,
             critical_gas_limit,
             injection_types,
@@ -195,11 +185,6 @@ impl<T: Into<Hash>> ConfigsBundle for StandardGearWasmConfigsBundle<T> {
         let mut syscalls_config_builder = SyscallsConfigBuilder::new(injection_types);
         if let Some(log_info) = log_info {
             syscalls_config_builder = syscalls_config_builder.with_log_info(log_info);
-        }
-        if let Some(addresses) = existing_addresses {
-            syscalls_config_builder = syscalls_config_builder.with_addresses_msg_dest(addresses);
-        } else {
-            syscalls_config_builder = syscalls_config_builder.with_source_msg_dest();
         }
         syscalls_config_builder = syscalls_config_builder.with_params_config(params_config);
 

--- a/utils/wasm-gen/src/config/syscalls.rs
+++ b/utils/wasm-gen/src/config/syscalls.rs
@@ -26,7 +26,7 @@ mod process_errors;
 
 use gear_utils::NonEmpty;
 use gear_wasm_instrument::syscalls::SyscallName;
-use gsys::{Hash, HashWithValue};
+use gsys::Hash;
 
 pub use injection::*;
 pub use param::*;
@@ -46,7 +46,6 @@ impl SyscallsConfigBuilder {
             injection_types,
             params_config: SyscallsParamsConfig::default(),
             precise_syscalls_config: PreciseSyscallsConfig::default(),
-            syscall_destination: SyscallDestination::default(),
             error_processing_config: ErrorProcessingConfig::None,
             log_info: None,
         })
@@ -54,6 +53,16 @@ impl SyscallsConfigBuilder {
 
     /// Set config for syscalls params.
     pub fn with_params_config(mut self, params_config: SyscallsParamsConfig) -> Self {
+        use PtrParamAllowedValues::*;
+        for v in params_config.ptr.values() {
+            if let ActorId(actor) | ActorIdWithValue { actor, .. } = v {
+                if actor.is_source() {
+                    self.0
+                        .injection_types
+                        .enable_syscall_import(InvocableSyscall::Loose(SyscallName::Source));
+                }
+            }
+        }
         self.0.params_config = params_config;
 
         self
@@ -65,29 +74,6 @@ impl SyscallsConfigBuilder {
         precise_syscalls_config: PreciseSyscallsConfig,
     ) -> Self {
         self.0.precise_syscalls_config = precise_syscalls_config;
-
-        self
-    }
-
-    /// Set whether syscalls with destination param (like `gr_*send*` or `gr_exit`) must use `gr_source` syscall result for a destination param.
-    pub fn with_source_msg_dest(mut self) -> Self {
-        self.0.syscall_destination = SyscallDestination::Source;
-        self.0
-            .injection_types
-            .enable_syscall_import(InvocableSyscall::Loose(SyscallName::Source));
-
-        self
-    }
-
-    /// Set whether syscalls with destination param (like `gr_*send*` or `gr_exit`) must use addresses from `addresses` collection
-    /// for a destination param.
-    pub fn with_addresses_msg_dest<T: Into<Hash>>(mut self, addresses: NonEmpty<T>) -> Self {
-        let addresses = NonEmpty::collect(addresses.into_iter().map(|pid| HashWithValue {
-            hash: pid.into(),
-            value: 0,
-        }))
-        .expect("collected from non empty");
-        self.0.syscall_destination = SyscallDestination::ExistingAddresses(addresses);
 
         self
     }
@@ -106,7 +92,7 @@ impl SyscallsConfigBuilder {
     }
 
     /// Setup fallible syscalls error processing options.
-    pub fn set_error_processing_config(mut self, config: ErrorProcessingConfig) -> Self {
+    pub fn with_error_processing_config(mut self, config: ErrorProcessingConfig) -> Self {
         self.0.error_processing_config = config;
 
         self
@@ -124,7 +110,6 @@ pub struct SyscallsConfig {
     injection_types: SyscallsInjectionTypes,
     params_config: SyscallsParamsConfig,
     precise_syscalls_config: PreciseSyscallsConfig,
-    syscall_destination: SyscallDestination,
     error_processing_config: ErrorProcessingConfig,
     log_info: Option<String>,
 }
@@ -133,13 +118,6 @@ impl SyscallsConfig {
     /// Get possible number of times (range) the syscall can be injected in the wasm.
     pub fn injection_types(&self, name: InvocableSyscall) -> SyscallInjectionType {
         self.injection_types.get(name)
-    }
-
-    /// Get defined syscall destination for `gr_send*` and `gr_exit` syscalls.
-    ///
-    /// For more info, read [`SyscallDestination`].
-    pub fn syscall_destination(&self) -> &SyscallDestination {
-        &self.syscall_destination
     }
 
     /// Get defined log info.
@@ -174,7 +152,7 @@ impl SyscallsConfig {
 #[derive(Debug, Clone, Default)]
 pub enum SyscallDestination {
     Source,
-    ExistingAddresses(NonEmpty<HashWithValue>),
+    ExistingAddresses(NonEmpty<Hash>),
     #[default]
     Random,
 }

--- a/utils/wasm-gen/src/config/syscalls.rs
+++ b/utils/wasm-gen/src/config/syscalls.rs
@@ -24,9 +24,7 @@ mod param;
 mod precise;
 mod process_errors;
 
-use gear_utils::NonEmpty;
 use gear_wasm_instrument::syscalls::SyscallName;
-use gsys::Hash;
 
 pub use injection::*;
 pub use param::*;
@@ -55,7 +53,11 @@ impl SyscallsConfigBuilder {
     pub fn with_params_config(mut self, params_config: SyscallsParamsConfig) -> Self {
         use PtrParamAllowedValues::*;
         for v in params_config.ptr.values() {
-            if let ActorId(actor) | ActorIdWithValue { actor, .. } = v {
+            if let ActorId(actor)
+            | ActorIdWithValue {
+                actor_kind: actor, ..
+            } = v
+            {
                 if actor.is_source() {
                     self.0
                         .injection_types
@@ -140,36 +142,5 @@ impl SyscallsConfig {
     /// Error processing config for fallible syscalls.
     pub fn error_processing_config(&self) -> &ErrorProcessingConfig {
         &self.error_processing_config
-    }
-}
-
-/// Syscall destination choice.
-///
-/// `gr_send*` and `gr_exit` syscalls generated from this crate can be sent
-/// to different destination in accordance to the config.
-/// It's either to the message source, to some existing known address,
-/// or to some random, most probably non-existing, address.
-#[derive(Debug, Clone, Default)]
-pub enum SyscallDestination {
-    Source,
-    ExistingAddresses(NonEmpty<Hash>),
-    #[default]
-    Random,
-}
-
-impl SyscallDestination {
-    /// Check whether syscall destination is a result of `gr_source`.
-    pub fn is_source(&self) -> bool {
-        matches!(&self, SyscallDestination::Source)
-    }
-
-    /// Check whether syscall destination is defined randomly.
-    pub fn is_random(&self) -> bool {
-        matches!(&self, SyscallDestination::Random)
-    }
-
-    /// Check whether syscall destination is defined from a collection of existing addresses.
-    pub fn is_existing_addresses(&self) -> bool {
-        matches!(&self, SyscallDestination::ExistingAddresses(_))
     }
 }

--- a/utils/wasm-gen/src/config/syscalls/param.rs
+++ b/utils/wasm-gen/src/config/syscalls/param.rs
@@ -70,8 +70,7 @@ impl SyscallsParamsConfig {
         let free_end = free_start + 5;
 
         // Setting regular params rules.
-        self
-            .with_rule(Length, (0..=1600).into())
+        self.with_rule(Length, (0..=1600).into())
             .with_rule(Gas, (0..=250_000_000_000).into())
             .with_rule(Offset, (0..=10).into())
             .with_rule(DurationBlockNumber, (1..=8).into())
@@ -85,8 +84,7 @@ impl SyscallsParamsConfig {
     pub fn with_default_ptr_config(self) -> Self {
         let range = 0..=100_000_000_000;
         // Setting ptr params rules.
-        self
-            .with_ptr_rule(PtrParamAllowedValues::Value(range.clone()))
+        self.with_ptr_rule(PtrParamAllowedValues::Value(range.clone()))
             .with_ptr_rule(PtrParamAllowedValues::ActorIdWithValue {
                 actor_kind: ActorKind::default(),
                 range,

--- a/utils/wasm-gen/src/config/syscalls/param.rs
+++ b/utils/wasm-gen/src/config/syscalls/param.rs
@@ -84,7 +84,7 @@ impl SyscallsParamsConfig {
         this.set_ptr_rule(PtrParamAllowedValues::Value(range.clone()));
         this.set_ptr_rule(PtrParamAllowedValues::ActorIdWithValue {
             actor: SyscallDestination::default(),
-            range: range.clone(),
+            range,
         });
         this.set_ptr_rule(PtrParamAllowedValues::ActorId(SyscallDestination::default()));
 

--- a/utils/wasm-gen/src/config/syscalls/param.rs
+++ b/utils/wasm-gen/src/config/syscalls/param.rs
@@ -16,15 +16,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! Entities describing syscall param, more precisely, it's allowed values.
+//! Entities configuring syscalls params allowed values.
 //!
 //! Types here are used to create [`crate::SyscallsConfig`].
 
-use crate::DEFAULT_INITIAL_SIZE;
+use crate::{SyscallDestination, DEFAULT_INITIAL_SIZE};
 use arbitrary::{Result, Unstructured};
 use std::{collections::HashMap, ops::RangeInclusive};
 
-pub use gear_wasm_instrument::syscalls::{ParamType, RegularParamType};
+pub use gear_wasm_instrument::syscalls::{HashType, Ptr, RegularParamType};
 
 /// Syscalls params config.
 ///
@@ -32,98 +32,168 @@ pub use gear_wasm_instrument::syscalls::{ParamType, RegularParamType};
 /// param, that a syscall can have, and allowed values ("rules") for each of
 /// the params.
 ///
+/// The config manages differently memory pointer value params and other kinds
+/// of params, like gas, length, offset and etc.
+///
 /// # Note:
 ///
-/// Configs with some [`ParamType`] variants will not be applied, as we select
-/// values for all memory-related operations in accordance to generated WASM
-/// module parameters:
-///  - [`ParamType::Alloc`] and [`ParamType::Ptr`] will always be ignored.
-///  - [`ParamType::Size`] will be ignored when it means length of some in-memory
-/// array.
+/// By default rules for `Alloc` param *can be, but are not* defined in current
+/// module. That's because this is a param of the memory-related syscall, params
+/// to which must be defined based on the memory configuration of the wasm module.
+/// The client knows more about the memory configuration and possibly allowed values
+/// for the param.
+///
+/// Should be also stated that `Length` param is processed differently, if it's a length
+/// of the memory array read by backend from wasm. In this case, this param value is computed
+/// based on memory size of the wasm module during syscall params processing. For other cases,
+/// the values for the param will regulated by rules, if they are set.
 #[derive(Debug, Clone)]
-pub struct SyscallsParamsConfig(HashMap<ParamType, SyscallParamAllowedValues>);
+pub struct SyscallsParamsConfig {
+    regular: HashMap<RegularParamType, RegularParamAllowedValues>,
+    pub(super) ptr: HashMap<Ptr, PtrParamAllowedValues>,
+}
 
 impl SyscallsParamsConfig {
-    pub fn empty() -> Self {
-        Self(HashMap::new())
-    }
-
-    /// New [`SyscallsParamsConfig`] with all rules set to produce one constant value.
-    pub fn all_constant_value(value: i64) -> Self {
-        use ParamType::*;
+    pub fn default_regular() -> Self {
         use RegularParamType::*;
 
-        let allowed_values: SyscallParamAllowedValues = (value..=value).into();
-        Self(
-            [
-                Regular(Length),
-                Regular(Gas),
-                Regular(Offset),
-                Regular(DurationBlockNumber),
-                Regular(DelayBlockNumber),
-                Regular(Handler),
-                Regular(Free),
-                Regular(FreeUpperBound),
-                Regular(Version),
+        let free_start = DEFAULT_INITIAL_SIZE as i64;
+        let free_end = free_start + 5;
+
+        let mut this = Self::empty();
+
+        // Setting regular params rules.
+        this.set_rule(Length, (0..=1600).into());
+        this.set_rule(Gas, (0..=250_000_000_000).into());
+        this.set_rule(Offset, (0..=10).into());
+        this.set_rule(DurationBlockNumber, (1..=8).into());
+        this.set_rule(DelayBlockNumber, (0..=4).into());
+        this.set_rule(Handler, (0..=100).into());
+        this.set_rule(Free, (free_start..=free_end).into());
+        this.set_rule(FreeUpperBound, (0..=10).into());
+        this.set_rule(Version, (1..=1).into());
+
+        this
+    }
+
+    pub fn default_ptr() -> Self {
+        let mut this = Self::empty();
+
+        let range = 0..=100_000_000_000;
+        // Setting ptr params rules.
+        this.set_ptr_rule(PtrParamAllowedValues::Value(range.clone()));
+        this.set_ptr_rule(PtrParamAllowedValues::ActorIdWithValue {
+            actor: SyscallDestination::default(),
+            range: range.clone(),
+        });
+        this.set_ptr_rule(PtrParamAllowedValues::ActorId(SyscallDestination::default()));
+
+        this
+    }
+
+    pub fn empty() -> Self {
+        Self {
+            regular: HashMap::new(),
+            ptr: HashMap::new(),
+        }
+    }
+
+    /// New [`SyscallsParamsConfig`] with all rules set to produce one constant value
+    /// for regular (non memory ptr value) params.
+    pub fn const_regular_params(value: i64) -> Self {
+        use RegularParamType::*;
+
+        let allowed_values: RegularParamAllowedValues = (value..=value).into();
+        Self {
+            regular: [
+                Length,
+                Gas,
+                Offset,
+                DurationBlockNumber,
+                DelayBlockNumber,
+                Handler,
+                Free,
+                FreeUpperBound,
+                Version,
             ]
             .into_iter()
             .map(|param_type| (param_type, allowed_values.clone()))
             .collect(),
-        )
+            ptr: HashMap::new(),
+        }
     }
 
-    /// Get allowed values for the `param`.
-    pub fn get_rule(&self, param: &ParamType) -> Option<SyscallParamAllowedValues> {
-        self.0.get(param).cloned()
+    /// Get allowed values for the regular syscall param.
+    pub fn get_rule(&self, param: RegularParamType) -> Option<RegularParamAllowedValues> {
+        self.regular.get(&param).cloned()
     }
 
-    /// Set allowed values for the `param`.
-    pub fn add_rule(&mut self, param: ParamType, allowed_values: SyscallParamAllowedValues) {
-        matches!(param, ParamType::Regular(RegularParamType::Pointer(_)))
-            .then(|| panic!("ParamType::Ptr(..) isn't supported in SyscallsParamsConfig"));
+    /// Get allowed values for the pointer syscall param.
+    pub fn get_ptr_rule(&self, ptr: Ptr) -> Option<PtrParamAllowedValues> {
+        self.ptr.get(&ptr).cloned()
+    }
 
-        self.0.insert(param, allowed_values);
+    /// Set rules for a regular syscall param.
+    pub fn set_rule(&mut self, param: RegularParamType, allowed_values: RegularParamAllowedValues) {
+        matches!(param, RegularParamType::Pointer(_))
+            .then(|| panic!("Rules for pointers are defined in `set_ptr_rule` method."));
+
+        self.regular.insert(param, allowed_values);
+    }
+
+    /// Set rules for memory pointer syscall param.
+    pub fn set_ptr_rule(&mut self, allowed_values: PtrParamAllowedValues) {
+        use Ptr::*;
+
+        let ptr = allowed_values.clone().into();
+        let allowed_values = match ptr {
+            Hash(HashType::ActorId) | Value | HashWithValue(HashType::ActorId) => allowed_values,
+            ptr_ty @ (Hash(_) | HashWithValue(_) | TwoHashes(_, _) | TwoHashesWithValue(_, _)) => {
+                unimplemented!(
+                    "Currently unsupported defining ptr param filler config for {ptr_ty:?}."
+                )
+            }
+            BlockNumber
+            | BlockTimestamp
+            | SizedBufferStart { .. }
+            | BufferStart
+            | Gas
+            | Length
+            | BlockNumberWithHash(_) => panic!("Impossible to set rules for non ptr params."),
+            MutBlockNumber
+            | MutBlockTimestamp
+            | MutSizedBufferStart { .. }
+            | MutBufferStart
+            | MutHash(_)
+            | MutGas
+            | MutLength
+            | MutValue
+            | MutBlockNumberWithHash(_)
+            | MutHashWithValue(_)
+            | MutTwoHashes(_, _)
+            | MutTwoHashesWithValue(_, _) => {
+                panic!("Mutable pointers values are set by executor, not by wasm itself.")
+            }
+        };
+
+        self.ptr.insert(ptr, allowed_values);
     }
 }
 
 impl Default for SyscallsParamsConfig {
     fn default() -> Self {
-        use ParamType::*;
-        use RegularParamType::*;
+        let SyscallsParamsConfig { regular, .. } = Self::default_regular();
+        let SyscallsParamsConfig { ptr, .. } = Self::default_ptr();
 
-        let free_start = DEFAULT_INITIAL_SIZE as i64;
-        let free_end = free_start + 5;
-        Self(
-            [
-                (Regular(Length), (0..=0x10000).into()),
-                // There are no rules for memory arrays and pointers as they are chosen
-                // in accordance to memory pages config.
-                (Regular(Gas), (0..=250_000_000_000).into()),
-                (Regular(Offset), (0..=10).into()),
-                (Regular(DurationBlockNumber), (1..=8).into()),
-                (Regular(DelayBlockNumber), (0..=4).into()),
-                (Regular(Handler), (0..=100).into()),
-                (Regular(Free), (free_start..=free_end).into()),
-                (Regular(Version), (1..=1).into()),
-                (Regular(FreeUpperBound), (0..=10).into()),
-            ]
-            .into_iter()
-            .collect(),
-        )
+        Self { regular, ptr }
     }
 }
 
 /// Range of allowed values for the syscall param.
 #[derive(Debug, Clone)]
-pub struct SyscallParamAllowedValues(RangeInclusive<i64>);
+pub struct RegularParamAllowedValues(RangeInclusive<i64>);
 
-impl From<RangeInclusive<i64>> for SyscallParamAllowedValues {
-    fn from(range: RangeInclusive<i64>) -> Self {
-        Self(range)
-    }
-}
-
-impl SyscallParamAllowedValues {
+impl RegularParamAllowedValues {
     /// Zero param value.
     ///
     /// That means that for particular param `0` will be always
@@ -139,15 +209,7 @@ impl SyscallParamAllowedValues {
     pub fn constant(value: i64) -> Self {
         Self(value..=value)
     }
-}
 
-impl Default for SyscallParamAllowedValues {
-    fn default() -> Self {
-        Self::zero()
-    }
-}
-
-impl SyscallParamAllowedValues {
     /// Get i32 value for the param from it's allowed range.
     pub fn get_i32(&self, unstructured: &mut Unstructured) -> Result<i32> {
         let current_range_start = *self.0.start();
@@ -170,5 +232,42 @@ impl SyscallParamAllowedValues {
     /// Get i64 value for the param from it's allowed range.
     pub fn get_i64(&self, unstructured: &mut Unstructured) -> Result<i64> {
         unstructured.int_in_range(self.0.clone())
+    }
+}
+
+impl From<RangeInclusive<i64>> for RegularParamAllowedValues {
+    fn from(range: RangeInclusive<i64>) -> Self {
+        Self(range)
+    }
+}
+
+impl Default for RegularParamAllowedValues {
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
+/// Allowed values for syscalls pointer params.
+///
+/// Currently it allows defining only actor kinds (`SyscallDestination`)
+/// and message values for syscalls that send messages to actors.
+// TODO #3591 Support other hash types.
+#[derive(Debug, Clone)]
+pub enum PtrParamAllowedValues {
+    Value(RangeInclusive<u128>),
+    ActorIdWithValue {
+        actor: SyscallDestination,
+        range: RangeInclusive<u128>,
+    },
+    ActorId(SyscallDestination),
+}
+
+impl From<PtrParamAllowedValues> for Ptr {
+    fn from(ptr_data: PtrParamAllowedValues) -> Self {
+        match ptr_data {
+            PtrParamAllowedValues::Value(_) => Ptr::Value,
+            PtrParamAllowedValues::ActorIdWithValue { .. } => Ptr::HashWithValue(HashType::ActorId),
+            PtrParamAllowedValues::ActorId(_) => Ptr::Hash(HashType::ActorId),
+        }
     }
 }

--- a/utils/wasm-gen/src/generator/syscalls.rs
+++ b/utils/wasm-gen/src/generator/syscalls.rs
@@ -215,26 +215,6 @@ impl InvocableSyscall {
         })
     }
 
-    /// Returns the index of the destination param if a syscall has it.
-    fn destination_param_idx(&self) -> Option<usize> {
-        use InvocableSyscall::*;
-        use SyscallName::*;
-
-        match *self {
-            Loose(Send | SendWGas | SendInput | SendInputWGas | Exit)
-            | Precise(ReservationSend | SendCommit | SendCommitWGas | ReplyDeposit) => Some(0),
-            Loose(SendCommit | SendCommitWGas) => Some(1),
-            _ => None,
-        }
-    }
-
-    /// Returns `true` for every syscall which has a destination param idx and that is not `gr_exit` syscall,
-    /// as it only has destination param.
-    fn has_destination_param_with_value(&self) -> bool {
-        self.destination_param_idx().is_some()
-            && !matches!(self, InvocableSyscall::Loose(SyscallName::Exit))
-    }
-
     /// Checks whether syscall is error-prone either by returning error indicating value
     /// or by providing error pointer as a syscall param.
     ///

--- a/utils/wasm-gen/src/generator/syscalls/additional_data.rs
+++ b/utils/wasm-gen/src/generator/syscalls/additional_data.rs
@@ -23,34 +23,14 @@ use crate::{
         CallIndexes, CallIndexesHandle, DisabledSyscallsImportsGenerator, ModuleWithCallIndexes,
         SyscallsImportsGenerationProof,
     },
-    utils, EntryPointName, InvocableSyscall, SyscallDestination, SyscallsConfig, WasmModule,
+    EntryPointName, InvocableSyscall, SyscallsConfig, WasmModule,
 };
 use arbitrary::Unstructured;
-use gear_core::ids::ProgramId;
 use gear_wasm_instrument::{
     parity_wasm::{builder, elements::Instruction},
     syscalls::SyscallName,
 };
-use std::{collections::BTreeMap, iter::Cycle, num::NonZeroU32, vec::IntoIter};
-
-/// Cycled iterator over wasm module data offsets.
-///
-/// By data offsets we mean pointers to the beginning of
-/// each data entry in wasm module's data section.
-///
-/// By implementation this type is not instantiated, when no
-/// data is set to the wasm module. More precisely, if no
-/// additional data was set to [`SyscallsConfig`].
-pub struct AddressesOffsets(Cycle<IntoIter<u32>>);
-
-impl AddressesOffsets {
-    /// Get the next offset.
-    pub fn next_offset(&mut self) -> u32 {
-        self.0
-            .next()
-            .expect("offsets is created only from non empty vec")
-    }
-}
+use std::{collections::BTreeMap, num::NonZeroU32};
 
 /// Additional data injector.
 ///
@@ -65,7 +45,6 @@ pub struct AdditionalDataInjector<'a, 'b> {
     config: SyscallsConfig,
     last_offset: u32,
     module: WasmModule,
-    addresses_offsets: Vec<u32>,
     syscalls_imports: BTreeMap<InvocableSyscall, (Option<NonZeroU32>, CallIndexesHandle)>,
 }
 
@@ -90,7 +69,6 @@ impl<'a, 'b>
             config: disabled_gen.config,
             last_offset: data_offset as u32,
             module: disabled_gen.module,
-            addresses_offsets: Vec::new(),
             syscalls_imports: disabled_gen.syscalls_imports,
             call_indexes: disabled_gen.call_indexes,
         }
@@ -101,20 +79,12 @@ impl<'a, 'b> AdditionalDataInjector<'a, 'b> {
     /// Injects additional data from config to the wasm module.
     ///
     /// Returns disabled additional data injector and injection outcome.
-    pub fn inject(
-        mut self,
-    ) -> (
-        DisabledAdditionalDataInjector<'a, 'b>,
-        AddressesInjectionOutcome,
-    ) {
+    pub fn inject(mut self) -> DisabledAdditionalDataInjector<'a, 'b> {
         log::trace!("Injecting additional data");
 
-        let offsets = self.inject_addresses();
         self.inject_log_info_printing();
 
-        let outcome = AddressesInjectionOutcome { offsets };
-
-        (self.disable(), outcome)
+        self.disable()
     }
 
     /// Disable current generator.
@@ -126,59 +96,6 @@ impl<'a, 'b> AdditionalDataInjector<'a, 'b> {
             config: self.config,
             unstructured: self.unstructured,
         }
-    }
-
-    /// Injects addresses from config, if they were defined, into the data section.
-    ///
-    /// Returns `Some` with pointers to each address entry in the data section.
-    /// If no addresses were defined in the config, then returns `None`.
-    pub fn inject_addresses(&mut self) -> Option<AddressesOffsets> {
-        if !self.addresses_offsets.is_empty() {
-            log::trace!("Called address injection again");
-            return Some(AddressesOffsets(
-                self.addresses_offsets.clone().into_iter().cycle(),
-            ));
-        }
-
-        let SyscallDestination::ExistingAddresses(existing_addresses) =
-            self.config.syscall_destination()
-        else {
-            return None;
-        };
-
-        log::trace!("Inserting {} addresses into wasm", existing_addresses.len());
-        for address in existing_addresses {
-            self.addresses_offsets.push(self.last_offset);
-
-            let address_data_bytes = utils::hash_with_value_to_vec(address);
-            let data_len = address_data_bytes.len();
-            self.module.with(|module| {
-                let module = builder::from_module(module)
-                    .data()
-                    .offset(Instruction::I32Const(self.last_offset as i32))
-                    .value(address_data_bytes)
-                    .build()
-                    .build();
-
-                (module, ())
-            });
-
-            log::trace!(
-                "Inserted {} program address into wasm",
-                ProgramId::from(address.hash.as_slice())
-            );
-
-            self.last_offset += data_len as u32;
-        }
-
-        log::trace!(
-            "Last offset after inserting addresses - {}",
-            self.last_offset
-        );
-
-        Some(AddressesOffsets(
-            self.addresses_offsets.clone().into_iter().cycle(),
-        ))
     }
 
     /// Injects logging calls for the log info defined by the config.
@@ -253,16 +170,6 @@ impl<'a, 'b> AdditionalDataInjector<'a, 'b> {
             (module, ())
         });
     }
-}
-
-/// Data injection outcome.
-///
-/// Basically this type just carries inserted into data section
-/// addresses offsets.
-///
-/// There's design point of having this type, which is described in [`super::SyscallsInvocator`] docs.
-pub struct AddressesInjectionOutcome {
-    pub(super) offsets: Option<AddressesOffsets>,
 }
 
 /// Disabled additional data injector.

--- a/utils/wasm-gen/src/generator/syscalls/invocator.rs
+++ b/utils/wasm-gen/src/generator/syscalls/invocator.rs
@@ -20,11 +20,13 @@
 
 use crate::{
     generator::{
-        AddressesInjectionOutcome, AddressesOffsets, CallIndexes, CallIndexesHandle,
-        DisabledAdditionalDataInjector, FunctionIndex, ModuleWithCallIndexes,
+        CallIndexes, CallIndexesHandle, DisabledAdditionalDataInjector, FunctionIndex,
+        ModuleWithCallIndexes,
     },
+    utils::{self, WasmWords},
     wasm::{PageCount as WasmPageCount, WasmModule},
-    InvocableSyscall, SyscallParamAllowedValues, SyscallsConfig, SyscallsParamsConfig,
+    InvocableSyscall, PtrParamAllowedValues, RegularParamAllowedValues, SyscallDestination,
+    SyscallsConfig, SyscallsParamsConfig,
 };
 use arbitrary::{Result, Unstructured};
 use gear_wasm_instrument::{
@@ -37,6 +39,7 @@ use gear_wasm_instrument::{
 use gsys::Hash;
 use std::{
     collections::{btree_map::Entry, BTreeMap, BinaryHeap, HashSet},
+    fmt::{self, Debug, Display},
     iter, mem,
     num::NonZeroU32,
 };
@@ -44,18 +47,20 @@ use std::{
 #[derive(Debug)]
 pub(crate) enum ProcessedSyscallParams {
     Alloc {
-        allowed_values: Option<SyscallParamAllowedValues>,
+        allowed_values: Option<RegularParamAllowedValues>,
     },
     FreeUpperBound {
-        allowed_values: Option<SyscallParamAllowedValues>,
+        allowed_values: Option<RegularParamAllowedValues>,
     },
     Value {
         value_type: ValueType,
-        allowed_values: Option<SyscallParamAllowedValues>,
+        allowed_values: Option<RegularParamAllowedValues>,
     },
     MemoryArrayLength,
     MemoryArrayPtr,
-    MemoryPtrValue,
+    MemoryPtrValue {
+        allowed_values: Option<PtrParamAllowedValues>,
+    },
 }
 
 pub(crate) fn process_syscall_params(
@@ -79,28 +84,32 @@ pub(crate) fn process_syscall_params(
     let mut res = Vec::with_capacity(params.len());
     for (param_idx, &param) in params.iter().enumerate() {
         let processed_param = match param {
-            Regular(Alloc) => ProcessedSyscallParams::Alloc {
-                allowed_values: params_config.get_rule(&param),
+            Regular(regular) => match regular {
+                alloc @ Alloc => ProcessedSyscallParams::Alloc {
+                    allowed_values: params_config.get_rule(alloc),
+                },
+                free_upped_bound @ FreeUpperBound => ProcessedSyscallParams::FreeUpperBound {
+                    allowed_values: params_config.get_rule(free_upped_bound),
+                },
+                Length if length_param_indexes.contains(&param_idx) => {
+                    // Due to match guard `RegularParamType::Length` can be processed in two ways:
+                    // 1. The function will return `ProcessedSyscallParams::MemoryArraySize`
+                    //    if this parameter is associated with Ptr::BufferStart { .. }`.
+                    // 2. Otherwise, `ProcessedSyscallParams::Value` will be returned from the function.
+                    ProcessedSyscallParams::MemoryArrayLength
+                }
+                Pointer(Ptr::SizedBufferStart { .. }) => ProcessedSyscallParams::MemoryArrayPtr,
+                // It's guaranteed that fallible syscall has error pointer as a last param.
+                Pointer(ptr) => ProcessedSyscallParams::MemoryPtrValue {
+                    allowed_values: params_config.get_ptr_rule(ptr),
+                },
+                regular_param => ProcessedSyscallParams::Value {
+                    value_type: param.into(),
+                    allowed_values: params_config.get_rule(regular_param),
+                },
             },
-            Regular(Length) if length_param_indexes.contains(&param_idx) => {
-                // Due to match guard `ParamType::Size` can be processed in two ways:
-                // 1. The function will return `ProcessedSyscallParams::MemoryArraySize`
-                //    if this parameter is associated with PtrType::BufferStart { .. }`.
-                // 2. Otherwise, `ProcessedSyscallParams::Value` will be returned from the function.
-                ProcessedSyscallParams::MemoryArrayLength
-            }
-            Regular(Pointer(Ptr::SizedBufferStart { .. })) => {
-                ProcessedSyscallParams::MemoryArrayPtr
-            }
-            // It's guaranteed that fallible syscall has error pointer as a last param.
-            Regular(Pointer(_)) | Error(_) => ProcessedSyscallParams::MemoryPtrValue,
-            Regular(FreeUpperBound) => {
-                let allowed_values = params_config.get_rule(&param);
-                ProcessedSyscallParams::FreeUpperBound { allowed_values }
-            }
-            _ => ProcessedSyscallParams::Value {
-                value_type: param.into(),
-                allowed_values: params_config.get_rule(&param),
+            Error(_) => ProcessedSyscallParams::MemoryPtrValue {
+                allowed_values: None,
             },
         };
 
@@ -128,72 +137,20 @@ pub struct SyscallsInvocator<'a, 'b> {
     call_indexes: CallIndexes,
     module: WasmModule,
     config: SyscallsConfig,
-    offsets: Option<AddressesOffsets>,
     syscalls_imports: BTreeMap<InvocableSyscall, (Option<NonZeroU32>, CallIndexesHandle)>,
 }
 
-impl<'a, 'b>
-    From<(
-        DisabledAdditionalDataInjector<'a, 'b>,
-        AddressesInjectionOutcome,
-    )> for SyscallsInvocator<'a, 'b>
-{
-    fn from(
-        (disabled_gen, outcome): (
-            DisabledAdditionalDataInjector<'a, 'b>,
-            AddressesInjectionOutcome,
-        ),
-    ) -> Self {
+impl<'a, 'b> From<DisabledAdditionalDataInjector<'a, 'b>> for SyscallsInvocator<'a, 'b> {
+    fn from(disabled_gen: DisabledAdditionalDataInjector<'a, 'b>) -> Self {
         Self {
             unstructured: disabled_gen.unstructured,
             call_indexes: disabled_gen.call_indexes,
             module: disabled_gen.module,
             config: disabled_gen.config,
-            offsets: outcome.offsets,
             syscalls_imports: disabled_gen.syscalls_imports,
         }
     }
 }
-
-/// Newtype used to mark that some instruction is used to push values to stack before syscall execution.
-#[derive(Clone)]
-struct ParamSetter(Instruction);
-
-impl ParamSetter {
-    fn new_i32(value: i32) -> Self {
-        Self(Instruction::I32Const(value))
-    }
-
-    fn new_i64(value: i64) -> Self {
-        Self(Instruction::I64Const(value))
-    }
-
-    fn into_ix(self) -> Instruction {
-        self.0
-    }
-
-    fn as_i32(&self) -> Option<i32> {
-        if let Instruction::I32Const(value) = self.0 {
-            Some(value)
-        } else {
-            None
-        }
-    }
-
-    /// Get value of the instruction.
-    ///
-    /// # Panics
-    /// Panics if the instruction is not `I32Const` or `I64Const`.
-    fn get_value(&self) -> i64 {
-        match self.0 {
-            Instruction::I32Const(value) => value as i64,
-            Instruction::I64Const(value) => value,
-            _ => unimplemented!("Incorrect instruction found"),
-        }
-    }
-}
-
-pub type SyscallInvokeInstructions = Vec<Instruction>;
 
 impl<'a, 'b> SyscallsInvocator<'a, 'b> {
     /// Insert syscalls invokes.
@@ -328,124 +285,20 @@ impl<'a, 'b> SyscallsInvocator<'a, 'b> {
         &mut self,
         invocable: InvocableSyscall,
         call_indexes_handle: CallIndexesHandle,
-    ) -> Result<SyscallInvokeInstructions> {
+    ) -> Result<Vec<Instruction>> {
         log::trace!(
             "Random data before building `{}` syscall invoke instructions - {}",
             invocable.to_str(),
             self.unstructured.len()
         );
 
-        if let Some(argument_index) = invocable.destination_param_idx() {
-            log::trace!(
-                " -- Building call instructions for a `{}` syscall with destination",
-                invocable.to_str()
-            );
-
-            self.build_call_with_destination(invocable, call_indexes_handle, argument_index)
-        } else {
-            log::trace!(
-                " -- Building call for a common syscall `{}`",
-                invocable.to_str()
-            );
-
-            self.build_call(invocable, call_indexes_handle)
-        }
-    }
-
-    fn build_call_with_destination(
-        &mut self,
-        invocable: InvocableSyscall,
-        call_indexes_handle: CallIndexesHandle,
-        destination_arg_idx: usize,
-    ) -> Result<Vec<Instruction>> {
-        // The value for the destination param is chosen from config.
-        // It's either the result of `gr_source`, some existing address (set in the data section) or a completely random value.
-        let mut original_instructions = self.build_call(invocable, call_indexes_handle)?;
-
-        let destination_instructions = if self.config.syscall_destination().is_source() {
-            log::trace!("  ---  Syscall destination is result of `gr_source`");
-
-            let gr_source_call_indexes_handle = self
-                .syscalls_imports
-                .get(&InvocableSyscall::Loose(SyscallName::Source))
-                .map(|&(_, call_indexes_handle)| call_indexes_handle as u32)
-                .expect("by config if destination is source, then `gr_source` is generated");
-
-            let mem_size = self
-                .module
-                .initial_mem_size()
-                .map(Into::<WasmPageCount>::into)
-                // To instantiate this generator, we must instantiate SyscallImportsGenerator, which can be
-                // instantiated only with memory import generation proof.
-                .expect("generator is instantiated with a memory import generation proof")
-                .memory_size();
-            // Subtract a bit more so entities from `gsys` fit.
-            let upper_limit = mem_size.saturating_sub(100);
-            let offset = self.unstructured.int_in_range(0..=upper_limit)?;
-
-            // 3 instructions for invoking `gsys::gr_source` and possibly 3 more
-            // for defining value param so HashWithValue will be constructed.
-            let mut ret = Vec::with_capacity(6);
-            ret.extend_from_slice(&[
-                // call `gsys::gr_source` storing actor id and some `offset` pointer.
-                Instruction::I32Const(offset as i32),
-                Instruction::Call(gr_source_call_indexes_handle),
-                Instruction::I32Const(offset as i32),
-            ]);
-
-            if invocable.has_destination_param_with_value() {
-                // We have to skip actor id bytes to define the following value param.
-                let skip_bytes = mem::size_of::<Hash>();
-                ret.extend_from_slice(&[
-                    // Define 0 value for HashWithValue
-                    Instruction::I32Const(0),
-                    // Store value on the offset + skip_bytes. That will form HashWithValue.
-                    Instruction::I32Store(2, skip_bytes as u32),
-                    // Pass the offset as the first argument to the syscall with destination.
-                    Instruction::I32Const(offset as i32),
-                ]);
-            }
-
-            ret
-        } else {
-            let address_offset = match self.offsets.as_mut() {
-                Some(offsets) => {
-                    assert!(self.config.syscall_destination().is_existing_addresses());
-                    log::trace!("  ----  Syscall destination is an existing program address");
-
-                    offsets.next_offset()
-                }
-                None => {
-                    assert!(self.config.syscall_destination().is_random());
-                    log::trace!("  ----  Syscall destination is a random address");
-
-                    self.unstructured.arbitrary()?
-                }
-            };
-
-            vec![Instruction::I32Const(address_offset as i32)]
-        };
-
-        original_instructions.splice(
-            destination_arg_idx..destination_arg_idx + 1,
-            destination_instructions,
-        );
-
-        Ok(original_instructions)
-    }
-
-    fn build_call(
-        &mut self,
-        invocable: InvocableSyscall,
-        call_indexes_handle: CallIndexesHandle,
-    ) -> Result<Vec<Instruction>> {
         let signature = invocable.into_signature();
-        let param_setters = self.build_param_setters(signature.params())?;
-        let mut instructions: Vec<_> = param_setters
+        let param_instructions = self.build_params_instructions(signature.params())?;
+        let mut instructions = param_instructions
             .iter()
             .cloned()
-            .map(ParamSetter::into_ix)
-            .collect();
+            .flat_map(ParamInstructions::into_inner)
+            .collect::<Vec<_>>();
 
         instructions.push(Instruction::Call(call_indexes_handle as u32));
 
@@ -464,7 +317,7 @@ impl<'a, 'b> SyscallsInvocator<'a, 'b> {
                 // It's guaranteed by definition that these variants return an error either by returning
                 // error indicating value or by having err mut pointer in params.
                 if process_error {
-                    Self::build_error_processing(signature, param_setters)
+                    Self::build_error_processing(signature, param_instructions)
                 } else {
                     Self::build_error_processing_ignored(signature)
                 }
@@ -472,12 +325,21 @@ impl<'a, 'b> SyscallsInvocator<'a, 'b> {
         };
         instructions.append(&mut result_processing);
 
+        log::trace!(
+            "Random data after building `{}` syscall invoke instructions - {}",
+            invocable.to_str(),
+            self.unstructured.len()
+        );
+
         Ok(instructions)
     }
 
-    fn build_param_setters(&mut self, params: &[ParamType]) -> Result<Vec<ParamSetter>> {
+    fn build_params_instructions(
+        &mut self,
+        params: &[ParamType],
+    ) -> Result<Vec<ParamInstructions>> {
         log::trace!(
-            "  -- Random data before building param setters - {}",
+            "  -- Random data before building param instructions - {}",
             self.unstructured.len()
         );
 
@@ -489,9 +351,8 @@ impl<'a, 'b> SyscallsInvocator<'a, 'b> {
             .expect("generator is instantiated with a memory import generation proof");
         let mem_size = Into::<WasmPageCount>::into(mem_size_pages).memory_size();
 
-        let mut setters = Vec::with_capacity(params.len());
+        let mut ret = Vec::with_capacity(params.len());
         let mut memory_array_definition: Option<(i32, Option<i32>)> = None;
-
         for processed_param in process_syscall_params(params, self.config.params_config()) {
             match processed_param {
                 ProcessedSyscallParams::Alloc { allowed_values } => {
@@ -504,7 +365,7 @@ impl<'a, 'b> SyscallsInvocator<'a, 'b> {
 
                     log::trace!("  ----  Allocate memory - {pages_to_alloc}");
 
-                    setters.push(ParamSetter::new_i32(pages_to_alloc));
+                    ret.push(pages_to_alloc.into());
                 }
                 ProcessedSyscallParams::Value {
                     value_type,
@@ -517,21 +378,21 @@ impl<'a, 'b> SyscallsInvocator<'a, 'b> {
                             panic!("gear wasm must not have any floating nums")
                         }
                     };
-                    let setter = if let Some(allowed_values) = allowed_values {
+                    let param_instructions = if let Some(allowed_values) = allowed_values {
                         if is_i32 {
-                            ParamSetter::new_i32(allowed_values.get_i32(self.unstructured)?)
+                            allowed_values.get_i32(self.unstructured)?.into()
                         } else {
-                            ParamSetter::new_i64(allowed_values.get_i64(self.unstructured)?)
+                            allowed_values.get_i64(self.unstructured)?.into()
                         }
                     } else if is_i32 {
-                        ParamSetter::new_i32(self.unstructured.arbitrary()?)
+                        self.unstructured.arbitrary::<i32>()?.into()
                     } else {
-                        ParamSetter::new_i64(self.unstructured.arbitrary()?)
+                        self.unstructured.arbitrary::<i64>()?.into()
                     };
 
-                    log::trace!("  ----  Value - {}", setter.get_value());
+                    log::trace!("  ----  Value param instrs - {param_instructions}");
 
-                    setters.push(setter);
+                    ret.push(param_instructions);
                 }
                 ProcessedSyscallParams::MemoryArrayLength => {
                     let length;
@@ -549,7 +410,8 @@ impl<'a, 'b> SyscallsInvocator<'a, 'b> {
                     };
 
                     log::trace!("  ----  Memory array length - {length}");
-                    setters.push(ParamSetter::new_i32(length));
+
+                    ret.push(length.into());
                 }
                 ProcessedSyscallParams::MemoryArrayPtr => {
                     let offset;
@@ -564,21 +426,27 @@ impl<'a, 'b> SyscallsInvocator<'a, 'b> {
                         };
 
                     log::trace!("  ----  Memory array offset - {offset}");
-                    setters.push(ParamSetter::new_i32(offset));
+
+                    ret.push(offset.into());
                 }
-                ProcessedSyscallParams::MemoryPtrValue => {
+                ProcessedSyscallParams::MemoryPtrValue { allowed_values } => {
                     // Subtract a bit more so entities from `gsys` fit.
                     let upper_limit = mem_size.saturating_sub(100);
                     let offset = self.unstructured.int_in_range(0..=upper_limit)? as i32;
 
-                    let setter = ParamSetter::new_i32(offset);
-                    log::trace!("  ----  Memory pointer value - {offset}");
+                    let param_instructions = if let Some(allowed_values) = allowed_values {
+                        self.build_ptr_param_instructions(allowed_values, offset)?
+                    } else {
+                        offset.into()
+                    };
 
-                    setters.push(setter);
+                    log::trace!("  ----  Memory pointer value instructions - {param_instructions}");
+
+                    ret.push(param_instructions);
                 }
                 ProcessedSyscallParams::FreeUpperBound { allowed_values } => {
                     // This is the case only for `free_range` syscall.
-                    let previous_param = setters
+                    let previous_param = ret
                         .last()
                         .expect("free_range syscall has at least 2 params")
                         .as_i32()
@@ -589,33 +457,138 @@ impl<'a, 'b> SyscallsInvocator<'a, 'b> {
                         .get_i32(self.unstructured)?;
                     let param = previous_param.saturating_add(delta);
 
-                    log::trace!("  ----  Free upper bound - {param}, and delta - {delta}");
+                    log::trace!("  ----  Free upper bound param - {param}, and delta - {delta}");
 
-                    setters.push(ParamSetter::new_i32(param))
+                    ret.push(param.into());
                 }
             }
         }
 
         log::trace!(
-            "  -- Random data after building param setters - {}",
+            "  -- Random data after building param instructions - {}",
             self.unstructured.len()
         );
 
-        assert_eq!(setters.len(), params.len());
+        assert_eq!(ret.len(), params.len());
 
-        Ok(setters)
+        Ok(ret)
+    }
+
+    fn build_ptr_param_instructions(
+        &mut self,
+        ptr_allowed_values: PtrParamAllowedValues,
+        value_set_ptr: i32,
+    ) -> Result<ParamInstructions> {
+        let ret = match ptr_allowed_values {
+            PtrParamAllowedValues::Value(range) => {
+                let value = self.unstructured.int_in_range(range)?;
+                utils::translate_ptr_data(
+                    WasmWords::new(value.to_le_bytes()),
+                    (value_set_ptr, value_set_ptr),
+                )
+            }
+            PtrParamAllowedValues::ActorId(actor) => {
+                match actor {
+                    SyscallDestination::Source => {
+                        let gr_source_call_indexes_handle = self
+                            .syscalls_imports
+                            .get(&InvocableSyscall::Loose(SyscallName::Source))
+                            .map(|&(_, call_indexes_handle)| call_indexes_handle as u32)
+                            .expect(
+                                "by config if destination is source, then `gr_source` is generated",
+                            );
+
+                        vec![
+                            // call `gsys::gr_source` storing actor id at `value_set_ptr` pointer.
+                            Instruction::I32Const(value_set_ptr as i32),
+                            Instruction::Call(gr_source_call_indexes_handle),
+                            Instruction::I32Const(value_set_ptr as i32),
+                        ]
+                    }
+                    SyscallDestination::ExistingAddresses(addresses) => {
+                        let addresses = utils::non_empty_to_vec(addresses);
+                        let address = self.unstructured.choose(&addresses)?;
+                        utils::translate_ptr_data(
+                            WasmWords::new(*address),
+                            (value_set_ptr, value_set_ptr),
+                        )
+                    }
+                    SyscallDestination::Random => {
+                        let random_address: [u8; 32] = self.unstructured.arbitrary()?;
+                        utils::translate_ptr_data(
+                            WasmWords::new(random_address),
+                            (value_set_ptr, value_set_ptr),
+                        )
+                    }
+                }
+            }
+            PtrParamAllowedValues::ActorIdWithValue { actor, range } => {
+                match actor {
+                    SyscallDestination::Source => {
+                        let gr_source_call_indexes_handle = self
+                            .syscalls_imports
+                            .get(&InvocableSyscall::Loose(SyscallName::Source))
+                            .map(|&(_, call_indexes_handle)| call_indexes_handle as u32)
+                            .expect(
+                                "by config if destination is source, then `gr_source` is generated",
+                            );
+
+                        // Put call to `gr_source`` instructions
+                        let mut ret_instr = vec![
+                            // call `gsys::gr_source` storing actor id at `value_set_ptr` pointer.
+                            Instruction::I32Const(value_set_ptr as i32),
+                            Instruction::Call(gr_source_call_indexes_handle),
+                        ];
+                        // Generate value definition instructions.
+                        // Value data is put right after `gr_source` bytes (value_set_ptr + hash len).
+                        let mut value_instr = utils::translate_ptr_data(
+                            WasmWords::new(self.unstructured.int_in_range(range)?.to_le_bytes()),
+                            (value_set_ptr + mem::size_of::<Hash>() as i32, value_set_ptr),
+                        );
+                        ret_instr.append(&mut value_instr);
+
+                        ret_instr
+                    }
+                    SyscallDestination::ExistingAddresses(addresses) => {
+                        let address_words = WasmWords::new(
+                            *self
+                                .unstructured
+                                .choose(&utils::non_empty_to_vec(addresses))?,
+                        );
+                        let value_words =
+                            WasmWords::new(self.unstructured.int_in_range(range)?.to_le_bytes());
+                        utils::translate_ptr_data(
+                            address_words.merge(value_words),
+                            (value_set_ptr, value_set_ptr),
+                        )
+                    }
+                    SyscallDestination::Random => {
+                        let random_address_words =
+                            WasmWords::new(self.unstructured.arbitrary::<[u8; 32]>()?);
+                        let value_words =
+                            WasmWords::new(self.unstructured.int_in_range(range)?.to_le_bytes());
+                        utils::translate_ptr_data(
+                            random_address_words.merge(value_words),
+                            (value_set_ptr, value_set_ptr),
+                        )
+                    }
+                }
+            }
+        };
+
+        Ok(ParamInstructions(ret))
     }
 
     fn build_error_processing(
         signature: SyscallSignature,
-        param_setters: Vec<ParamSetter>,
+        param_instructions: Vec<ParamInstructions>,
     ) -> Vec<Instruction>
     where
         'a: 'b,
     {
         match signature {
             SyscallSignature::Fallible(fallible) => {
-                Self::build_fallible_syscall_error_processing(fallible, param_setters)
+                Self::build_fallible_syscall_error_processing(fallible, param_instructions)
             }
             SyscallSignature::System(system) => Self::build_system_syscall_error_processing(system),
             SyscallSignature::Infallible(_) => unreachable!(
@@ -626,22 +599,17 @@ impl<'a, 'b> SyscallsInvocator<'a, 'b> {
 
     fn build_fallible_syscall_error_processing(
         fallible_signature: FallibleSyscallSignature,
-        param_setters: Vec<ParamSetter>,
+        param_instructions: Vec<ParamInstructions>,
     ) -> Vec<Instruction> {
-        // TODO: #3129.
-        // Assume here that:
-        // 1. All the fallible syscalls write error to the pointer located in the last argument in syscall.
-        // 2. All the errors contain `ErrorCode` in the start of memory where pointer points.
-
         static_assertions::assert_eq_size!(gsys::ErrorCode, u32);
         let no_error_val = gsys::ErrorCode::default() as i32;
 
         assert_eq!(
             fallible_signature.params().len(),
-            param_setters.len(),
+            param_instructions.len(),
             "ParamsSetter is inconsistent with syscall params."
         );
-        let res_ptr = param_setters
+        let res_ptr = param_instructions
             .last()
             .expect("At least one argument in fallible syscall")
             .as_i32()
@@ -792,5 +760,44 @@ impl From<DisabledSyscallsInvocator> for ModuleWithCallIndexes {
             module: disabled_syscalls_invocator.module,
             call_indexes: disabled_syscalls_invocator.call_indexes,
         }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ParamInstructions(Vec<Instruction>);
+
+impl ParamInstructions {
+    fn into_inner(self) -> Vec<Instruction> {
+        self.0
+    }
+
+    fn as_i32(&self) -> Option<i32> {
+        if self.0.len() != 1 {
+            return None;
+        }
+
+        if let Some(Instruction::I32Const(ret)) = self.0.last() {
+            Some(*ret)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<i32> for ParamInstructions {
+    fn from(value: i32) -> Self {
+        ParamInstructions(vec![Instruction::I32Const(value)])
+    }
+}
+
+impl From<i64> for ParamInstructions {
+    fn from(value: i64) -> Self {
+        ParamInstructions(vec![Instruction::I64Const(value)])
+    }
+}
+
+impl Display for ParamInstructions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Self as Debug>::fmt(self, f)
     }
 }

--- a/utils/wasm-gen/src/generator/syscalls/invocator.rs
+++ b/utils/wasm-gen/src/generator/syscalls/invocator.rs
@@ -500,9 +500,9 @@ impl<'a, 'b> SyscallsInvocator<'a, 'b> {
 
                         vec![
                             // call `gsys::gr_source` storing actor id at `value_set_ptr` pointer.
-                            Instruction::I32Const(value_set_ptr as i32),
+                            Instruction::I32Const(value_set_ptr),
                             Instruction::Call(gr_source_call_indexes_handle),
-                            Instruction::I32Const(value_set_ptr as i32),
+                            Instruction::I32Const(value_set_ptr),
                         ]
                     }
                     SyscallDestination::ExistingAddresses(addresses) => {
@@ -536,7 +536,7 @@ impl<'a, 'b> SyscallsInvocator<'a, 'b> {
                         // Put call to `gr_source`` instructions
                         let mut ret_instr = vec![
                             // call `gsys::gr_source` storing actor id at `value_set_ptr` pointer.
-                            Instruction::I32Const(value_set_ptr as i32),
+                            Instruction::I32Const(value_set_ptr),
                             Instruction::Call(gr_source_call_indexes_handle),
                         ];
                         // Generate value definition instructions.

--- a/utils/wasm-gen/src/generator/syscalls/invocator.rs
+++ b/utils/wasm-gen/src/generator/syscalls/invocator.rs
@@ -94,7 +94,7 @@ pub(crate) fn process_syscall_params(
                 Length if length_param_indexes.contains(&param_idx) => {
                     // Due to match guard `RegularParamType::Length` can be processed in two ways:
                     // 1. The function will return `ProcessedSyscallParams::MemoryArraySize`
-                    //    if this parameter is associated with Ptr::BufferStart { .. }`.
+                    //    if this parameter is associated with Ptr::SizedBufferStart { .. }`.
                     // 2. Otherwise, `ProcessedSyscallParams::Value` will be returned from the function.
                     ProcessedSyscallParams::MemoryArrayLength
                 }

--- a/utils/wasm-gen/src/lib.rs
+++ b/utils/wasm-gen/src/lib.rs
@@ -73,3 +73,7 @@ pub fn generate_gear_program_module(
 
     GearWasmGenerator::new_with_config(wasm_module, u, gear_wasm_generator_config).generate()
 }
+
+// TODOs:
+// 1. re-write docs to all types (separate PR)
+// 2. update tasks list for fuzzer

--- a/utils/wasm-gen/src/lib.rs
+++ b/utils/wasm-gen/src/lib.rs
@@ -73,7 +73,3 @@ pub fn generate_gear_program_module(
 
     GearWasmGenerator::new_with_config(wasm_module, u, gear_wasm_generator_config).generate()
 }
-
-// TODOs:
-// 1. re-write docs to all types (separate PR)
-// 2. update tasks list for fuzzer

--- a/utils/wasm-gen/src/tests.rs
+++ b/utils/wasm-gen/src/tests.rs
@@ -179,8 +179,9 @@ fn test_source_as_address_param() {
     rng.fill_bytes(&mut buf);
     let mut unstructured = Unstructured::new(&buf);
 
-    let mut params_config = SyscallsParamsConfig::default_regular();
-    params_config.set_ptr_rule(PtrParamAllowedValues::ActorId(ActorKind::Source));
+    let params_config = SyscallsParamsConfig::new()
+        .with_default_regular_config()
+        .with_ptr_rule(PtrParamAllowedValues::ActorId(ActorKind::Source));
 
     let mut injection_types = SyscallsInjectionTypes::all_never();
     injection_types.set(InvocableSyscall::Loose(SyscallName::Exit), 1, 1);
@@ -206,11 +207,12 @@ fn test_existing_address_as_address_param() {
     let mut unstructured = Unstructured::new(&buf);
 
     let some_address = [5; 32];
-    let mut params_config = SyscallsParamsConfig::default_regular();
-    params_config.set_ptr_rule(PtrParamAllowedValues::ActorIdWithValue {
-        actor_kind: ActorKind::ExistingAddresses(NonEmpty::new(some_address)),
-        range: 0..=0,
-    });
+    let params_config = SyscallsParamsConfig::new()
+        .with_default_regular_config()
+        .with_ptr_rule(PtrParamAllowedValues::ActorIdWithValue {
+            actor_kind: ActorKind::ExistingAddresses(NonEmpty::new(some_address)),
+            range: 0..=0,
+        });
 
     let mut injection_types = SyscallsInjectionTypes::all_never();
     injection_types.set(InvocableSyscall::Loose(SyscallName::Send), 1, 1);
@@ -255,8 +257,9 @@ fn test_msg_value_ptr() {
     rng.fill_bytes(&mut buf);
     let mut unstructured = Unstructured::new(&buf);
 
-    let mut params_config = SyscallsParamsConfig::default_regular();
-    params_config.set_ptr_rule(PtrParamAllowedValues::Value(REPLY_VALUE..=REPLY_VALUE));
+    let params_config = SyscallsParamsConfig::new()
+        .with_default_regular_config()
+        .with_ptr_rule(PtrParamAllowedValues::Value(REPLY_VALUE..=REPLY_VALUE));
 
     let mut injection_types = SyscallsInjectionTypes::all_never();
     injection_types.set(InvocableSyscall::Loose(SyscallName::Reply), 1, 1);
@@ -310,12 +313,13 @@ fn test_msg_value_ptr_dest() {
         ActorKind::ExistingAddresses(NonEmpty::new(some_address)),
     ];
     for dest_var in destination_variants {
-        let mut params_config = SyscallsParamsConfig::default_regular();
-        params_config.set_rule(RegularParamType::Gas, (0..=0).into());
-        params_config.set_ptr_rule(PtrParamAllowedValues::ActorIdWithValue {
-            actor_kind: dest_var.clone(),
-            range: REPLY_VALUE..=REPLY_VALUE,
-        });
+        let params_config = SyscallsParamsConfig::new()
+            .with_default_regular_config()
+            .with_rule(RegularParamType::Gas, (0..=0).into())
+            .with_ptr_rule(PtrParamAllowedValues::ActorIdWithValue {
+                actor_kind: dest_var.clone(),
+                range: REPLY_VALUE..=REPLY_VALUE,
+            });
 
         for syscall in tested_syscalls {
             let mut rng = SmallRng::seed_from_u64(123);
@@ -466,8 +470,9 @@ fn precise_syscalls_works() {
         let mut injection_types = SyscallsInjectionTypes::all_never();
         injection_types.set(syscall, INJECTED_SYSCALLS, INJECTED_SYSCALLS);
 
-        let mut param_config = SyscallsParamsConfig::default_regular();
-        param_config.set_rule(RegularParamType::Gas, (0..=0).into());
+        let param_config = SyscallsParamsConfig::new()
+            .with_default_regular_config()
+            .with_rule(RegularParamType::Gas, (0..=0).into());
 
         // Assert that syscalls results will be processed.
         let termination_reason = execute_wasm_with_custom_configs(

--- a/utils/wasm-gen/src/tests.rs
+++ b/utils/wasm-gen/src/tests.rs
@@ -597,26 +597,25 @@ fn execute_wasm_with_custom_configs(
     )
     .expect("Failed to create environment");
 
-    env
-        .execute(|mem, _stack_end, globals_config| -> Result<(), u32> {
-            gear_core_processor::Ext::lazy_pages_init_for_program(
-                mem,
-                program_id,
-                Default::default(),
-                Some(mem.size()),
-                globals_config,
-                Default::default(),
-            );
+    env.execute(|mem, _stack_end, globals_config| -> Result<(), u32> {
+        gear_core_processor::Ext::lazy_pages_init_for_program(
+            mem,
+            program_id,
+            Default::default(),
+            Some(mem.size()),
+            globals_config,
+            Default::default(),
+        );
 
-            if let Some(mem_write) = initial_memory_write {
-                return mem
-                    .write(mem_write.offset, &mem_write.content)
-                    .map_err(|_| 1);
-            };
+        if let Some(mem_write) = initial_memory_write {
+            return mem
+                .write(mem_write.offset, &mem_write.content)
+                .map_err(|_| 1);
+        };
 
-            Ok(())
-        })
-        .expect("Failed to execute WASM module")
+        Ok(())
+    })
+    .expect("Failed to execute WASM module")
 }
 
 fn message_sender() -> ProgramId {

--- a/utils/wasm-gen/src/tests.rs
+++ b/utils/wasm-gen/src/tests.rs
@@ -597,7 +597,7 @@ fn execute_wasm_with_custom_configs(
     )
     .expect("Failed to create environment");
 
-    let report = env
+    env
         .execute(|mem, _stack_end, globals_config| -> Result<(), u32> {
             gear_core_processor::Ext::lazy_pages_init_for_program(
                 mem,
@@ -616,9 +616,7 @@ fn execute_wasm_with_custom_configs(
 
             Ok(())
         })
-        .expect("Failed to execute WASM module");
-
-    report
+        .expect("Failed to execute WASM module")
 }
 
 fn message_sender() -> ProgramId {

--- a/utils/wasm-gen/src/tests.rs
+++ b/utils/wasm-gen/src/tests.rs
@@ -180,7 +180,7 @@ fn test_source_as_address_param() {
     let mut unstructured = Unstructured::new(&buf);
 
     let mut params_config = SyscallsParamsConfig::default_regular();
-    params_config.set_ptr_rule(PtrParamAllowedValues::ActorId(SyscallDestination::Source));
+    params_config.set_ptr_rule(PtrParamAllowedValues::ActorId(ActorKind::Source));
 
     let mut injection_types = SyscallsInjectionTypes::all_never();
     injection_types.set(InvocableSyscall::Loose(SyscallName::Exit), 1, 1);
@@ -208,7 +208,7 @@ fn test_existing_address_as_address_param() {
     let some_address = [5; 32];
     let mut params_config = SyscallsParamsConfig::default_regular();
     params_config.set_ptr_rule(PtrParamAllowedValues::ActorIdWithValue {
-        actor: SyscallDestination::ExistingAddresses(NonEmpty::new(some_address)),
+        actor_kind: ActorKind::ExistingAddresses(NonEmpty::new(some_address)),
         range: 0..=0,
     });
 
@@ -305,15 +305,15 @@ fn test_msg_value_ptr_dest() {
 
     let some_address = [10; 32];
     let destination_variants = [
-        SyscallDestination::Random,
-        SyscallDestination::Source,
-        SyscallDestination::ExistingAddresses(NonEmpty::new(some_address)),
+        ActorKind::Random,
+        ActorKind::Source,
+        ActorKind::ExistingAddresses(NonEmpty::new(some_address)),
     ];
     for dest_var in destination_variants {
         let mut params_config = SyscallsParamsConfig::default_regular();
         params_config.set_rule(RegularParamType::Gas, (0..=0).into());
         params_config.set_ptr_rule(PtrParamAllowedValues::ActorIdWithValue {
-            actor: dest_var.clone(),
+            actor_kind: dest_var.clone(),
             range: REPLY_VALUE..=REPLY_VALUE,
         });
 
@@ -360,11 +360,11 @@ fn test_msg_value_ptr_dest() {
                 let destination = dispatch.destination();
 
                 match dest_var {
-                    SyscallDestination::Source => assert_eq!(destination, message_sender()),
-                    SyscallDestination::ExistingAddresses(_) => {
+                    ActorKind::Source => assert_eq!(destination, message_sender()),
+                    ActorKind::ExistingAddresses(_) => {
                         assert_eq!(destination, ProgramId::from(some_address.as_ref()))
                     }
-                    SyscallDestination::Random => {}
+                    ActorKind::Random => {}
                 }
             }
         }

--- a/utils/wasm-gen/src/utils.rs
+++ b/utils/wasm-gen/src/utils.rs
@@ -17,6 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::wasm::PageCount as WasmPageCount;
+use gear_utils::NonEmpty;
 use gear_wasm_instrument::{
     parity_wasm::{
         builder,
@@ -28,10 +29,9 @@ use gear_wasm_instrument::{
     syscalls::SyscallName,
     wasm_instrument::{self, InjectionConfig},
 };
-use gsys::HashWithValue;
 use std::{
     collections::{BTreeMap, BTreeSet},
-    mem, slice,
+    iter, mem,
 };
 
 const PREALLOCATE: usize = 1_000;
@@ -464,17 +464,63 @@ pub fn inject_critical_gas_limit(module: Module, critical_gas_limit: u64) -> Mod
     module
 }
 
-pub(crate) fn hash_with_value_to_vec(hash_with_value: &HashWithValue) -> Vec<u8> {
-    let address_data_size = mem::size_of::<HashWithValue>();
-    let address_data_slice = unsafe {
-        // # Safety:
-        // The `unsafe` block constructs raw bytes vector of an existing rust struct
-        // received by reference.
-        slice::from_raw_parts(
-            hash_with_value as *const HashWithValue as *const u8,
-            address_data_size,
-        )
-    };
+pub(crate) struct WasmWords(Vec<i32>);
 
-    address_data_slice.to_vec()
+impl WasmWords {
+    pub(crate) fn new(data: impl AsRef<[u8]>) -> Self {
+        let data = data.as_ref();
+
+        let data_size = data.len();
+        let wasm_ptr_size = mem::size_of::<i32>();
+
+        if data_size % wasm_ptr_size != 0 {
+            panic!("data size isn't multiply of wasm word size")
+        }
+
+        let words = data
+            .chunks(wasm_ptr_size)
+            .map(|word_bytes| {
+                i32::from_le_bytes(
+                    word_bytes
+                        .try_into()
+                        .expect("Chunks are of the exact size."),
+                )
+            })
+            .collect();
+
+        Self(words)
+    }
+
+    pub(crate) fn merge(mut self, other: Self) -> Self {
+        let Self(mut other) = other;
+        self.0.append(&mut other);
+
+        Self(self.0)
+    }
+}
+
+pub(crate) fn translate_ptr_data(
+    words: WasmWords,
+    (start_offset, end_offset): (i32, i32),
+) -> Vec<Instruction> {
+    let WasmWords(words) = words;
+    words
+        .into_iter()
+        .enumerate()
+        .flat_map(|(word_idx, word)| {
+            vec![
+                Instruction::I32Const(start_offset),
+                Instruction::I32Const(word),
+                Instruction::I32Store(2, (word_idx * mem::size_of::<i32>()) as u32),
+            ]
+        })
+        .chain(iter::once(Instruction::I32Const(end_offset)))
+        .collect()
+}
+
+pub(crate) fn non_empty_to_vec<T>(non_empty: NonEmpty<T>) -> Vec<T> {
+    let (head, mut tail) = non_empty.into();
+    tail.push(head);
+
+    tail
 }

--- a/utils/wasm-gen/src/utils.rs
+++ b/utils/wasm-gen/src/utils.rs
@@ -467,18 +467,18 @@ pub fn inject_critical_gas_limit(module: Module, critical_gas_limit: u64) -> Mod
 pub(crate) struct WasmWords(Vec<i32>);
 
 impl WasmWords {
+    const WASM_WORD_SIZE: usize = mem::size_of::<i32>();
+
     pub(crate) fn new(data: impl AsRef<[u8]>) -> Self {
         let data = data.as_ref();
-
         let data_size = data.len();
-        let wasm_ptr_size = mem::size_of::<i32>();
 
-        if data_size % wasm_ptr_size != 0 {
+        if data_size % Self::WASM_WORD_SIZE != 0 {
             panic!("data size isn't multiply of wasm word size")
         }
 
         let words = data
-            .chunks_exact(wasm_ptr_size)
+            .chunks_exact(Self::WASM_WORD_SIZE)
             .map(|word_bytes| {
                 i32::from_le_bytes(
                     word_bytes

--- a/utils/wasm-gen/src/utils.rs
+++ b/utils/wasm-gen/src/utils.rs
@@ -478,7 +478,7 @@ impl WasmWords {
         }
 
         let words = data
-            .chunks(wasm_ptr_size)
+            .chunks_exact(wasm_ptr_size)
             .map(|word_bytes| {
                 i32::from_le_bytes(
                     word_bytes
@@ -491,8 +491,7 @@ impl WasmWords {
         Self(words)
     }
 
-    pub(crate) fn merge(mut self, other: Self) -> Self {
-        let Self(mut other) = other;
+    pub(crate) fn merge(mut self, Self(mut other): Self) -> Self {
         self.0.append(&mut other);
 
         Self(self.0)
@@ -500,10 +499,9 @@ impl WasmWords {
 }
 
 pub(crate) fn translate_ptr_data(
-    words: WasmWords,
+    WasmWords(words): WasmWords,
     (start_offset, end_offset): (i32, i32),
 ) -> Vec<Instruction> {
-    let WasmWords(words) = words;
     words
         .into_iter()
         .enumerate()

--- a/utils/wasm-instrument/src/syscalls.rs
+++ b/utils/wasm-instrument/src/syscalls.rs
@@ -771,15 +771,9 @@ mod pointers {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
     pub enum Ptr {
         // Const ptrs.
-        BlockNumber,
-        BlockTimestamp,
         SizedBufferStart { length_param_idx: usize },
-        BufferStart,
         Hash(HashType),
-        Gas,
-        Length,
         Value,
-        BlockNumberWithHash(HashType),
         HashWithValue(HashType),
         TwoHashes(HashType, HashType),
         TwoHashesWithValue(HashType, HashType),
@@ -793,9 +787,6 @@ mod pointers {
         MutLength,
         MutValue,
         MutBlockNumberWithHash(HashType),
-        MutHashWithValue(HashType),
-        MutTwoHashes(HashType, HashType),
-        MutTwoHashesWithValue(HashType, HashType),
     }
 
     impl Ptr {
@@ -803,15 +794,9 @@ mod pointers {
             use Ptr::*;
 
             match self {
-                BlockNumber
-                | BlockTimestamp
-                | SizedBufferStart { .. }
-                | BufferStart
+                SizedBufferStart { .. }
                 | Hash(_)
-                | Gas
-                | Length
                 | Value
-                | BlockNumberWithHash(_)
                 | HashWithValue(_)
                 | TwoHashes(_, _)
                 | TwoHashesWithValue(_, _) => false,
@@ -823,10 +808,7 @@ mod pointers {
                 | MutGas
                 | MutLength
                 | MutValue
-                | MutBlockNumberWithHash(_)
-                | MutHashWithValue(_)
-                | MutTwoHashes(_, _)
-                | MutTwoHashesWithValue(_, _) => true,
+                | MutBlockNumberWithHash(_) => true,
             }
         }
     }


### PR DESCRIPTION
This PR introduces value fuzzing to the `wasm-gen` and partially resolves #3269 and #3296.

Changes:
- Config for syscall destination arguments is moved to syscalls params config.
- Syscalls params config is now more complexed config type, it includes two separate config maps: one for regular params and the other one for pointers. Pointers config is focused on `Value`, `Hash` and `HashWithValue` pointer types. The two latter pointers include syscall destination config, which gives more control over type of destination for different syscalls. Before these changes if you defined syscalls destination config, it will be reused for every syscall.
- There's no separation for syscalls `with destionation`/`without destionation`. Destination value is generated in the common syscalls params processing flow.