### PR TITLE
fix(rpc-calls): Calculate gas for empty accounts

### DIFF
--- a/pallets/gear/src/runtime_api.rs
+++ b/pallets/gear/src/runtime_api.rs
@@ -45,7 +45,7 @@ where
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn calculate_gas_info_impl(
-        source: H256,
+        origin: H256,
         kind: HandleKind,
         initial_gas: u64,
         payload: Vec<u8>,
@@ -56,16 +56,21 @@ where
     ) -> Result<GasInfo, Vec<u8>> {
         Self::enable_lazy_pages();
 
-        let account = source.cast();
+        let origin = origin.cast();
+        let value = value.unique_saturated_into();
 
-        let balance = CurrencyOf::<T>::free_balance(&account);
-        let max_balance: BalanceOf<T> = <T as pallet_gear_bank::Config>::GasMultiplier::get()
-            .gas_to_value(initial_gas)
-            + value.unique_saturated_into();
-        CurrencyOf::<T>::deposit_creating(&account, max_balance.saturating_sub(balance));
+        let origin_balance = CurrencyOf::<T>::free_balance(&origin);
 
-        let who = frame_support::dispatch::RawOrigin::Signed(account);
-        let value: BalanceOf<T> = value.unique_saturated_into();
+        let value_for_gas =
+            <T as pallet_gear_bank::Config>::GasMultiplier::get().gas_to_value(initial_gas);
+
+        let required_balance = CurrencyOf::<T>::minimum_balance()
+            .saturating_add(value_for_gas)
+            .saturating_add(value);
+
+        CurrencyOf::<T>::deposit_creating(&origin, required_balance.saturating_sub(origin_balance));
+
+        let who = frame_support::dispatch::RawOrigin::Signed(origin);
 
         QueueOf::<T>::clear();
 

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -86,7 +86,6 @@ use utils::*;
 type Gas = <<Test as Config>::GasProvider as common::GasProvider>::GasTree;
 
 #[test]
-#[should_panic]
 fn calculate_gas_zero_balance() {
     init_logger();
     new_test_ext().execute_with(|| {

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -75,12 +75,40 @@ use gear_core_errors::*;
 use gear_wasm_instrument::{gas_metering::ConstantCostRules, STACK_END_EXPORT_NAME};
 use gstd::{collections::BTreeMap, errors::Error as GstdError};
 use pallet_gear_voucher::PrepaidCall;
-use sp_runtime::{traits::UniqueSaturatedInto, SaturatedConversion};
+use sp_runtime::{
+    traits::{One, UniqueSaturatedInto},
+    SaturatedConversion,
+};
 use sp_std::convert::TryFrom;
 pub use utils::init_logger;
 use utils::*;
 
 type Gas = <<Test as Config>::GasProvider as common::GasProvider>::GasTree;
+
+#[test]
+#[should_panic]
+fn calculate_gas_zero_balance() {
+    init_logger();
+    new_test_ext().execute_with(|| {
+        const ZERO_BALANCE_USER: AccountId = 12122023;
+        assert!(Balances::free_balance(ZERO_BALANCE_USER).is_zero());
+
+        let gas_below_ed = get_ed()
+            .saturating_div(gas_price(1))
+            .saturating_sub(One::one());
+
+        assert_ok!(Gear::calculate_gas_info_impl(
+            ZERO_BALANCE_USER.into_origin(),
+            HandleKind::Init(ProgramCodeKind::Default.to_bytes()),
+            gas_below_ed as u64,
+            vec![],
+            0,
+            false,
+            false,
+            None,
+        ));
+    });
+}
 
 #[test]
 fn delayed_send_from_reservation_not_for_mailbox() {


### PR DESCRIPTION
## Bug description
Sometimes it happened that user couldn't calculate if his balance is zero. Especially it caused vouchers consumers.

This was happening despite the fact that the balance is mocked to suit the requirements of the call.

## Bug mechanic
In order to increase accuracy of required gas measurement, the measurement is done twice:
* First time we run message with maximum gas limit, receiving some minimal limit
* Second time we run message with minimal limit from previous step to receive even smaller gas amount in case of gas-dependency of the message execution.

**It happened that minimal limit (in gas) can has value equivalent less than existential deposit, so our balance mocking using deposit_creating occurred no-op.**

## Bug fix
Always add up existential deposit in calculate gas rpc call balance mock.


#### NOTE: Minor refactoring is done as well
