### PR TITLE
refactor(workspace): Use hard pin to `gear-dlmalloc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ tempfile = "3.8.1"
 # Published deps
 #
 # https://github.com/gear-tech/gear-dlmalloc/tree/0.2.0
-dlmalloc = { package = "gear-dlmalloc", version = "0.2.0" }
+dlmalloc = { package = "gear-dlmalloc", version = "=0.2.0" }
 # https://github.com/gear-tech/wasm-instrument/tree/gear-stable-v0.3.0
 gwasm-instrument = { version = "0.3.0", default-features = false }
 # https://github.com/gear-tech/wasm-utils/tree/v0.19.0


### PR DESCRIPTION
Inspired by the fear of poorly held semver in future