### PR TITLE
chore(sandbox): inherit manifest from workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4193,7 +4193,7 @@ dependencies = [
  "mach",
  "nix 0.26.4",
  "region",
- "sp-wasm-interface",
+ "sp-wasm-interface-common",
  "winapi",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4379,7 +4379,7 @@ dependencies = [
 
 [[package]]
 name = "gear-sandbox"
-version = "0.1.0"
+version = "1.0.4"
 dependencies = [
  "assert_matches",
  "gear-runtime-interface",
@@ -4388,7 +4388,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-core",
  "sp-std 5.0.0",
- "sp-wasm-interface",
+ "sp-wasm-interface-common",
  "wasmi 0.30.0 (git+https://github.com/gear-tech/wasmi?branch=gear-v0.30.0)",
  "wat",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4398,7 +4398,7 @@ name = "gear-sandbox-env"
 version = "1.0.4"
 dependencies = [
  "parity-scale-codec",
- "sp-core",
+ "sp-debug-derive",
  "sp-std 5.0.0",
  "sp-wasm-interface-common",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -327,6 +327,7 @@ sp-core = { version = "7.0.0", git = "https://github.com/gear-tech/substrate.git
 sp-consensus = { version = "0.10.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.41-canary-no-sandbox-revert-oom-changes", default-features = false }
 sp-consensus-babe = { version = "0.10.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.41-canary-no-sandbox-revert-oom-changes", default-features = false }
 sp-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.41-canary-no-sandbox-revert-oom-changes", default-features = false }
+sp-debug-derive = { version = "5.0.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.41-canary-no-sandbox-revert-oom-changes", default-features = false }
 sp-externalities = { version = "0.13.0", git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.41-canary-no-sandbox-revert-oom-changes", default-features = false }
 sp-consensus-grandpa = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.41-canary-no-sandbox-revert-oom-changes", default-features = false }
 sp-inherents = { version = "4.0.0-dev", git = "https://github.com/gear-tech/substrate.git", branch = "gear-polkadot-v0.9.41-canary-no-sandbox-revert-oom-changes", default-features = false }

--- a/lazy-pages/Cargo.toml
+++ b/lazy-pages/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 
 [dependencies]
 log = { workspace = true, features = ["std"] }
-sp-wasm-interface = { workspace = true, features = ["std"] }
+sp-wasm-interface-common = { workspace = true, features = ["std"] }
 cfg-if.workspace = true
 region.workspace = true
 derive_more.workspace = true

--- a/lazy-pages/src/globals.rs
+++ b/lazy-pages/src/globals.rs
@@ -23,7 +23,7 @@ use core::any::Any;
 use gear_core::{memory::HostPointer, str::LimitedStr};
 use gear_lazy_pages_common::{GlobalsAccessError, GlobalsAccessMod, GlobalsAccessor};
 use gear_sandbox_host::sandbox::SandboxInstance;
-use sp_wasm_interface::Value;
+use sp_wasm_interface_common::Value;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum GlobalNo {

--- a/sandbox/env/Cargo.toml
+++ b/sandbox/env/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec.workspace = true
-sp-core.workspace = true
+sp-debug-derive.workspace = true
 sp-std.workspace = true
 sp-wasm-interface-common = { workspace = true, default-features = false }
 
@@ -21,7 +21,7 @@ sp-wasm-interface-common = { workspace = true, default-features = false }
 default = ["std"]
 std = [
 	"codec/std",
-	"sp-core/std",
+	"sp-debug-derive/std",
 	"sp-std/std",
 	"sp-wasm-interface-common/std",
 ]

--- a/sandbox/env/src/lib.rs
+++ b/sandbox/env/src/lib.rs
@@ -24,7 +24,7 @@ extern crate alloc;
 
 use alloc::string::String;
 use codec::{Decode, Encode};
-use sp_core::RuntimeDebug;
+use sp_debug_derive::RuntimeDebug;
 use sp_std::vec::Vec;
 use sp_wasm_interface_common::ReturnValue;
 

--- a/sandbox/sandbox/Cargo.toml
+++ b/sandbox/sandbox/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "gear-sandbox"
-version = "0.1.0"
-authors = ["Gear Technologies"]
-edition = "2021"
-license = "GPL-3.0"
-homepage = "https://gear-tech.io"
-repository = "https://github.com/gear-tech/gear"
 description = "This crate provides means to instantiate and execute wasm modules."
 readme = "README.md"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sandbox/sandbox/Cargo.toml
+++ b/sandbox/sandbox/Cargo.toml
@@ -18,7 +18,7 @@ log.workspace = true
 wasmi = { git = "https://github.com/gear-tech/wasmi", branch = "gear-v0.30.0", default-features = false }
 sp-core.workspace = true
 sp-std.workspace = true
-sp-wasm-interface.workspace = true
+sp-wasm-interface-common.workspace = true
 gear-runtime-interface.workspace = true
 gear-sandbox-env.workspace = true
 
@@ -33,7 +33,7 @@ std = [
 	"log/std",
 	"sp-core/std",
 	"sp-std/std",
-	"sp-wasm-interface/std",
+	"sp-wasm-interface-common/std",
 	"gear-runtime-interface/std",
 	"gear-sandbox-env/std",
 	"wasmi/std",

--- a/sandbox/sandbox/src/embedded_executor.rs
+++ b/sandbox/sandbox/src/embedded_executor.rs
@@ -25,7 +25,7 @@ use crate::{
 use alloc::string::String;
 use gear_sandbox_env::GLOBAL_NAME_GAS;
 use sp_std::{collections::btree_map::BTreeMap, marker::PhantomData, prelude::*};
-use sp_wasm_interface::HostPointer;
+use sp_wasm_interface_common::HostPointer;
 use wasmi::{
     core::{Pages, Trap},
     Engine, ExternType, Linker, MemoryType, Module, StoreContext, StoreContextMut,

--- a/sandbox/sandbox/src/host_executor.rs
+++ b/sandbox/sandbox/src/host_executor.rs
@@ -27,7 +27,7 @@ use alloc::string::String;
 use gear_runtime_interface::sandbox;
 use gear_sandbox_env::WasmReturnValue;
 use sp_std::{marker, mem, prelude::*, rc::Rc, slice, vec};
-use sp_wasm_interface::HostPointer;
+use sp_wasm_interface_common::HostPointer;
 
 mod ffi {
     use super::HostFuncType;

--- a/sandbox/sandbox/src/lib.rs
+++ b/sandbox/sandbox/src/lib.rs
@@ -50,9 +50,9 @@ pub mod host_executor;
 use alloc::string::String;
 use sp_core::RuntimeDebug;
 use sp_std::prelude::*;
-use sp_wasm_interface::HostPointer;
+use sp_wasm_interface_common::HostPointer;
 
-pub use sp_wasm_interface::{IntoValue, ReturnValue, Value};
+pub use sp_wasm_interface_common::{IntoValue, ReturnValue, Value};
 
 #[cfg(feature = "std")]
 pub use self::embedded_executor as default_executor;


### PR DESCRIPTION
This PR is part of #3594 

- [x] inherit manifest of sandbox from workspace
- [x] use `sp-debug-derive` in `sandbox-host`
- [x] use sp-wasm-interface-common in sandbox
- [x] use `-common` in `lazy-pages`


@gear-tech/dev 
