### PR TITLE
refactor(wasm-instrument): add docs, simplify code

### DIFF
--- a/core-backend/src/env.rs
+++ b/core-backend/src/env.rs
@@ -322,7 +322,7 @@ where
         // condition is not met.
         assert_eq!(
             builder.funcs_count,
-            SyscallName::count(),
+            SyscallName::all().count(),
             "Not all existing syscalls were added to the module's env."
         );
 

--- a/core-backend/src/tests.rs
+++ b/core-backend/src/tests.rs
@@ -606,8 +606,8 @@ fn test_syscalls_table() {
     };
     use gear_core::message::DispatchKind;
     use gear_wasm_instrument::{
-        gas_metering::ConstantCostRules,
         parity_wasm::{self, builder},
+        rules::CustomConstantCostRules,
         InstrumentationBuilder, SyscallName,
     };
 
@@ -637,7 +637,7 @@ fn test_syscalls_table() {
     }
 
     let module = InstrumentationBuilder::new("env")
-        .with_gas_limiter(|_| ConstantCostRules::default())
+        .with_gas_limiter(|_| CustomConstantCostRules::default())
         .instrument(module)
         .unwrap();
     let code = module.into_bytes().unwrap();

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -120,7 +120,7 @@ mod tests {
     use super::Program;
     use crate::{code::Code, ids::ProgramId};
     use alloc::vec::Vec;
-    use gear_wasm_instrument::wasm_instrument::gas_metering::ConstantCostRules;
+    use gear_wasm_instrument::rules::CustomConstantCostRules;
 
     fn parse_wat(source: &str) -> Vec<u8> {
         let module_bytes = wabt::Wat2Wasm::new()
@@ -164,7 +164,7 @@ mod tests {
 
         let binary: Vec<u8> = parse_wat(wat);
 
-        let code = Code::try_new(binary, 1, |_| ConstantCostRules::default(), None).unwrap();
+        let code = Code::try_new(binary, 1, |_| CustomConstantCostRules::default(), None).unwrap();
         let (code, _) = code.into_parts();
         let program = Program::new(ProgramId::from(1), Default::default(), code);
 

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -42,7 +42,7 @@ use gear_core::{
     reservation::{GasReservationMap, GasReserver},
 };
 use gear_core_errors::{ErrorReplyReason, SignalCode, SimpleExecutionError};
-use gear_wasm_instrument::wasm_instrument::gas_metering::ConstantCostRules;
+use gear_wasm_instrument::rules::CustomConstantCostRules;
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 use std::{
     cell::{Ref, RefCell, RefMut},
@@ -1129,9 +1129,13 @@ impl JournalHandler for ExtManager {
         if let Some(code) = self.opt_binaries.get(&code_id).cloned() {
             for (init_message_id, candidate_id) in candidates {
                 if !self.actors.contains_key(&candidate_id) {
-                    let code =
-                        Code::try_new(code.clone(), 1, |_| ConstantCostRules::default(), None)
-                            .expect("Program can't be constructed with provided code");
+                    let code = Code::try_new(
+                        code.clone(),
+                        1,
+                        |_| CustomConstantCostRules::default(),
+                        None,
+                    )
+                    .expect("Program can't be constructed with provided code");
 
                     let code_and_id: InstrumentedCodeAndId =
                         CodeAndId::from_parts_unchecked(code, code_id).into();

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -31,7 +31,7 @@ use gear_core::{
 };
 use gear_core_errors::SignalCode;
 use gear_utils::{MemoryPageDump, ProgramMemoryDump};
-use gear_wasm_instrument::wasm_instrument::gas_metering::ConstantCostRules;
+use gear_wasm_instrument::rules::CustomConstantCostRules;
 use path_clean::PathClean;
 use std::{
     cell::RefCell,
@@ -489,7 +489,7 @@ impl<'a> Program<'a> {
         optimized: Vec<u8>,
         metadata: Option<Vec<u8>>,
     ) -> Self {
-        let code = Code::try_new(optimized, 1, |_| ConstantCostRules::default(), None)
+        let code = Code::try_new(optimized, 1, |_| CustomConstantCostRules::default(), None)
             .expect("Failed to create Program from code");
 
         let code_and_id: InstrumentedCodeAndId = CodeAndId::new(code).into();

--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -34,7 +34,10 @@ use gear_core::{
     message,
     pages::{GearPage, PageU32Size, WasmPage, GEAR_PAGE_SIZE},
 };
-use gear_wasm_instrument::{parity_wasm::elements, wasm_instrument::gas_metering};
+use gear_wasm_instrument::{
+    gas_metering::{MemoryGrowCost, Rules},
+    parity_wasm::elements,
+};
 use pallet_gear_proc_macro::{ScheduleDebug, WeightDebug};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
@@ -333,6 +336,7 @@ pub struct InstructionWeights<T: Config> {
     pub i32rotr: u32,
     /// The type parameter is used in the default implementation.
     #[codec(skip)]
+    #[cfg_attr(feature = "std", serde(skip))]
     pub _phantom: PhantomData<T>,
 }
 
@@ -556,6 +560,7 @@ pub struct HostFnWeights<T: Config> {
 
     /// The type parameter is used in the default implementation.
     #[codec(skip)]
+    #[cfg_attr(feature = "std", serde(skip))]
     pub _phantom: PhantomData<T>,
 }
 
@@ -615,6 +620,7 @@ pub struct MemoryWeights<T: Config> {
 
     /// The type parameter is used in the default implementation.
     #[codec(skip)]
+    #[cfg_attr(feature = "std", serde(skip))]
     pub _phantom: PhantomData<T>,
 }
 
@@ -1119,7 +1125,7 @@ struct ScheduleRules<'a, T: Config> {
 }
 
 impl<T: Config> Schedule<T> {
-    pub fn rules(&self, module: &elements::Module) -> impl gas_metering::Rules + '_ {
+    pub fn rules(&self, module: &elements::Module) -> impl Rules + '_ {
         ScheduleRules {
             schedule: self,
             params: module
@@ -1135,7 +1141,7 @@ impl<T: Config> Schedule<T> {
     }
 }
 
-impl<'a, T: Config> gas_metering::Rules for ScheduleRules<'a, T> {
+impl<'a, T: Config> Rules for ScheduleRules<'a, T> {
     fn instruction_cost(&self, instruction: &elements::Instruction) -> Option<u32> {
         use self::elements::{Instruction::*, SignExtInstruction::*};
         let w = &self.schedule.instruction_weights;
@@ -1248,8 +1254,8 @@ impl<'a, T: Config> gas_metering::Rules for ScheduleRules<'a, T> {
         Some(weight)
     }
 
-    fn memory_grow_cost(&self) -> gas_metering::MemoryGrowCost {
-        gas_metering::MemoryGrowCost::Free
+    fn memory_grow_cost(&self) -> MemoryGrowCost {
+        MemoryGrowCost::Free
     }
 
     fn call_per_local_cost(&self) -> u32 {

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -57,7 +57,7 @@ use gear_core_backend::error::{
     TrapExplanation, UnrecoverableExecutionError, UnrecoverableExtError, UnrecoverableWaitError,
 };
 use gear_core_errors::*;
-use gear_wasm_instrument::{gas_metering::ConstantCostRules, STACK_END_EXPORT_NAME};
+use gear_wasm_instrument::{rules::CustomConstantCostRules, STACK_END_EXPORT_NAME};
 use gstd::{collections::BTreeMap, errors::Error as GstdError};
 use pallet_gear_voucher::PrepaidCall;
 use sp_runtime::{
@@ -13034,7 +13034,7 @@ fn wrong_entry_type() {
             Code::try_new(
                 ProgramCodeKind::Custom(wat).to_bytes(),
                 1,
-                |_| ConstantCostRules::default(),
+                |_| CustomConstantCostRules::default(),
                 None
             ),
             Err(CodeError::Export(ExportError::InvalidExportFnSignature(0)))

--- a/utils/wasm-gen/src/config/syscalls/injection.rs
+++ b/utils/wasm-gen/src/config/syscalls/injection.rs
@@ -68,13 +68,10 @@ impl SyscallsInjectionTypes {
 
     /// Instantiate a syscalls map with given injection type.
     fn new_with_injection_type(injection_type: SyscallInjectionType) -> Self {
-        let syscalls = SyscallName::instrumentable();
         Self(
-            syscalls
-                .iter()
-                .cloned()
+            SyscallName::instrumentable()
                 .map(|name| (InvocableSyscall::Loose(name), injection_type.clone()))
-                .chain(syscalls.iter().cloned().filter_map(|name| {
+                .chain(SyscallName::instrumentable().filter_map(|name| {
                     InvocableSyscall::has_precise_variant(name)
                         .then_some((InvocableSyscall::Precise(name), injection_type.clone()))
                 }))

--- a/utils/wasm-gen/src/tests.rs
+++ b/utils/wasm-gen/src/tests.rs
@@ -414,12 +414,10 @@ fn error_processing_works_for_fallible_syscalls() {
     let mut unstructured = Unstructured::new(&buf);
     let mut unstructured2 = Unstructured::new(&buf);
 
-    let fallible_syscalls = SyscallName::instrumentable()
-        .into_iter()
-        .filter_map(|syscall| {
-            let invocable_syscall = InvocableSyscall::Loose(syscall);
-            invocable_syscall.is_fallible().then_some(invocable_syscall)
-        });
+    let fallible_syscalls = SyscallName::instrumentable().filter_map(|syscall| {
+        let invocable_syscall = InvocableSyscall::Loose(syscall);
+        invocable_syscall.is_fallible().then_some(invocable_syscall)
+    });
 
     for syscall in fallible_syscalls {
         // Prepare syscalls config & context settings for test case.
@@ -486,12 +484,9 @@ fn precise_syscalls_works() {
     rng.fill_bytes(&mut buf);
     let mut unstructured = Unstructured::new(&buf);
 
-    let precise_syscalls = SyscallName::instrumentable()
-        .into_iter()
-        .filter_map(|syscall| {
-            InvocableSyscall::has_precise_variant(syscall)
-                .then_some(InvocableSyscall::Precise(syscall))
-        });
+    let precise_syscalls = SyscallName::instrumentable().filter_map(|syscall| {
+        InvocableSyscall::has_precise_variant(syscall).then_some(InvocableSyscall::Precise(syscall))
+    });
 
     for syscall in precise_syscalls {
         // Prepare syscalls config & context settings for test case.

--- a/utils/wasm-instrument/src/lib.rs
+++ b/utils/wasm-instrument/src/lib.rs
@@ -44,14 +44,15 @@ pub mod rules;
 pub mod syscalls;
 
 // TODO #3057
+/// Gas global export name in WASM module.
 pub const GLOBAL_NAME_GAS: &str = "gear_gas";
-pub const GLOBAL_NAME_FLAGS: &str = "gear_flags";
 
-/// '__gear_stack_end' export is inserted by wasm-proc or wasm-builder,
+/// `__gear_stack_end` export is inserted by wasm-proc or wasm-builder,
 /// it indicates the end of program stack memory.
 pub const STACK_END_EXPORT_NAME: &str = "__gear_stack_end";
-/// '__gear_stack_height' export is inserted by gwasm-instrument,
-/// it points to stack height global that is used by [`gwasm_instrument::stack_limiter`].
+/// `__gear_stack_height` export is inserted by gwasm-instrument,
+/// it points to stack height global that is used by
+/// [`gwasm_instrument::stack_limiter`].
 pub const STACK_HEIGHT_EXPORT_NAME: &str = "__gear_stack_height";
 
 /// System break code for [`SyscallName::SystemBreak`] syscall.
@@ -61,7 +62,8 @@ pub enum SystemBreakCode {
     StackLimitExceeded = 1,
 }
 
-/// The error type returned when a conversion from `i32` or `u32` to [`SystemBreakCode`] fails.
+/// The error type returned when a conversion from `i32` or `u32` to
+/// [`SystemBreakCode`] fails.
 #[derive(Clone, Debug, derive_more::Display)]
 #[display(fmt = "Unsupported system break code")]
 pub struct SystemBreakCodeTryFromError;
@@ -108,8 +110,8 @@ pub enum InstrumentationError {
     InstructionCostNotFound,
     /// Error occurred during injecting gas metering instructions.
     ///
-    /// This might be due to program contained unsupported/non-deterministic instructions
-    /// (floats, memory grow, etc.).
+    /// This might be due to program contained unsupported/non-deterministic
+    /// instructions (floats, memory grow, etc.).
     #[display(fmt = "Failed to inject instructions for gas metrics: may be in case \
         program contains unsupported instructions (floats, memory grow, etc.)")]
     GasInjection,
@@ -134,7 +136,8 @@ where
     R: Rules,
     GetRulesFn: FnMut(&Module) -> R,
 {
-    /// Creates a new [`InstrumentationBuilder`] with the given module name to import syscalls.
+    /// Creates a new [`InstrumentationBuilder`] with the given module name to
+    /// import syscalls.
     pub fn new(module_name: &'a str) -> Self {
         Self {
             module_name,

--- a/utils/wasm-instrument/src/rules.rs
+++ b/utils/wasm-instrument/src/rules.rs
@@ -1,9 +1,36 @@
+// This file is part of Gear.
+
+// Copyright (C) 2023-2024 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Mock for `ScheduleRules`.
+
 use core::num::NonZeroU32;
 use gwasm_instrument::{
     gas_metering::{MemoryGrowCost, Rules},
     parity_wasm::elements::{self, Instruction},
 };
 
+/// This type provides the functionality of
+/// [`gwasm_instrument::gas_metering::ConstantCostRules`].
+///
+/// This implementation of [`Rules`] will also check the WASM module for
+/// instructions that are not supported by Gear Protocol. So, it's preferable to
+/// use this type instead of `pallet_gear::Schedule::default().rules()` in unit
+/// testing.
 pub struct CustomConstantCostRules {
     instruction_cost: u32,
     memory_grow_cost: u32,
@@ -11,6 +38,10 @@ pub struct CustomConstantCostRules {
 }
 
 impl CustomConstantCostRules {
+    /// Create a new [`CustomConstantCostRules`].
+    ///
+    /// Uses `instruction_cost` for every instruction and `memory_grow_cost` to
+    /// dynamically meter the memory growth instruction.
     pub fn new(instruction_cost: u32, memory_grow_cost: u32, call_per_local_cost: u32) -> Self {
         Self {
             instruction_cost,
@@ -21,6 +52,7 @@ impl CustomConstantCostRules {
 }
 
 impl Default for CustomConstantCostRules {
+    /// Uses instruction cost of `1` and disables memory growth instrumentation.
     fn default() -> Self {
         Self {
             instruction_cost: 1,
@@ -34,7 +66,8 @@ impl Rules for CustomConstantCostRules {
     fn instruction_cost(&self, instruction: &Instruction) -> Option<u32> {
         use self::elements::Instruction::*;
 
-        // list of allowed instructions from `ScheduleRules::<T>::instruction_cost(...)` method
+        // list of allowed instructions from `ScheduleRules::<T>::instruction_cost(...)`
+        // method
         match *instruction {
             End
             | Unreachable

--- a/utils/wasm-instrument/src/rules.rs
+++ b/utils/wasm-instrument/src/rules.rs
@@ -23,8 +23,7 @@ use gwasm_instrument::{
     parity_wasm::elements::{self, Instruction},
 };
 
-/// This type provides the functionality of
-/// [`gwasm_instrument::gas_metering::ConstantCostRules`].
+/// This type provides the functionality of [`ConstantCostRules`].
 ///
 /// This implementation of [`Rules`] will also check the WASM module for
 /// instructions that are not supported by Gear Protocol. So, it's preferable to

--- a/utils/wasm-instrument/src/syscalls.rs
+++ b/utils/wasm-instrument/src/syscalls.rs
@@ -19,20 +19,15 @@
 //! Gear syscalls for programs execution signatures.
 
 use crate::parity_wasm::elements::{FunctionType, ValueType};
-use alloc::{
-    borrow::ToOwned,
-    collections::{BTreeMap, BTreeSet},
-    string::String,
-    vec::Vec,
-};
+use alloc::{borrow::ToOwned, collections::BTreeMap, string::String, vec::Vec};
 use core::iter;
 use enum_iterator::{self, Sequence};
 pub use pointers::*;
 
 /// All available syscalls.
 ///
-/// The type is mainly used to prevent from skipping syscall integration test for
-/// a newly introduced syscall or from typo in syscall name.
+/// The type is mainly used to prevent from skipping syscall integration test
+/// for a newly introduced syscall or from typo in syscall name.
 #[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Sequence, Hash)]
 pub enum SyscallName {
     // Message sending related
@@ -113,141 +108,82 @@ pub enum SyscallName {
 }
 
 impl SyscallName {
+    /// Returns name of the syscall.
     pub fn to_str(&self) -> &'static str {
         match self {
-            SyscallName::Alloc => "alloc",
-            SyscallName::EnvVars => "gr_env_vars",
-            SyscallName::BlockHeight => "gr_block_height",
-            SyscallName::BlockTimestamp => "gr_block_timestamp",
-            SyscallName::CreateProgram => "gr_create_program",
-            SyscallName::CreateProgramWGas => "gr_create_program_wgas",
-            SyscallName::ReplyDeposit => "gr_reply_deposit",
-            SyscallName::Debug => "gr_debug",
-            SyscallName::Panic => "gr_panic",
-            SyscallName::OomPanic => "gr_oom_panic",
-            SyscallName::Exit => "gr_exit",
-            SyscallName::Free => "free",
-            SyscallName::FreeRange => "free_range",
-            SyscallName::GasAvailable => "gr_gas_available",
-            SyscallName::Leave => "gr_leave",
-            SyscallName::MessageId => "gr_message_id",
-            SyscallName::SystemBreak => "gr_system_break",
-            SyscallName::ProgramId => "gr_program_id",
-            SyscallName::Random => "gr_random",
-            SyscallName::Read => "gr_read",
-            SyscallName::Reply => "gr_reply",
-            SyscallName::ReplyCommit => "gr_reply_commit",
-            SyscallName::ReplyCommitWGas => "gr_reply_commit_wgas",
-            SyscallName::ReplyPush => "gr_reply_push",
-            SyscallName::ReplyTo => "gr_reply_to",
-            SyscallName::SignalFrom => "gr_signal_from",
-            SyscallName::ReplyWGas => "gr_reply_wgas",
-            SyscallName::ReplyInput => "gr_reply_input",
-            SyscallName::ReplyPushInput => "gr_reply_push_input",
-            SyscallName::ReplyInputWGas => "gr_reply_input_wgas",
-            SyscallName::ReservationReply => "gr_reservation_reply",
-            SyscallName::ReservationReplyCommit => "gr_reservation_reply_commit",
-            SyscallName::ReservationSend => "gr_reservation_send",
-            SyscallName::ReservationSendCommit => "gr_reservation_send_commit",
-            SyscallName::ReserveGas => "gr_reserve_gas",
-            SyscallName::Send => "gr_send",
-            SyscallName::SendCommit => "gr_send_commit",
-            SyscallName::SendCommitWGas => "gr_send_commit_wgas",
-            SyscallName::SendInit => "gr_send_init",
-            SyscallName::SendPush => "gr_send_push",
-            SyscallName::SendWGas => "gr_send_wgas",
-            SyscallName::SendInput => "gr_send_input",
-            SyscallName::SendPushInput => "gr_send_push_input",
-            SyscallName::SendInputWGas => "gr_send_input_wgas",
-            SyscallName::Size => "gr_size",
-            SyscallName::Source => "gr_source",
-            SyscallName::ReplyCode => "gr_reply_code",
-            SyscallName::SignalCode => "gr_signal_code",
-            SyscallName::SystemReserveGas => "gr_system_reserve_gas",
-            SyscallName::UnreserveGas => "gr_unreserve_gas",
-            SyscallName::Value => "gr_value",
-            SyscallName::ValueAvailable => "gr_value_available",
-            SyscallName::Wait => "gr_wait",
-            SyscallName::WaitFor => "gr_wait_for",
-            SyscallName::WaitUpTo => "gr_wait_up_to",
-            SyscallName::Wake => "gr_wake",
+            Self::Alloc => "alloc",
+            Self::EnvVars => "gr_env_vars",
+            Self::BlockHeight => "gr_block_height",
+            Self::BlockTimestamp => "gr_block_timestamp",
+            Self::CreateProgram => "gr_create_program",
+            Self::CreateProgramWGas => "gr_create_program_wgas",
+            Self::ReplyDeposit => "gr_reply_deposit",
+            Self::Debug => "gr_debug",
+            Self::Panic => "gr_panic",
+            Self::OomPanic => "gr_oom_panic",
+            Self::Exit => "gr_exit",
+            Self::Free => "free",
+            Self::FreeRange => "free_range",
+            Self::GasAvailable => "gr_gas_available",
+            Self::Leave => "gr_leave",
+            Self::MessageId => "gr_message_id",
+            Self::SystemBreak => "gr_system_break",
+            Self::ProgramId => "gr_program_id",
+            Self::Random => "gr_random",
+            Self::Read => "gr_read",
+            Self::Reply => "gr_reply",
+            Self::ReplyCommit => "gr_reply_commit",
+            Self::ReplyCommitWGas => "gr_reply_commit_wgas",
+            Self::ReplyPush => "gr_reply_push",
+            Self::ReplyTo => "gr_reply_to",
+            Self::SignalFrom => "gr_signal_from",
+            Self::ReplyWGas => "gr_reply_wgas",
+            Self::ReplyInput => "gr_reply_input",
+            Self::ReplyPushInput => "gr_reply_push_input",
+            Self::ReplyInputWGas => "gr_reply_input_wgas",
+            Self::ReservationReply => "gr_reservation_reply",
+            Self::ReservationReplyCommit => "gr_reservation_reply_commit",
+            Self::ReservationSend => "gr_reservation_send",
+            Self::ReservationSendCommit => "gr_reservation_send_commit",
+            Self::ReserveGas => "gr_reserve_gas",
+            Self::Send => "gr_send",
+            Self::SendCommit => "gr_send_commit",
+            Self::SendCommitWGas => "gr_send_commit_wgas",
+            Self::SendInit => "gr_send_init",
+            Self::SendPush => "gr_send_push",
+            Self::SendWGas => "gr_send_wgas",
+            Self::SendInput => "gr_send_input",
+            Self::SendPushInput => "gr_send_push_input",
+            Self::SendInputWGas => "gr_send_input_wgas",
+            Self::Size => "gr_size",
+            Self::Source => "gr_source",
+            Self::ReplyCode => "gr_reply_code",
+            Self::SignalCode => "gr_signal_code",
+            Self::SystemReserveGas => "gr_system_reserve_gas",
+            Self::UnreserveGas => "gr_unreserve_gas",
+            Self::Value => "gr_value",
+            Self::ValueAvailable => "gr_value_available",
+            Self::Wait => "gr_wait",
+            Self::WaitFor => "gr_wait_for",
+            Self::WaitUpTo => "gr_wait_up_to",
+            Self::Wake => "gr_wake",
         }
     }
 
+    /// Returns iterator of all syscalls.
     pub fn all() -> impl Iterator<Item = Self> {
         enum_iterator::all()
     }
 
-    pub fn count() -> usize {
-        Self::all().count()
-    }
-
-    /// Returns list of all syscall names (actually supported by this module syscalls).
-    pub fn instrumentable() -> BTreeSet<Self> {
-        [
-            Self::Alloc,
-            Self::Free,
-            Self::FreeRange,
-            Self::Debug,
-            Self::Panic,
-            Self::OomPanic,
-            Self::BlockHeight,
-            Self::BlockTimestamp,
-            Self::Exit,
-            Self::GasAvailable,
-            Self::ProgramId,
-            Self::Leave,
-            Self::ValueAvailable,
-            Self::Wait,
-            Self::WaitUpTo,
-            Self::WaitFor,
-            Self::Wake,
-            Self::ReplyCode,
-            Self::SignalCode,
-            Self::MessageId,
-            Self::Read,
-            Self::Reply,
-            Self::ReplyWGas,
-            Self::ReplyInput,
-            Self::ReplyInputWGas,
-            Self::ReplyCommit,
-            Self::ReplyCommitWGas,
-            Self::ReservationReply,
-            Self::ReservationReplyCommit,
-            Self::ReplyPush,
-            Self::ReplyPushInput,
-            Self::ReplyTo,
-            Self::SignalFrom,
-            Self::Send,
-            Self::SendWGas,
-            Self::SendInput,
-            Self::SendInputWGas,
-            Self::SendCommit,
-            Self::SendCommitWGas,
-            Self::SendInit,
-            Self::SendPush,
-            Self::SendPushInput,
-            Self::ReservationSend,
-            Self::ReservationSendCommit,
-            Self::Size,
-            Self::Source,
-            Self::Value,
-            Self::CreateProgram,
-            Self::CreateProgramWGas,
-            Self::ReplyDeposit,
-            Self::ReserveGas,
-            Self::UnreserveGas,
-            Self::Random,
-            Self::SystemReserveGas,
-            Self::EnvVars,
-        ]
-        .into()
+    /// Returns iterator of all syscall names (actually supported by this module
+    /// syscalls).
+    pub fn instrumentable() -> impl Iterator<Item = Self> {
+        Self::all().filter(|syscall| *syscall != Self::SystemBreak)
     }
 
     /// Returns map of all syscall string values to syscall names.
     pub fn instrumentable_map() -> BTreeMap<String, SyscallName> {
         Self::instrumentable()
-            .into_iter()
             .map(|syscall| (syscall.to_str().into(), syscall))
             .collect()
     }
@@ -540,23 +476,11 @@ impl SyscallName {
         }
     }
 
-    pub fn to_wgas(self) -> Option<Self> {
-        Some(match self {
-            Self::Reply => Self::ReplyWGas,
-            Self::ReplyInput => Self::ReplyInputWGas,
-            Self::ReplyCommit => Self::ReplyCommitWGas,
-            Self::Send => Self::SendWGas,
-            Self::SendInput => Self::SendInputWGas,
-            Self::SendCommit => Self::SendCommitWGas,
-            Self::CreateProgram => Self::CreateProgramWGas,
-            _ => return None,
-        })
-    }
-
-    /// Checks whether the syscall returns error either by writing to input error pointer
-    /// or by returning value indicating an error.
+    /// Checks whether the syscall returns error either by writing to input
+    /// error pointer or by returning value indicating an error.
     ///
-    /// There are only 3 syscalls returning error value: `Alloc`, `Free` & `FreeRange`.
+    /// There are only 3 syscalls returning error value: `Alloc`, `Free` &
+    /// `FreeRange`.
     pub fn returns_error(self) -> bool {
         let signature = self.signature();
 
@@ -569,7 +493,7 @@ impl SyscallName {
     /// Checks whether the syscall is fallible.
     ///
     /// ### Note:
-    /// This differs from `SysCallName::returns_error` as fallible syscalls
+    /// This differs from [`SyscallName::returns_error`] as fallible syscalls
     /// are those last param of which is a mutable error pointer.
     pub fn is_fallible(self) -> bool {
         self.signature().is_fallible()
@@ -577,15 +501,16 @@ impl SyscallName {
 }
 
 /// Syscall param type.
-///
-/// `Ptr` variant contains additional data about the type this pointer
-/// belongs to. See [`PtrInfo`] and [`PtrType`] for more details.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ParamType {
     Regular(RegularParamType),
     Error(ErrPtr),
 }
 
+/// Syscall regular param type.
+///
+/// `Pointer` variant contains additional data about the type this pointer
+/// belongs to, see [`Ptr`] for more details.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum RegularParamType {
     Length,              // i32 buffers length
@@ -776,6 +701,7 @@ impl<const N: usize, const M: usize> From<([RegularParamType; N], [ValueType; M]
 mod pointers {
     use super::{HashType, ParamType, RegularParamType};
 
+    /// Pointer type.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
     pub enum Ptr {
         // Const ptrs.
@@ -827,6 +753,7 @@ mod pointers {
         }
     }
 
+    /// Error pointer type.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
     pub enum ErrPtr {
         ErrorCode,

--- a/utils/wasm-instrument/src/tests.rs
+++ b/utils/wasm-instrument/src/tests.rs
@@ -643,8 +643,7 @@ test_gas_counter_injection! {
 
 #[test]
 fn check_memory_array_pointers_definition_correctness() {
-    let syscalls = SyscallName::instrumentable();
-    for syscall in syscalls {
+    for syscall in SyscallName::instrumentable() {
         let signature = syscall.signature();
         let size_param_indexes = signature
             .params()
@@ -662,8 +661,11 @@ fn check_memory_array_pointers_definition_correctness() {
     }
 }
 
-// Basically checks that mutable error pointer is always last in every fallible syscall params set.
-// WARNING: this test must never fail, unless a huge redesign in syscalls signatures has occurred.
+/// Basically checks that mutable error pointer is always last in every fallible
+/// syscall params set.
+///
+/// WARNING: this test must never fail, unless a huge redesign in syscalls
+/// signatures has occurred.
 #[test]
 fn check_syscall_err_ptr_position() {
     for syscall in SyscallName::instrumentable() {

--- a/utils/wasm-instrument/src/tests.rs
+++ b/utils/wasm-instrument/src/tests.rs
@@ -90,7 +90,7 @@ fn duplicate_import() {
             (import "env" "{system_break}" (func))
             (func (result i32)
                 global.get 0
-                memory.grow)
+            )
             (global i32 (i32.const 42))
             (memory 0 1)
             )"#,
@@ -110,7 +110,7 @@ fn duplicate_export() {
         r#"(module
         (func (result i32)
             global.get 0
-            memory.grow)
+        )
         (global (;0;) i32 (i32.const 42))
         (memory 0 1)
         (global (;1;) (mut i32) (i32.const 0))
@@ -127,12 +127,30 @@ fn duplicate_export() {
 
 #[test]
 fn unsupported_instruction() {
+    // floats
     let module = parse_wat(
         r#"(module
         (func (result f64)
             f64.const 10
             f64.const 3
             f64.div)
+        (global i32 (i32.const 42))
+        (memory 0 1)
+        )"#,
+    );
+
+    assert_eq!(
+        inject(module, |_| CustomConstantCostRules::default(), "env"),
+        Err(InstrumentationError::GasInjection)
+    );
+
+    // memory grow
+    let module = parse_wat(
+        r#"(module
+        (func (result i32)
+            global.get 0
+            memory.grow
+        )
         (global i32 (i32.const 42))
         (memory 0 1)
         )"#,


### PR DESCRIPTION
Changes:
```diff
impl SyscallName {
     // removed in favour of `SyscallName::{all, instrumentable}().count()`
-    pub fn count() -> usize { ... }

     // with some code refactoring
-    pub fn instrumentable() -> BTreeSet<Self> { ... }
+    pub fn instrumentable() -> impl Iterator<Item = Self> { ... }

     // not used since wasmi was removed?
-    pub fn to_wgas(self) -> Option<Self> { ... }
}
```

@gear-tech/dev
