### PR TITLE
feat(core): Add From<[T; N]> for LimitedVec

### DIFF
--- a/core/src/buffer.rs
+++ b/core/src/buffer.rs
@@ -37,6 +37,13 @@ use scale_info::{
 #[derive(Clone, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Decode, Encode, TypeInfo)]
 pub struct LimitedVec<T, E, const N: usize>(Vec<T>, PhantomData<E>);
 
+impl<T, E, const M: usize, const N: usize> From<[T; M]> for LimitedVec<T, E, N> {
+    fn from(value: [T; M]) -> Self {
+        assert!(M <= N);
+        Self(value.into(), Default::default())
+    }
+}
+
 /// Formatter for [`LimitedVec`] will print to precision of 8 by default, to print the whole data, use `{:+}`.
 impl<T: Clone + Default, E: Default, const N: usize> Display for LimitedVec<T, E, N>
 where


### PR DESCRIPTION
Resolves #3641 

- There is no way to compare M <= N in trait bounds
- static_assert!() doesnt work on const generics
- One potential solution I think could work uses ```where [(); {N - M}]:```, however, it needs `#![feature(generic_const_expr)]`. If you think this is better I can change it to that

@reviewer-or-team
