### PR TITLE
chore(migrations): Fix migrations warning

### DIFF
--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -480,12 +480,6 @@ pub mod pallet {
     where
         T::AccountId: Origin,
     {
-        fn on_runtime_upgrade() -> Weight {
-            log::debug!(target: "gear::runtime", "⚙️ Runtime upgrade");
-
-            Zero::zero()
-        }
-
         /// Initialization
         fn on_initialize(bn: BlockNumberFor<T>) -> Weight {
             // Incrementing Gear block number

--- a/runtime/vara/src/migrations.rs
+++ b/runtime/vara/src/migrations.rs
@@ -97,6 +97,6 @@ pub type Migrations = (
     pallet_offences::migration::v1::MigrateToV1<Runtime>,
     // v1040
     pallet_im_online::migration::v1::Migration<Runtime>,
-    // unreleased
+    // v1050
     pallet_gear_program::migrations::MigrateToV3<Runtime>,
 );


### PR DESCRIPTION
Fixes `try-runtime::on-runtime-upgrade` warning: `⚠️ Gear declares internal migrations (which *might* execute). On-chain 'StorageVersion(1)' vs current storage version 'StorageVersion(1)'`