### PR TITLE
Make re-instrumentation fallible

### DIFF
--- a/core-errors/src/simple.rs
+++ b/core-errors/src/simple.rs
@@ -183,6 +183,14 @@ pub enum ErrorReplyReason {
     #[display(fmt = "removal from waitlist")]
     RemovedFromWaitlist = 3,
 
+    /// Init message is sent, but destination actor is already initialized.
+    #[display(fmt = "init message sent to already initialized actor")]
+    AlreadyInitialized = 4,
+
+    /// Program re-instrumentation failed.
+    #[display(fmt = "program re-instrumentation failed")]
+    Reinstrumentation = 5,
+
     /// Unsupported reason of error reply.
     /// Variant exists for backward compatibility.
     #[default]
@@ -204,7 +212,11 @@ impl ErrorReplyReason {
         match self {
             Self::Execution(error) => bytes[1..].copy_from_slice(&error.to_bytes()),
             Self::FailedToCreateProgram(error) => bytes[1..].copy_from_slice(&error.to_bytes()),
-            Self::InactiveProgram | Self::RemovedFromWaitlist | Self::Unsupported => {}
+            Self::InactiveProgram
+            | Self::RemovedFromWaitlist
+            | Self::AlreadyInitialized
+            | Self::Reinstrumentation
+            | Self::Unsupported => {}
         }
 
         bytes

--- a/core-processor/src/handler.rs
+++ b/core-processor/src/handler.rs
@@ -113,6 +113,10 @@ pub fn handle_journal(
                 future_reply_id,
                 amount,
             } => handler.reply_deposit(message_id, future_reply_id, amount),
+            JournalNote::WaitingInitMessage {
+                dispatch,
+                destination,
+            } => handler.waiting_init_message(dispatch, destination),
         }
     }
 

--- a/core-processor/src/lib.rs
+++ b/core-processor/src/lib.rs
@@ -49,7 +49,7 @@ pub use precharge::{
     precharge_for_code_length, precharge_for_instrumentation, precharge_for_memory,
     precharge_for_program,
 };
-pub use processing::process;
+pub use processing::{process, process_non_executable, process_reinstrumentation_error};
 
 /// Informational functions for core-processor and executor.
 pub mod informational {

--- a/core-processor/src/processing.rs
+++ b/core-processor/src/processing.rs
@@ -19,7 +19,8 @@
 use crate::{
     common::{
         ActorExecutionErrorReplyReason, DispatchOutcome, DispatchResult, DispatchResultKind,
-        ExecutionError, JournalNote, SystemExecutionError, WasmExecutionContext,
+        ExecutionError, JournalNote, PrechargedDispatch, SystemExecutionError,
+        WasmExecutionContext,
     },
     configs::{BlockConfig, ExecutionSettings},
     context::*,
@@ -27,7 +28,10 @@ use crate::{
     ext::ProcessorExternalities,
     precharge::SuccessfulDispatchResultKind,
 };
-use alloc::{string::ToString, vec::Vec};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use gear_core::{
     env::Externalities,
     ids::{MessageId, ProgramId},
@@ -136,7 +140,7 @@ where
 
     match exec_result {
         Ok(res) => Ok(match res.kind {
-            DispatchResultKind::Trap(reason) => process_error(
+            DispatchResultKind::Trap(reason) => process_execution_error(
                 res.dispatch,
                 program_id,
                 res.gas_amount.burned(),
@@ -155,26 +159,46 @@ where
                 process_allowance_exceed(dispatch, program_id, res.gas_amount.burned())
             }
         }),
-        Err(ExecutionError::Actor(e)) => Ok(process_error(
+        Err(ExecutionError::Actor(e)) => Ok(process_execution_error(
             dispatch,
             program_id,
             e.gas_amount.burned(),
             SystemReservationContext::default(),
             e.reason,
-            true,
+            false,
         )),
         Err(ExecutionError::System(e)) => Err(e),
     }
 }
 
-/// Helper function for journal creation in trap/error case
-pub fn process_error(
+enum ProcessErrorCase {
+    /// Message is not executable error.
+    NonExecutable(ErrorReplyReason),
+    /// Error is considered as execution failed.
+    ExecutionFailed(ActorExecutionErrorReplyReason, bool),
+    /// Message is executable, but it's execution failed due to re-instrumentation.
+    ReinstrumentationFailed,
+}
+
+impl ProcessErrorCase {
+    pub fn to_reason_and_payload(&self) -> (ErrorReplyReason, String) {
+        match self {
+            ProcessErrorCase::NonExecutable(err) => (*err, err.to_string()),
+            ProcessErrorCase::ExecutionFailed(err, _) => (err.as_simple().into(), err.to_string()),
+            ProcessErrorCase::ReinstrumentationFailed => {
+                let err = ErrorReplyReason::Reinstrumentation;
+                (err, err.to_string())
+            }
+        }
+    }
+}
+
+fn process_error(
     dispatch: IncomingDispatch,
     program_id: ProgramId,
     gas_burned: u64,
     system_reservation_ctx: SystemReservationContext,
-    err: ActorExecutionErrorReplyReason,
-    executed: bool,
+    case: ProcessErrorCase,
 ) -> Vec<JournalNote> {
     let mut journal = Vec::new();
 
@@ -208,27 +232,30 @@ pub fn process_error(
     }
 
     if system_reservation_ctx.has_any() {
-        if !dispatch.is_error_reply()
-            && !matches!(dispatch.kind(), DispatchKind::Signal | DispatchKind::Init)
-        {
-            journal.push(JournalNote::SendSignal {
-                message_id,
-                destination: program_id,
-                code: SignalCode::Execution(err.as_simple()),
-            });
+        if let ProcessErrorCase::ExecutionFailed(err, allow_signal) = &case {
+            if *allow_signal
+                && !dispatch.is_error_reply()
+                && !matches!(dispatch.kind(), DispatchKind::Signal | DispatchKind::Init)
+            {
+                journal.push(JournalNote::SendSignal {
+                    message_id,
+                    destination: program_id,
+                    code: SignalCode::Execution(err.as_simple()),
+                });
+            }
         }
 
         journal.push(JournalNote::SystemUnreserveGas { message_id });
     }
 
     if !dispatch.is_reply() && dispatch.kind() != DispatchKind::Signal {
-        // This expect panic is unreachable, unless error message is too large or max payload size is too small.
-        let err_payload = err
-            .to_string()
+        let (err, err_payload) = case.to_reason_and_payload();
+
+        // Panic is impossible, unless error message is too large or [Payload] max size is too small.
+        let err_payload = err_payload
             .into_bytes()
             .try_into()
             .unwrap_or_else(|_| unreachable!("Error message is too large"));
-        let err = err.as_simple();
 
         // # Safety
         //
@@ -250,17 +277,22 @@ pub fn process_error(
         });
     }
 
-    let outcome = match dispatch.kind() {
-        DispatchKind::Init => DispatchOutcome::InitFailure {
-            program_id,
-            origin,
-            reason: err.to_string(),
-            executed,
-        },
-        _ => DispatchOutcome::MessageTrap {
-            program_id,
-            trap: err.to_string(),
-        },
+    let outcome = match case {
+        ProcessErrorCase::ExecutionFailed { .. } | ProcessErrorCase::ReinstrumentationFailed => {
+            let (_, err_payload) = case.to_reason_and_payload();
+            match dispatch.kind() {
+                DispatchKind::Init => DispatchOutcome::InitFailure {
+                    program_id,
+                    origin,
+                    reason: err_payload,
+                },
+                _ => DispatchOutcome::MessageTrap {
+                    program_id,
+                    trap: err_payload,
+                },
+            }
+        }
+        ProcessErrorCase::NonExecutable(_) => DispatchOutcome::NoExecution,
     };
 
     journal.push(JournalNote::MessageDispatched {
@@ -271,6 +303,60 @@ pub fn process_error(
     journal.push(JournalNote::MessageConsumed(message_id));
 
     journal
+}
+
+/// Helper function for journal creation in trap/error case.
+pub fn process_execution_error(
+    dispatch: IncomingDispatch,
+    program_id: ProgramId,
+    gas_burned: u64,
+    system_reservation_ctx: SystemReservationContext,
+    err: impl Into<ActorExecutionErrorReplyReason>,
+    allow_signal: bool,
+) -> Vec<JournalNote> {
+    process_error(
+        dispatch,
+        program_id,
+        gas_burned,
+        system_reservation_ctx,
+        ProcessErrorCase::ExecutionFailed(err.into(), allow_signal),
+    )
+}
+
+/// Helper function for journal creation in case of re-instrumentation error.
+pub fn process_reinstrumentation_error(
+    context: ContextChargedForInstrumentation,
+) -> Vec<JournalNote> {
+    let dispatch = context.data.dispatch;
+    let program_id = context.data.destination_id;
+    let gas_burned = context.data.gas_counter.burned();
+    let system_reservation_ctx = SystemReservationContext::from_dispatch(&dispatch);
+
+    process_error(
+        dispatch,
+        program_id,
+        gas_burned,
+        system_reservation_ctx,
+        ProcessErrorCase::ReinstrumentationFailed,
+    )
+}
+
+/// Helper function for journal creation in message no execution case.
+pub fn process_non_executable(
+    context: PrechargedDispatch,
+    destination_id: ProgramId,
+    reason: impl Into<ErrorReplyReason>,
+) -> Vec<JournalNote> {
+    let (dispatch, gas_counter, _) = context.into_parts();
+    let system_reservation_ctx = SystemReservationContext::from_dispatch(&dispatch);
+
+    process_error(
+        dispatch,
+        destination_id,
+        gas_counter.burned(),
+        system_reservation_ctx,
+        ProcessErrorCase::NonExecutable(reason.into()),
+    )
 }
 
 /// Helper function for journal creation in success case
@@ -475,66 +561,6 @@ pub fn process_allowance_exceed(
         dispatch,
         gas_burned,
     });
-
-    journal
-}
-
-/// Helper function for journal creation in message no execution case
-pub fn process_non_executable(
-    dispatch: IncomingDispatch,
-    program_id: ProgramId,
-    system_reservation_ctx: SystemReservationContext,
-) -> Vec<JournalNote> {
-    // Number of notes is predetermined
-    let mut journal = Vec::with_capacity(4);
-
-    let message_id = dispatch.id();
-    let source = dispatch.source();
-    let value = dispatch.value();
-
-    if dispatch.context().is_none() && value != 0 {
-        // Send value back
-        journal.push(JournalNote::SendValue {
-            from: dispatch.source(),
-            to: None,
-            value,
-        });
-    }
-
-    // Reply back to the message `source`
-    if !dispatch.is_reply() && dispatch.kind() != DispatchKind::Signal {
-        let err = ErrorReplyReason::InactiveProgram;
-        let err_payload = err
-            .to_string()
-            .into_bytes()
-            .try_into()
-            .unwrap_or_else(|_| unreachable!("Error message is too large"));
-
-        let dispatch = ReplyMessage::system(dispatch.id(), err_payload, err).into_dispatch(
-            program_id,
-            dispatch.source(),
-            dispatch.id(),
-        );
-
-        journal.push(JournalNote::SendDispatch {
-            message_id,
-            dispatch,
-            delay: 0,
-            reservation: None,
-        });
-    }
-
-    if system_reservation_ctx.has_any() {
-        journal.push(JournalNote::SystemUnreserveGas { message_id });
-    }
-
-    journal.push(JournalNote::MessageDispatched {
-        message_id,
-        source,
-        outcome: DispatchOutcome::NoExecution,
-    });
-
-    journal.push(JournalNote::MessageConsumed(message_id));
 
     journal
 }

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -593,7 +593,7 @@ benchmarks! {
 
         let schedule = T::Schedule::get();
     }: {
-        Gear::<T>::reinstrument_code(code_id, &schedule);
+        let _ = Gear::<T>::reinstrument_code(code_id, &schedule);
     }
 
     // Alloc there 1 page because `alloc` execution time is non-linear along with other amounts of pages.

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -71,7 +71,7 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::{BlockNumberFor, *};
 use gear_core::{
-    code::{Code, CodeAndId, InstrumentedCode, InstrumentedCodeAndId},
+    code::{Code, CodeAndId, CodeError, InstrumentedCode, InstrumentedCodeAndId},
     ids::{CodeId, MessageId, ProgramId, ReservationId},
     message::*,
     percent::Percent,
@@ -1064,7 +1064,7 @@ pub mod pallet {
         pub(crate) fn reinstrument_code(
             code_id: CodeId,
             schedule: &Schedule<T>,
-        ) -> InstrumentedCode {
+        ) -> Result<InstrumentedCode, CodeError> {
             debug_assert!(T::CodeStorage::get_code(code_id).is_some());
 
             // By the invariant set in CodeStorage trait, original code can't exist in storage
@@ -1079,15 +1079,14 @@ pub mod pallet {
                 schedule.instruction_weights.version,
                 |module| schedule.rules(module),
                 schedule.limits.stack_height,
-            )
-            .unwrap_or_else(|e| unreachable!("Unexpected re-instrumentation failure: {:?}", e));
+            )?;
 
             let code_and_id = CodeAndId::from_parts_unchecked(code, code_id);
             let code_and_id = InstrumentedCodeAndId::from(code_and_id);
             T::CodeStorage::update_code(code_and_id.clone());
             let (code, _) = code_and_id.into_parts();
 
-            code
+            Ok(code)
         }
 
         pub(crate) fn try_new_code(code: Vec<u8>) -> Result<CodeAndId, DispatchError> {

--- a/pallets/gear/src/manager/task.rs
+++ b/pallets/gear/src/manager/task.rs
@@ -176,7 +176,7 @@ where
 
         if waitlisted.kind() == DispatchKind::Init {
             let origin = waitlisted.source();
-            Self::process_failed_init(program_id, origin, true);
+            Self::process_failed_init(program_id, origin);
         }
 
         let gas = <T as Config>::WeightInfo::tasks_remove_from_waitlist().ref_time();

--- a/pallets/gear/src/queue.rs
+++ b/pallets/gear/src/queue.rs
@@ -17,42 +17,34 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
-use core_processor::{common::PrechargedDispatch, ContextChargedForInstrumentation};
+use common::ActiveProgram;
+use core_processor::ContextChargedForInstrumentation;
+use gear_core_errors::ErrorReplyReason;
 
-pub(crate) struct QueueStep<'a, T: Config, F> {
+pub(crate) struct QueueStep<'a, T: Config> {
     pub block_config: &'a BlockConfig,
     pub ext_manager: &'a mut ExtManager<T>,
     pub gas_limit: GasBalanceOf<T>,
     pub dispatch: StoredDispatch,
     pub balance: u128,
-    pub get_actor_data: F,
 }
 
-#[derive(Debug)]
-pub(crate) enum QueueStepError {
-    ActorData(PrechargedDispatch),
-}
-
-impl<'a, T, F> QueueStep<'a, T, F>
+impl<T: Config> pallet::Pallet<T>
 where
-    T: Config,
     T::AccountId: Origin,
-    F: FnOnce(
-        PrechargedDispatch,
-    ) -> Result<(PrechargedDispatch, Option<ExecutableActorData>), PrechargedDispatch>,
 {
-    pub(crate) fn execute(self) -> Result<Vec<JournalNote>, QueueStepError> {
-        let Self {
+    pub(crate) fn queue_step(queue_step: QueueStep<'_, T>) -> Vec<JournalNote> {
+        let QueueStep {
             block_config,
             ext_manager,
             gas_limit,
             dispatch,
             balance,
-            get_actor_data,
-        } = self;
+        } = queue_step;
 
-        let program_id = dispatch.destination();
+        let destination_id = dispatch.destination();
         let dispatch_id = dispatch.id();
+        let dispatch_kind = dispatch.kind();
 
         // To start executing a message resources of a destination program should be
         // fetched from the storage.
@@ -61,25 +53,72 @@ where
             block_config,
             GasAllowanceOf::<T>::get(),
             dispatch.into_incoming(gas_limit),
-            program_id,
+            destination_id,
         ) {
             Ok(dispatch) => dispatch,
-            Err(journal) => return Ok(journal),
+            Err(journal) => return journal,
         };
 
-        let (precharged_dispatch, actor_data) =
-            get_actor_data(precharged_dispatch).map_err(QueueStepError::ActorData)?;
+        // Can't process messages for non-active program.
+        let Some(program) = Self::get_active_program(destination_id) else {
+            log::trace!("Message is sent to non-active program");
+            return core_processor::process_non_executable(
+                precharged_dispatch,
+                destination_id,
+                ErrorReplyReason::InactiveProgram,
+            );
+        };
+
+        // Can't process init messages for already initialized program.
+        if program.state == ProgramState::Initialized && dispatch_kind == DispatchKind::Init {
+            log::trace!("Init message is sent to already initialized program");
+            return core_processor::process_non_executable(
+                precharged_dispatch,
+                destination_id,
+                ErrorReplyReason::AlreadyInitialized,
+            );
+        }
+
+        // If the destination program is uninitialized, then we allow
+        // to process message, if it's a reply or the creating init message.
+        // Otherwise, we appends message to the waiting init message list.
+        if matches!(program.state, ProgramState::Uninitialized { message_id }
+            if message_id != dispatch_id && dispatch_kind != DispatchKind::Reply)
+        {
+            let (dispatch, gas, _) = precharged_dispatch.into_parts();
+            return vec![
+                JournalNote::GasBurned {
+                    message_id: dispatch.id(),
+                    amount: gas.burned(),
+                },
+                JournalNote::WaitingInitMessage {
+                    dispatch,
+                    destination: destination_id,
+                },
+            ];
+        }
+
+        let actor_data = ExecutableActorData {
+            allocations: program.allocations,
+            code_id: program.code_hash.cast(),
+            code_exports: program.code_exports,
+            static_pages: program.static_pages,
+            initialized: matches!(program.state, ProgramState::Initialized),
+            pages_with_data: program.pages_with_data,
+            gas_reservation_map: program.gas_reservation_map,
+            memory_infix: program.memory_infix,
+        };
 
         // The second step is to load instrumented binary code of the program but
         // first its correct length should be obtained.
         let context = match core_processor::precharge_for_code_length(
             block_config,
             precharged_dispatch,
-            program_id,
+            destination_id,
             actor_data,
         ) {
             Ok(context) => context,
-            Err(journal) => return Ok(journal),
+            Err(journal) => return journal,
         };
 
         // Load correct code length value.
@@ -87,7 +126,7 @@ where
         let code_len_bytes = T::CodeStorage::get_code_len(code_id).unwrap_or_else(|| {
             unreachable!(
                 "Program '{:?}' exists so do code len '{:?}'",
-                program_id, code_id
+                destination_id, code_id
             )
         });
 
@@ -95,14 +134,14 @@ where
         let context =
             match core_processor::precharge_for_code(block_config, context, code_len_bytes) {
                 Ok(context) => context,
-                Err(journal) => return Ok(journal),
+                Err(journal) => return journal,
             };
 
         // Load instrumented binary code from storage.
         let code = T::CodeStorage::get_code(code_id).unwrap_or_else(|| {
             unreachable!(
                 "Program '{:?}' exists so do code '{:?}'",
-                program_id, code_id
+                destination_id, code_id
             )
         });
 
@@ -112,7 +151,7 @@ where
             if code.instruction_weights_version() == schedule.instruction_weights.version {
                 (code, ContextChargedForInstrumentation::from(context))
             } else {
-                log::debug!("Re-instrumenting code for program '{:?}'", program_id);
+                log::debug!("Re-instrumenting code for program '{:?}'", destination_id);
 
                 let context = match core_processor::precharge_for_instrumentation(
                     block_config,
@@ -120,43 +159,39 @@ where
                     code.original_code_len(),
                 ) {
                     Ok(context) => context,
-                    Err(journal) => return Ok(journal),
+                    Err(journal) => return journal,
                 };
 
-                (Pallet::<T>::reinstrument_code(code_id, &schedule), context)
+                let code = match Pallet::<T>::reinstrument_code(code_id, &schedule) {
+                    Ok(code) => code,
+                    Err(e) => {
+                        log::debug!("Re-instrumentation error: {:?}", e);
+                        return core_processor::process_reinstrumentation_error(context);
+                    }
+                };
+
+                (code, context)
             };
 
         // The last one thing is to load program memory. Adjust gas counters for memory pages.
         let context = match core_processor::precharge_for_memory(block_config, context) {
             Ok(context) => context,
-            Err(journal) => return Ok(journal),
+            Err(journal) => return journal,
         };
 
         // Load program memory pages.
-        ext_manager.insert_program_id_loaded_pages(program_id);
+        ext_manager.insert_program_id_loaded_pages(destination_id);
 
         let (random, bn) = T::Randomness::random(dispatch_id.as_ref());
 
-        let journal = core_processor::process::<Ext>(
+        core_processor::process::<Ext>(
             block_config,
             (context, code, balance).into(),
             (random.encode(), bn.unique_saturated_into()),
         )
-        .unwrap_or_else(|e| unreachable!("core-processor logic invalidated: {}", e));
-
-        Ok(journal)
+        .unwrap_or_else(|e| unreachable!("core-processor logic invalidated: {}", e))
     }
-}
 
-pub(crate) enum ActorResult {
-    Continue,
-    Data(Option<ExecutableActorData>),
-}
-
-impl<T: Config> pallet::Pallet<T>
-where
-    T::AccountId: Origin,
-{
     /// Message Queue processing.
     pub(crate) fn process_queue(mut ext_manager: ExtManager<T>) {
         Self::enable_lazy_pages();
@@ -199,52 +234,18 @@ where
             });
 
             let program_id = dispatch.destination();
-            let dispatch_id = dispatch.id();
-            let dispatch_reply = dispatch.reply_details().is_some();
 
             let balance = CurrencyOf::<T>::free_balance(&program_id.cast());
 
-            let get_actor_data = |precharged_dispatch: PrechargedDispatch| {
-                // At this point gas counters should be changed accordingly so fetch the program data.
-                match Self::get_active_actor_data(program_id, dispatch_id, dispatch_reply) {
-                    ActorResult::Data(data) => Ok((precharged_dispatch, data)),
-                    ActorResult::Continue => Err(precharged_dispatch),
-                }
-            };
-
-            let step = QueueStep {
+            let journal = Self::queue_step(QueueStep {
                 block_config: &block_config,
                 ext_manager: &mut ext_manager,
                 gas_limit,
                 dispatch,
                 balance: balance.unique_saturated_into(),
-                get_actor_data,
-            };
-            match step.execute() {
-                Ok(journal) => {
-                    core_processor::handle_journal(journal, &mut ext_manager);
-                }
-                Err(QueueStepError::ActorData(precharged_dispatch)) => {
-                    let (dispatch, journal) = precharged_dispatch.into_dispatch_and_note();
-                    let (kind, message, context) = dispatch.into();
-                    let dispatch =
-                        StoredDispatch::new(kind, message.into_stored(program_id), context);
+            });
 
-                    core_processor::handle_journal(journal, &mut ext_manager);
-
-                    // Adding id in on-init wake list.
-                    ProgramStorageOf::<T>::waiting_init_append_message_id(
-                        dispatch.destination(),
-                        dispatch.id(),
-                    );
-
-                    Self::wait_dispatch(
-                        dispatch,
-                        None,
-                        MessageWaitedSystemReason::ProgramIsNotInitialized.into_reason(),
-                    );
-                }
-            }
+            core_processor::handle_journal(journal, &mut ext_manager);
         }
 
         let post_data: QueuePostProcessingData = ext_manager.into();
@@ -259,48 +260,27 @@ where
         }
     }
 
-    pub(crate) fn get_active_actor_data(
-        program_id: ProgramId,
-        dispatch_id: MessageId,
-        reply: bool,
-    ) -> ActorResult {
+    fn get_active_program(program_id: ProgramId) -> Option<ActiveProgram<BlockNumberFor<T>>> {
         let Some(maybe_active_program) = ProgramStorageOf::<T>::get_program(program_id) else {
             // When an actor sends messages, which is intended to be added to the queue
             // it's destination existence is always checked. There are two cases this
             // doesn't happen:
             // 1. program tries to submit another program with non-existing code hash;
             // 2. program was being paused after message enqueued.
-            return ActorResult::Data(None);
+            return None;
         };
 
-        let program = match maybe_active_program {
-            Program::Active(p) => p,
+        match maybe_active_program {
+            Program::Active(p) => Some(p),
             _ => {
                 // Reaching this branch is possible when init message was processed with failure,
                 // while other kind of messages were already in the queue/were added to the queue
                 // (for example. moved from wait list in case of async init).
                 // Also this branch is reachable when program sends a message to a terminated
                 // program.
-                log::debug!("Program '{program_id:?}' is not active");
-                return ActorResult::Data(None);
+                log::trace!("Program '{program_id:?}' exists, but it isn't active");
+                None
             }
-        };
-
-        if matches!(program.state, ProgramState::Uninitialized {message_id} if message_id != dispatch_id)
-            && !reply
-        {
-            return ActorResult::Continue;
         }
-
-        ActorResult::Data(Some(ExecutableActorData {
-            allocations: program.allocations,
-            code_id: program.code_hash.cast(),
-            code_exports: program.code_exports,
-            static_pages: program.static_pages,
-            initialized: matches!(program.state, ProgramState::Initialized),
-            pages_with_data: program.pages_with_data,
-            gas_reservation_map: program.gas_reservation_map,
-            memory_infix: program.memory_infix,
-        }))
     }
 }

--- a/pallets/gear/src/runtime_api.rs
+++ b/pallets/gear/src/runtime_api.rs
@@ -17,10 +17,9 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
-use crate::queue::{ActorResult, QueueStep};
+use crate::queue::QueueStep;
 use common::ActiveProgram;
 use core::convert::TryFrom;
-use core_processor::common::PrechargedDispatch;
 use frame_support::traits::PalletInfo;
 use gear_core::{code::TryNewCodeConfig, pages::WasmPage, program::MemoryInfix};
 use gear_wasm_instrument::syscalls::SyscallName;
@@ -177,17 +176,8 @@ where
 
             let actor_id = queued_dispatch.destination();
             let dispatch_id = queued_dispatch.id();
-            let dispatch_reply = queued_dispatch.reply_details().is_some();
 
             let balance = CurrencyOf::<T>::free_balance(&actor_id.cast());
-
-            let get_actor_data = |precharged_dispatch: PrechargedDispatch| {
-                // At this point gas counters should be changed accordingly so fetch the program data.
-                match Self::get_active_actor_data(actor_id, dispatch_id, dispatch_reply) {
-                    ActorResult::Data(data) => Ok((precharged_dispatch, data)),
-                    ActorResult::Continue => Err(precharged_dispatch),
-                }
-            };
 
             let success_reply = queued_dispatch
                 .reply_details()
@@ -205,12 +195,9 @@ where
                 gas_limit,
                 dispatch: queued_dispatch,
                 balance: balance.unique_saturated_into(),
-                get_actor_data,
             };
 
-            let journal = step
-                .execute()
-                .map_err(|_| internal_err("Queue execution error"))?;
+            let journal = Self::queue_step(step);
 
             let get_main_limit = || {
                 // For case when node is not consumed and has any (even zero) balance

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -2270,20 +2270,20 @@ fn delayed_program_creation_no_code() {
         //
         // Total dequeued: message to skip execution + error reply on it.
         //
-        // Single db read burned for querying program data from storage.
+        // One db read burned for querying program data from storage when creating program,
+        // and one more to process error reply.
         assert_last_dequeued(2);
 
         let delayed_block_amount: u64 = 1;
-
         let delay_holding_fee = gas_price(
             delayed_block_amount.saturating_mul(CostsPerBlockOf::<Test>::dispatch_stash()),
         );
+        let read_program_from_storage_fee =
+            gas_price(DbWeightOf::<Test>::get().reads(1).ref_time());
 
         assert_eq!(
             Balances::free_balance(USER_1),
-            free_balance + reserved_balance
-                - delay_holding_fee
-                - gas_price(DbWeightOf::<Test>::get().reads(1).ref_time())
+            free_balance + reserved_balance - delay_holding_fee - 2 * read_program_from_storage_fee
         );
         assert!(GearBank::<Test>::account_total(&USER_1).is_zero());
     })
@@ -9649,6 +9649,49 @@ fn test_reinstrumentation_works() {
         // check new version stands still
         let code = <Test as Config>::CodeStorage::get_code(code_id).unwrap();
         assert_eq!(code.instruction_weights_version(), 0xdeadbeef);
+    })
+}
+
+#[test]
+fn test_reinstrumentation_failure() {
+    init_logger();
+    new_test_ext().execute_with(|| {
+        let code_id = CodeId::generate(&ProgramCodeKind::Default.to_bytes());
+        let pid = upload_program_default(USER_1, ProgramCodeKind::Default).unwrap();
+
+        run_to_block(2, None);
+
+        let mut old_version = 0;
+        let _reset_guard = DynamicSchedule::mutate(|schedule| {
+            // Insert new original code to cause re-instrumentation failure.
+            let wasm = ProgramCodeKind::Custom("(module)").to_bytes();
+            <<Test as Config>::CodeStorage as CodeStorage>::OriginalCodeStorage::insert(
+                code_id, wasm,
+            );
+
+            old_version = schedule.instruction_weights.version;
+            schedule.instruction_weights.version = 0xdeadbeef;
+        });
+
+        assert_ok!(Gear::send_message(
+            RuntimeOrigin::signed(USER_1),
+            pid,
+            vec![],
+            10_000_000_000,
+            0,
+            false,
+        ));
+
+        let mid = get_last_message_id();
+
+        run_to_block(3, None);
+
+        // After message processing the code must have the old instrumentation version.
+        let code = <Test as Config>::CodeStorage::get_code(code_id).unwrap();
+        assert_eq!(code.instruction_weights_version(), old_version);
+
+        // Error reply must be returned with the reason of re-instrumentation failure.
+        assert_failed(mid, ErrorReplyReason::Reinstrumentation);
     })
 }
 


### PR DESCRIPTION
1. When re-instrumentation error occurs, we now acts like it's common execution error, except signal sending - system reservation will be unreserved and that it.
2. Make refactoring for queue and core-processor logic: 
- Add charging for non-executable case
- Move to queue logic of identifying non-executable cases
- Join error processing cases in one function: `process_error`
- Remove field executed in `InitFailure`, because it is used only to cause panics.