### PR TITLE
feat(sandbox): Implement LRU cache for Wasmer modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4232,6 +4232,7 @@ dependencies = [
  "sp-wasm-interface-common",
  "tempfile",
  "thiserror",
+ "uluru",
  "wasmer",
  "wasmer-cache",
  "wasmer-types",
@@ -13207,6 +13208,15 @@ dependencies = [
  "crunchy",
  "hex",
  "static_assertions",
+]
+
+[[package]]
+name = "uluru"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794a32261a1f5eb6a4462c81b59cec87b5c27d5deea7dd1ac8fc781c41d226db"
+dependencies = [
+ "arrayvec 0.7.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,7 @@ subxt-codegen = "0.32.1"
 syn = "2.0.49"
 thiserror = "1.0.57"
 tokio = { version = "1.36.0" }
+uluru = "3.0.0"
 url = "2.5.0"
 wat = "1.0.83"
 wabt = "0.10.0"

--- a/sandbox/host/Cargo.toml
+++ b/sandbox/host/Cargo.toml
@@ -24,8 +24,8 @@ sp-allocator = { workspace = true, features = ["std"] }
 sp-wasm-interface-common = { workspace = true, features = ["std"] }
 gear-sandbox-env = { workspace = true, features = ["std"] }
 wasmer-cache = { workspace = true, optional = true }
-tempfile = { workspace = true, optional = true }
+tempfile.workspace = true 
 uluru.workspace = true
 
 [features]
-default = ["tempfile", "wasmer-cache"]
+default = ["wasmer-cache"]

--- a/sandbox/host/Cargo.toml
+++ b/sandbox/host/Cargo.toml
@@ -24,7 +24,8 @@ sp-allocator = { workspace = true, features = ["std"] }
 sp-wasm-interface-common = { workspace = true, features = ["std"] }
 gear-sandbox-env = { workspace = true, features = ["std"] }
 wasmer-cache = { workspace = true, optional = true }
-tempfile.workspace = true
+tempfile = { workspace = true, optional = true }
+uluru.workspace = true
 
 [features]
-default = ["wasmer-cache"]
+default = ["tempfile", "wasmer-cache"]

--- a/sandbox/host/Cargo.toml
+++ b/sandbox/host/Cargo.toml
@@ -25,7 +25,7 @@ sp-wasm-interface-common = { workspace = true, features = ["std"] }
 gear-sandbox-env = { workspace = true, features = ["std"] }
 wasmer-cache = { workspace = true, optional = true }
 tempfile.workspace = true 
-uluru.workspace = true
+uluru = { workspace = true, optional = true }
 
 [features]
-default = ["wasmer-cache"]
+default = ["wasmer-cache", "uluru"]

--- a/sandbox/host/src/lib.rs
+++ b/sandbox/host/src/lib.rs
@@ -20,7 +20,6 @@
 
 #![warn(missing_docs)]
 #![deny(unused_crate_dependencies)]
-#![feature(lazy_cell)]
 
 pub mod error;
 pub mod sandbox;

--- a/sandbox/host/src/lib.rs
+++ b/sandbox/host/src/lib.rs
@@ -20,6 +20,7 @@
 
 #![warn(missing_docs)]
 #![deny(unused_crate_dependencies)]
+#![feature(lazy_cell)]
 
 pub mod error;
 pub mod sandbox;

--- a/sandbox/host/src/sandbox/wasmer_backend.rs
+++ b/sandbox/host/src/sandbox/wasmer_backend.rs
@@ -238,13 +238,14 @@ pub fn instantiate(
     #[cfg(not(feature = "wasmer-cache"))]
     let module = {
         let code_hash = Hash::generate(wasm);
-        let modules = CACHED_MODULES.read().expect("CACHED_MODULES write fail");
-        let module = modules.get(&code_hash).or_else(|| {
-            Arc::new(
+        let mut modules = CACHED_MODULES.write().expect("CACHED_MODULES write fail");
+        modules
+            .entry(code_hash)
+            .or_insert(Arc::new(
                 sandbox_wasmer::Module::new(&context.store, wasm)
                     .map_err(|_| InstantiationError::ModuleDecoding)?,
-            )
-        })?;
+            ))
+            .clone()
     };
 
     type Exports = HashMap<String, sandbox_wasmer::Exports>;

--- a/sandbox/host/src/sandbox/wasmer_backend.rs
+++ b/sandbox/host/src/sandbox/wasmer_backend.rs
@@ -25,10 +25,10 @@ use std::{
     sync::{Arc, Mutex, OnceLock},
 };
 
-use sandbox_wasmer::{Exportable, Module, RuntimeError};
-use sandbox_wasmer_types::TrapCode;
 use codec::{Decode, Encode};
 use gear_sandbox_env::{HostError, Instantiate, WasmReturnValue, GLOBAL_NAME_GAS};
+use sandbox_wasmer::{Exportable, Module, RuntimeError};
+use sandbox_wasmer_types::TrapCode;
 use sp_wasm_interface_common::{util, Pointer, ReturnValue, Value, WordSize};
 use uluru::LRUCache;
 

--- a/sandbox/host/src/sandbox/wasmer_backend.rs
+++ b/sandbox/host/src/sandbox/wasmer_backend.rs
@@ -27,11 +27,9 @@ use std::{
 
 use sandbox_wasmer::{Exportable, Module, RuntimeError};
 use sandbox_wasmer_types::TrapCode;
-
 use codec::{Decode, Encode};
 use gear_sandbox_env::{HostError, Instantiate, WasmReturnValue, GLOBAL_NAME_GAS};
 use sp_wasm_interface_common::{util, Pointer, ReturnValue, Value, WordSize};
-
 use uluru::LRUCache;
 
 use crate::{


### PR DESCRIPTION
```rust
type CachedModule = (Vec<u8>, Arc<Module>);

static CACHED_MODULES: OnceLock<Mutex<LRUCache<CachedModule, 1024>>> =
    OnceLock::new();
```
In-memory cache reduces wasmer module access latency by up to 50%.
It also has a small memory footprint (I will do more testing on the testnet) that can be moved to the swap if something goes wrong.
We don't need to rely on the filesystem, now a new temporary directory is created every time, so there is no point in serializing modules to the filesystem, temp сache lifetime is the same as that of the node.
I would remove file caching if in-memory approach doesn't cause any problems.

- LRU cache with 1024 cap.
- BLAKE3 Hash only on cache miss (to store to temp file cache).

`module <- LRU <- file cache <- compile`

benches:

```bash
# instantiate_module_per_kb
./gear-master benchmark pallet --chain=vara-dev --steps=20 --repeat=10 --heap-pages=4096 --pallet=pallet_gear --extrinsic="instantiate_module_per_kb"
Model:
Time ~=    55.35
    + c    1.297
              µs

./gear-master-lru-hash benchmark pallet --chain=vara-dev --steps=20 --repeat=10 --heap-pages=4096 --pallet=pallet_gear --extrinsic="instantiate_module_per_kb"
Model:
Time ~=    33.42
    + c     0.76
              µs

# avoid BLAKE3 hash on cache hit
./gear-master-lru-wasm benchmark pallet --chain=vara-dev --steps=20 --repeat=10 --heap-pages=4096 --pallet=pallet_gear --extrinsic="instantiate_module_per_kb"
Model:
Time ~=    29.95
    + c    0.111
              µs
```

@gear-tech/dev 
