### PR TITLE
fix(pallet-gear-builtin): Fix the issue of bi-replying

### DIFF
--- a/pallets/gear-builtin/src/lib.rs
+++ b/pallets/gear-builtin/src/lib.rs
@@ -292,6 +292,9 @@ impl<T: Config> BuiltinDispatcher for BuiltinRegistry<T> {
                         ..
                     } = outcome.drain();
                     dispatch_result.generated_dispatches = generated_dispatches;
+                    dispatch_result.reply_sent = true;
+                } else {
+                    unreachable!("Failed to send reply from builtin actor");
                 };
 
                 // Using the core processor logic create necessary `JournalNote`'s for us.


### PR DESCRIPTION
An issue appeared due to improper merging of #3475 with builtins pallet

Incorrect merging produced the following error:
```
--- STDERR:              pallet-gear-builtin tests::basic::invoking_builtin_from_program_works ---
thread 'tests::basic::invoking_builtin_from_program_works' panicked at /Users/runner/work/gear/gear/pallets/gear/src/internal.rs:920:37:
internal error: entered unreachable code: GasTree corrupted! Module(ModuleError { index: 9, error: [1, 0, 0, 0], message: Some("NodeAlreadyExists") })
stack backtrace:
   0: rust_begin_unwind
             at /rustc/7ffc697ce10f19447c0ce338428ae4b9bc0c041c/library/std/src/panicking.rs:647:5
   1: core::panicking::panic_fmt
             at /rustc/7ffc697ce10f19447c0ce338428ae4b9bc0c041c/library/core/src/panicking.rs:72:14
   2: pallet_gear::internal::<impl pallet_gear::pallet::Pallet<T>>::split::{{closure}}
             at /Users/runner/work/gear/gear/pallets/gear/src/internal.rs:920:37
   3: core::result::Result<T,E>::unwrap_or_else
             at /rustc/7ffc697ce10f19447c0ce338428ae4b9bc0c041c/library/core/src/result.rs:1426:23
   4: pallet_gear::internal::<impl pallet_gear::pallet::Pallet<T>>::split
             at /Users/runner/work/gear/gear/pallets/gear/src/internal.rs:919:13
   5: pallet_gear::manager::journal::<impl gear_core_processor::common::JournalHandler for pallet_gear::manager::ExtManager<T>>::send_dispatch
             at /Users/runner/work/gear/gear/pallets/gear/src/manager/journal.rs:245:33
   6: gear_core_processor::handler::handle_journal
             at /Users/runner/work/gear/gear/core-processor/src/handler.rs:49:18
   7: pallet_gear::runtime_api::<impl pallet_gear::pallet::Pallet<T>>::calculate_gas_info_impl
             at /Users/runner/work/gear/gear/pallets/gear/src/runtime_api.rs:239:17
   8: pallet_gear::pallet::Pallet<T>::calculate_gas_info
```

see: https://github.com/gear-tech/gear/actions/runs/8060686017/job/22017781608