### PR TITLE
fix(core): set taken payload back in case of errors in `MessageContext`

### DIFF
--- a/core/src/message/handle.rs
+++ b/core/src/message/handle.rs
@@ -28,8 +28,6 @@ use scale_info::{
     TypeInfo,
 };
 
-use super::PayloadSizeError;
-
 /// Message for Handle entry point.
 /// Represents a standard message that sends between actors.
 #[derive(Clone, Default, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Decode, Encode, TypeInfo)]
@@ -167,8 +165,13 @@ impl HandlePacket {
     }
 
     /// Prepend payload.
-    pub(super) fn try_prepend(&mut self, data: Payload) -> Result<(), PayloadSizeError> {
-        self.payload.try_prepend(data)
+    pub(super) fn try_prepend(&mut self, mut data: Payload) -> Result<(), Payload> {
+        if data.try_extend_from_slice(self.payload_bytes()).is_err() {
+            Err(data)
+        } else {
+            self.payload = data;
+            Ok(())
+        }
     }
 
     /// Packet destination.

--- a/core/src/message/reply.rs
+++ b/core/src/message/reply.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use super::{common::ReplyDetails, PayloadSizeError};
+use super::common::ReplyDetails;
 use crate::{
     ids::{MessageId, ProgramId},
     message::{
@@ -222,8 +222,13 @@ impl ReplyPacket {
     }
 
     /// Prepend payload.
-    pub(super) fn try_prepend(&mut self, data: Payload) -> Result<(), PayloadSizeError> {
-        self.payload.try_prepend(data)
+    pub(super) fn try_prepend(&mut self, mut data: Payload) -> Result<(), Payload> {
+        if data.try_extend_from_slice(self.payload_bytes()).is_err() {
+            Err(data)
+        } else {
+            self.payload = data;
+            Ok(())
+        }
     }
 
     /// Packet status code.


### PR DESCRIPTION
resolves #3779 