### PR TITLE
refactor(core): Remove useless string conversion (`with_string_payload()`)

### DIFF
--- a/core/src/message/common.rs
+++ b/core/src/message/common.rs
@@ -20,8 +20,7 @@ use crate::{
     ids::{MessageId, ProgramId},
     message::{DispatchKind, GasLimit, Payload, StoredDispatch, StoredMessage, Value},
 };
-use alloc::string::ToString;
-use core::{convert::TryInto, ops::Deref};
+use core::ops::Deref;
 use gear_core_errors::{ReplyCode, SignalCode};
 use scale_info::{
     scale::{Decode, Encode},
@@ -126,23 +125,6 @@ impl Message {
     /// Message signal.
     pub fn signal_details(&self) -> Option<SignalDetails> {
         self.details.and_then(|d| d.to_signal_details())
-    }
-
-    #[allow(clippy::result_large_err)]
-    /// Consumes self in order to create new `StoredMessage`, which payload
-    /// contains string representation of initial bytes,
-    /// decoded into given type.
-    // TODO: issue #2849.
-    pub fn with_string_payload<D: Decode + ToString>(self) -> Result<Self, Self> {
-        if let Ok(decoded) = D::decode(&mut self.payload.inner()) {
-            if let Ok(payload) = decoded.to_string().into_bytes().try_into() {
-                Ok(Self { payload, ..self })
-            } else {
-                Err(self)
-            }
-        } else {
-            Err(self)
-        }
     }
 
     /// Returns bool defining if message is error reply.

--- a/core/src/message/stored.rs
+++ b/core/src/message/stored.rs
@@ -23,8 +23,7 @@ use crate::{
         IncomingMessage, Payload, ReplyDetails, Value,
     },
 };
-use alloc::string::ToString;
-use core::{convert::TryInto, ops::Deref};
+use core::ops::Deref;
 use gear_core_errors::ReplyCode;
 use scale_info::{
     scale::{Decode, Encode},
@@ -116,23 +115,6 @@ impl StoredMessage {
     /// Message reply.
     pub fn reply_details(&self) -> Option<ReplyDetails> {
         self.details.and_then(|d| d.to_reply_details())
-    }
-
-    #[allow(clippy::result_large_err)]
-    /// Consumes self in order to create new `StoredMessage`, which payload
-    /// contains string representation of initial bytes,
-    /// decoded into given type.
-    // TODO: issue #2849.
-    pub fn with_string_payload<D: Decode + ToString>(self) -> Result<Self, Self> {
-        if let Ok(decoded) = D::decode(&mut self.payload.inner()) {
-            if let Ok(payload) = decoded.to_string().into_bytes().try_into() {
-                Ok(Self { payload, ..self })
-            } else {
-                Err(self)
-            }
-        } else {
-            Err(self)
-        }
     }
 
     /// Returns bool defining if message is error reply.

--- a/core/src/message/user.rs
+++ b/core/src/message/user.rs
@@ -20,7 +20,6 @@ use crate::{
     ids::{MessageId, ProgramId},
     message::{Payload, ReplyDetails, Value},
 };
-use alloc::string::ToString;
 use core::convert::TryFrom;
 use gear_core_errors::ReplyCode;
 use scale_info::{
@@ -96,23 +95,6 @@ impl UserMessage {
     /// Message reply details.
     pub fn details(&self) -> Option<ReplyDetails> {
         self.details
-    }
-
-    #[allow(clippy::result_large_err)]
-    /// Consumes self in order to create new `StoredMessage`, which payload
-    /// contains string representation of initial bytes,
-    /// decoded into given type.
-    // TODO: issue #2849.
-    pub fn with_string_payload<D: Decode + ToString>(self) -> Result<Self, Self> {
-        if let Ok(decoded) = D::decode(&mut self.payload.inner()) {
-            if let Ok(payload) = decoded.to_string().into_bytes().try_into() {
-                Ok(Self { payload, ..self })
-            } else {
-                Err(self)
-            }
-        } else {
-            Err(self)
-        }
     }
 
     /// Returns `ReplyCode` of message if reply.

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -994,17 +994,6 @@ impl JournalHandler for ExtManager {
         } else {
             let message = dispatch.into_stored().into_parts().1;
 
-            let message = match message
-                .details()
-                .and_then(|d| d.to_reply_details().map(|d| d.to_reply_code()))
-            {
-                None => message,
-                Some(code) if code.is_success() => message,
-                _ => message
-                    .with_string_payload::<ActorExecutionErrorReplyReason>()
-                    .unwrap_or_else(|e| e),
-            };
-
             self.mailbox
                 .entry(message.destination())
                 .or_default()

--- a/pallets/gear/src/internal.rs
+++ b/pallets/gear/src/internal.rs
@@ -36,7 +36,6 @@ use common::{
     GasTree, LockId, LockableTree, Origin,
 };
 use core::cmp::{Ord, Ordering};
-use core_processor::common::ActorExecutionErrorReplyReason;
 use frame_support::traits::{Currency, ExistenceRequirement};
 use frame_system::pallet_prelude::BlockNumberFor;
 use gear_core::{
@@ -704,21 +703,6 @@ where
             })
             .unwrap_or_default();
 
-        // Converting payload into string.
-        //
-        // Note: for users, trap replies always contain
-        // string explanation of the error.
-        let message = if message.is_error_reply() {
-            message
-                .with_string_payload::<ActorExecutionErrorReplyReason>()
-                .unwrap_or_else(|e| {
-                    log::debug!("Failed to decode error to string");
-                    e
-                })
-        } else {
-            message
-        };
-
         // Converting message into stored one and user one.
         let message = message.into_stored();
         let message: UserMessage = message
@@ -814,28 +798,6 @@ where
 
     /// Sends user message, once delay reached.
     pub(crate) fn send_user_message_after_delay(message: UserMessage, to_mailbox: bool) {
-        // Converting payload into string.
-        //
-        // Note: for users, trap replies always contain
-        // string explanation of the error.
-        //
-        // We don't plan to send delayed error replies yet,
-        // but this logic appears here for future purposes.
-        let message = if message
-            .details()
-            .map(|r_d| r_d.to_reply_code().is_error())
-            .unwrap_or(false)
-        {
-            message
-        } else {
-            message
-                .with_string_payload::<ActorExecutionErrorReplyReason>()
-                .unwrap_or_else(|e| {
-                    log::debug!("Failed to decode error to string");
-                    e
-                })
-        };
-
         // Taking data for funds manipulations.
         let from = message.source().cast();
         let to = message.destination().cast();


### PR DESCRIPTION
Resolves #2849  - payload is already created from a string in error replies.
https://github.com/gear-tech/gear/blob/eb526152014e69443bdcd4ceac9cd441ad87fe49/core-processor/src/processing.rs#L224-L251