### PR TITLE
chore!(workspace): Bump versions and dump gas price

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "actor-system-error"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derive_more",
 ]
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "calc-stack-height"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "crates-io"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -3664,14 +3664,14 @@ dependencies = [
 
 [[package]]
 name = "galloc"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "gear-dlmalloc",
 ]
 
 [[package]]
 name = "gcli"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "gclient"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "gcore"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "galloc",
  "gear-core-errors",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "gear-authorship"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "demo-constructor",
  "env_logger",
@@ -3838,7 +3838,7 @@ dependencies = [
 
 [[package]]
 name = "gear-cli"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "clap 4.5.1",
  "frame-benchmarking",
@@ -3870,7 +3870,7 @@ dependencies = [
 
 [[package]]
 name = "gear-common"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derive_more",
  "enum-iterator 1.5.0",
@@ -3895,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "gear-common-codegen"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "quote",
  "syn 2.0.49",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "gear-core"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -3929,7 +3929,7 @@ dependencies = [
 
 [[package]]
 name = "gear-core-backend"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "actor-system-error",
  "blake2-rfc",
@@ -3947,7 +3947,7 @@ dependencies = [
 
 [[package]]
 name = "gear-core-errors"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derive_more",
  "enum-iterator 1.5.0",
@@ -3957,7 +3957,7 @@ dependencies = [
 
 [[package]]
 name = "gear-core-processor"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "actor-system-error",
  "derive_more",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "gear-key-finder"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "directories 5.0.1",
  "hex",
@@ -3997,7 +3997,7 @@ dependencies = [
 
 [[package]]
 name = "gear-lazy-pages"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "cfg-if",
  "derive_more",
@@ -4017,7 +4017,7 @@ dependencies = [
 
 [[package]]
 name = "gear-lazy-pages-common"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "gear-core",
  "num_enum",
@@ -4026,7 +4026,7 @@ dependencies = [
 
 [[package]]
 name = "gear-lazy-pages-interface"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "byteorder",
  "gear-common",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "gear-node-loader"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "clap 4.5.1",
@@ -4067,7 +4067,7 @@ dependencies = [
 
 [[package]]
 name = "gear-node-testing"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4146,7 +4146,7 @@ dependencies = [
 
 [[package]]
 name = "gear-runtime-common"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "gear-runtime-interface"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "byteorder",
  "gear-core",
@@ -4189,7 +4189,7 @@ dependencies = [
 
 [[package]]
 name = "gear-runtime-primitives"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "gear-sandbox"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "assert_matches",
  "gear-runtime-interface",
@@ -4213,7 +4213,7 @@ dependencies = [
 
 [[package]]
 name = "gear-sandbox-env"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "parity-scale-codec",
  "sp-debug-derive",
@@ -4223,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "gear-sandbox-host"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "environmental",
  "gear-sandbox-env",
@@ -4241,7 +4241,7 @@ dependencies = [
 
 [[package]]
 name = "gear-service"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -4318,14 +4318,14 @@ dependencies = [
 
 [[package]]
 name = "gear-stack-buffer"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "gear-utils"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "env_logger",
  "gear-core",
@@ -4361,7 +4361,7 @@ checksum = "bbfbfa701dc65e683fcd2fb24f046bcef22634acbdf47ad14724637dc39ad05b"
 
 [[package]]
 name = "gear-wasm-builder"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "gear-wasm-instrument"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derive_more",
  "enum-iterator 1.5.0",
@@ -4564,7 +4564,7 @@ dependencies = [
 
 [[package]]
 name = "gmeta"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "blake2-rfc",
  "derive_more",
@@ -4578,7 +4578,7 @@ dependencies = [
 
 [[package]]
 name = "gmeta-codegen"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "gmeta",
  "gstd",
@@ -4591,7 +4591,7 @@ dependencies = [
 
 [[package]]
 name = "gring"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -4624,7 +4624,7 @@ dependencies = [
 
 [[package]]
 name = "gsdk"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -4678,7 +4678,7 @@ dependencies = [
 
 [[package]]
 name = "gsdk-codegen"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4687,7 +4687,7 @@ dependencies = [
 
 [[package]]
 name = "gstd"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "arrayvec 0.7.4",
  "bs58 0.5.0",
@@ -4707,7 +4707,7 @@ dependencies = [
 
 [[package]]
 name = "gstd-codegen"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "gstd",
  "proc-macro2",
@@ -4718,11 +4718,11 @@ dependencies = [
 
 [[package]]
 name = "gsys"
-version = "1.1.2"
+version = "1.2.0"
 
 [[package]]
 name = "gtest"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "colored",
  "demo-custom",
@@ -7022,7 +7022,7 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "numerated"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derive_more",
  "env_logger",
@@ -7352,7 +7352,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "blake2-rfc",
  "demo-async",
@@ -7451,7 +7451,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-bank"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7469,7 +7469,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-builtin"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "demo-waiting-proxy",
  "derive_more",
@@ -7507,7 +7507,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-builtin-rpc"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "jsonrpsee 0.16.3",
  "pallet-gear-builtin-rpc-runtime-api",
@@ -7519,7 +7519,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-builtin-rpc-runtime-api"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7527,7 +7527,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-debug"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "demo-vec",
  "env_logger",
@@ -7562,7 +7562,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-gas"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "env_logger",
  "frame-benchmarking",
@@ -7590,7 +7590,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-messenger"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "env_logger",
  "frame-benchmarking",
@@ -7615,7 +7615,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-payment"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "env_logger",
  "frame-benchmarking",
@@ -7648,7 +7648,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-proc-macro"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7657,7 +7657,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-program"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7681,7 +7681,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-rpc"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "gear-common",
  "gear-core",
@@ -7697,7 +7697,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-rpc-runtime-api"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "pallet-gear",
  "sp-api",
@@ -7708,7 +7708,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-scheduler"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "env_logger",
  "frame-benchmarking",
@@ -7739,7 +7739,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-staking-rewards"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "env_logger",
  "frame-benchmarking",
@@ -7774,7 +7774,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-staking-rewards-rpc"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "jsonrpsee 0.16.3",
  "pallet-gear-staking-rewards-rpc-runtime-api",
@@ -7785,7 +7785,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-staking-rewards-rpc-runtime-api"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "pallet-gear-staking-rewards",
  "sp-api",
@@ -7793,7 +7793,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-gear-voucher"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derive_more",
  "env_logger",
@@ -13308,7 +13308,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vara-runtime"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "const-str",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.1.2"
+version = "1.2.0"
 authors = ["Gear Technologies"]
 edition = "2021"
 license = "GPL-3.0"

--- a/gcli/tests/cmd/claim.rs
+++ b/gcli/tests/cmd/claim.rs
@@ -23,7 +23,7 @@ use crate::common::{
 };
 use gsdk::Api;
 
-const REWARD_PER_BLOCK: u128 = 75_000; // 3_000 gas * 25 value per gas
+const REWARD_PER_BLOCK: u128 = 18_000; // 3_000 gas * 6 value per gas
 
 #[tokio::test]
 async fn test_command_claim_works() -> Result<()> {

--- a/gtest/src/lib.rs
+++ b/gtest/src/lib.rs
@@ -459,7 +459,7 @@ pub mod constants {
     /// requirement.
     pub const EXISTENTIAL_DEPOSIT: Value = 10 * UNITS;
     /// Value per gas.
-    pub const VALUE_PER_GAS: Value = 25;
+    pub const VALUE_PER_GAS: Value = 6;
     /// Duration of one block in msecs.
     pub const BLOCK_DURATION_IN_MSECS: u64 = 3000;
     /// Duration of one epoch.

--- a/pallets/gear-bank/src/mock.rs
+++ b/pallets/gear-bank/src/mock.rs
@@ -52,7 +52,7 @@ mod consts {
 
     pub const EXISTENTIAL_DEPOSIT: Balance = 100_000;
 
-    pub const VALUE_PER_GAS: Balance = 25;
+    pub const VALUE_PER_GAS: Balance = 6;
 }
 
 pub use consts::*;

--- a/pallets/gear-bank/src/tests.rs
+++ b/pallets/gear-bank/src/tests.rs
@@ -277,7 +277,7 @@ fn withdraw_gas_small_amount() {
 #[test]
 fn withdraw_gas_small_amount_user_account_deleted() {
     new_test_ext().execute_with(|| {
-        const GAS_VALUE_AMOUNT: Balance = EXISTENTIAL_DEPOSIT - VALUE_PER_GAS;
+        const GAS_VALUE_AMOUNT: Balance = (EXISTENTIAL_DEPOSIT - 1) / VALUE_PER_GAS * VALUE_PER_GAS;
         assert!(GAS_VALUE_AMOUNT < CurrencyOf::<Test>::minimum_balance());
 
         const GAS_AMOUNT: u64 = (GAS_VALUE_AMOUNT / VALUE_PER_GAS) as u64;
@@ -523,7 +523,7 @@ fn spend_gas_small_amount() {
 #[test]
 fn spend_gas_small_amount_validator_account_deleted() {
     new_test_ext().execute_with(|| {
-        const GAS_VALUE_AMOUNT: Balance = EXISTENTIAL_DEPOSIT - VALUE_PER_GAS;
+        const GAS_VALUE_AMOUNT: Balance = (EXISTENTIAL_DEPOSIT - 1) / VALUE_PER_GAS * VALUE_PER_GAS;
         assert!(GAS_VALUE_AMOUNT < CurrencyOf::<Test>::minimum_balance());
 
         const GAS_AMOUNT: u64 = (GAS_VALUE_AMOUNT / VALUE_PER_GAS) as u64;

--- a/pallets/gear/src/schedule.rs
+++ b/pallets/gear/src/schedule.rs
@@ -776,7 +776,7 @@ impl Default for Limits {
 impl<T: Config> Default for InstructionWeights<T> {
     fn default() -> Self {
         Self {
-            version: 1110,
+            version: 1200,
             i64const: cost_instr!(instr_i64const, 1),
             i64load: cost_instr!(instr_i64load, 0),
             i32load: cost_instr!(instr_i32load, 0),

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -73,7 +73,7 @@ parameter_types! {
     pub const BlockHashCount: BlockNumber = 2400;
 }
 
-pub const VALUE_PER_GAS: u128 = 25;
+pub const VALUE_PER_GAS: u128 = 6;
 
 pub type NegativeImbalance<T> = <pallet_balances::Pallet<T> as Currency<
     <T as frame_system::Config>::AccountId,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -157,7 +157,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 1120,
+    spec_version: 1200,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/vara/src/migrations.rs
+++ b/runtime/vara/src/migrations.rs
@@ -20,7 +20,8 @@ use crate::*;
 
 /// All migrations that will run on the next runtime upgrade.
 pub type Migrations = (
-    // not yet executed
+    /* release v1.2.0 */
+    // migration for stored contexts
     pallet_gear_messenger::migrations::MigrateToV3<Runtime>,
     // check for existence of the rent pool account
     pallet_gear_staking_rewards::migrations::CheckRentPoolId<Runtime>,


### PR DESCRIPTION
Schedule version bump is required to force reinstrumentation due to changes from #3733  