### PR TITLE
fix(rpc-call): Return known value in case of finite waits

### DIFF
--- a/examples/constructor/src/scheme/mod.rs
+++ b/examples/constructor/src/scheme/mod.rs
@@ -52,6 +52,15 @@ impl Scheme {
         )
     }
 
+    pub fn with_handle(handle: Calls) -> Self {
+        Self::Predefined(
+            Default::default(),
+            handle.calls(),
+            Default::default(),
+            Default::default(),
+        )
+    }
+
     pub fn init(&self) -> &Vec<Call> {
         match self {
             Self::Direct(init) => init,

--- a/pallets/gear/src/runtime_api.rs
+++ b/pallets/gear/src/runtime_api.rs
@@ -247,11 +247,11 @@ where
                         // 'wait_for' and 'wait_up_to' should not consume all available gas
                         // because of the limited durations. If a duration is a big enough then it
                         // won't matter how to calculate the limit: it will be the same.
-                        JournalNote::WaitDispatch { ref dispatch, .. }
-                            if from_main_chain(dispatch.id())? =>
-                        {
-                            min_limit = initial_gas
-                        }
+                        JournalNote::WaitDispatch {
+                            ref dispatch,
+                            waited_type: MessageWaitedType::Wait,
+                            ..
+                        } if from_main_chain(dispatch.id())? => min_limit = initial_gas,
                         _ => (),
                     },
                 }

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -71,6 +71,8 @@ type Gas = <<Test as Config>::GasProvider as common::GasProvider>::GasTree;
 fn calculate_gas_results_in_finite_wait() {
     use demo_constructor::{Calls, Scheme};
 
+    // Imagine that this is async `send_for_reply` to some user
+    // with wait up to 20 that is not rare case.
     let receiver_scheme = Scheme::with_handle(Calls::builder().wait_for(20));
 
     let sender_scheme = |receiver_id: ProgramId| {


### PR DESCRIPTION
By repr case of @LouiseMedova.

Release, included the bug: v1.1.0
PR, created the bug: #3609 

Ref comment: https://github.com/gear-tech/gear/pull/3609#discussion_r1436070409