### PR TITLE
chore(wasm-builder): Test features tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4374,6 +4374,7 @@ dependencies = [
  "gmeta",
  "log",
  "once_cell",
+ "parity-wasm",
  "pathdiff",
  "regex",
  "thiserror",

--- a/utils/wasm-builder/Cargo.toml
+++ b/utils/wasm-builder/Cargo.toml
@@ -31,6 +31,7 @@ regex.workspace = true
 [dev-dependencies]
 wabt.workspace = true
 wasmi = { workspace = true, features = ["std"] }
+parity-wasm.workspace = true
 
 [features]
 metawasm = ["gmeta/codegen"]

--- a/utils/wasm-builder/src/lib.rs
+++ b/utils/wasm-builder/src/lib.rs
@@ -103,7 +103,10 @@ impl WasmBuilder {
 
     /// Build the program and produce an output WASM binary.
     pub fn build(self) {
-        if env::var("__GEAR_WASM_BUILDER_NO_BUILD").is_ok() {
+        if env::var("__GEAR_WASM_BUILDER_NO_BUILD").is_ok()
+            || env::var("SKIP_WASM_BUILD").is_ok()
+            || is_intellij_sync()
+        {
             self.wasm_project.provide_dummy_wasm_binary_if_not_exist();
             return;
         }
@@ -223,6 +226,13 @@ impl Default for WasmBuilder {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn is_intellij_sync() -> bool {
+    // Intellij Rust uses rustc wrapper during project sync
+    env::var("RUSTC_WRAPPER")
+        .unwrap_or_default()
+        .contains("intellij")
 }
 
 // The `std` feature is excluded by default because it is usually used for

--- a/utils/wasm-builder/test-program/Cargo.toml
+++ b/utils/wasm-builder/test-program/Cargo.toml
@@ -15,3 +15,7 @@ gear-wasm-builder = { path = ".." }
 
 # To exclude this project from the outer workspace
 [workspace]
+
+[features]
+a = []
+b = []

--- a/utils/wasm-builder/test-program/src/lib.rs
+++ b/utils/wasm-builder/test-program/src/lib.rs
@@ -4,6 +4,14 @@ include!("rebuild_test.rs");
 
 use gstd::{debug, msg};
 
+#[cfg(feature = "a")]
+#[no_mangle]
+extern "C" fn handle_reply() {}
+
+#[cfg(feature = "b")]
+#[no_mangle]
+extern "C" fn handle_signal() {}
+
 #[no_mangle]
 extern "C" fn handle() {
     debug!("handle()");
@@ -29,12 +37,7 @@ mod gtest_tests {
         let this_program = Program::current(&system);
 
         let res = this_program.send_bytes(123, "INIT");
-        assert!(res.contains(
-            &Log::builder()
-                .source(1)
-                .dest(123)
-                .payload_bytes([])
-        ));
+        assert!(res.contains(&Log::builder().source(1).dest(123).payload_bytes([])));
 
         let res = this_program.send_bytes(123, "Hi");
         assert!(res.contains(

--- a/utils/wasm-builder/tests/smoke.rs
+++ b/utils/wasm-builder/tests/smoke.rs
@@ -146,7 +146,7 @@ fn features_tracking() {
 
     CargoRunner::new().args(["build", "--features=a"]).run();
     assert!(read_export_entry("handle_reply").is_some());
-
+    assert!(read_export_entry("handle_signal").is_none());
     CargoRunner::new().args(["build", "--features=b"]).run();
     assert!(read_export_entry("handle_signal").is_some());
 }

--- a/utils/wasm-builder/tests/smoke.rs
+++ b/utils/wasm-builder/tests/smoke.rs
@@ -149,4 +149,5 @@ fn features_tracking() {
     assert!(read_export_entry("handle_signal").is_none());
     CargoRunner::new().args(["build", "--features=b"]).run();
     assert!(read_export_entry("handle_signal").is_some());
+    assert!(read_export_entry("handle_reply").is_none());
 }


### PR DESCRIPTION
Also skip WASM compilation during Intellij project sync because Intellij itself cannot yet.

Actually this was attempt to get rid of constant build script re-run :/

Idea was to use `CARGO_FEATURE_*` environment variables listing (`cargo_metadata`) and tracking (`cargo:rerun-if-env-changed`) [but](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-env-changed):
> Note that the environment variables here are intended for global environment variables like CC and such, it is not possible to use this for environment variables like TARGET that [Cargo sets for build scripts](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts). The environment variables in use are those received by cargo invocations, not those received by the executable of the build script.