### PR TITLE
feat!(gear-core): check data section for uploading codes

### DIFF
--- a/common/src/paused_program_storage.rs
+++ b/common/src/paused_program_storage.rs
@@ -19,13 +19,13 @@
 use super::{program_storage::MemoryMap, *};
 use crate::storage::{MapStorage, ValueStorage};
 use gear_core::{
-    code::MAX_WASM_PAGE_COUNT,
+    code::MAX_WASM_PAGE_AMOUNT,
     pages::{GEAR_PAGE_SIZE, WASM_PAGE_SIZE},
 };
 use sp_core::MAX_POSSIBLE_ALLOCATION;
 use sp_io::hashing;
 
-const SPLIT_COUNT: u16 = (WASM_PAGE_SIZE / GEAR_PAGE_SIZE) as u16 * MAX_WASM_PAGE_COUNT / 2;
+const SPLIT_COUNT: u16 = (WASM_PAGE_SIZE / GEAR_PAGE_SIZE) as u16 * MAX_WASM_PAGE_AMOUNT / 2;
 
 pub type SessionId = u32;
 

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -65,6 +65,7 @@ actor_system_error! {
     pub type PrepareMemoryError = ActorSystemError<ActorPrepareMemoryError, SystemPrepareMemoryError>;
 }
 
+// TODO: add this cases checks to Code::try_new in gear-core #3735
 /// Prepare memory error
 #[derive(Encode, Decode, TypeInfo, Debug, PartialEq, Eq, PartialOrd, Ord, derive_more::Display)]
 #[codec(crate = scale)]
@@ -79,8 +80,8 @@ pub enum ActorPrepareMemoryError {
 
 #[derive(Debug, Eq, PartialEq, derive_more::Display)]
 pub enum SystemPrepareMemoryError {
-    /// Mem size less then static pages num
-    #[display(fmt = "Mem size less then static pages num")]
+    /// Mem size less than static pages num
+    #[display(fmt = "Mem size less than static pages num")]
     InsufficientMemorySize,
 }
 

--- a/core-processor/src/precharge.rs
+++ b/core-processor/src/precharge.rs
@@ -164,8 +164,8 @@ impl<'a> GasPrecharger<'a> {
 
         if let Some(page) = allocations.iter().next_back() {
             // It means we somehow violated some constraints:
-            // 1. one of allocated pages > MAX_WASM_PAGE_COUNT
-            // 2. static pages > MAX_WASM_PAGE_COUNT
+            // 1. one of allocated pages > MAX_WASM_PAGE_AMOUNT
+            // 2. static pages > MAX_WASM_PAGE_AMOUNT
             Ok(page
                 .inc()
                 .unwrap_or_else(|_| unreachable!("WASM memory size is too big")))

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,4 +39,4 @@ rand = { workspace = true, features = ["std", "std_rng"] }
 [features]
 default = []
 strict = []
-std = ["serde/std"]
+std = ["serde/std", "wasmparser/std"]

--- a/core/src/code/errors.rs
+++ b/core/src/code/errors.rs
@@ -18,8 +18,8 @@
 
 //! Module that describes various code errors.
 
-use gear_wasm_instrument::{parity_wasm::SerializationError, InstrumentationError};
-use wasmparser::BinaryReaderError;
+pub use gear_wasm_instrument::{parity_wasm::SerializationError, InstrumentationError};
+pub use wasmparser::BinaryReaderError;
 
 /// Section name in WASM module.
 #[derive(Debug, derive_more::Display)]
@@ -143,9 +143,10 @@ pub enum CodecError {
 #[derive(Debug, derive_more::Display, derive_more::From)]
 pub enum CodeError {
     /// Validation by wasmparser failed.
-    #[display(fmt = "Wasm validation failed")]
+    #[display(fmt = "Wasmer validation error: {_0}")]
     Validation(BinaryReaderError),
     /// Module encode/decode error.
+    #[display(fmt = "Codec error: {_0}")]
     Codec(CodecError),
     /// The provided code contains section error.
     #[display(fmt = "Section error: {_0}")]

--- a/core/src/code/errors.rs
+++ b/core/src/code/errors.rs
@@ -22,7 +22,7 @@ use gear_wasm_instrument::{parity_wasm::SerializationError, InstrumentationError
 use wasmparser::BinaryReaderError;
 
 /// Section name in WASM module.
-#[derive(Debug, PartialEq, Eq, derive_more::Display)]
+#[derive(Debug, derive_more::Display)]
 pub enum SectionName {
     /// Type section.
     #[display(fmt = "Type section")]
@@ -42,7 +42,7 @@ pub enum SectionName {
 }
 
 /// Section error in WASM module.
-#[derive(Debug, PartialEq, Eq, derive_more::Display)]
+#[derive(Debug, derive_more::Display)]
 pub enum SectionError {
     /// Section not found.
     #[display(fmt = "{_0} not found")]
@@ -53,7 +53,7 @@ pub enum SectionError {
 }
 
 /// Memory error in WASM module.
-#[derive(Debug, PartialEq, Eq, derive_more::Display)]
+#[derive(Debug, derive_more::Display)]
 pub enum MemoryError {
     /// Memory entry not found in import section.
     #[display(fmt = "Memory entry not found")]
@@ -64,10 +64,10 @@ pub enum MemoryError {
 }
 
 /// Stack end error in WASM module.
-#[derive(Debug, PartialEq, Eq, derive_more::Display)]
+#[derive(Debug, derive_more::Display)]
 pub enum StackEndError {
     /// Unsupported initialization of gear stack end global variable.
-    #[display(fmt = "Unsupported initialization of gear stack end global variable")]
+    #[display(fmt = "Unsupported initialization of gear stack end global")]
     Initialization,
     /// Too many globals to create new global for stack end.
     #[display(fmt = "Too many globals to create new global for stack end")]
@@ -75,7 +75,7 @@ pub enum StackEndError {
 }
 
 /// Stack end error in WASM module.
-#[derive(Debug, PartialEq, Eq, derive_more::Display)]
+#[derive(Debug, derive_more::Display)]
 pub enum DataSectionError {
     /// Unsupported initialization of data segment.
     #[display(fmt = "Unsupported initialization of data segment")]
@@ -87,12 +87,12 @@ pub enum DataSectionError {
     #[display(fmt = "Data segment {_0:#x} ends out of possible 32 bits address space")]
     EndAddressOverflow(u32),
     /// Data segment end address is out of static memory.
-    #[display(fmt = "Data segment {_0:#x} end address {_1:#x} is out of static memory {_2:?}")]
+    #[display(fmt = "Data segment {_0:#x} last byte offset {_1:#x} is out of static memory {_2:#x}")]
     EndAddressOutOfStaticMemory(u32, u32, u32),
 }
 
 /// Export error in WASM module.
-#[derive(Debug, PartialEq, Eq, derive_more::Display)]
+#[derive(Debug, derive_more::Display)]
 pub enum ExportError {
     /// Incorrect global export index. Can occur when export refers to not existing global index.
     #[display(fmt = "Global index `{_0}` in export index `{_1}` is incorrect")]
@@ -115,7 +115,7 @@ pub enum ExportError {
 }
 
 /// Import error in WASM module.
-#[derive(Debug, PartialEq, Eq, derive_more::Display)]
+#[derive(Debug, derive_more::Display)]
 pub enum ImportError {
     /// The imported function is not supported by the Gear protocol.
     #[display(fmt = "Unknown imported function with index `{_0}`")]

--- a/core/src/code/errors.rs
+++ b/core/src/code/errors.rs
@@ -69,8 +69,8 @@ pub enum StackEndError {
     /// Unsupported initialization of gear stack end global variable.
     #[display(fmt = "Unsupported initialization of gear stack end global")]
     Initialization,
-    /// Too many globals to create new global for stack end.
-    #[display(fmt = "Too many globals to create new global for stack end")]
+    /// Too many globals to create new const global for stack end.
+    #[display(fmt = "Too many globals, so cannot create new global for stack end")]
     GlobalIndexOverflow,
 }
 
@@ -81,13 +81,13 @@ pub enum DataSectionError {
     #[display(fmt = "Unsupported initialization of data segment")]
     Initialization,
     /// Data section overlaps user stack.
-    #[display(fmt = "Data segment {_0:#x} overlaps user stack: {_1:#x}")]
+    #[display(fmt = "Data segment {_0:#x} overlaps user stack [0x0, {_1:#x})")]
     UserStackOverlaps(u32, u32),
     /// Data segment end address is out of possible 32 bits address space.
     #[display(fmt = "Data segment {_0:#x} ends out of possible 32 bits address space")]
     EndAddressOverflow(u32),
     /// Data segment end address is out of static memory.
-    #[display(fmt = "Data segment {_0:#x} last byte offset {_1:#x} is out of static memory {_2:#x}")]
+    #[display(fmt = "Data segment [{_0:#x}, {_1:#x}] is out of static memory [0x0, {_2:#x})")]
     EndAddressOutOfStaticMemory(u32, u32, u32),
 }
 

--- a/core/src/code/errors.rs
+++ b/core/src/code/errors.rs
@@ -80,9 +80,9 @@ pub enum DataSectionError {
     /// Unsupported initialization of data segment.
     #[display(fmt = "Unsupported initialization of data segment")]
     Initialization,
-    /// Data section overlaps user stack.
-    #[display(fmt = "Data segment {_0:#x} overlaps user stack [0x0, {_1:#x})")]
-    UserStackOverlaps(u32, u32),
+    /// Data section overlaps gear stack.
+    #[display(fmt = "Data segment {_0:#x} overlaps gear stack [0x0, {_1:#x})")]
+    GearStackOverlaps(u32, u32),
     /// Data segment end address is out of possible 32 bits address space.
     #[display(fmt = "Data segment {_0:#x} ends out of possible 32 bits address space")]
     EndAddressOverflow(u32),

--- a/core/src/code/utils.rs
+++ b/core/src/code/utils.rs
@@ -301,7 +301,7 @@ pub fn check_data_section(module: &Module, check_stack_end: bool) -> Result<(), 
             // Checks, that each data segment does not overlap the user stack.
             (data_segment_offset >= stack_end_offset as u32)
                 .then_some(())
-                .ok_or(DataSectionError::UserStackOverlaps(
+                .ok_or(DataSectionError::GearStackOverlaps(
                     data_segment_offset,
                     stack_end_offset as u32,
                 ))?;

--- a/core/src/code/utils.rs
+++ b/core/src/code/utils.rs
@@ -255,8 +255,8 @@ fn get_global_entry(module: &Module, global_index: u32) -> Option<&GlobalEntry> 
 }
 
 struct StackEndInfo {
-    pub offset: i32,
-    pub is_mutable: bool,
+    offset: i32,
+    is_mutable: bool,
 }
 
 fn get_stack_end_info(module: &Module) -> Result<Option<StackEndInfo>, CodeError> {

--- a/core/src/code/utils.rs
+++ b/core/src/code/utils.rs
@@ -36,7 +36,7 @@ use gear_wasm_instrument::{
 };
 
 /// Defines maximal permitted count of memory pages.
-pub const MAX_WASM_PAGE_COUNT: u16 = 512;
+pub const MAX_WASM_PAGE_AMOUNT: u16 = 512;
 
 /// Name of exports allowed on chain.
 pub const ALLOWED_EXPORTS: [&str; 6] = [
@@ -66,7 +66,7 @@ pub fn get_static_pages(module: &Module) -> Result<WasmPage, CodeError> {
         .ok_or(MemoryError::EntryNotFound)?
         .map_err(|_| MemoryError::InvalidStaticPageCount)?;
 
-    if static_pages.raw() > MAX_WASM_PAGE_COUNT as u32 {
+    if static_pages.raw() > MAX_WASM_PAGE_AMOUNT as u32 {
         Err(MemoryError::InvalidStaticPageCount)?;
     }
 
@@ -254,56 +254,95 @@ fn get_global_entry(module: &Module, global_index: u32) -> Option<&GlobalEntry> 
         .get(global_index as usize)
 }
 
-fn get_global_init_const_i32(
-    module: &Module,
-    global_index: u32,
-    export_inedx: u32,
-) -> Result<i32, CodeError> {
-    let init_expr = get_global_entry(module, global_index)
-        .ok_or(ExportError::IncorrectGlobalIndex(
-            global_index,
-            export_inedx,
-        ))?
-        .init_expr();
-    get_init_expr_const_i32(init_expr)
-        .ok_or(InitializationError::StackEnd)
-        .map_err(CodeError::Initialization)
+struct StackEndInfo {
+    pub offset: i32,
+    pub is_mutable: bool,
+}
+
+fn get_stack_end_info(module: &Module) -> Result<Option<StackEndInfo>, CodeError> {
+    let Some((export_index, global_index)) =
+        get_export_global_with_index(module, STACK_END_EXPORT_NAME)
+    else {
+        return Ok(None);
+    };
+
+    let entry = get_global_entry(module, global_index).ok_or(ExportError::IncorrectGlobalIndex(
+        global_index,
+        export_index,
+    ))?;
+
+    Ok(Some(StackEndInfo {
+        offset: get_init_expr_const_i32(entry.init_expr()).ok_or(StackEndError::Initialization)?,
+        is_mutable: entry.global_type().is_mutable(),
+    }))
+}
+
+/// Check that data segments are not overlapping with stack and are inside static pages.
+pub fn check_data_section(module: &Module, check_stack_end: bool) -> Result<(), CodeError> {
+    let Some(data_section) = module.data_section() else {
+        // No data section - nothing to check.
+        return Ok(());
+    };
+
+    let static_pages = get_static_pages(module)?;
+    let stack_end_offset = match check_stack_end {
+        true => get_stack_end_info(module)?.map(|info| info.offset),
+        false => None,
+    };
+
+    for data_segment in data_section.entries() {
+        let data_segment_offset = data_segment
+            .offset()
+            .as_ref()
+            .and_then(get_init_expr_const_i32)
+            .ok_or(DataSectionError::Initialization)? as u32;
+
+        if let Some(stack_end_offset) = stack_end_offset {
+            // Checks, that each data segment does not overlap the user stack.
+            (data_segment_offset >= stack_end_offset as u32)
+                .then_some(())
+                .ok_or(DataSectionError::UserStackOverlaps(
+                    data_segment_offset,
+                    stack_end_offset as u32,
+                ))?;
+        }
+
+        let Some(size) = u32::try_from(data_segment.value().len())
+            .map_err(|_| DataSectionError::EndAddressOverflow(data_segment_offset))?
+            .checked_sub(1)
+        else {
+            // Zero size data segment - strange, but allowed.
+            continue;
+        };
+
+        let data_segment_last_byte_offset = data_segment_offset
+            .checked_add(size)
+            .ok_or(DataSectionError::EndAddressOverflow(data_segment_offset))?;
+
+        (data_segment_last_byte_offset < static_pages.offset())
+            .then_some(())
+            .ok_or(DataSectionError::EndAddressOutOfStaticMemory(
+                data_segment_offset,
+                data_segment_last_byte_offset,
+                static_pages.offset(),
+            ))?;
+    }
+
+    Ok(())
 }
 
 pub fn check_and_canonize_gear_stack_end(module: &mut Module) -> Result<(), CodeError> {
-    let Some((stack_end_export_index, stack_end_global_index)) =
-        get_export_global_with_index(module, STACK_END_EXPORT_NAME)
+    let Some(StackEndInfo {
+        offset: stack_end_offset,
+        is_mutable: stack_end_global_is_mutable,
+    }) = get_stack_end_info(module)?
     else {
         return Ok(());
-    };
-    let stack_end_offset =
-        get_global_init_const_i32(module, stack_end_global_index, stack_end_export_index)?;
-
-    // Checks, that each data segment does not overlap with stack.
-    if let Some(data_section) = module.data_section() {
-        for data_segment in data_section.entries() {
-            let offset = data_segment
-                .offset()
-                .as_ref()
-                .and_then(get_init_expr_const_i32)
-                .ok_or(InitializationError::DataSegment)?;
-
-            if offset < stack_end_offset {
-                Err(StackEndError::StackEndOverlaps)?;
-            }
-        }
     };
 
     // If [STACK_END_EXPORT_NAME] points to mutable global, then make new const global
     // with the same init expr and change the export internal to point to the new global.
-    if get_global_entry(module, stack_end_global_index)
-        .ok_or(ExportError::IncorrectGlobalIndex(
-            stack_end_global_index,
-            stack_end_export_index,
-        ))?
-        .global_type()
-        .is_mutable()
-    {
+    if stack_end_global_is_mutable {
         // Panic is impossible, because we have checked above, that global section exists.
         let global_section = module
             .global_section_mut()

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -1107,7 +1107,7 @@ pub mod pallet {
                 schedule.limits.stack_height,
             )
             .map_err(|e| {
-                log::debug!("Code failed to load: {:?}", e);
+                log::debug!("Code checking or instrumentation failed: {e:?}");
                 Error::<T>::ProgramConstructionFailed
             })?;
 

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -1107,7 +1107,7 @@ pub mod pallet {
                 schedule.limits.stack_height,
             )
             .map_err(|e| {
-                log::debug!("Code checking or instrumentation failed: {e:?}");
+                log::debug!("Code checking or instrumentation failed: {e}");
                 Error::<T>::ProgramConstructionFailed
             })?;
 

--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -29,7 +29,7 @@ use frame_support::{
     weights::Weight,
 };
 use gear_core::{
-    code,
+    code::MAX_WASM_PAGE_AMOUNT,
     costs::HostFnWeights as CoreHostFnWeights,
     message,
     pages::{GearPage, PageU32Size, WasmPage, GEAR_PAGE_SIZE},
@@ -755,7 +755,7 @@ impl Default for Limits {
             globals: 256,
             locals: 1024,
             parameters: 128,
-            memory_pages: code::MAX_WASM_PAGE_COUNT,
+            memory_pages: MAX_WASM_PAGE_AMOUNT,
             // 4k function pointers (This is in count not bytes).
             table_size: 4096,
             br_table_size: 256,

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -12866,76 +12866,8 @@ fn relay_messages() {
     );
 }
 
-#[test]
-fn wasm_data_section_out_of_static_memory() {
-    let wat1 = r#"
-        (module
-            (import "env" "memory" (memory 1))
-            (export "init" (func $init))
-            (func $init)
-            (data (;0;) (i32.const 0x10000) "gear")
-        )
-    "#;
 
-    let wat2 = r#"
-        (module
-            (import "env" "memory" (memory 1))
-            (export "init" (func $init))
-            (func $init)
-            (data (;0;) (i32.const 0xfffd) "gear")
-        )
-    "#;
-
-    let wat3 = r#"
-        (module
-            (import "env" "memory" (memory 1))
-            (export "init" (func $init))
-            (func $init)
-            (data (;0;) (i32.const 0xffffffff) "gear")
-        )
-    "#;
-
-    init_logger();
-    new_test_ext().execute_with(|| {
-        Gear::upload_program(
-            RuntimeOrigin::signed(USER_1),
-            ProgramCodeKind::Custom(wat1).to_bytes(),
-            DEFAULT_SALT.to_vec(),
-            EMPTY_PAYLOAD.to_vec(),
-            50_000_000_000,
-            0,
-            false,
-        )
-        .expect_err("Must be error, because data segment offset is out of static memory bounds");
-
-        Gear::upload_program(
-            RuntimeOrigin::signed(USER_1),
-            ProgramCodeKind::Custom(wat2).to_bytes(),
-            DEFAULT_SALT.to_vec(),
-            EMPTY_PAYLOAD.to_vec(),
-            50_000_000_000,
-            0,
-            false,
-        )
-        .expect_err(
-            "Must be error, because data segment last byte offset is out of static memory bounds",
-        );
-
-        Gear::upload_program(
-            RuntimeOrigin::signed(USER_1),
-            ProgramCodeKind::Custom(wat3).to_bytes(),
-            DEFAULT_SALT.to_vec(),
-            EMPTY_PAYLOAD.to_vec(),
-            50_000_000_000,
-            0,
-            false,
-        )
-        .expect_err(
-            "Must be error, because data segment last byte offset is out of 32 bit address space",
-        );
-    });
-}
-
+// TODO: move to gear-core after #3736
 #[test]
 fn module_instantiation_error() {
     // Unknown global import leads to instantiation error.

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -12866,7 +12866,6 @@ fn relay_messages() {
     );
 }
 
-
 // TODO: move to gear-core after #3736
 #[test]
 fn module_instantiation_error() {

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -12888,7 +12888,7 @@ fn wasm_data_section_out_of_static_memory() {
 
     let wat3 = r#"
         (module
-            (import "env" "memory" (memory 0x10000)) ;; 4GB static memory
+            (import "env" "memory" (memory 1))
             (export "init" (func $init))
             (func $init)
             (data (;0;) (i32.const 0xffffffff) "gear")

--- a/utils/wasm-builder/src/builder_error.rs
+++ b/utils/wasm-builder/src/builder_error.rs
@@ -278,8 +278,8 @@ impl fmt::Display for CodeErrorWithContext {
         let Self(module, error) = self;
 
         match error {
-            Validation | Decode | Encode | Section(_) | Memory(_) | StackEnd(_)
-            | Initialization(_) | Instrumentation(_) => write!(f, "{error}"),
+            Validation(_) | Codec(_) | Section(_) | Memory(_) | StackEnd(_) | DataSection(_)
+            | Instrumentation(_) => write!(f, "{error}"),
             Export(error) => {
                 let error_with_context: ExportErrorWithContext =
                     (module, error).try_into().map_err(|_| fmt::Error)?;

--- a/utils/wasm-instrument/Cargo.toml
+++ b/utils/wasm-instrument/Cargo.toml
@@ -23,4 +23,5 @@ wat.workspace = true
 default = ["std"]
 std = [
     "gwasm-instrument/std",
+    "wasmparser/std",
 ]


### PR DESCRIPTION
Add checking that data section lies inside static memory (or inside wasm min memory pages).

After runtime upgrade codes with incorrect data sections cannot be re-instrumented or uploaded. 

Insignificant:
1) rename `MAX_WASM_PAGE_COUNT` -> `MAX_WASM_PAGE_AMOUNT`
2) forward `std` feature to `wasmparser` deps.
3) refactoring for `CodeError`: now it contains new internal errors from other crates in order to log full information about code errors in one place: see `try_new_code` in `pallets/gear/src/lib.rs`.
4) remove `InitializationError` and add `DataSectionError`

