### PR TITLE
refactor(rpc-call): Never return `<wasm:stripped>` from rpc calls

### DIFF
--- a/gsdk/tests/rpc.rs
+++ b/gsdk/tests/rpc.rs
@@ -49,7 +49,7 @@ async fn pallet_errors_formatting() -> Result<()> {
         CallError::Custom(ErrorObject::owned(
             8000,
             "Runtime error",
-            Some("\"Extrinsic `gear.upload_program` failed: 'ProgramConstructionFailed'\""),
+            Some("Extrinsic `gear.upload_program` failed: 'ProgramConstructionFailed'"),
         )),
     ))));
 

--- a/pallets/gear/rpc/src/lib.rs
+++ b/pallets/gear/rpc/src/lib.rs
@@ -39,11 +39,11 @@ use sp_runtime::traits::Block as BlockT;
 use std::sync::Arc;
 
 /// Converts a runtime trap into a [`CallError`].
-fn runtime_error_into_rpc_error(err: impl std::fmt::Debug) -> JsonRpseeError {
+fn runtime_error_into_rpc_error(err: impl std::fmt::Display) -> JsonRpseeError {
     CallError::Custom(ErrorObject::owned(
         8000,
         "Runtime error",
-        Some(format!("{err:?}")),
+        Some(format!("{err}")),
     ))
     .into()
 }

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -8341,22 +8341,19 @@ fn call_forbidden_function() {
 
         run_to_block(2, None);
 
-        let res = Gear::calculate_gas_info(
+        let err = Gear::calculate_gas_info(
             USER_1.into_origin(),
             HandleKind::Handle(prog_id),
             EMPTY_PAYLOAD.to_vec(),
             0,
             true,
             true,
-        );
+        )
+        .expect_err("Must return error");
 
-        assert_eq!(
-            res,
-            Err(format!(
-                "Program terminated with a trap: {}",
-                TrapExplanation::ForbiddenFunction,
-            ))
-        );
+        let trap = TrapExplanation::ForbiddenFunction;
+
+        assert_eq!(err, format!("Program terminated with a trap: '{trap}'"));
     });
 }
 

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -44,7 +44,7 @@ use crate::{
         USER_3,
     },
     pallet,
-    runtime_api::RUNTIME_API_BLOCK_LIMITS_COUNT,
+    runtime_api::{ALLOWANCE_LIMIT_ERR, RUNTIME_API_BLOCK_LIMITS_COUNT},
     AccountIdOf, BlockGasLimitOf, Config, CostsPerBlockOf, CurrencyOf, DbWeightOf, DispatchStashOf,
     Error, Event, GasAllowanceOf, GasBalanceOf, GasHandlerOf, GasInfo, GearBank, MailboxOf,
     ProgramStorageOf, QueueOf, Schedule, TaskPoolOf, WaitlistOf,
@@ -13111,10 +13111,7 @@ fn calculate_gas_fails_when_calculation_limit_exceeded() {
         );
 
         assert!(gas_info_result.is_err());
-        assert_eq!(
-            gas_info_result.unwrap_err(),
-            "Calculation gas limit exceeded. Consider using custom built node."
-        );
+        assert_eq!(gas_info_result.unwrap_err(), ALLOWANCE_LIMIT_ERR);
 
         // ok result when we use custom multiplier
         let gas_info_result = Gear::calculate_gas_info_impl(


### PR DESCRIPTION
These changes formalise error output of calculate gas calls:
* Internal errors (that are supposed to be unreachable) if occur will be thrown as "Internal error: entered unreachable code '`{ERROR EXPLANATION}`'" 
* 🥳 Rpc calls no longer return `<wasm:stripped>`, that happened to be in case of underlying extrinsic failure. Instead, it returns name of the error occurred.
* In case of non pallet-gear error returned it will contain pallet/module index within the runtime of the chain to resolve name collision.

### Before
```shell
curl http://testnet.vara.network:9944 -H "Content-Type:application/json;charset=utf-8" -d "{
    \"jsonrpc\":\"2.0\",
    \"id\":1,
    \"method\":\"gear_calculateInitCreateGas\",
    \"params\": [
        \"0x0000000000000000000000000000000000000000000000000000000000000000\",
        \"0x0000000000000000000000000000000000000000000000000000000000000000\",
        \"\",
        0,
        true
    ]
}"
{"jsonrpc":"2.0","error":{"code":8000,"message":"Runtime error","data":"\"Internal error: create_program failed with '<wasm:stripped>'\""},"id":1}%   
```

### Now
```shell
curl http://localhost:9944 -H "Content-Type:application/json;charset=utf-8" -d "{
    \"jsonrpc\":\"2.0\",
    \"id\":1,
    \"method\":\"gear_calculateInitCreateGas\",
    \"params\": [
        \"0x0000000000000000000000000000000000000000000000000000000000000000\",
        \"0x0000000000000000000000000000000000000000000000000000000000000000\",
        \"\",
        0,
        true
    ]
}"
{"jsonrpc":"2.0","error":{"code":8000,"message":"Runtime error","data":"Extrinsic `gear.create_program` failed: 'CodeDoesntExist'"},"id":1}
```