### PR TITLE
refactor(core): Add `gr_user_break` syscall to replace all non returning syscalls.

### DIFF
--- a/core-backend/src/env.rs
+++ b/core-backend/src/env.rs
@@ -190,16 +190,12 @@ where
         builder.add_func(CreateProgram, wrap_syscall!(create_program));
         builder.add_func(CreateProgramWGas, wrap_syscall!(create_program_wgas));
         builder.add_func(Debug, wrap_syscall!(debug));
-        builder.add_func(Panic, wrap_syscall!(panic));
-        builder.add_func(OomPanic, wrap_syscall!(oom_panic));
-        builder.add_func(Exit, wrap_syscall!(exit));
         builder.add_func(ReplyCode, wrap_syscall!(reply_code));
         builder.add_func(SignalCode, wrap_syscall!(signal_code));
         builder.add_func(ReserveGas, wrap_syscall!(reserve_gas));
         builder.add_func(ReplyDeposit, wrap_syscall!(reply_deposit));
         builder.add_func(UnreserveGas, wrap_syscall!(unreserve_gas));
         builder.add_func(GasAvailable, wrap_syscall!(gas_available));
-        builder.add_func(Leave, wrap_syscall!(leave));
         builder.add_func(MessageId, wrap_syscall!(message_id));
         builder.add_func(PayProgramRent, wrap_syscall!(pay_program_rent));
         builder.add_func(ProgramId, wrap_syscall!(program_id));
@@ -228,9 +224,6 @@ where
         builder.add_func(Source, wrap_syscall!(source));
         builder.add_func(Value, wrap_syscall!(value));
         builder.add_func(ValueAvailable, wrap_syscall!(value_available));
-        builder.add_func(Wait, wrap_syscall!(wait));
-        builder.add_func(WaitFor, wrap_syscall!(wait_for));
-        builder.add_func(WaitUpTo, wrap_syscall!(wait_up_to));
         builder.add_func(Wake, wrap_syscall!(wake));
         builder.add_func(SystemReserveGas, wrap_syscall!(system_reserve_gas));
         builder.add_func(ReservationReply, wrap_syscall!(reservation_reply));
@@ -238,6 +231,7 @@ where
         builder.add_func(ReservationSend, wrap_syscall!(reservation_send));
         builder.add_func(ReservationSendCommit, wrap_syscall!(reservation_send_commit));
         builder.add_func(SystemBreak, wrap_syscall!(system_break));
+        builder.add_func(UserBreak, wrap_syscall!(user_break));
 
         builder.add_func(Alloc, wrap_syscall!(alloc));
         builder.add_func(Free, wrap_syscall!(free));

--- a/core/src/costs.rs
+++ b/core/src/costs.rs
@@ -20,6 +20,7 @@
 
 use crate::{gas::Token, pages::PageU32Size};
 use core::{fmt::Debug, marker::PhantomData};
+use gear_wasm_instrument::syscalls::UserBreakKind;
 use paste::paste;
 use scale_info::scale::{Decode, Encode};
 
@@ -547,5 +548,18 @@ impl RuntimeCosts {
             ),
         };
         RuntimeToken { weight }
+    }
+}
+
+impl From<UserBreakKind> for RuntimeCosts {
+    fn from(value: UserBreakKind) -> Self {
+        match value {
+            UserBreakKind::Exit => RuntimeCosts::Exit,
+            UserBreakKind::Leave => RuntimeCosts::Leave,
+            UserBreakKind::Wait => RuntimeCosts::Wait,
+            UserBreakKind::WaitFor => RuntimeCosts::WaitFor,
+            UserBreakKind::WaitUpTo => RuntimeCosts::WaitUpTo,
+            _ => RuntimeCosts::Null,
+        }
     }
 }

--- a/gcore/src/exec.rs
+++ b/gcore/src/exec.rs
@@ -146,7 +146,13 @@ pub fn reply_deposit(message_id: MessageId, amount: u64) -> Result<()> {
 /// }
 /// ```
 pub fn exit(inheritor_id: ActorId) -> ! {
-    unsafe { gsys::gr_exit(inheritor_id.as_ptr()) }
+    let mut data = [0u8; 8];
+    let ptr = (inheritor_id.as_ptr() as u32).to_le_bytes();
+    data[2] = ptr[0];
+    data[3] = ptr[1];
+    data[4] = ptr[2];
+    data[5] = ptr[3];
+    unsafe { gsys::gr_user_break(u64::from_le_bytes(data)) }
 }
 
 /// Reserve the `amount` of gas for further usage.
@@ -282,7 +288,9 @@ pub fn gas_available() -> u64 {
 /// }
 /// ```
 pub fn leave() -> ! {
-    unsafe { gsys::gr_leave() }
+    let mut data = [0u8; 8];
+    data[0] = 1;
+    unsafe { gsys::gr_user_break(u64::from_le_bytes(data)) }
 }
 
 /// Get the total available value amount.
@@ -332,7 +340,9 @@ pub fn value_available() -> u128 {
 /// }
 /// ```
 pub fn wait() -> ! {
-    unsafe { gsys::gr_wait() }
+    let mut data = [0u8; 8];
+    data[0] = 2;
+    unsafe { gsys::gr_user_break(u64::from_le_bytes(data)) }
 }
 
 /// Same as [`wait`], but delays handling for a specific number of blocks.
@@ -341,13 +351,27 @@ pub fn wait() -> ! {
 ///
 /// Panics if it is impossible to pay the given `duration`.
 pub fn wait_for(duration: u32) -> ! {
-    unsafe { gsys::gr_wait_for(duration) }
+    let mut data = [0u8; 8];
+    data[0] = 3;
+    let raw_duration = duration.to_le_bytes();
+    data[2] = raw_duration[0];
+    data[3] = raw_duration[1];
+    data[4] = raw_duration[2];
+    data[5] = raw_duration[3];
+    unsafe { gsys::gr_user_break(u64::from_le_bytes(data)) }
 }
 
 /// Same as [`wait`], but delays handling for the maximum number of blocks that
 /// can be paid for and doesn't exceed the given `duration`.
 pub fn wait_up_to(duration: u32) -> ! {
-    unsafe { gsys::gr_wait_up_to(duration) }
+    let mut data = [0u8; 8];
+    data[0] = 4;
+    let raw_duration = duration.to_le_bytes();
+    data[2] = raw_duration[0];
+    data[3] = raw_duration[1];
+    data[4] = raw_duration[2];
+    data[5] = raw_duration[3];
+    unsafe { gsys::gr_user_break(u64::from_le_bytes(data)) }
 }
 
 /// Resume previously paused message handling.

--- a/gcore/src/utils.rs
+++ b/gcore/src/utils.rs
@@ -57,7 +57,17 @@ pub mod ext {
     /// }
     /// ```
     pub fn panic(data: &str) -> ! {
-        unsafe { gsys::gr_panic(data.as_ptr(), data.len() as u32) }
+        let mut data = [0u8; 8];
+        data[0] = 5;
+        let ptr = (data.as_ptr() as u32).to_le_bytes();
+        data[2] = ptr[0];
+        data[3] = ptr[1];
+        data[4] = ptr[2];
+        data[5] = ptr[3];
+        let len = (data.len() as u16).to_le_bytes();
+        data[6] = len[0];
+        data[7] = len[1];
+        unsafe { gsys::gr_user_break(u64::from_le_bytes(data)) }
     }
 
     /// Out of memory panic
@@ -90,6 +100,8 @@ pub mod ext {
     /// }
     /// ```
     pub fn oom_panic() -> ! {
-        unsafe { gsys::gr_oom_panic() }
+        let mut data = [0u8; 8];
+        data[0] = 6;
+        unsafe { gsys::gr_user_break(u64::from_le_bytes(data)) }
     }
 }

--- a/gsys/src/lib.rs
+++ b/gsys/src/lib.rs
@@ -66,6 +66,9 @@ pub type SignalCode = u32;
 /// Represents value type.
 pub type Value = u128;
 
+/// Represents data for `gr_user_break`
+pub type Data = u64;
+
 /// Represents type defining concatenated block number with hash. 36 bytes.
 #[repr(C, packed)]
 #[derive(Default, Debug)]
@@ -489,18 +492,6 @@ extern "C" {
     /// - `len`: `u32` length of the payload buffer.
     pub fn gr_debug(payload: *const SizedBufferStart, len: Length);
 
-    /// Infallible `gr_panic` control syscall.
-    ///
-    /// Stops the execution.
-    ///
-    /// Arguments type:
-    /// - `payload`: `const ptr` for the begging of the payload buffer.
-    /// - `len`: `u32` length of the payload buffer.
-    pub fn gr_panic(payload: *const SizedBufferStart, len: Length) -> !;
-
-    /// Infallible `gr_oom_panic` control syscall.
-    pub fn gr_oom_panic() -> !;
-
     /// Fallible `gr_reply_code` get syscall.
     ///
     /// Arguments type:
@@ -513,20 +504,11 @@ extern "C" {
     /// - `err_code`: `mut ptr` for concatenated error code and signal code.
     pub fn gr_signal_code(err_code: *mut ErrorWithSignalCode);
 
-    /// Infallible `gr_exit` control syscall.
-    ///
-    /// Arguments type:
-    /// - `inheritor_id`: `const ptr` for program id.
-    pub fn gr_exit(inheritor_id: *const Hash) -> !;
-
     /// Infallible `gr_gas_available` get syscall.
     ///
     /// Arguments type:
     /// - `gas`: `mut ptr` for `u64`.
     pub fn gr_gas_available(gas: *mut Gas);
-
-    /// Infallible `gr_leave` control syscall.
-    pub fn gr_leave() -> !;
 
     /// Infallible `gr_message_id` get syscall.
     ///
@@ -907,21 +889,6 @@ extern "C" {
     /// - `value`: `mut ptr` for incoming value of the message.
     pub fn gr_value(value: *mut Value);
 
-    /// Infallible `gr_wait_for` control syscall.
-    ///
-    /// Arguments type:
-    /// - `duration`: `u32` defining amount of blocks to wait.
-    pub fn gr_wait_for(duration: BlockNumber) -> !;
-
-    /// Infallible `gr_wait_up_to` control syscall.
-    ///
-    /// Arguments type:
-    /// - `duration`: `u32` defining amount of blocks to wait.
-    pub fn gr_wait_up_to(duration: BlockNumber) -> !;
-
-    /// Infallible `gr_wait` control syscall.
-    pub fn gr_wait() -> !;
-
     /// Fallible `gr_wake` control syscall.
     ///
     /// Arguments type:
@@ -929,4 +896,10 @@ extern "C" {
     /// - `delay`: `u32` amount of blocks to delay.
     /// - `err_mid`: `mut ptr` for error code.
     pub fn gr_wake(message_id: *const Hash, delay: BlockNumber, err: *mut ErrorCode);
+
+    /// Infallible `gr_user_break` control syscall.
+    ///
+    /// Arguments type:
+    /// - `data`: `u64` which contains syscall data as le bytes.
+    pub fn gr_user_break(data: Data) -> !;
 }

--- a/pallets/gear/src/benchmarking/tests/syscalls_integrity.rs
+++ b/pallets/gear/src/benchmarking/tests/syscalls_integrity.rs
@@ -247,15 +247,9 @@ where
             SyscallName::BlockTimestamp => check_gr_block_timestamp::<T>(),
             SyscallName::GasAvailable => check_gr_gas_available::<T>(),
             SyscallName::ValueAvailable => check_gr_value_available::<T>(),
-            SyscallName::Exit
-            | SyscallName::Leave
-            | SyscallName::Wait
-            | SyscallName::WaitFor
-            | SyscallName::WaitUpTo
+            SyscallName::UserBreak
             | SyscallName::Wake
-            | SyscallName::Debug
-            | SyscallName::Panic
-            | SyscallName::OomPanic => {/* tests here aren't required, read module docs for more info */},
+            | SyscallName::Debug => {/* tests here aren't required, read module docs for more info */},
             SyscallName::Alloc
             | SyscallName::Free
             | SyscallName::FreeRange => check_mem::<T>(),

--- a/utils/wasm-instrument/src/syscalls.rs
+++ b/utils/wasm-instrument/src/syscalls.rs
@@ -497,7 +497,7 @@ impl SyscallName {
                 Ptr::Hash(HashType::SubjectId).into(),
                 Ptr::MutBlockNumberWithHash(HashType::SubjectId).into(),
             ]),
-            Self::UserBreak => SyscallSignature::gr_infallible([ValueType::I64.into()]),
+            Self::UserBreak => SyscallSignature::gr_infallible([Data]),
             Self::SystemBreak => unimplemented!("Unsupported syscall signature for system_break"),
         }
     }
@@ -564,7 +564,7 @@ impl TryFrom<u8> for UserBreakKind {
             4 => Ok(UserBreakKind::WaitUpTo),
             5 => Ok(UserBreakKind::Panic),
             6 => Ok(UserBreakKind::OomPanic),
-            _ => Err(())
+            _ => Err(()),
         }
     }
 }
@@ -578,7 +578,7 @@ impl From<UserBreakKind> for u8 {
             UserBreakKind::WaitFor => 3,
             UserBreakKind::WaitUpTo => 4,
             UserBreakKind::Panic => 5,
-            UserBreakKind::OomPanic => 6
+            UserBreakKind::OomPanic => 6,
         }
     }
 }
@@ -606,6 +606,7 @@ pub enum RegularParamType {
     Free,                // i32 page number to free
     FreeUpperBound,      // i32 free upper bound for use with free_range
     Version,             // i32 version number of exec settings
+    Data,                // i64 data for user_break
 }
 
 /// Hash type.
@@ -629,7 +630,7 @@ impl From<ParamType> for ValueType {
             ParamType::Regular(regular_ptr) => match regular_ptr {
                 Length | Pointer(_) | Offset | DurationBlockNumber | DelayBlockNumber | Handler
                 | Alloc | Free | FreeUpperBound | Version => ValueType::I32,
-                Gas => ValueType::I64,
+                Gas | Data => ValueType::I64,
             },
             ParamType::Error(_) => ValueType::I32,
         }


### PR DESCRIPTION
Resolves #3216 

@reviewer-or-team
