### PR TITLE
refactor(benchmarks): remove garbage from benchmarks 

### DIFF
--- a/.github/workflows/comparison-table.yml
+++ b/.github/workflows/comparison-table.yml
@@ -8,7 +8,6 @@ on:
         required: true
         type: choice
         options:
-          - gear
           - vara
 
 env:

--- a/.maintain/frame-weight-template.hbs
+++ b/.maintain/frame-weight-template.hbs
@@ -45,10 +45,6 @@ pub trait WeightInfo {
     ) -> Weight;
     {{/each}}
     {{#if (eq pallet "pallet_gear")}}
-    fn allocation_cost() -> Weight;
-    fn grow_cost() -> Weight;
-    fn initial_cost() -> Weight;
-    fn load_cost() -> Weight;
     fn instr_i64const(r: u32, ) -> Weight;
     {{/if}}
 }
@@ -59,22 +55,6 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> frame_system::WeightInfo for SubstrateWeight<T> {
 {{else}}
 impl<T: frame_system::Config> {{pallet}}::WeightInfo for SubstrateWeight<T> {
-{{/if}}
-{{#if (eq pallet "pallet_gear")}}
-    fn allocation_cost() -> Weight {
-        // To be changed with the proper value.
-        T::DbWeight::get().writes(1)
-    }
-    fn grow_cost() -> Weight {
-        // To be changed with the proper value.
-        T::DbWeight::get().writes(1)
-    }
-    fn initial_cost() -> Weight {
-        T::DbWeight::get().writes(1)
-    }
-    fn load_cost() -> Weight {
-        T::DbWeight::get().reads(1)
-    }
 {{/if}}
     {{#each benchmarks as |benchmark|}}
     {{#if (eq benchmark.name "instr_call")}}
@@ -128,22 +108,6 @@ impl<T: frame_system::Config> {{pallet}}::WeightInfo for SubstrateWeight<T> {
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
-    {{#if (eq pallet "pallet_gear")}}
-    fn allocation_cost() -> Weight {
-        // To be changed with the proper value.
-        RocksDbWeight::get().writes(1)
-    }
-    fn grow_cost() -> Weight {
-        // To be changed with the proper value.
-        RocksDbWeight::get().writes(1)
-    }
-    fn initial_cost() -> Weight {
-        RocksDbWeight::get().writes(1)
-    }
-    fn load_cost() -> Weight {
-        RocksDbWeight::get().reads(1)
-    }
-    {{/if}}
     {{#each benchmarks as |benchmark|}}
     {{#if (eq benchmark.name "instr_call")}}
             {{#each benchmark.component_weight as |cw|}}

--- a/common/src/benchmarking.rs
+++ b/common/src/benchmarking.rs
@@ -19,7 +19,7 @@
 use super::*;
 
 use gear_core::{
-    pages::{PageNumber, PageU32Size, WasmPage},
+    pages::{PageNumber, WasmPage},
     program::MemoryInfix,
 };
 use gear_wasm_instrument::parity_wasm::{self, elements::*};
@@ -115,39 +115,27 @@ pub fn generate_wasm(num_pages: WasmPage) -> Result<Vec<u8>, &'static str> {
     Ok(code)
 }
 
-pub fn set_program<
-    ProgramStorage: super::ProgramStorage<BlockNumber = BlockNumber>,
-    BlockNumber: Zero + Copy + Saturating,
->(
+pub fn set_program<ProgramStorage, BlockNumber>(
     program_id: ProgramId,
     code: Vec<u8>,
     static_pages: WasmPage,
-) {
-    let code_id = CodeId::generate(&code).into_origin();
-    let allocations: BTreeSet<WasmPage> = static_pages.iter_from_zero().collect();
-    let persistent_pages_data: BTreeMap<GearPage, PageBuf> = allocations
-        .iter()
-        .flat_map(|p| p.to_pages_iter())
-        .map(|p| (p, PageBuf::new_zeroed()))
-        .collect();
-    let pages_with_data = persistent_pages_data.keys().copied().collect();
-
-    let memory_infix = MemoryInfix::new(1u32);
-    let program = ActiveProgram {
-        allocations,
-        pages_with_data,
-        code_hash: code_id,
-        code_exports: Default::default(),
-        static_pages,
-        state: ProgramState::Initialized,
-        gas_reservation_map: GasReservationMap::default(),
-        expiration_block: Zero::zero(),
-        memory_infix,
-    };
-    for (page, page_buf) in persistent_pages_data {
-        ProgramStorage::set_program_page_data(program_id, memory_infix, page, page_buf);
-    }
-
-    ProgramStorage::add_program(program_id, program)
-        .expect("benchmarking; program duplicates should not exist");
+) where
+    ProgramStorage: super::ProgramStorage<BlockNumber = BlockNumber>,
+    BlockNumber: Zero + Copy + Saturating,
+{
+    ProgramStorage::add_program(
+        program_id,
+        ActiveProgram {
+            allocations: Default::default(),
+            pages_with_data: Default::default(),
+            code_hash: CodeId::generate(&code).into_origin(),
+            code_exports: Default::default(),
+            static_pages,
+            state: ProgramState::Initialized,
+            gas_reservation_map: GasReservationMap::default(),
+            expiration_block: Zero::zero(),
+            memory_infix: MemoryInfix::new(1u32),
+        },
+    )
+    .expect("benchmarking; program duplicates should not exist");
 }

--- a/pallets/gear/src/weights.rs
+++ b/pallets/gear/src/weights.rs
@@ -220,10 +220,6 @@ pub trait WeightInfo {
     fn tasks_wake_message_no_wake() -> Weight;
     fn tasks_remove_from_waitlist() -> Weight;
     fn tasks_remove_from_mailbox() -> Weight;
-    fn allocation_cost() -> Weight;
-    fn grow_cost() -> Weight;
-    fn initial_cost() -> Weight;
-    fn load_cost() -> Weight;
     fn instr_i64const(r: u32, ) -> Weight;
 }
 
@@ -357,20 +353,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         Weight::from_parts(105_649_884, 0)
             // Standard Error: 2_260_663
             .saturating_add(Weight::from_parts(188_425_504, 0).saturating_mul(r.into()))
-    }
-    fn allocation_cost() -> Weight {
-        // To be changed with the proper value.
-        T::DbWeight::get().writes(1)
-    }
-    fn grow_cost() -> Weight {
-        // To be changed with the proper value.
-        T::DbWeight::get().writes(1)
-    }
-    fn initial_cost() -> Weight {
-        T::DbWeight::get().writes(1)
-    }
-    fn load_cost() -> Weight {
-        T::DbWeight::get().reads(1)
     }
     /// The range of component `c` is `[0, 512]`.
     fn db_write_per_kb(c: u32, ) -> Weight {
@@ -2233,20 +2215,6 @@ impl WeightInfo for () {
         Weight::from_parts(105_649_884, 0)
             // Standard Error: 2_260_663
             .saturating_add(Weight::from_parts(188_425_504, 0).saturating_mul(r.into()))
-    }
-    fn allocation_cost() -> Weight {
-        // To be changed with the proper value.
-        RocksDbWeight::get().writes(1)
-    }
-    fn grow_cost() -> Weight {
-        // To be changed with the proper value.
-        RocksDbWeight::get().writes(1)
-    }
-    fn initial_cost() -> Weight {
-        RocksDbWeight::get().writes(1)
-    }
-    fn load_cost() -> Weight {
-        RocksDbWeight::get().reads(1)
     }
     /// The range of component `c` is `[0, 512]`.
     fn db_write_per_kb(c: u32, ) -> Weight {

--- a/runtime/vara/src/weights/pallet_gear.rs
+++ b/runtime/vara/src/weights/pallet_gear.rs
@@ -220,10 +220,6 @@ pub trait WeightInfo {
     fn tasks_wake_message_no_wake() -> Weight;
     fn tasks_remove_from_waitlist() -> Weight;
     fn tasks_remove_from_mailbox() -> Weight;
-    fn allocation_cost() -> Weight;
-    fn grow_cost() -> Weight;
-    fn initial_cost() -> Weight;
-    fn load_cost() -> Weight;
     fn instr_i64const(r: u32, ) -> Weight;
 }
 
@@ -357,20 +353,6 @@ impl<T: frame_system::Config> pallet_gear::WeightInfo for SubstrateWeight<T> {
         Weight::from_parts(105_649_884, 0)
             // Standard Error: 2_260_663
             .saturating_add(Weight::from_parts(188_425_504, 0).saturating_mul(r.into()))
-    }
-    fn allocation_cost() -> Weight {
-        // To be changed with the proper value.
-        T::DbWeight::get().writes(1)
-    }
-    fn grow_cost() -> Weight {
-        // To be changed with the proper value.
-        T::DbWeight::get().writes(1)
-    }
-    fn initial_cost() -> Weight {
-        T::DbWeight::get().writes(1)
-    }
-    fn load_cost() -> Weight {
-        T::DbWeight::get().reads(1)
     }
     /// The range of component `c` is `[0, 512]`.
     fn db_write_per_kb(c: u32, ) -> Weight {
@@ -2233,20 +2215,6 @@ impl WeightInfo for () {
         Weight::from_parts(105_649_884, 0)
             // Standard Error: 2_260_663
             .saturating_add(Weight::from_parts(188_425_504, 0).saturating_mul(r.into()))
-    }
-    fn allocation_cost() -> Weight {
-        // To be changed with the proper value.
-        RocksDbWeight::get().writes(1)
-    }
-    fn grow_cost() -> Weight {
-        // To be changed with the proper value.
-        RocksDbWeight::get().writes(1)
-    }
-    fn initial_cost() -> Weight {
-        RocksDbWeight::get().writes(1)
-    }
-    fn load_cost() -> Weight {
-        RocksDbWeight::get().reads(1)
     }
     /// The range of component `c` is `[0, 512]`.
     fn db_write_per_kb(c: u32, ) -> Weight {


### PR DESCRIPTION
Does not cause some real changes in benchmark weights

| name                    | master  | weights/patch-efc32551 | diff    |
|-------------------------|---------|------------------------|---------|
| i64const                | 155 ps  | 180 ps                 | +13.89% |
| i64load                 | 9.5 ns  | 9.7 ns                 | +2.39%  |
| i32load                 | 9.2 ns  | 9.2 ns                 | +0.89%  |
| i64store                | 23.7 ns | 19.7 ns                | -19.89% |
| i32store                | 14.2 ns | 23.8 ns                | +40.30% |
| select                  | 7.3 ns  | 7.2 ns                 | -0.98%  |
| if                      | 6.3 ns  | 6.2 ns                 | -2.19%  |
| br                      | 3.2 ns  | 3.2 ns                 | -0.38%  |
| br_if                   | 5.9 ns  | 5.7 ns                 | -3.72%  |
| br_table                | 9.3 ns  | 9.5 ns                 | +1.72%  |
| br_table_per_entry      | 361 ps  | 343 ps                 | -5.25%  |
| call                    | 4.5 ns  | 4.5 ns                 | -1.00%  |
| call_indirect           | 20.2 ns | 20.1 ns                | -0.06%  |
| call_indirect_per_param | 2.2 ns  | 2.4 ns                 | +6.55%  |
| call_per_local          | 0 ps    | 0 ps                   | N/A     |
| local_get               | 1.1 ns  | 1.0 ns                 | -6.09%  |
| local_set               | 2.6 ns  | 2.2 ns                 | -13.62% |
| local_tee               | 2.9 ns  | 2.2 ns                 | -30.78% |
| global_get              | 1.9 ns  | 1.6 ns                 | -14.53% |
| global_set              | 2.8 ns  | 2.7 ns                 | -5.80%  |
| memory_current          | 14.4 ns | 12.3 ns                | -16.64% |
| i64clz                  | 6.8 ns  | 6.4 ns                 | -5.73%  |
| i32clz                  | 6.3 ns  | 6.1 ns                 | -2.89%  |
| i64ctz                  | 6.2 ns  | 6.1 ns                 | -2.32%  |
| i32ctz                  | 5.3 ns  | 5.2 ns                 | -0.27%  |
| i64popcnt               | 1.2 ns  | 1.2 ns                 | +1.69%  |
| i32popcnt               | 746 ps  | 736 ps                 | -1.36%  |
| i64eqz                  | 3.7 ns  | 3.6 ns                 | -3.61%  |
| i32eqz                  | 2.4 ns  | 2.3 ns                 | -4.71%  |
| i32extend8s             | 976 ps  | 842 ps                 | -15.91% |
| i32extend16s            | 885 ps  | 832 ps                 | -6.37%  |
| i64extend8s             | 993 ps  | 907 ps                 | -9.48%  |
| i64extend16s            | 1.0 ns  | 1.0 ns                 | +0.48%  |
| i64extend32s            | 936 ps  | 921 ps                 | -1.63%  |
| i64extendsi32           | 866 ps  | 695 ps                 | -24.60% |
| i64extendui32           | 556 ps  | 358 ps                 | -55.31% |
| i32wrapi64              | 346 ps  | 241 ps                 | -43.57% |
| i64eq                   | 3.6 ns  | 3.2 ns                 | -10.62% |
| i32eq                   | 2.3 ns  | 2.0 ns                 | -17.52% |
| i64ne                   | 3.5 ns  | 3.2 ns                 | -10.15% |
| i32ne                   | 2.3 ns  | 2.0 ns                 | -17.87% |
| i64lts                  | 3.6 ns  | 3.5 ns                 | -4.24%  |
| i32lts                  | 2.4 ns  | 2.1 ns                 | -18.18% |
| i64ltu                  | 3.9 ns  | 3.3 ns                 | -17.47% |
| i32ltu                  | 2.5 ns  | 1.9 ns                 | -27.92% |
| i64gts                  | 4.0 ns  | 3.3 ns                 | -19.72% |
| i32gts                  | 2.4 ns  | 2.2 ns                 | -10.29% |
| i64gtu                  | 3.8 ns  | 3.6 ns                 | -4.50%  |
| i32gtu                  | 2.5 ns  | 2.0 ns                 | -21.56% |
| i64les                  | 3.6 ns  | 3.5 ns                 | -3.95%  |
| i32les                  | 2.3 ns  | 2.0 ns                 | -13.88% |
| i64leu                  | 3.5 ns  | 3.5 ns                 | -0.06%  |
| i32leu                  | 2.3 ns  | 2.1 ns                 | -5.84%  |
| i64ges                  | 3.5 ns  | 3.4 ns                 | -1.99%  |
| i32ges                  | 2.2 ns  | 2.0 ns                 | -6.85%  |
| i64geu                  | 3.6 ns  | 3.3 ns                 | -9.88%  |
| i32geu                  | 2.2 ns  | 2.1 ns                 | -3.19%  |
| i64add                  | 2.6 ns  | 2.4 ns                 | -8.43%  |
| i32add                  | 1.2 ns  | 999 ps                 | -25.13% |
| i64sub                  | 2.7 ns  | 2.3 ns                 | -15.86% |
| i32sub                  | 1.1 ns  | 906 ps                 | -21.41% |
| i64mul                  | 3.5 ns  | 3.2 ns                 | -11.92% |
| i32mul                  | 2.3 ns  | 2.1 ns                 | -11.29% |
| i64divs                 | 3.3 ns  | 3.8 ns                 | +11.54% |
| i32divs                 | 3.7 ns  | 4.2 ns                 | +12.73% |
| i64divu                 | 4.4 ns  | 5.1 ns                 | +12.89% |
| i32divu                 | 4.2 ns  | 3.4 ns                 | -22.90% |
| i64rems                 | 15.5 ns | 16.4 ns                | +6.02%  |
| i32rems                 | 13.3 ns | 13.5 ns                | +0.95%  |
| i64remu                 | 4.1 ns  | 5.0 ns                 | +17.64% |
| i32remu                 | 4.2 ns  | 4.2 ns                 | -0.62%  |
| i64and                  | 2.7 ns  | 2.4 ns                 | -13.73% |
| i32and                  | 1.2 ns  | 1.0 ns                 | -12.67% |
| i64or                   | 2.6 ns  | 2.5 ns                 | -4.84%  |
| i32or                   | 1.2 ns  | 1.1 ns                 | -7.59%  |
| i64xor                  | 2.7 ns  | 2.5 ns                 | -6.96%  |
| i32xor                  | 1.3 ns  | 1.3 ns                 | +1.03%  |
| i64shl                  | 2.1 ns  | 2.0 ns                 | -3.52%  |
| i32shl                  | 1.1 ns  | 1.0 ns                 | -4.67%  |
| i64shrs                 | 2.2 ns  | 2.0 ns                 | -12.12% |
| i32shrs                 | 1.2 ns  | 918 ps                 | -27.89% |
| i64shru                 | 2.4 ns  | 2.0 ns                 | -17.60% |
| i32shru                 | 1.1 ns  | 896 ps                 | -26.79% |
| i64rotl                 | 2.2 ns  | 2.0 ns                 | -11.06% |
| i32rotl                 | 1.3 ns  | 896 ps                 | -40.96% |
| i64rotr                 | 2.3 ns  | 2.0 ns                 | -17.90% |
| i32rotr                 | 1.2 ns  | 970 ps                 | -28.25% |

Comparison table for Vara runtime for HostFn

| name                                    | master   | weights/patch-efc32551 | diff     |
|-----------------------------------------|----------|------------------------|----------|
| alloc                                   | 7.2 µs   | 5.0 µs                 | -42.67%  |
| alloc_per_page                          | 355.7 ns | 230.4 ns               | -54.40%  |
| free                                    | 757.9 ns | 735.8 ns               | -3.01%   |
| free_range                              | 901.0 ns | 901.9 ns               | +0.10%   |
| free_range_per_page                     | 61.6 ns  | 64.9 ns                | +5.07%   |
| gr_reserve_gas                          | 2.4 µs   | 2.3 µs                 | -3.00%   |
| gr_unreserve_gas                        | 2.2 µs   | 2.0 µs                 | -7.08%   |
| gr_system_reserve_gas                   | 1.2 µs   | 1.2 µs                 | -1.65%   |
| gr_gas_available                        | 1.1 µs   | 1.0 µs                 | -1.08%   |
| gr_message_id                           | 1.1 µs   | 1.0 µs                 | -8.77%   |
| gr_program_id                           | 1.1 µs   | 1.0 µs                 | -2.90%   |
| gr_source                               | 1.0 µs   | 1.0 µs                 | -0.69%   |
| gr_value                                | 1.1 µs   | 1.1 µs                 | -3.70%   |
| gr_value_available                      | 1.1 µs   | 1.1 µs                 | -2.75%   |
| gr_size                                 | 1.1 µs   | 1.0 µs                 | -4.75%   |
| gr_read                                 | 1.8 µs   | 1.8 µs                 | -2.01%   |
| gr_read_per_byte                        | 165 ps   | 157 ps                 | -5.10%   |
| gr_env_vars                             | 1.3 µs   | 1.2 µs                 | -11.94%  |
| gr_block_height                         | 1.1 µs   | 1.0 µs                 | -2.38%   |
| gr_block_timestamp                      | 1.1 µs   | 1.0 µs                 | -4.05%   |
| gr_random                               | 2.1 µs   | 2.0 µs                 | -4.25%   |
| gr_reply_deposit                        | 6.5 µs   | 6.5 µs                 | +0.07%   |
| gr_send                                 | 3.2 µs   | 3.1 µs                 | -1.65%   |
| gr_send_per_byte                        | 271 ps   | 301 ps                 | +9.97%   |
| gr_send_wgas                            | 3.2 µs   | 3.1 µs                 | -1.91%   |
| gr_send_wgas_per_byte                   | 269 ps   | 303 ps                 | +11.22%  |
| gr_send_init                            | 1.2 µs   | 1.1 µs                 | -3.24%   |
| gr_send_push                            | 2.1 µs   | 2.1 µs                 | +0.83%   |
| gr_send_push_per_byte                   | 382 ps   | 414 ps                 | +7.73%   |
| gr_send_commit                          | 2.7 µs   | 2.6 µs                 | -3.73%   |
| gr_send_commit_wgas                     | 2.7 µs   | 2.7 µs                 | +0.08%   |
| gr_reservation_send                     | 3.4 µs   | 3.3 µs                 | -4.37%   |
| gr_reservation_send_per_byte            | 267 ps   | 310 ps                 | +13.87%  |
| gr_reservation_send_commit              | 2.9 µs   | 2.9 µs                 | -0.21%   |
| gr_reply_commit                         | 16.0 µs  | 15.9 µs                | -0.21%   |
| gr_reply_commit_wgas                    | 21.4 µs  | 17.8 µs                | -20.24%  |
| gr_reservation_reply                    | 9.3 µs   | 8.1 µs                 | -14.26%  |
| gr_reservation_reply_per_byte           | 432.2 ns | 480.7 ns               | +10.09%  |
| gr_reservation_reply_commit             | 7.2 µs   | 8.2 µs                 | +12.29%  |
| gr_reply_push                           | 1.8 µs   | 1.8 µs                 | -3.45%   |
| gr_reply                                | 18.4 µs  | 18.6 µs                | +1.08%   |
| gr_reply_per_byte                       | 417 ps   | 486 ps                 | +14.20%  |
| gr_reply_wgas                           | 17.6 µs  | 17.1 µs                | -2.80%   |
| gr_reply_wgas_per_byte                  | 423 ps   | 469 ps                 | +9.81%   |
| gr_reply_push_per_byte                  | 675 ps   | 684 ps                 | +1.32%   |
| gr_reply_to                             | 1.1 µs   | 1.1 µs                 | -1.01%   |
| gr_signal_code                          | 1.1 µs   | 1.0 µs                 | -1.05%   |
| gr_signal_from                          | 1.1 µs   | 1.0 µs                 | -4.84%   |
| gr_reply_input                          | 33.6 µs  | 32.3 µs                | -3.84%   |
| gr_reply_input_wgas                     | 0 ps     | 23.0 µs                | +100.00% |
| gr_reply_push_input                     | 1.4 µs   | 1.3 µs                 | -1.20%   |
| gr_reply_push_input_per_byte            | 163 ps   | 110 ps                 | -48.18%  |
| gr_send_input                           | 3.4 µs   | 3.3 µs                 | -1.79%   |
| gr_send_input_wgas                      | 3.6 µs   | 3.3 µs                 | -8.76%   |
| gr_send_push_input                      | 1.6 µs   | 1.6 µs                 | -3.84%   |
| gr_send_push_input_per_byte             | 170 ps   | 152 ps                 | -11.84%  |
| gr_debug                                | 1.5 µs   | 1.3 µs                 | -9.73%   |
| gr_debug_per_byte                       | 321 ps   | 374 ps                 | +14.17%  |
| gr_reply_code                           | 1.1 µs   | 1.0 µs                 | -2.97%   |
| gr_exit                                 | 197.4 µs | 112.1 µs               | -76.12%  |
| gr_leave                                | 191.2 µs | 149.6 µs               | -27.82%  |
| gr_wait                                 | 127.7 µs | 126.0 µs               | -1.37%   |
| gr_wait_for                             | 191.9 µs | 106.3 µs               | -80.57%  |
| gr_wait_up_to                           | 188.4 µs | 144.6 µs               | -30.28%  |
| gr_wake                                 | 2.0 µs   | 3.5 µs                 | +41.32%  |
| gr_create_program                       | 4.3 µs   | 4.1 µs                 | -4.65%   |
| gr_create_program_payload_per_byte      | 86 ps    | 306 ps                 | +71.90%  |
| gr_create_program_salt_per_byte         | 1.9 ns   | 2.1 ns                 | +7.04%   |
| gr_create_program_wgas                  | 4.3 µs   | 4.2 µs                 | -2.62%   |
| gr_create_program_wgas_payload_per_byte | 87 ps    | 103 ps                 | +15.53%  |
| gr_create_program_wgas_salt_per_byte    | 1.9 ns   | 1.9 ns                 | -1.80%   |

Comparison table for Vara runtime for Memory

| name                                  | master   | weights/patch-efc32551 | diff    |
|---------------------------------------|----------|------------------------|---------|
| lazy_pages_signal_read                | 29.1 µs  | 28.6 µs                | -1.69%  |
| lazy_pages_signal_write               | 36.0 µs  | 35.6 µs                | -1.15%  |
| lazy_pages_signal_write_after_read    | 10.6 µs  | 10.6 µs                | +0.62%  |
| lazy_pages_host_func_read             | 30.9 µs  | 29.6 µs                | -4.37%  |
| lazy_pages_host_func_write            | 37.4 µs  | 35.4 µs                | -5.77%  |
| lazy_pages_host_func_write_after_read | 9.2 µs   | 10.3 µs                | +10.42% |
| load_page_data                        | 10.3 µs  | 10.4 µs                | +0.97%  |
| upload_page_data                      | 104.0 µs | 103.5 µs               | -0.45%  |
| static_page                           | 100 ps   | 100 ps                 | +0.00%  |
| mem_grow                              | 1.3 µs   | 944.8 ns               | -37.32% |
| parachain_read_heuristic              | 0 ps     | 0 ps                   | N/A     |

