### PR TITLE
chore(examples): introduce program creation test in async-tester

### DIFF
--- a/examples/async-tester/src/lib.rs
+++ b/examples/async-tester/src/lib.rs
@@ -22,4 +22,5 @@ pub enum Kind {
     SendCommit,
     SendCommitWithGas(u64),
     CreateProgram(CodeId),
+    CreateProgramWithGas(CodeId, u64),
 }

--- a/examples/async-tester/src/lib.rs
+++ b/examples/async-tester/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+use gstd::CodeId;
 use parity_scale_codec::{Decode, Encode};
 
 #[cfg(feature = "std")]
@@ -20,4 +21,5 @@ pub enum Kind {
     SendBytesWithGas(u64),
     SendCommit,
     SendCommitWithGas(u64),
+    CreateProgram(CodeId),
 }

--- a/examples/async-tester/src/wasm.rs
+++ b/examples/async-tester/src/wasm.rs
@@ -54,7 +54,7 @@ async fn main() {
             ProgramGenerator::create_program_bytes_for_reply(id, b"PING", 0, 0)
                 .expect("create program failed")
                 .await
-                .map(|(p, r)| r)
+                .map(|(_p, r)| r)
         }
     }
     .expect("ran into error-reply");

--- a/examples/async-tester/src/wasm.rs
+++ b/examples/async-tester/src/wasm.rs
@@ -51,10 +51,23 @@ async fn main() {
                 .await
         }
         Kind::CreateProgram(id) => {
-            ProgramGenerator::create_program_bytes_for_reply(id, b"PING", 0, 0)
+            let (_, reply) = ProgramGenerator::create_program_bytes_for_reply(id, b"PING", 0, 0)
                 .expect("create program failed")
                 .await
-                .map(|(_p, r)| r)
+                .expect("Send message failed");
+
+            assert_eq!(reply, b"PONG");
+            Ok(reply)
+        }
+        Kind::CreateProgramWithGas(id, gas) => {
+            let (_, reply) =
+                ProgramGenerator::create_program_bytes_with_gas_for_reply(id, b"PING", gas, 0, 0)
+                    .expect("create program failed")
+                    .await
+                    .expect("Send message failed");
+
+            assert_eq!(reply, b"PONG");
+            Ok(reply)
         }
     }
     .expect("ran into error-reply");

--- a/examples/async-tester/src/wasm.rs
+++ b/examples/async-tester/src/wasm.rs
@@ -2,6 +2,7 @@ use crate::Kind;
 use gstd::{
     msg::{self, MessageHandle},
     prelude::*,
+    prog::ProgramGenerator,
 };
 
 #[no_mangle]
@@ -49,6 +50,10 @@ async fn main() {
                 .expect("send message failed")
                 .await
         }
+        Kind::CreateProgram(id) => ProgramGenerator::create_program_bytes_for_reply(id, b"", 0, 0)
+            .expect("create program failed")
+            .await
+            .map(|(_pid, reply)| reply),
     }
     .expect("ran into error-reply");
 

--- a/examples/async-tester/src/wasm.rs
+++ b/examples/async-tester/src/wasm.rs
@@ -50,10 +50,12 @@ async fn main() {
                 .expect("send message failed")
                 .await
         }
-        Kind::CreateProgram(id) => ProgramGenerator::create_program_bytes_for_reply(id, b"", 0, 0)
-            .expect("create program failed")
-            .await
-            .map(|(_pid, reply)| reply),
+        Kind::CreateProgram(id) => {
+            ProgramGenerator::create_program_bytes_for_reply(id, b"PING", 0, 0)
+                .expect("create program failed")
+                .await
+                .map(|(p, r)| r)
+        }
     }
     .expect("ran into error-reply");
 

--- a/examples/ping/src/wasm.rs
+++ b/examples/ping/src/wasm.rs
@@ -19,6 +19,15 @@
 use gstd::{msg, prelude::*};
 
 #[no_mangle]
+extern "C" fn init() {
+    let payload = msg::load_bytes().expect("Failed to load payload");
+    gstd::debug!("Received payload: {payload:?}");
+    if payload == b"PING" {
+        msg::reply_bytes("PONG", 0).expect("Failed to send reply");
+    }
+}
+
+#[no_mangle]
 extern "C" fn handle() {
     let payload = msg::load_bytes().expect("Failed to load payload");
 

--- a/pallets/gear/Cargo.toml
+++ b/pallets/gear/Cargo.toml
@@ -111,7 +111,7 @@ demo-state-rollback.workspace = true
 demo-async-signal-entry.workspace = true
 demo-async-custom-entry.workspace = true
 demo-out-of-memory.workspace = true
-demo-ping.workspace = true
+demo-ping = { workspace = true, features = ["debug"] }
 demo-sync-duplicate.workspace = true
 demo-custom.workspace = true
 demo-delayed-reservation-sender = { workspace = true, features = ["debug"] }

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -9408,21 +9408,41 @@ fn test_async_program_creation() {
             REPLIER.into()
         ));
 
-        // create program from code id.
+        // 1. create program from code id.
         run_to_next_block(None);
-        let msg = Kind::CreateProgram(code_id.into());
+        let kind = Kind::CreateProgram(code_id.into());
         assert_ok!(Gear::send_message(
             RuntimeOrigin::signed(USER_1),
             pid,
-            msg.encode(),
+            kind.encode(),
             30_000_000_000u64,
             0,
             false,
         ));
 
-        // verify the new created program is active.
+        // verify the new created program has been initialized successfully.
         run_to_next_block(None);
+        let last_mail = get_last_mail(USER_1);
+        assert_eq!(last_mail.payload_bytes(), b"PONG");
         assert_init_success(2);
+
+        // 2. create program from with gas code id.
+        run_to_next_block(None);
+        let kind = Kind::CreateProgramWithGas(code_id.into(), 10_000_000_000u64);
+        assert_ok!(Gear::send_message(
+            RuntimeOrigin::signed(USER_1),
+            pid,
+            kind.encode(),
+            30_000_000_000u64,
+            0,
+            false,
+        ));
+
+        // verify the new created program has been initialized successfully.
+        run_to_next_block(None);
+        let last_mail = get_last_mail(USER_1);
+        assert_eq!(last_mail.payload_bytes(), b"PONG");
+        assert_init_success(3);
     })
 }
 #[test]

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -9402,7 +9402,7 @@ fn test_async_program_creation() {
 
         // upload a replier.
         run_to_next_block(None);
-        let code_id = CodeId::generate(&REPLIER).into_bytes();
+        let code_id = CodeId::generate(REPLIER).into_bytes();
         assert_ok!(Gear::upload_code(
             RuntimeOrigin::signed(USER_1),
             REPLIER.into()

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -9382,6 +9382,7 @@ fn test_async_messages() {
 #[test]
 fn test_async_program_creation() {
     use demo_async_tester::{Kind, WASM_BINARY};
+    use demo_ping::WASM_BINARY as REPLIER;
 
     init_logger();
     new_test_ext().execute_with(|| {
@@ -9399,11 +9400,13 @@ fn test_async_program_creation() {
 
         let pid = utils::get_last_program_id();
 
-        // Upload a template code.
+        // upload a replier.
         run_to_next_block(None);
-        let code = ProgramCodeKind::Default.to_bytes();
-        let code_id = CodeId::generate(&code).into_bytes();
-        assert_ok!(Gear::upload_code(RuntimeOrigin::signed(USER_1), code));
+        let code_id = CodeId::generate(&REPLIER).into_bytes();
+        assert_ok!(Gear::upload_code(
+            RuntimeOrigin::signed(USER_1),
+            REPLIER.into()
+        ));
 
         // create program from code id.
         run_to_next_block(None);
@@ -9416,11 +9419,10 @@ fn test_async_program_creation() {
             0,
             false,
         ));
-        let pid = utils::get_last_program_id();
 
         // verify the new created program is active.
         run_to_next_block(None);
-        assert!(Gear::is_active(pid))
+        assert_init_success(2);
     })
 }
 #[test]


### PR DESCRIPTION
Resolves #3797 

met no problem in this test, everything works

for cases that never continue execution after the lock, imo the reason could be

- invalid arguments
- wrong code id or the target program failed to reply the the creator program

- [x] extend program create in async-tester
- [x] add test to pallet-gear
- [x] pass the test

@gear-tech/dev 
