### PR TITLE
refactor(afit)!: Replace `async_trait` with AFIT

### DIFF
--- a/examples/messager/src/bin/demo_messager.rs
+++ b/examples/messager/src/bin/demo_messager.rs
@@ -18,7 +18,7 @@
 #![cfg(feature = "gcli")]
 
 use gcli::{
-    anyhow, async_trait,
+    anyhow,
     clap::{self, Parser},
     cmd::Upload,
     color_eyre, tokio, App,
@@ -35,7 +35,6 @@ pub struct Messager {
     command: Command,
 }
 
-#[async_trait]
 impl App for Messager {
     async fn exec(&self) -> anyhow::Result<()> {
         let lookup = gcli::lookup!();

--- a/gcli/examples/mycli.rs
+++ b/gcli/examples/mycli.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use gcli::{async_trait, clap::Parser, App, Command};
+use gcli::{clap::Parser, App, Command};
 
 /// My customized sub commands.
 #[derive(Debug, Parser)]
@@ -35,7 +35,6 @@ pub struct MyGCli {
     command: SubCommand,
 }
 
-#[async_trait]
 impl App for MyGCli {
     async fn exec(&self) -> anyhow::Result<()> {
         match &self.command {

--- a/gcli/src/app.rs
+++ b/gcli/src/app.rs
@@ -21,13 +21,14 @@
 use crate::keystore;
 use clap::Parser;
 use color_eyre::{eyre::eyre, Result};
+use core::future::Future;
 use env_logger::{Builder, Env};
 use gsdk::{signer::Signer, Api};
 
 /// Command line gear program application abstraction.
 ///
 /// ```ignore
-/// use gcli::{async_trait, App, Command, clap::Parser, color_eyre, anyhow};
+/// use gcli::{App, Command, clap::Parser, color_eyre, anyhow};
 ///
 /// /// My customized sub commands.
 /// #[derive(Debug, Parser)]
@@ -46,7 +47,6 @@ use gsdk::{signer::Signer, Api};
 ///     command: SubCommand,
 /// }
 ///
-/// #[async_trait]
 /// impl App for MyGCli {
 ///     async fn exec(&self) -> anyhow::Result<()> {
 ///         match &self.command {
@@ -64,7 +64,6 @@ use gsdk::{signer::Signer, Api};
 ///     MyGCli::parse().run().await
 /// }
 /// ```
-#[async_trait::async_trait]
 pub trait App: Parser + Sync {
     /// Timeout of rpc requests.
     fn timeout(&self) -> u64 {
@@ -87,49 +86,53 @@ pub trait App: Parser + Sync {
     }
 
     /// Exec program from the parsed arguments.
-    async fn exec(&self) -> anyhow::Result<()>;
+    fn exec(&self) -> impl Future<Output = anyhow::Result<()>> + Send;
 
     /// Get signer.
-    async fn signer(&self) -> anyhow::Result<Signer> {
-        let endpoint = self.endpoint().clone();
-        let timeout = self.timeout();
-        let passwd = self.passwd();
+    fn signer(&self) -> impl Future<Output = anyhow::Result<Signer>> + Send {
+        async {
+            let endpoint = self.endpoint().clone();
+            let timeout = self.timeout();
+            let passwd = self.passwd();
 
-        let api = Api::new_with_timeout(endpoint.as_deref(), Some(timeout)).await?;
-        let pair = if let Ok(s) = keystore::cache(passwd.as_deref()) {
-            s
-        } else {
-            keystore::keyring(passwd.as_deref())?
-        };
+            let api = Api::new_with_timeout(endpoint.as_deref(), Some(timeout)).await?;
+            let pair = if let Ok(s) = keystore::cache(passwd.as_deref()) {
+                s
+            } else {
+                keystore::keyring(passwd.as_deref())?
+            };
 
-        Ok((api, pair).into())
+            Ok((api, pair).into())
+        }
     }
 
     /// Run application.
     ///
     /// This is a wrapper of [`Self::exec`] with preset retry
     /// and verbose level.
-    async fn run(&self) -> Result<()> {
-        color_eyre::install()?;
-        sp_core::crypto::set_default_ss58_version(runtime_primitives::VARA_SS58_PREFIX.into());
+    fn run(&self) -> impl Future<Output = Result<()>> + Send {
+        async {
+            color_eyre::install()?;
+            sp_core::crypto::set_default_ss58_version(runtime_primitives::VARA_SS58_PREFIX.into());
 
-        let name = Self::command().get_name().to_string();
-        let filter = match self.verbose() {
-            0 => format!("{name}=info,gsdk=info"),
-            1 => format!("{name}=debug,gsdk=debug"),
-            2 => "debug".into(),
-            _ => "trace".into(),
-        };
+            let name = Self::command().get_name().to_string();
+            let filter = match self.verbose() {
+                0 => format!("{name}=info,gsdk=info"),
+                1 => format!("{name}=debug,gsdk=debug"),
+                2 => "debug".into(),
+                _ => "trace".into(),
+            };
 
-        let mut builder = Builder::from_env(Env::default().default_filter_or(filter));
-        builder
-            .format_target(false)
-            .format_module_path(false)
-            .format_timestamp(None);
-        builder.try_init()?;
+            let mut builder = Builder::from_env(Env::default().default_filter_or(filter));
+            builder
+                .format_target(false)
+                .format_module_path(false)
+                .format_timestamp(None);
+            builder.try_init()?;
 
-        self.exec()
-            .await
-            .map_err(|e| eyre!("Failed to run app, {e}"))
+            self.exec()
+                .await
+                .map_err(|e| eyre!("Failed to run app, {e}"))
+        }
     }
 }

--- a/gcli/src/cmd/mod.rs
+++ b/gcli/src/cmd/mod.rs
@@ -119,7 +119,6 @@ pub struct Opt {
     pub passwd: Option<String>,
 }
 
-#[async_trait::async_trait]
 impl App for Opt {
     fn timeout(&self) -> u64 {
         self.timeout

--- a/gclient/src/api/listener/iterator.rs
+++ b/gclient/src/api/listener/iterator.rs
@@ -18,7 +18,6 @@
 
 use super::EventProcessor;
 use crate::{Error, Result};
-use async_trait::async_trait;
 use gsdk::{
     config::GearConfig,
     ext::sp_core::H256,
@@ -46,7 +45,6 @@ use subxt::events::Events;
 /// ```
 pub struct EventListener(pub(crate) Blocks);
 
-#[async_trait(?Send)]
 impl EventProcessor for EventListener {
     fn not_waited() -> Error {
         unreachable!()

--- a/gclient/src/api/listener/mod.rs
+++ b/gclient/src/api/listener/mod.rs
@@ -24,7 +24,6 @@ pub use iterator::*;
 pub use subscription::*;
 
 use crate::{Error, Result};
-use async_trait::async_trait;
 use gear_core::ids::MessageId;
 use gear_core_errors::ReplyCode;
 use gsdk::metadata::runtime_types::{
@@ -81,7 +80,7 @@ impl DispatchStatus {
 /// several default implementations.
 ///
 /// See implementation example in [`EventListener`].
-#[async_trait(?Send)]
+#[allow(async_fn_in_trait)] // doesn't need Send
 pub trait EventProcessor {
     /// This function is called if a received event has an unexpected type.
     ///

--- a/gclient/src/api/listener/subscription.rs
+++ b/gclient/src/api/listener/subscription.rs
@@ -18,10 +18,8 @@
 
 use super::EventProcessor;
 use crate::{Error, Result};
-use async_trait::async_trait;
 use gsdk::Event;
 
-#[async_trait(?Send)]
 impl<I: IntoIterator<Item = Event> + Clone> EventProcessor for I {
     fn not_waited() -> Error {
         Error::EventNotFoundInIterator

--- a/pallets/gear/rpc/src/lib.rs
+++ b/pallets/gear/rpc/src/lib.rs
@@ -250,7 +250,6 @@ fn into_call_err(error: impl ToString, desc: &'static str) -> CallError {
     CallError::Custom(ErrorObject::owned(8000, desc, Some(error.to_string())))
 }
 
-#[async_trait]
 impl<C, Block> GearApiServer<<Block as BlockT>::Hash, Result<u64, Vec<u8>>> for Gear<C, Block>
 where
     Block: BlockT,

--- a/pallets/gear/rpc/src/lib.rs
+++ b/pallets/gear/rpc/src/lib.rs
@@ -26,7 +26,7 @@
 use gear_common::Origin;
 use gear_core_errors::*;
 use jsonrpsee::{
-    core::{async_trait, Error as JsonRpseeError, RpcResult},
+    core::{Error as JsonRpseeError, RpcResult},
     proc_macros::rpc,
     types::error::{CallError, ErrorObject},
 };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-09-05"
+channel = "nightly-2023-10-31"
 components = [ "llvm-tools" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "default"


### PR DESCRIPTION
## Motivation

[Rust 1.75][rust-1.75] stabilized [AFIT and RPITIT][afit-rpitit].
These allow removing unnecessary indirections and allocations: while [`async_trait`][async_trait] desugars `async fn`s into`-> Pin<Box<dyn Future<Output=…> + Send + '_>>`, AFIT uses proper RPIT (`-> impl Future<Output=…>`), which has already been used for `async fn` outside of traits.

## Caveats

- Traits with RPITIT are **not** object safe.
  If a trait with `async fn` is supposed to be used as a trait object (`dyn Trait`), `async_trait` should be used.
- Additional `Future` bounds like `Send`/`Sync` are a bit painful to add -- that requires manual desugaring of the function in question (see `gcli/src/app.rs`)
- Has MSRV of 1.75

Because of these, `rustc` currently warns about AFIT usage (see `async_fn_in_trait` lint):
```rs
warning: use of `async fn` in public traits is discouraged as auto trait bounds cannot be specified
 --> src/lib.rs:7:5
  |
7 |     async fn fetch(&self, url: Url) -> HtmlBody;
  |     ^^^^^
  |
help: you can desugar to a normal `fn` that returns `impl Future` and add any desired bounds such as `Send`, but these cannot be relaxed without a breaking API change
  |
7 -     async fn fetch(&self, url: Url) -> HtmlBody;
7 +     fn fetch(&self, url: Url) -> impl std::future::Future<Output = HtmlBody> + Send;
  |
```
(example from the [announcement post][afit-rpitit])

## TODO

- [ ] Decide what to do with `gcli::async_trait` re-export
- [ ] Replace other usages of dynamic dispatch in traits with RPITIT.
      I was unable to find any traits with functions returning `Box<dyn …>`; however, I recall discussing that with someone a month ago.

[rust-1.75]: https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html
[afit-rpitit]: https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html
[async_trait]: https://docs.rs/async-trait/latest/async_trait/
