### PR TITLE
fix(gcore, gstd): improve docs & re-export `EnvVars` from gsys

### DIFF
--- a/core-errors/src/simple.rs
+++ b/core-errors/src/simple.rs
@@ -166,6 +166,7 @@ impl SuccessReplyReason {
 )]
 #[cfg_attr(feature = "codec", derive(Encode, Decode, TypeInfo, Sequence), codec(crate = scale), allow(clippy::unnecessary_cast))]
 /// Reason of error reply creation.
+///
 /// NOTE: Adding new variants to this enum you must also update `ErrorReplyReason::to_bytes` and
 /// `ErrorReplyReason::from_bytes` methods.
 pub enum ErrorReplyReason {

--- a/gcore/src/exec.rs
+++ b/gcore/src/exec.rs
@@ -23,10 +23,10 @@
 
 use crate::{
     errors::{Result, SyscallError},
-    ActorId, MessageId, ReservationId,
+    ActorId, EnvVars, MessageId, ReservationId,
 };
 use core::mem::MaybeUninit;
-use gsys::{BlockNumberWithHash, EnvVars, ErrorWithGas, ErrorWithHash};
+use gsys::{BlockNumberWithHash, ErrorWithGas, ErrorWithHash};
 
 /// Get current version of environment variables.
 pub fn env_vars() -> EnvVars {

--- a/gcore/src/lib.rs
+++ b/gcore/src/lib.rs
@@ -81,7 +81,7 @@ pub use general::*;
 mod utils;
 pub use utils::ext;
 
-pub use gsys::{BlockCount, BlockNumber, Gas, GasMultiplier, Percent, Value};
+pub use gsys::{BlockCount, BlockNumber, EnvVars, Gas, GasMultiplier, Percent, Value};
 
 // This allows all casts from u32 into usize be safe.
 const _: () = assert!(core::mem::size_of::<u32>() <= core::mem::size_of::<usize>());

--- a/gstd/src/exec/async.rs
+++ b/gstd/src/exec/async.rs
@@ -28,10 +28,10 @@ use core::{
 use gcore::exec;
 
 /// Delays message execution in asynchronous way for the specified number of
-/// blocks. It works pretty much like the `exec::wait_for` function, but allows
-/// to continue execution after the delay in the same handler. It is worth
-/// mentioning that the program state gets persisted inside the call, and the
-/// execution resumes with potentially different state.
+/// blocks. It works pretty much like the [`exec::wait_for`] function, but
+/// allows to continue execution after the delay in the same handler. It is
+/// worth mentioning that the program state gets persisted inside the call, and
+/// the execution resumes with potentially different state.
 pub fn sleep_for(block_count: u32) -> impl Future<Output = ()> {
     MessageSleepFuture::new(msg::id(), exec::block_height().saturating_add(block_count))
 }

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -170,7 +170,7 @@ pub mod util;
 pub use async_runtime::{handle_signal, message_loop, record_reply};
 pub use common::{errors, primitives::*};
 pub use config::Config;
-pub use gcore::{ext, BlockCount, BlockNumber, Gas, GasMultiplier, Percent, Value};
+pub use gcore::{ext, BlockCount, BlockNumber, EnvVars, Gas, GasMultiplier, Percent, Value};
 pub use gstd_codegen::{async_init, async_main};
 pub use prelude::*;
 pub use reservations::*;


### PR DESCRIPTION
now you can do:
```rust
use gstd::{exec, EnvVars};

let EnvVars {
    existential_deposit,
    ..
} = exec::env_vars();
```

@gear-tech/dev
