### PR TITLE
fix(node): Do not take SKIP_WASM_BUILD into account

### DIFF
--- a/utils/wasm-builder/src/lib.rs
+++ b/utils/wasm-builder/src/lib.rs
@@ -104,7 +104,6 @@ impl WasmBuilder {
     /// Build the program and produce an output WASM binary.
     pub fn build(self) {
         if env::var("__GEAR_WASM_BUILDER_NO_BUILD").is_ok()
-            || env::var("SKIP_WASM_BUILD").is_ok()
             || is_intellij_sync()
         {
             self.wasm_project.provide_dummy_wasm_binary_if_not_exist();

--- a/utils/wasm-builder/src/lib.rs
+++ b/utils/wasm-builder/src/lib.rs
@@ -103,9 +103,7 @@ impl WasmBuilder {
 
     /// Build the program and produce an output WASM binary.
     pub fn build(self) {
-        if env::var("__GEAR_WASM_BUILDER_NO_BUILD").is_ok()
-            || is_intellij_sync()
-        {
+        if env::var("__GEAR_WASM_BUILDER_NO_BUILD").is_ok() || is_intellij_sync() {
             self.wasm_project.provide_dummy_wasm_binary_if_not_exist();
             return;
         }


### PR DESCRIPTION
Accepting the env variable produces a tiny regression in benchmarks:
1. https://github.com/gear-tech/gear/actions/runs/8376284584/job/22935648871
2. https://github.com/gear-tech/gear/actions/runs/8368060285/job/22911543652
3. https://github.com/gear-tech/gear/actions/runs/8381856918/job/22954349120

@gear-tech/dev 
