### PR TITLE
feat(pallet-gear): test program with large indexes

### DIFF
--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -1440,16 +1440,16 @@ mod test {
 
         // NOTE:
         //
-        // For triggering the bug, assigning `max_idx` to `u32::MAX`.
+        // For triggering the bug, assigning `u32::MAX` to `max_idx`.
         let max_idx = ((code_limit - empty_program_len) / empty_fn_len + 1) as u32;
 
         // NOTE:
         //
-        // We are not generating the wasm module in memory
-        // because it takes too much.
+        // We are not generating the wasm module in memory because it
+        // takes too much.
         //
         // Mock the max idx in the index map of parity-wasm, cherry-pick
-        // https://github.com/casper-network/casper-wasm/pull/1 not our
+        // https://github.com/casper-network/casper-wasm/pull/1 to our
         // parity-wasm fork when this test getting failed which could be
         // happened on **raising the code len limit of our programs**.
         //

--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -1423,7 +1423,7 @@ mod test {
     /// functions, and returns the size of the wasm code.
     fn module_with_full_idx(count: usize) -> usize {
         let funcs = (0..count)
-            .map(|_| format!(r#"(func (type 0) nop)"#))
+            .map(|_| "(func (type 0) nop)".to_string())
             .collect::<Vec<String>>()
             .concat();
 

--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -1460,11 +1460,11 @@ mod test {
         // because it takes too much.
         //
         // Mock the max idx in the index map of parity-wasm, cherry-pick
-        // https://github.com/casper-network/casper-wasm/pull/1 nto our
+        // https://github.com/casper-network/casper-wasm/pull/1 not our
         // parity-wasm fork when this test getting failed which could be
         // happened on **raising the code len limit of our programs**.
         //
-        // For the curent testing machine, Apple M1 chip, 16GB memory,
+        // For the current testing machine, Apple M1 chip, 16GB memory,
         // deserializing a program with full of indexes in code size 4GB
         // will lead to the problem.
         let mut buffer = vec![];

--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -1418,4 +1418,65 @@ mod test {
             assert!(custom_cost_rules.instruction_cost(i).is_some());
         })
     }
+
+    /// This function creates a program with full of empty
+    /// functions, and returns the size of the wasm code.
+    fn module_with_full_idx(count: usize) -> usize {
+        let funcs = (0..count)
+            .map(|_| format!(r#"(func (type 0) nop)"#))
+            .collect::<Vec<String>>()
+            .concat();
+
+        let wat = format!(
+            r#"
+              (module
+               (type (func))
+               {funcs}
+              )
+            "#
+        );
+        wabt::wat2wasm(wat).expect("Failed to serialize wasm").len()
+    }
+
+    #[test]
+    fn deserialize_max_fn_idx_with_code_limit() {
+        use gear_wasm_instrument::parity_wasm::elements::{IndexMap, Serialize, VarUint32};
+        use std::io;
+
+        // Calculates the max limit of the function indexes
+        // with our code length limit.
+        let code_limit = Limits::default().code_len as usize;
+        let empty_program_len = module_with_full_idx(1);
+        let empty_fn_len = module_with_full_idx(2) - empty_program_len;
+
+        // NOTE:
+        //
+        // For triggering the bug, assigning `max_idx` to `u32::MAX`.
+        let max_idx = ((code_limit - empty_program_len) / empty_fn_len + 1) as u32;
+
+        // NOTE:
+        //
+        // We are not generating the wasm module in memory
+        // because it takes too much.
+        //
+        // Mock the max idx in the index map of parity-wasm, cherry-pick
+        // https://github.com/casper-network/casper-wasm/pull/1 nto our
+        // parity-wasm fork when this test getting failed which could be
+        // happened on **raising the code len limit of our programs**.
+        //
+        // For the curent testing machine, Apple M1 chip, 16GB memory,
+        // deserializing a program with full of indexes in code size 4GB
+        // will lead to the problem.
+        let mut buffer = vec![];
+        VarUint32::from(1u32).serialize(&mut buffer).unwrap();
+        VarUint32::from(max_idx - 1).serialize(&mut buffer).unwrap();
+        "foobar".to_string().serialize(&mut buffer).unwrap();
+
+        let indexmap =
+            IndexMap::<String>::deserialize(max_idx as usize, &mut io::Cursor::new(buffer))
+                .unwrap();
+
+        assert_eq!(indexmap.get(max_idx - 1), Some(&"foobar".to_string()));
+        assert_eq!(indexmap.len(), 1);
+    }
 }

--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -1422,19 +1422,8 @@ mod test {
     /// This function creates a program with full of empty
     /// functions, and returns the size of the wasm code.
     fn module_with_full_idx(count: usize) -> usize {
-        let funcs = (0..count)
-            .map(|_| "(func (type 0) nop)".to_string())
-            .collect::<Vec<String>>()
-            .concat();
-
-        let wat = format!(
-            r#"
-              (module
-               (type (func))
-               {funcs}
-              )
-            "#
-        );
+        let funcs = "(func)".repeat(count);
+        let wat = format!("(module {funcs})");
         wabt::wat2wasm(wat).expect("Failed to serialize wasm").len()
     }
 

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -14588,7 +14588,7 @@ fn program_with_large_indexes() {
     // check `CodeTooLarge`.
     let indexes_limit = (code_len_limit - 61) / 5 - 28;
     let funcs = (0..indexes_limit)
-        .map(|_| format!(r#"(func (type 0) nop)"#))
+        .map(|_| "(func (type 0) nop)".to_string())
         .collect::<Vec<String>>()
         .concat();
     let wat = format!(

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -14564,9 +14564,9 @@ fn export_is_import() {
 
 #[test]
 fn program_with_large_indexes() {
-    // There is a security problem in module deserialization
-    // found by casper-wasm https://github.com/casper-network/casper-wasm/pull/1,
-    // parity-wasm results OOM on deserializing a module with large indices.
+    // There is a security problem in module deserialization found by
+    // casper-wasm https://github.com/casper-network/casper-wasm/pull/1,
+    // parity-wasm results OOM on deserializing a module with large indexes.
     //
     // bytecodealliance/wasm-tools has similar tests:
     // https://github.com/bytecodealliance/wasm-tools/blob/main/crates/wasmparser/tests/big-module.rs
@@ -14577,16 +14577,16 @@ fn program_with_large_indexes() {
     // Here we generate a valid program full with empty functions to reach the limit
     // of both the function indexes and the code length in our node.
     //
-    // The testing program has length `60` with only 1 mocked function, each mocked
-    // function takes byte code size `4`
+    // The testing program has length `60` with only 1 mocked function, each empty
+    // function takes byte code size `4`.
     //
-    // FIXME: Failed to upload wasm right matched with the limit, leaving 35 indexes
-    // ( 140 bytes ) for passing the check `CodeTooLarge`.
+    // NOTE: Leaving 35 indexes (140 bytes) for injecting the stack limiter
+    // [`wasm_instrument::InstrumentationBuilder::instrument`].
     let empty_prog_len = 60;
     let empty_fn_len = 4;
-    let indexes_in_bytes_140 = 35;
-    let indexes_limit = (code_len_limit - empty_prog_len) / empty_fn_len - indexes_in_bytes_140;
-    let funcs = "(func)".repeat(indexes_limit);
+    let indexes_in_stack_limiter = 35;
+    let indexes_limit = (code_len_limit - empty_prog_len) / empty_fn_len - indexes_in_stack_limiter;
+    let funcs = "(func)".repeat(indexes_limit as usize);
     let wat = format!(
         r#"
           (module

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -14577,16 +14577,16 @@ fn program_with_large_indexes() {
     // Here we generate a valid program full with empty functions to reach the limit
     // of both the function indexes and the code length in our node.
     //
-    // The testing program has length `61` with only 1 mocked function, each mocked
-    // function takes byte code size `5`
+    // The testing program has length `60` with only 1 mocked function, each mocked
+    // function takes byte code size `4`
     //
-    // NOTE: Failed to upload wasm closed to the limit, leaving 28 indexes ( 140 bytes )
-    // for passing the check `CodeTooLarge`.
-    let indexes_limit = (code_len_limit - 61) / 5 - 28;
-    let funcs = (0..indexes_limit)
-        .map(|_| "(func (type 0) nop)".to_string())
-        .collect::<Vec<String>>()
-        .concat();
+    // FIXME: Failed to upload wasm right matched with the limit, leaving 35 indexes
+    // ( 140 bytes ) for passing the check `CodeTooLarge`.
+    let empty_prog_len = 60;
+    let empty_fn_len = 4;
+    let indexes_in_bytes_140 = 35;
+    let indexes_limit = (code_len_limit - empty_prog_len) / empty_fn_len - indexes_in_bytes_140;
+    let funcs = "(func)".repeat(indexes_limit);
     let wat = format!(
         r#"
           (module

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -14577,7 +14577,7 @@ fn program_with_large_indexes() {
     // This test is to make sure that we are not affected by the same problem.
     let code_len_limit = Limits::default().code_len;
 
-    // The testing program has length `61` with only
+    // The testing program has length `25` with only
     // 1 mocked function, each mocked function takes
     // byte code size `5`
     //
@@ -14585,10 +14585,10 @@ fn program_with_large_indexes() {
     // functions to reach the limit of both the function
     // indexes and the code length in our network.
     //
-    // NOTE: Failed to upload wasm closed to the limit
-    // leaving 28 indexes ( 140 bytes ) for passing the
+    // NOTE: Failed to upload wasm closed to the limit,
+    // leaving 21 indexes ( 110 bytes ) for passing the
     // check `CodeTooLarge`.
-    let indexes_limit = (code_len_limit - 61) / 5 - 28;
+    let indexes_limit = (code_len_limit - 25) / 5 - 21;
     let funcs = (0..indexes_limit)
         .map(|_| "(func (type 0) nop)".to_string())
         .collect::<Vec<String>>()
@@ -14597,17 +14597,14 @@ fn program_with_large_indexes() {
         r#"
           (module
            (type (func))
-           (import "env" "memory" (memory (;0;) 17))
            {funcs}
-           (export "handle" (func 0))
-           (export "init" (func 0))
           )
     "#
     );
 
     let wasm = wabt::wat2wasm(&wat).expect("failed to compile wat to wasm");
     assert!(
-        code_len_limit as usize - wasm.len() < 140,
+        code_len_limit as usize - wasm.len() < 110,
         "Failed to reach the max limit of code size."
     );
 

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -14589,7 +14589,7 @@ fn program_with_large_indices() {
 
     new_test_ext().execute_with(|| {
         let code = ProgramCodeKind::Custom(&wat).to_bytes();
-        assert_ok!(Gear::upload_code(RuntimeOrigin::signed(USER_1), code))
+        assert_ok!(Gear::upload_code(RuntimeOrigin::signed(USER_1), code));
     });
 }
 


### PR DESCRIPTION
Resolves #3754

This PR provides a testing program filled by empty functions to reach the indexes limit and the code length limit to confirm we are not affected by the deserialization problem of parity-wasm

From my point of view I prefer not cherry picking the fix from `casper-wasm` at the moment:

1. we have the code size limit `512 * 1024 (512kb)`,  and the deserializing logic slows down significantly on my 16GM memory machine when the indexes reaches `268_435_441`, at least code size `1024 * 1024 * 1024 (1gb)`
   1. I can dig the specific result of the cost between `Vec` and `BTreeMap` as the `IndexMap` of `parity-wasm`, if anybody like to see it.
3. the stability of `parity-wasm` has been verified by the whole industry for years, picking the update may lead us to new problems since `parity-wasm` has already been archived
4. instead of picking the update, I'd vote on switching to [wasm-tools](https://github.com/bytecodealliance/wasm-tools) since its code base is still under active development

On the other hand:

this issue is also considerable for the runtime upgrades or WASM modules used for the chain configuration, but it could be discovered on general tests of launching a new runtime upgrades

- [x] add program test with large indexes
- [x] add index-map test with large indexes
- [ ] ~~update parity-wasm if it can solve the problem~~

@gear-tech/dev 
