### PR TITLE
feat(runtime): Add a builtin actor for staking operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4262,6 +4262,7 @@ name = "gbuiltin-staking"
 version = "1.4.2"
 dependencies = [
  "derive_more",
+ "gprimitives",
  "scale-info",
 ]
 
@@ -8308,6 +8309,7 @@ dependencies = [
  "gear-core-errors",
  "gear-core-processor",
  "gear-runtime-interface",
+ "gprimitives",
  "hex-literal",
  "impl-trait-for-tuples",
  "log",
@@ -14302,6 +14304,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
+ "gbuiltin-staking",
  "gear-common",
  "gear-core-processor",
  "gear-lazy-pages-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8331,6 +8331,7 @@ dependencies = [
  "sp-externalities",
  "sp-io",
  "sp-runtime",
+ "sp-staking",
  "sp-std 8.0.0 (git+https://github.com/gear-tech/polkadot-sdk.git?branch=gear-v1.3.0)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,6 +2812,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "demo-staking-broker"
+version = "0.1.0"
+dependencies = [
+ "gbuiltin-staking",
+ "gear-wasm-builder",
+ "gstd",
+ "hashbrown 0.14.5",
+ "hex",
+ "hex-literal",
+ "parity-scale-codec",
+]
+
+[[package]]
 name = "demo-state-rollback"
 version = "0.1.0"
 dependencies = [
@@ -4242,6 +4255,14 @@ dependencies = [
  "ark-serialize",
  "derive_more",
  "parity-scale-codec",
+]
+
+[[package]]
+name = "gbuiltin-staking"
+version = "1.4.2"
+dependencies = [
+ "derive_more",
+ "scale-info",
 ]
 
 [[package]]
@@ -8270,15 +8291,18 @@ dependencies = [
  "ark-scale 0.0.12",
  "ark-serialize",
  "ark-std",
+ "demo-staking-broker",
  "demo-waiting-proxy",
  "derive_more",
  "env_logger",
  "frame-benchmarking",
+ "frame-election-provider-support",
  "frame-executive",
  "frame-support",
  "frame-support-test",
  "frame-system",
  "gbuiltin-bls381",
+ "gbuiltin-staking",
  "gear-common",
  "gear-core",
  "gear-core-errors",
@@ -8295,6 +8319,8 @@ dependencies = [
  "pallet-gear-messenger",
  "pallet-gear-program",
  "pallet-gear-scheduler",
+ "pallet-session",
+ "pallet-staking",
  "pallet-timestamp",
  "parity-scale-codec",
  "primitive-types",
@@ -8555,7 +8581,6 @@ dependencies = [
  "gear-common",
  "log",
  "pallet-authorship",
- "pallet-bags-list",
  "pallet-balances",
  "pallet-election-provider-multi-phase",
  "pallet-session",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ members = [
     "examples/wat",
     "galloc",
     "gbuiltins/bls381",
+    "gbuiltins/staking",
     "gcli",
     "gclient",
     "gcore",
@@ -202,6 +203,7 @@ common = { package = "gear-common", path = "common", default-features = false }
 core-processor = { package = "gear-core-processor", path = "core-processor", default-features = false }
 galloc = { path = "galloc" }
 gbuiltin-bls381 = { path = "gbuiltins/bls381", default-features = false }
+gbuiltin-staking = { path = "gbuiltins/staking" }
 gcore = { path = "gcore" }
 gcli = { path = "gcli" }
 gclient = { path = "gclient" }
@@ -443,6 +445,7 @@ demo-reserve-gas = { path = "examples/reserve-gas", default-features = false }
 demo-rwlock = { path = "examples/rwlock" }
 demo-send-from-reservation = { path = "examples/send-from-reservation" }
 demo-signal-entry = { path = "examples/signal-entry", default-features = false }
+demo-staking-broker = { path = "examples/staking-broker" }
 demo-state-rollback = { path = "examples/state-rollback" }
 demo-sync-duplicate = { path = "examples/sync-duplicate" }
 demo-vec = { path = "examples/vec" }

--- a/common/src/pallet_tests.rs
+++ b/common/src/pallet_tests.rs
@@ -212,7 +212,12 @@ macro_rules! impl_pallet_staking {
             }
         }
 
-        type X = (AccountId, BlockNumber, pallet_staking::Pallet<Test>, ConstU32<100>);
+        type DataProviderInfo = (
+            AccountId,
+            BlockNumber,
+            pallet_staking::Pallet<Test>,
+            ConstU32<100>,
+        );
 
         #[allow(dead_code)]
         type StakingConfigEraPayout = DummyEraPayout;
@@ -223,9 +228,14 @@ macro_rules! impl_pallet_staking {
         #[allow(dead_code)]
         type StakingConfigNextNewSession = ();
         #[allow(dead_code)]
-        type StakingConfigElectionProvider = frame_election_provider_support::NoElection<X>;
+        type StakingConfigElectionProvider =
+            frame_election_provider_support::NoElection<DataProviderInfo>;
         #[allow(dead_code)]
-        type StakingConfigGenesisElectionProvider = frame_election_provider_support::NoElection<X>;
+        type StakingConfigGenesisElectionProvider =
+            frame_election_provider_support::NoElection<DataProviderInfo>;
+        #[allow(dead_code)]
+        type StakingConfigMaxNominatorRewardedPerValidator =
+            ConstU32<256>;
 
         mod pallet_tests_staking_config_impl {
             use super::*;
@@ -244,7 +254,6 @@ macro_rules! impl_pallet_staking_inner {
             // 8 eras for unbonding
             pub const BondingDuration: u32 = 8;
             pub const SlashDeferDuration: u32 = 7;
-            pub const MaxNominatorRewardedPerValidator: u32 = 256;
             pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
             pub const HistoryDepth: u32 = 84;
             pub const MaxNominations: u32 = 16;
@@ -268,7 +277,7 @@ macro_rules! impl_pallet_staking_inner {
             type SessionInterface = ();
             type EraPayout = StakingConfigEraPayout;
             type NextNewSession = StakingConfigNextNewSession;
-            type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
+            type MaxNominatorRewardedPerValidator = StakingConfigMaxNominatorRewardedPerValidator;
             type OffendingValidatorsThreshold = OffendingValidatorsThreshold;
             type VoterList = pallet_staking::UseNominatorsAndValidatorsMap<Self>;
             type TargetList = pallet_staking::UseValidatorsMap<Self>;
@@ -315,6 +324,12 @@ macro_rules! impl_pallet_staking_inner {
         $runtime:ty, GenesisElectionProvider = $genesis_election_provider:ty $(, $( $rest:tt )*)?
     ) => {
         type StakingConfigGenesisElectionProvider = $genesis_election_provider;
+
+        $crate::impl_pallet_staking_inner!($runtime, $($( $rest )*)?);
+    };
+
+    ($runtime:ty, MaxNominatorRewardedPerValidator = $max_rewarded:ty $(, $( $rest:tt )*)?) => {
+        type StakingConfigMaxNominatorRewardedPerValidator = $max_rewarded;
 
         $crate::impl_pallet_staking_inner!($runtime, $($( $rest )*)?);
     };

--- a/common/src/pallet_tests.rs
+++ b/common/src/pallet_tests.rs
@@ -195,3 +195,127 @@ macro_rules! impl_pallet_authorship_inner {
         $crate::impl_pallet_authorship_inner!($runtime, $($( $rest )*)?);
     };
 }
+
+#[macro_export]
+macro_rules! impl_pallet_staking {
+    ($( $tokens:tt )*) => {
+        #[allow(dead_code)]
+        pub struct DummyEraPayout;
+        impl pallet_staking::EraPayout<u128> for DummyEraPayout {
+            fn era_payout(
+                _total_staked: u128,
+                total_issuance: u128,
+                _era_duration_millis: u64,
+            ) -> (u128, u128) {
+                // At each era have 1% `total_issuance` increase
+                (Permill::from_percent(1) * total_issuance, 0)
+            }
+        }
+
+        type X = (AccountId, BlockNumber, pallet_staking::Pallet<Test>, ConstU32<100>);
+
+        #[allow(dead_code)]
+        type StakingConfigEraPayout = DummyEraPayout;
+        #[allow(dead_code)]
+        type StakingConfigSlash = ();
+        #[allow(dead_code)]
+        type StakingConfigReward = ();
+        #[allow(dead_code)]
+        type StakingConfigNextNewSession = ();
+        #[allow(dead_code)]
+        type StakingConfigElectionProvider = frame_election_provider_support::NoElection<X>;
+        #[allow(dead_code)]
+        type StakingConfigGenesisElectionProvider = frame_election_provider_support::NoElection<X>;
+
+        mod pallet_tests_staking_config_impl {
+            use super::*;
+
+            $crate::impl_pallet_staking_inner!($( $tokens )*);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_pallet_staking_inner {
+    ($runtime:ty$(,)?) => {
+        parameter_types! {
+            // 6 sessions in an era
+            pub const SessionsPerEra: u32 = 6;
+            // 8 eras for unbonding
+            pub const BondingDuration: u32 = 8;
+            pub const SlashDeferDuration: u32 = 7;
+            pub const MaxNominatorRewardedPerValidator: u32 = 256;
+            pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
+            pub const HistoryDepth: u32 = 84;
+            pub const MaxNominations: u32 = 16;
+        }
+
+        impl pallet_staking::Config for Test {
+            type Currency = Balances;
+            type UnixTime = Timestamp;
+            type CurrencyBalance = <Self as pallet_balances::Config>::Balance;
+            type CurrencyToVote = ();
+            type ElectionProvider = StakingConfigElectionProvider;
+            type GenesisElectionProvider = StakingConfigGenesisElectionProvider;
+            type RewardRemainder = ();
+            type RuntimeEvent = RuntimeEvent;
+            type Slash = StakingConfigSlash;
+            type Reward = StakingConfigReward;
+            type SessionsPerEra = SessionsPerEra;
+            type BondingDuration = BondingDuration;
+            type SlashDeferDuration = SlashDeferDuration;
+            type AdminOrigin = frame_system::EnsureRoot<AccountId>;
+            type SessionInterface = ();
+            type EraPayout = StakingConfigEraPayout;
+            type NextNewSession = StakingConfigNextNewSession;
+            type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
+            type OffendingValidatorsThreshold = OffendingValidatorsThreshold;
+            type VoterList = pallet_staking::UseNominatorsAndValidatorsMap<Self>;
+            type TargetList = pallet_staking::UseValidatorsMap<Self>;
+            type NominationsQuota = pallet_staking::FixedNominationsQuota<16>;
+            type MaxUnlockingChunks = ConstU32<32>;
+            type HistoryDepth = HistoryDepth;
+            type EventListeners = ();
+            type WeightInfo = ();
+            type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
+        }
+    };
+
+    ($runtime:ty, EraPayout = $era_payout:ty $(, $( $rest:tt )*)?) => {
+        type StakingConfigEraPayout = $era_payout;
+
+        $crate::impl_pallet_staking_inner!($runtime, $($( $rest )*)?);
+    };
+
+    ($runtime:ty, Slash = $slash:ty $(, $( $rest:tt )*)?) => {
+        type StakingConfigSlash = $slash;
+
+        $crate::impl_pallet_staking_inner!($runtime, $($( $rest )*)?);
+    };
+
+    ($runtime:ty, Reward = $reward:ty $(, $( $rest:tt )*)?) => {
+        type StakingConfigReward = $reward;
+
+        $crate::impl_pallet_staking_inner!($runtime, $($( $rest )*)?);
+    };
+
+    ($runtime:ty, NextNewSession = $next_new_session:ty $(, $( $rest:tt )*)?) => {
+        type StakingConfigNextNewSession = $next_new_session;
+
+        $crate::impl_pallet_staking_inner!($runtime, $($( $rest )*)?);
+    };
+
+    ($runtime:ty, ElectionProvider = $election_provider:ty $(, $( $rest:tt )*)?) => {
+        type StakingConfigElectionProvider = $election_provider;
+
+        $crate::impl_pallet_staking_inner!($runtime, $($( $rest )*)?);
+    };
+
+    (
+        $runtime:ty, GenesisElectionProvider = $genesis_election_provider:ty $(, $( $rest:tt )*)?
+    ) => {
+        type StakingConfigGenesisElectionProvider = $genesis_election_provider;
+
+        $crate::impl_pallet_staking_inner!($runtime, $($( $rest )*)?);
+    };
+}

--- a/common/src/pallet_tests.rs
+++ b/common/src/pallet_tests.rs
@@ -272,7 +272,7 @@ macro_rules! impl_pallet_staking_inner {
             type BondingDuration = BondingDuration;
             type SlashDeferDuration = SlashDeferDuration;
             type AdminOrigin = frame_system::EnsureRoot<AccountId>;
-            type SessionInterface = Self;
+            type SessionInterface = ();
             type EraPayout = StakingConfigEraPayout;
             type NextNewSession = StakingConfigNextNewSession;
             type MaxExposurePageSize = MaxExposurePageSize;

--- a/examples/staking-broker/Cargo.toml
+++ b/examples/staking-broker/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "demo-staking-broker"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+gbuiltin-staking.workspace = true
+gstd.workspace = true
+hashbrown.workspace = true
+hex.workspace = true
+hex-literal.workspace = true
+parity-scale-codec.workspace = true
+
+[build-dependencies]
+gear-wasm-builder.workspace = true
+
+[features]
+debug = ["gstd/debug"]
+std = []
+default = ["std"]

--- a/examples/staking-broker/build.rs
+++ b/examples/staking-broker/build.rs
@@ -1,6 +1,6 @@
 // This file is part of Gear.
 
-// Copyright (C) 2021-2024 Gear Technologies Inc.
+// Copyright (C) 2024 Gear Technologies Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify
@@ -16,9 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! Builtin actor pallet tests.
-
-pub mod bad_builtin_ids;
-pub mod basic;
-pub mod bls381;
-pub mod staking;
+fn main() {
+    gear_wasm_builder::build();
+}

--- a/examples/staking-broker/src/lib.rs
+++ b/examples/staking-broker/src/lib.rs
@@ -1,24 +1,33 @@
 // This file is part of Gear.
-
-// Copyright (C) 2021-2024 Gear Technologies Inc.
+//
+// Copyright (C) 2024 Gear Technologies Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
-
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! Builtin actor pallet tests.
+#![cfg_attr(not(feature = "std"), no_std)]
 
-pub mod bad_builtin_ids;
-pub mod basic;
-pub mod bls381;
-pub mod staking;
+#[cfg(feature = "std")]
+mod code {
+    include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+}
+
+#[cfg(feature = "std")]
+pub use code::WASM_BINARY_OPT as WASM_BINARY;
+
+#[cfg(not(feature = "std"))]
+pub const WASM_BINARY: &[u8] = &[];
+
+#[cfg(not(feature = "std"))]
+pub mod wasm;

--- a/examples/staking-broker/src/wasm.rs
+++ b/examples/staking-broker/src/wasm.rs
@@ -1,0 +1,266 @@
+// This file is part of Gear.
+//
+// Copyright (C) 2024 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+// This is a very basic implementation of a staking broker program for demo purpose only.
+// It accepts users messages and bond, unbond or nominate some validators on their behalf.
+// It is not concerned with some important constraints like unbonding period etc., so a real
+// implementation of a liquid staking contract, for example, would be more complex.
+
+use gbuiltin_staking::*;
+use gstd::{debug, msg, prelude::*, ActorId};
+use hashbrown::HashMap;
+use hex_literal::hex;
+use parity_scale_codec::Encode;
+
+// Staking proxy builtin actor program id (hardcoded for all runtimes)
+const BUILTIN_ADDRESS: ActorId = ActorId::new(hex!(
+    "77f65ef190e11bfecb8fc8970fd3749e94bed66a23ec2f7a3623e785d0816761"
+));
+
+// Runtime AccountId type
+pub type AccountId = [u8; 32];
+
+#[derive(Debug, Default)]
+struct StakingBroker {
+    /// Has bonded any amount yet
+    has_bonded_any: bool,
+    /// Total debit
+    total_debit: u128,
+    /// Registry of bonded deposits
+    bonded: HashMap<ActorId, u128>,
+    /// Reward payee account id
+    reward_account: AccountId,
+}
+
+static mut STATE: Option<StakingBroker> = None;
+
+/// Do the actual message sending and reply handling.
+async fn do_send_message<E: Encode>(payload: E, mut on_success: impl FnMut()) {
+    match msg::send_for_reply(BUILTIN_ADDRESS, payload, 0, 0)
+        .expect("Error sending message")
+        .await
+    {
+        Ok(_) => {
+            debug!("[StakingBroker] Success reply from builtin actor received");
+            on_success();
+            msg::reply_bytes(b"Success", 0).expect("Failed to send reply");
+        }
+        Err(e) => {
+            debug!("[StakingBroker] Error reply from builtin actor received: {e:?}");
+            msg::reply_bytes(b"Error in upstream program", 0).expect("Failed to send reply");
+        }
+    };
+}
+
+impl StakingBroker {
+    /// Add bonded amount for the contract as both stash and controller.
+    async fn bond(&mut self, value: u128, payee: Option<RewardAccount>) {
+        // Prepare a message to the built-in actor
+        // Checking the flag to decide whether to use `Bond` or `BondExtra`
+        // Note: this is not how you'd do it in a real application, given the
+        // Staking pallet `unbonding` logic, but it's enough for the example.
+        let payload = if !self.has_bonded_any {
+            Request::V1(RequestV1::Bond { value, payee })
+        } else {
+            Request::V1(RequestV1::BondExtra { value })
+        };
+        debug!(
+            "[StakingBroker] Sending `bond` message {:?} at broker's state {:?}",
+            payload, self
+        );
+        do_send_message(payload, || {
+            // Update local state to account for value transfer in pallet
+            self.bonded
+                .entry(msg::source())
+                .and_modify(|old| *old += value)
+                .or_insert(value);
+            self.total_debit += value;
+            self.has_bonded_any = true;
+            self.reward_account = match payee {
+                Some(RewardAccount::Program) | None => msg::source().into(),
+                Some(RewardAccount::Custom(account_id)) => account_id,
+            };
+        })
+        .await
+    }
+
+    async fn unbond(&mut self, value: u128) {
+        let source = msg::source();
+
+        // The sender can unbond only so much as they have bonded
+        let value = self.bonded.get(&source).map_or(0, |v| (*v).min(value));
+        if value == 0 {
+            debug!("[StakingBroker::unbond] No bonded amount");
+            msg::reply_bytes(b"No bonded amount", 0).expect("Failed to send reply");
+            return;
+        }
+
+        // Prepare a message to the built-in actor
+        let payload = Request::V1(RequestV1::Unbond { value });
+        debug!(
+            "[StakingBroker] Sending `unbond` message {:?} at broker's state {:?}",
+            payload, self
+        );
+        do_send_message(payload, || {
+            // Update local state
+            if let Some(old) = self.bonded.get_mut(&source) {
+                *old = old.saturating_sub(value);
+            }
+            self.total_debit = self.total_debit.saturating_sub(value);
+        })
+        .await
+    }
+
+    async fn nominate(&mut self, targets: Vec<AccountId>) {
+        // Prepare a message to the built-in actor
+        let payload = Request::V1(RequestV1::Nominate { targets });
+        debug!(
+            "[StakingBroker] Sending `nominate` message {:?} at broker's state {:?}",
+            payload, self
+        );
+        do_send_message(payload, || {}).await
+    }
+
+    async fn chill(&mut self) {
+        // Prepare a message to the built-in actor
+        let payload = Request::V1(RequestV1::Chill {});
+        debug!(
+            "[StakingBroker] Sending `chill` message {:?} at broker's state {:?}",
+            payload, self
+        );
+        do_send_message(payload, || {}).await
+    }
+
+    async fn rebond(&mut self, value: u128) {
+        let source = msg::source();
+
+        // Prepare a message to the built-in actor
+        let payload = Request::V1(RequestV1::Rebond { value });
+        debug!(
+            "[StakingBroker] Sending `rebond` message {:?} at broker's state {:?}",
+            payload, self
+        );
+        do_send_message(payload, || {
+            // Update local state
+            if let Some(old) = self.bonded.get_mut(&source) {
+                *old = old.saturating_add(value);
+            }
+            self.total_debit = self.total_debit.saturating_add(value);
+        })
+        .await
+    }
+
+    async fn withdraw_unbonded(&mut self) {
+        let _sender = msg::source();
+
+        // Prepare a message to the built-in actor
+        let payload = Request::V1(RequestV1::WithdrawUnbonded {
+            num_slashing_spans: 0,
+        });
+        debug!(
+            "[StakingBroker] Sending `withdraw_unbonded` message {:?} at broker's state {:?}",
+            payload, self
+        );
+        do_send_message(payload, || {
+            // TODO: send a part of withdrawn amount to the sender and/or
+            // some other users who requested unbonding earlier
+        })
+        .await
+    }
+
+    async fn set_payee(&mut self, payee: RewardAccount) {
+        // Prepare a message to the built-in actor
+        let payload = Request::V1(RequestV1::SetPayee { payee });
+        debug!(
+            "[StakingBroker] Sending `set_payee` message {:?} at broker's state {:?}",
+            payload, self
+        );
+        do_send_message(payload, || {
+            self.reward_account = match payee {
+                RewardAccount::Program => msg::source().into(),
+                RewardAccount::Custom(account_id) => account_id,
+            }
+        })
+        .await
+    }
+
+    async fn payout_stakers(&mut self, validator_stash: AccountId, era: u32) {
+        // Prepare a message to the built-in actor
+        let payload = Request::V1(RequestV1::PayoutStakers {
+            validator_stash,
+            era,
+        });
+        debug!(
+            "[StakingBroker] Sending `payout_stakers` message {:?} at broker's state {:?}",
+            payload, self
+        );
+        do_send_message(payload, || {
+            // TODO: transfer fraction of rewards to nominators of the `validator_stash`
+        })
+        .await
+    }
+}
+
+#[gstd::async_main]
+async fn main() {
+    let broker = unsafe { STATE.get_or_insert(Default::default()) };
+
+    let payload = msg::load().expect("Expecting a valid payload");
+    match payload {
+        // Handle the V1 staking requests
+        Request::V1(request) => match request {
+            RequestV1::Bond { value, payee } => {
+                broker.bond(msg::value().min(value), payee).await;
+            }
+            RequestV1::BondExtra { value } => {
+                broker.bond(msg::value().min(value), None).await;
+            }
+            RequestV1::Unbond { value } => {
+                broker.unbond(value).await;
+            }
+            RequestV1::WithdrawUnbonded { .. } => {
+                broker.withdraw_unbonded().await;
+            }
+            RequestV1::Nominate { targets } => {
+                broker.nominate(targets).await;
+            }
+            RequestV1::Chill => {
+                broker.chill().await;
+            }
+            RequestV1::PayoutStakers {
+                validator_stash,
+                era,
+            } => {
+                broker.payout_stakers(validator_stash, era).await;
+            }
+            RequestV1::Rebond { value } => {
+                broker.rebond(value).await;
+            }
+            RequestV1::SetPayee { payee } => {
+                broker.set_payee(payee).await;
+            }
+        },
+        // More arms can be added in the future
+    }
+}
+
+#[no_mangle]
+extern "C" fn init() {
+    let sb: StakingBroker = Default::default();
+    unsafe { STATE = Some(sb) };
+}

--- a/gbuiltins/staking/Cargo.toml
+++ b/gbuiltins/staking/Cargo.toml
@@ -9,5 +9,6 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+gprimitives.workspace = true
 derive_more.workspace = true
 scale-info = { workspace = true, features = ["derive"] }

--- a/gbuiltins/staking/Cargo.toml
+++ b/gbuiltins/staking/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "gbuiltin-staking"
+description = "Types and traits to interact with staking builtin actor."
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+derive_more.workspace = true
+scale-info = { workspace = true, features = ["derive"] }

--- a/gbuiltins/staking/src/lib.rs
+++ b/gbuiltins/staking/src/lib.rs
@@ -1,0 +1,128 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2024 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Helper crate defining Gear built-in actors communication protocol.
+//!
+//! This crate defines a set of types that contracts can use to interact
+//! with the so-called "builtin" actors - that is the actors that are defined
+//! for any Gear runtime and provide an API for the applications to build on top
+//! of some blockchain logic like staking, governance, etc.
+
+//! For a builtin actor to process a message, it should be able to decode its
+//! payload into one of the supported message types.
+//!
+//! # Examples
+//!
+//! The following example shows how a contract can send a message to a builtin actor
+//! (specifically, a staking actor) to bond some `value` to self as the controller
+//! so that the contract can later use the staking API to nominate validators.
+//!
+//! ```ignore
+//! use gstd::{msg, ActorId};
+//! use gbuiltins::staking::{Request, RequestV1, RewardAccount};
+//! use parity_scale_codec::Encode;
+//!
+//! const BUILTIN_ADDRESS: ActorId = ActorId::new(hex_literal::hex!(
+//!     "9d765baea1938d17096421e4f881af7dc4ce5c15bb5022f409fc0d6265d97c3a"
+//! ));
+//!
+//! #[gstd::async_main]
+//! async fn main() {
+//!     let value = msg::value();
+//!     let payee: Option<RewardAccount> = None;
+//!     let payload = Request::V1(RequestV1::Bond { value, payee }).encode();
+//!     let _ = msg::send_bytes_for_reply(BUILTIN_ADDRESS, &payload[..], 0, 0)
+//!         .expect("Error sending message")
+//!         .await;
+//! }
+//! # fn main() {}
+//! ```
+//!
+
+#![no_std]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use scale_info::scale::{self, Decode, Encode};
+
+pub type AccountId = [u8; 32];
+
+/// Type that should be used to create a message to the staking built-in actor.
+///
+/// A [partial] mirror of the staking pallet interface. Not all extrinsics
+/// are supported, more can be added as needed for real-world use cases.
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
+#[codec(crate = scale)]
+pub enum Request {
+    /// Version 1 of the staking built-in actor protocol.
+    V1(RequestV1),
+}
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
+#[codec(crate = scale)]
+pub enum RequestV1 {
+    /// Bond up to the `value` from the sender to self as the controller.
+    Bond {
+        value: u128,
+        payee: Option<RewardAccount>,
+    },
+    /// Add up to the `value` to the sender's bonded amount.
+    BondExtra { value: u128 },
+    /// Unbond up to the `value` to allow withdrawal after undonding period.
+    Unbond { value: u128 },
+    /// Withdraw unbonded chunks for which undonding period has elapsed.
+    WithdrawUnbonded { num_slashing_spans: u32 },
+    /// Add sender as a nominator of `targets` or update the existing targets.
+    Nominate { targets: Vec<AccountId> },
+    /// Declare intention to [temporarily] stop nominating while still having funds bonded.
+    Chill,
+    /// Request stakers payout for the given era.
+    PayoutStakers {
+        validator_stash: AccountId,
+        era: u32,
+    },
+    /// Rebond a portion of the sender's stash scheduled to be unlocked.
+    Rebond { value: u128 },
+    /// Set the reward destination.
+    SetPayee { payee: RewardAccount },
+}
+
+/// An account where the rewards should accumulate on.
+///
+/// In order to separate the contract's own balance from the rewards earned by users funds,
+/// a separate account for the rewards can be assigned.
+#[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, Debug)]
+#[codec(crate = scale)]
+pub enum RewardAccount {
+    /// Accumulate the rewards on contract's account derived from its `program_id`.
+    Program,
+    /// Accumulate the rewards on a separate account.
+    Custom(AccountId),
+}
+
+/// Message processing output
+pub type Response = ();
+
+/// Type representing a dispatched Runtime call internal error.
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, derive_more::Display)]
+#[codec(crate = scale)]
+pub enum DispatchErrorReason {
+    #[display(fmt = "Runtime internal error")]
+    RuntimeError,
+}

--- a/gbuiltins/staking/src/lib.rs
+++ b/gbuiltins/staking/src/lib.rs
@@ -59,9 +59,8 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
+use gprimitives::ActorId;
 use scale_info::scale::{self, Decode, Encode};
-
-pub type AccountId = [u8; 32];
 
 /// Type that should be used to create a message to the staking built-in actor.
 ///
@@ -79,14 +78,11 @@ pub enum Request {
     /// Withdraw unbonded chunks for which undonding period has elapsed.
     WithdrawUnbonded { num_slashing_spans: u32 },
     /// Add sender as a nominator of `targets` or update the existing targets.
-    Nominate { targets: Vec<AccountId> },
+    Nominate { targets: Vec<ActorId> },
     /// Declare intention to [temporarily] stop nominating while still having funds bonded.
     Chill,
     /// Request stakers payout for the given era.
-    PayoutStakers {
-        validator_stash: AccountId,
-        era: u32,
-    },
+    PayoutStakers { validator_stash: ActorId, era: u32 },
     /// Rebond a portion of the sender's stash scheduled to be unlocked.
     Rebond { value: u128 },
     /// Set the reward destination.
@@ -105,7 +101,7 @@ pub enum RewardAccount {
     /// without increasing the amount at stake.
     Program,
     /// Pay rewards to a custom account.
-    Custom(AccountId),
+    Custom(ActorId),
     /// Opt for not receiving any rewards at all.
     None,
 }

--- a/gbuiltins/staking/src/lib.rs
+++ b/gbuiltins/staking/src/lib.rs
@@ -38,7 +38,7 @@
 //! use parity_scale_codec::Encode;
 //!
 //! const BUILTIN_ADDRESS: ActorId = ActorId::new(hex_literal::hex!(
-//!     "9d765baea1938d17096421e4f881af7dc4ce5c15bb5022f409fc0d6265d97c3a"
+//!     "77f65ef190e11bfecb8fc8970fd3749e94bed66a23ec2f7a3623e785d0816761"
 //! ));
 //!
 //! #[gstd::async_main]

--- a/pallets/gear-builtin/Cargo.toml
+++ b/pallets/gear-builtin/Cargo.toml
@@ -26,8 +26,10 @@ ark-ec = { workspace = true, optional = true }
 ark-ff = { workspace = true, optional = true }
 ark-std = { workspace = true, optional = true }
 
+common.workspace = true
 core-processor.workspace = true
 gbuiltin-bls381.workspace = true
+gbuiltin-staking.workspace = true
 gear-core.workspace = true
 gear-core-errors.workspace = true
 gear-runtime-interface.workspace = true
@@ -38,15 +40,18 @@ sp-crypto-ec-utils = { workspace = true, features = ["bls12-381"] }
 sp-std.workspace = true
 sp-runtime = { workspace = true, features = ["serde"] }
 pallet-gear.workspace = true
+pallet-staking.workspace = true
 
 [dev-dependencies]
-common = { workspace = true, features = ["std"] }
 demo-waiting-proxy.workspace = true
+demo-staking-broker.workspace = true
 sp-core = { workspace = true, features = ["std"] }
 sp-externalities = { workspace = true, features = ["std"] }
 sp-io = { workspace = true, features = ["std"] }
+frame-election-provider-support = { workspace = true, features = ["std"] }
 pallet-authorship = { workspace = true, features = ["std"] }
 pallet-balances = { workspace = true, features = ["std"] }
+pallet-session = { workspace = true, features = ["std"] }
 pallet-timestamp = { workspace = true, features = ["std"] }
 pallet-gear-bank = { workspace = true, features = ["std"] }
 pallet-gear-gas = { workspace = true, features = ["std"] }
@@ -66,13 +71,15 @@ sha2 = { workspace = true, features = ["std"] }
 [features]
 default = ["std"]
 std = [
+	"common/std",
 	"frame-benchmarking?/std",
 	"frame-support/std",
 	"frame-system/std",
 	"gear-core/std",
 	"gear-runtime-interface/std",
 	"pallet-gear/std",
-	"parity-scale-codec/std",
+	"pallet-staking/std",
+    "parity-scale-codec/std",
 	"scale-info/std",
 	"sp-crypto-ec-utils/std",
 	"sp-runtime/std",
@@ -85,6 +92,7 @@ std = [
 	"ark-std?/std",
 ]
 runtime-benchmarks = [
+	"common/runtime-benchmarks",
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",

--- a/pallets/gear-builtin/Cargo.toml
+++ b/pallets/gear-builtin/Cargo.toml
@@ -45,6 +45,7 @@ pallet-staking.workspace = true
 [dev-dependencies]
 demo-waiting-proxy.workspace = true
 demo-staking-broker.workspace = true
+gprimitives.workspace = true
 sp-core = { workspace = true, features = ["std"] }
 sp-externalities = { workspace = true, features = ["std"] }
 sp-io = { workspace = true, features = ["std"] }

--- a/pallets/gear-builtin/Cargo.toml
+++ b/pallets/gear-builtin/Cargo.toml
@@ -48,6 +48,7 @@ demo-staking-broker.workspace = true
 sp-core = { workspace = true, features = ["std"] }
 sp-externalities = { workspace = true, features = ["std"] }
 sp-io = { workspace = true, features = ["std"] }
+sp-staking = { workspace = true, features = ["std"] }
 frame-election-provider-support = { workspace = true, features = ["std"] }
 pallet-authorship = { workspace = true, features = ["std"] }
 pallet-balances = { workspace = true, features = ["std"] }

--- a/pallets/gear-builtin/Cargo.toml
+++ b/pallets/gear-builtin/Cargo.toml
@@ -81,7 +81,7 @@ std = [
 	"gear-runtime-interface/std",
 	"pallet-gear/std",
 	"pallet-staking/std",
-    "parity-scale-codec/std",
+	"parity-scale-codec/std",
 	"scale-info/std",
 	"sp-crypto-ec-utils/std",
 	"sp-runtime/std",

--- a/pallets/gear-builtin/src/benchmarking.rs
+++ b/pallets/gear-builtin/src/benchmarking.rs
@@ -26,12 +26,10 @@ use ark_ec::{pairing::Pairing, short_weierstrass::SWCurveConfig, Group, ScalarMu
 use ark_ff::biginteger::BigInt;
 use ark_scale::hazmat::ArkScaleProjective;
 use ark_std::{ops::Mul, UniformRand};
-use common::{benchmarking, Origin};
+use common::Origin;
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
-use gbuiltin_staking::*;
 use gear_core::message::MAX_PAYLOAD_SIZE;
 use parity_scale_codec::{Compact, Encode, Input};
-use primitive_types::H256;
 
 type ArkScale<T> = ark_scale::ArkScale<T, { ark_scale::HOST_CALL }>;
 type ScalarField = <G2 as Group>::ScalarField;
@@ -289,24 +287,6 @@ benchmarks! {
         _result = gear_runtime_interface::gear_bls_12_381::map_to_g2affine(&message);
     } verify {
         assert!(ArkScale::<G2Affine>::decode(&mut &_result.unwrap()[..]).is_ok())
-    }
-
-    staking_estimate_decode {
-        let l in 1 .. MAX_PAYLOAD_SIZE as u32;
-
-        // Longest payload corresponds to the `Request::Nominate` variant.
-        // Other variants have negligible payload sizes, thereby require near-zero decoding cost.
-        let num_targets = (l / 32).max(1_u32); // 32 bytes per target, at least 1 target.
-        let mut targets = vec![];
-        for i in 0_u32..num_targets {
-            targets.push(benchmarking::account::<T::AccountId>("target", 0, i).cast::<H256>().into());
-        }
-
-        let encoded_request = Request::Nominate { targets }.encode();
-    }: {
-        let _ = Request::decode(&mut encoded_request.as_slice());
-    } verify {
-        // No changes in runtime are expected since the actual dispatch doesn't take place.
     }
 }
 

--- a/pallets/gear-builtin/src/benchmarking.rs
+++ b/pallets/gear-builtin/src/benchmarking.rs
@@ -294,7 +294,7 @@ benchmarks! {
     staking_estimate_decode {
         let l in 1 .. MAX_PAYLOAD_SIZE as u32;
 
-        // Longest payload corresponds to the `RequestV1::Nominate` variant.
+        // Longest payload corresponds to the `Request::Nominate` variant.
         // Other variants have negligible payload sizes, thereby require near-zero decoding cost.
         let num_targets = (l / 32).max(1_u32); // 32 bytes per target, at least 1 target.
         let mut targets = vec![];
@@ -302,7 +302,7 @@ benchmarks! {
             targets.push(benchmarking::account::<T::AccountId>("target", 0, i).cast::<H256>().into());
         }
 
-        let encoded_request = Request::V1(RequestV1::Nominate { targets }).encode();
+        let encoded_request = Request::Nominate { targets }.encode();
     }: {
         let _ = Request::decode(&mut encoded_request.as_slice());
     } verify {

--- a/pallets/gear-builtin/src/benchmarking.rs
+++ b/pallets/gear-builtin/src/benchmarking.rs
@@ -26,9 +26,12 @@ use ark_ec::{pairing::Pairing, short_weierstrass::SWCurveConfig, Group, ScalarMu
 use ark_ff::biginteger::BigInt;
 use ark_scale::hazmat::ArkScaleProjective;
 use ark_std::{ops::Mul, UniformRand};
+use common::{benchmarking, Origin};
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
+use gbuiltin_staking::*;
 use gear_core::message::MAX_PAYLOAD_SIZE;
 use parity_scale_codec::{Compact, Encode, Input};
+use primitive_types::H256;
 
 type ArkScale<T> = ark_scale::ArkScale<T, { ark_scale::HOST_CALL }>;
 type ScalarField = <G2 as Group>::ScalarField;
@@ -49,6 +52,7 @@ benchmarks! {
     where_clause {
         where
             T: pallet_gear::Config,
+            T::AccountId: Origin,
     }
 
     calculate_id {
@@ -285,6 +289,24 @@ benchmarks! {
         _result = gear_runtime_interface::gear_bls_12_381::map_to_g2affine(&message);
     } verify {
         assert!(ArkScale::<G2Affine>::decode(&mut &_result.unwrap()[..]).is_ok())
+    }
+
+    staking_estimate_decode {
+        let l in 1 .. MAX_PAYLOAD_SIZE as u32;
+
+        // Longest payload corresponds to the `RequestV1::Nominate` variant.
+        // Other variants have negligible payload sizes, thereby require near-zero decoding cost.
+        let num_targets = (l / 32).max(1_u32); // 32 bytes per target, at least 1 target.
+        let mut targets = vec![];
+        for i in 0_u32..num_targets {
+            targets.push(benchmarking::account::<T::AccountId>("target", 0, i).cast::<H256>().into());
+        }
+
+        let encoded_request = Request::V1(RequestV1::Nominate { targets }).encode();
+    }: {
+        let _ = Request::decode(&mut encoded_request.as_slice());
+    } verify {
+        // No changes in runtime are expected since the actual dispatch doesn't take place.
     }
 }
 

--- a/pallets/gear-builtin/src/lib.rs
+++ b/pallets/gear-builtin/src/lib.rs
@@ -35,6 +35,7 @@ extern crate alloc;
 pub mod benchmarking;
 
 pub mod bls12_381;
+pub mod staking;
 pub mod weights;
 
 #[cfg(test)]
@@ -147,8 +148,12 @@ impl<E> BuiltinCollection<E> for Tuple {
 #[frame_support::pallet]
 pub mod pallet {
     use super::*;
-    use frame_support::pallet_prelude::*;
+    use frame_support::{
+        dispatch::{GetDispatchInfo, PostDispatchInfo},
+        pallet_prelude::*,
+    };
     use frame_system::pallet_prelude::*;
+    use sp_runtime::traits::Dispatchable;
 
     pub(crate) const SEED: [u8; 8] = *b"built/in";
 
@@ -158,7 +163,13 @@ pub mod pallet {
     pub struct Pallet<T>(PhantomData<T>);
 
     #[pallet::config]
-    pub trait Config: frame_system::Config {
+    pub trait Config: frame_system::Config + pallet_staking::Config {
+        /// The overarching call type.
+        type RuntimeCall: Parameter
+            + Dispatchable<RuntimeOrigin = Self::RuntimeOrigin, PostInfo = PostDispatchInfo>
+            + GetDispatchInfo
+            + From<pallet_staking::Call<Self>>;
+
         /// The builtin actor type.
         type Builtins: BuiltinCollection<BuiltinActorError>;
 

--- a/pallets/gear-builtin/src/lib.rs
+++ b/pallets/gear-builtin/src/lib.rs
@@ -81,9 +81,6 @@ pub enum BuiltinActorError {
     /// Occurs if the dispatch's message can't be decoded into a known type.
     #[display(fmt = "Failure to decode message")]
     DecodingError,
-    /// Occurs if a message payload size exceeds the maximum possible value.
-    #[display(fmt = "Message payload too large")]
-    PayloadTooLarge,
     /// Actor's inner error encoded as a String.
     #[display(fmt = "Builtin execution resulted in error: {_0}")]
     Custom(LimitedStr<'static>),
@@ -98,9 +95,6 @@ impl From<BuiltinActorError> for ActorExecutionErrorReplyReason {
             }
             BuiltinActorError::DecodingError => ActorExecutionErrorReplyReason::Trap(
                 TrapExplanation::Panic("Message decoding error".to_string().into()),
-            ),
-            BuiltinActorError::PayloadTooLarge => ActorExecutionErrorReplyReason::Trap(
-                TrapExplanation::Panic("Message payload too large".to_string().into()),
             ),
             BuiltinActorError::Custom(e) => {
                 ActorExecutionErrorReplyReason::Trap(TrapExplanation::Panic(e))

--- a/pallets/gear-builtin/src/mock.rs
+++ b/pallets/gear-builtin/src/mock.rs
@@ -31,8 +31,8 @@ use gear_core::{
 };
 use sp_core::H256;
 use sp_runtime::{
-    traits::{BlakeTwo256, IdentityLookup},
-    BuildStorage,
+    traits::{BlakeTwo256, ConstU32, IdentityLookup},
+    BuildStorage, Perbill, Permill,
 };
 use sp_std::convert::{TryFrom, TryInto};
 
@@ -46,7 +46,10 @@ pub(crate) type GasHandlerOf<T> = <<T as pallet_gear::Config>::GasProvider as Ga
 pub(crate) type GasTreeOf<T> = pallet_gear_gas::GasNodes<T>;
 
 pub(crate) const SIGNER: AccountId = 1;
-pub(crate) const BLOCK_AUTHOR: AccountId = 10;
+pub(crate) const VAL_1_STASH: AccountId = 10;
+pub(crate) const VAL_2_STASH: AccountId = 20;
+pub(crate) const VAL_3_STASH: AccountId = 30;
+pub(crate) const BLOCK_AUTHOR: AccountId = VAL_1_STASH;
 
 pub(crate) const EXISTENTIAL_DEPOSIT: u128 = 10 * UNITS;
 pub(crate) const ENDOWMENT: u128 = 1_000 * UNITS;
@@ -75,6 +78,7 @@ construct_runtime!(
         Balances: pallet_balances,
         Authorship: pallet_authorship,
         Timestamp: pallet_timestamp,
+        Staking: pallet_staking,
         GearProgram: pallet_gear_program,
         GearMessenger: pallet_gear_messenger,
         GearScheduler: pallet_gear_scheduler,
@@ -94,6 +98,7 @@ common::impl_pallet_system!(Test);
 common::impl_pallet_balances!(Test);
 common::impl_pallet_authorship!(Test);
 common::impl_pallet_timestamp!(Test);
+common::impl_pallet_staking!(Test);
 
 parameter_types! {
     pub const BlockGasLimit: u64 = 100_000_000_000;
@@ -211,6 +216,7 @@ impl BuiltinActor for HonestBuiltinActor {
 }
 
 impl pallet_gear_builtin::Config for Test {
+    type RuntimeCall = RuntimeCall;
     type Builtins = (
         SuccessBuiltinActor,
         ErrorBuiltinActor,
@@ -223,6 +229,7 @@ impl pallet_gear_builtin::Config for Test {
 // Build genesis storage according to the mock runtime.
 #[derive(Default)]
 pub struct ExtBuilder {
+    initial_authorities: Vec<AccountId>,
     endowed_accounts: Vec<AccountId>,
     endowment: Balance,
 }
@@ -249,6 +256,28 @@ impl ExtBuilder {
                 .iter()
                 .map(|k| (*k, self.endowment))
                 .collect(),
+        }
+        .assimilate_storage(&mut storage)
+        .unwrap();
+
+        pallet_staking::GenesisConfig::<Test> {
+            validator_count: self.initial_authorities.len() as u32,
+            minimum_validator_count: self.initial_authorities.len() as u32,
+            stakers: self
+                .initial_authorities
+                .iter()
+                .map(|x| {
+                    (
+                        *x,
+                        *x,
+                        self.endowment,
+                        pallet_staking::StakerStatus::<AccountId>::Validator,
+                    )
+                })
+                .collect::<Vec<_>>(),
+            invulnerables: self.initial_authorities.to_vec(),
+            slash_reward_fraction: Perbill::from_percent(10),
+            ..Default::default()
         }
         .assimilate_storage(&mut storage)
         .unwrap();

--- a/pallets/gear-builtin/src/mock.rs
+++ b/pallets/gear-builtin/src/mock.rs
@@ -31,7 +31,7 @@ use gear_core::{
 };
 use sp_core::H256;
 use sp_runtime::{
-    traits::{BlakeTwo256, ConstU32, IdentityLookup},
+    traits::{BlakeTwo256, IdentityLookup},
     BuildStorage, Perbill, Permill,
 };
 use sp_std::convert::{TryFrom, TryInto};

--- a/pallets/gear-builtin/src/staking.rs
+++ b/pallets/gear-builtin/src/staking.rs
@@ -161,7 +161,7 @@ where
                 * 11
                 / 10;
         if payload.len() > max_payload_size {
-            return (Err(BuiltinActorError::PayloadTooLarge), 0);
+            return (Err(BuiltinActorError::DecodingError), 0);
         }
 
         // Decode the message payload to derive the desired action

--- a/pallets/gear-builtin/src/staking.rs
+++ b/pallets/gear-builtin/src/staking.rs
@@ -23,19 +23,22 @@ use common::Origin;
 use core::marker::PhantomData;
 use frame_support::dispatch::{extract_actual_weight, GetDispatchInfo};
 use gbuiltin_staking::*;
-use pallet_staking::RewardDestination;
+use pallet_staking::{Config as StakingConfig, NominationsQuota, RewardDestination};
 use parity_scale_codec::Decode;
 use sp_runtime::traits::{Dispatchable, StaticLookup, UniqueSaturatedInto};
 
-pub struct Actor<T: Config>(PhantomData<T>);
+type CallOf<T> = <T as Config>::RuntimeCall;
 
-impl<T: Config> Actor<T>
+pub struct Actor<T: Config + StakingConfig>(PhantomData<T>);
+
+impl<T: Config + StakingConfig> Actor<T>
 where
     T::AccountId: Origin,
+    CallOf<T>: From<pallet_staking::Call<T>>,
 {
     fn dispatch_call(
         origin: T::AccountId,
-        call: <T as Config>::RuntimeCall,
+        call: CallOf<T>,
         gas_limit: u64,
     ) -> (Result<(), BuiltinActorError>, u64) {
         let call_info = call.get_dispatch_info();
@@ -67,11 +70,77 @@ where
             }
         }
     }
+
+    fn cast(request: Request) -> CallOf<T> {
+        match request {
+            Request::Bond { value, payee } => {
+                let payee = match payee {
+                    RewardAccount::Staked => RewardDestination::Staked,
+                    RewardAccount::Program => RewardDestination::Stash,
+                    RewardAccount::Custom(account_id) => {
+                        RewardDestination::Account(account_id.cast())
+                    }
+                    RewardAccount::None => RewardDestination::None,
+                };
+                pallet_staking::Call::<T>::bond {
+                    value: value.unique_saturated_into(),
+                    payee,
+                }
+                .into()
+            }
+            Request::BondExtra { value } => pallet_staking::Call::<T>::bond_extra {
+                max_additional: value.unique_saturated_into(),
+            }
+            .into(),
+            Request::Unbond { value } => pallet_staking::Call::<T>::unbond {
+                value: value.unique_saturated_into(),
+            }
+            .into(),
+            Request::WithdrawUnbonded { num_slashing_spans } => {
+                pallet_staking::Call::<T>::withdraw_unbonded { num_slashing_spans }.into()
+            }
+            Request::Nominate { targets } => pallet_staking::Call::<T>::nominate {
+                targets: targets
+                    .into_iter()
+                    .map(|account_id| T::Lookup::unlookup(account_id.cast()))
+                    .collect(),
+            }
+            .into(),
+            Request::Chill => pallet_staking::Call::<T>::chill {}.into(),
+            Request::PayoutStakers {
+                validator_stash,
+                era,
+            } => {
+                let stash_id = validator_stash.cast();
+                pallet_staking::Call::<T>::payout_stakers {
+                    validator_stash: stash_id,
+                    era,
+                }
+                .into()
+            }
+            Request::Rebond { value } => pallet_staking::Call::<T>::rebond {
+                value: value.unique_saturated_into(),
+            }
+            .into(),
+            Request::SetPayee { payee } => {
+                let payee = match payee {
+                    RewardAccount::Staked => RewardDestination::Staked,
+                    RewardAccount::Program => RewardDestination::Stash,
+                    RewardAccount::Custom(account_id) => {
+                        RewardDestination::Account(account_id.cast())
+                    }
+                    RewardAccount::None => RewardDestination::None,
+                };
+                pallet_staking::Call::<T>::set_payee { payee }.into()
+            }
+        }
+    }
 }
 
-impl<T: Config> BuiltinActor for Actor<T>
+impl<T: Config + StakingConfig> BuiltinActor for Actor<T>
 where
     T::AccountId: Origin,
+    CallOf<T>: From<pallet_staking::Call<T>>,
 {
     const ID: u64 = 2;
 
@@ -82,97 +151,28 @@ where
         let origin: T::AccountId = dispatch.source().cast();
         let mut payload = message.payload_bytes();
 
-        let decoding_cost =
-            <T as Config>::WeightInfo::staking_estimate_decode(payload.len() as u32).ref_time();
+        // Rule out payloads that exceed the largest reasonable size.
+        // The longest payload corresponds to the `Request::Nominate` variant and is capped at
+        // MaxNominatorTargets * 32 bytes + 2 bytes for the length prefix.
+        // Adding extra 10% we can safely assume that any payload exceeding this size is invalid.
+        let max_payload_size =
+            (<T as StakingConfig>::NominationsQuota::get_quota(Default::default()) as usize * 32
+                + 2)
+                * 11
+                / 10;
+        if payload.len() > max_payload_size {
+            return (Err(BuiltinActorError::PayloadTooLarge), 0);
+        }
 
         // Decode the message payload to derive the desired action
-        let (result, gas_spent) = match Request::decode(&mut payload) {
-            Ok(request) => {
-                // Handle staking requests
-                let gas_limit = gas_limit.saturating_sub(decoding_cost);
-                let call = match request {
-                    Request::Bond { value, payee } => {
-                        let payee = match payee {
-                            RewardAccount::Staked => RewardDestination::Staked,
-                            RewardAccount::Program => RewardDestination::Stash,
-                            RewardAccount::Custom(account_id) => {
-                                let dest = ProgramId::try_from(&account_id[..])
-                                    .unwrap_or_else(|_e| unreachable!("32 bytes type; qed"))
-                                    .cast();
-                                RewardDestination::Account(dest)
-                            }
-                            RewardAccount::None => RewardDestination::None,
-                        };
-                        pallet_staking::Call::<T>::bond {
-                            value: value.unique_saturated_into(),
-                            payee,
-                        }
-                        .into()
-                    }
-                    Request::BondExtra { value } => pallet_staking::Call::<T>::bond_extra {
-                        max_additional: value.unique_saturated_into(),
-                    }
-                    .into(),
-                    Request::Unbond { value } => pallet_staking::Call::<T>::unbond {
-                        value: value.unique_saturated_into(),
-                    }
-                    .into(),
-                    Request::WithdrawUnbonded { num_slashing_spans } => {
-                        pallet_staking::Call::<T>::withdraw_unbonded { num_slashing_spans }.into()
-                    }
-                    Request::Nominate { targets } => pallet_staking::Call::<T>::nominate {
-                        targets: targets
-                            .into_iter()
-                            .map(|account_id| {
-                                let origin = ProgramId::try_from(&account_id[..])
-                                    .unwrap_or_else(|_e| unreachable!("32 bytes type; qed"))
-                                    .cast();
-                                T::Lookup::unlookup(origin)
-                            })
-                            .collect(),
-                    }
-                    .into(),
-                    Request::Chill => pallet_staking::Call::<T>::chill {}.into(),
-                    Request::PayoutStakers {
-                        validator_stash,
-                        era,
-                    } => {
-                        let stash_id = ProgramId::try_from(&validator_stash[..])
-                            .unwrap_or_else(|_e| unreachable!("32 bytes type; qed"))
-                            .cast();
-                        pallet_staking::Call::<T>::payout_stakers {
-                            validator_stash: stash_id,
-                            era,
-                        }
-                        .into()
-                    }
-                    Request::Rebond { value } => pallet_staking::Call::<T>::rebond {
-                        value: value.unique_saturated_into(),
-                    }
-                    .into(),
-                    Request::SetPayee { payee } => {
-                        let payee = match payee {
-                            RewardAccount::Staked => RewardDestination::Staked,
-                            RewardAccount::Program => RewardDestination::Stash,
-                            RewardAccount::Custom(account_id) => {
-                                let dest = ProgramId::try_from(&account_id[..])
-                                    .unwrap_or_else(|_e| unreachable!("32 bytes type; qed"))
-                                    .cast();
-                                RewardDestination::Account(dest)
-                            }
-                            RewardAccount::None => RewardDestination::None,
-                        };
-                        pallet_staking::Call::<T>::set_payee { payee }.into()
-                    }
-                };
-                Self::dispatch_call(origin, call, gas_limit)
-            }
-            _ => (Err(BuiltinActorError::DecodingError), Default::default()),
+        let Ok(request) = Request::decode(&mut payload) else {
+            return (Err(BuiltinActorError::DecodingError), 0);
         };
 
-        (
-            result.map(|_| Default::default()),
-            gas_spent.saturating_add(decoding_cost),
-        )
+        // Handle staking requests
+        let call = Self::cast(request);
+        let (result, gas_spent) = Self::dispatch_call(origin, call, gas_limit);
+
+        (result.map(|_| Default::default()), gas_spent)
     }
 }

--- a/pallets/gear-builtin/src/tests/bad_builtin_ids.rs
+++ b/pallets/gear-builtin/src/tests/bad_builtin_ids.rs
@@ -29,7 +29,7 @@ use gear_core::{
 };
 use sp_core::H256;
 use sp_runtime::{
-    traits::{BlakeTwo256, ConstU32, IdentityLookup},
+    traits::{BlakeTwo256, IdentityLookup},
     BuildStorage, Perbill, Permill,
 };
 use sp_std::convert::{TryFrom, TryInto};

--- a/pallets/gear-builtin/src/tests/bad_builtin_ids.rs
+++ b/pallets/gear-builtin/src/tests/bad_builtin_ids.rs
@@ -29,8 +29,8 @@ use gear_core::{
 };
 use sp_core::H256;
 use sp_runtime::{
-    traits::{BlakeTwo256, IdentityLookup},
-    BuildStorage,
+    traits::{BlakeTwo256, ConstU32, IdentityLookup},
+    BuildStorage, Perbill, Permill,
 };
 use sp_std::convert::{TryFrom, TryInto};
 
@@ -47,6 +47,7 @@ construct_runtime!(
         Balances: pallet_balances,
         Authorship: pallet_authorship,
         Timestamp: pallet_timestamp,
+        Staking: pallet_staking,
         GearProgram: pallet_gear_program,
         GearMessenger: pallet_gear_messenger,
         GearScheduler: pallet_gear_scheduler,
@@ -66,6 +67,7 @@ common::impl_pallet_system!(Test);
 common::impl_pallet_balances!(Test);
 common::impl_pallet_authorship!(Test);
 common::impl_pallet_timestamp!(Test);
+common::impl_pallet_staking!(Test);
 
 parameter_types! {
     pub const BlockGasLimit: u64 = 100_000_000_000;
@@ -159,6 +161,7 @@ impl BuiltinActor for DuplicateBuiltinActor {
 }
 
 impl pallet_gear_builtin::Config for Test {
+    type RuntimeCall = RuntimeCall;
     type Builtins = (
         FirstBuiltinActor,
         SecondBuiltinActor,

--- a/pallets/gear-builtin/src/tests/staking.rs
+++ b/pallets/gear-builtin/src/tests/staking.rs
@@ -1,0 +1,868 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2024 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    self as pallet_gear_builtin,
+    mock::{
+        BLOCK_AUTHOR, ENDOWMENT, EXISTENTIAL_DEPOSIT, MILLISECS_PER_BLOCK, SIGNER, UNITS,
+        VAL_1_STASH, VAL_2_STASH, VAL_3_STASH,
+    },
+    staking::Actor as StakingBuiltin,
+};
+use common::Origin;
+use demo_staking_broker::WASM_BINARY;
+use frame_support::{
+    assert_ok, construct_runtime, parameter_types,
+    traits::{ConstBool, ConstU64, FindAuthor, OnFinalize, OnInitialize},
+};
+use frame_support_test::TestRandomness;
+use frame_system::{self as system, pallet_prelude::BlockNumberFor};
+use gbuiltin_staking::*;
+use gear_core::ids::{CodeId, ProgramId};
+use pallet_session::historical::{self as pallet_session_historical};
+use parity_scale_codec::Encode;
+use sp_core::{crypto::key_types, H256};
+use sp_runtime::{
+    testing::UintAuthorityId,
+    traits::{BlakeTwo256, ConstU32, IdentityLookup, OpaqueKeys},
+    BuildStorage, KeyTypeId, Perbill, Permill,
+};
+use sp_std::convert::{TryFrom, TryInto};
+
+pub(crate) const SESSION_DURATION: u64 = 250;
+pub(crate) const REWARD_PAYEE: AccountId = 2;
+pub(crate) const VAL_1_AUTH_ID: UintAuthorityId = UintAuthorityId(11);
+pub(crate) const VAL_2_AUTH_ID: UintAuthorityId = UintAuthorityId(21);
+pub(crate) const VAL_3_AUTH_ID: UintAuthorityId = UintAuthorityId(31);
+
+type AccountId = u64;
+type BlockNumber = u64;
+type Balance = u128;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+// Configure a mock runtime to test the pallet.
+construct_runtime!(
+    pub enum Test
+    {
+        System: system,
+        Balances: pallet_balances,
+        Authorship: pallet_authorship,
+        Timestamp: pallet_timestamp,
+        Session: pallet_session,
+        Historical: pallet_session_historical,
+        Staking: pallet_staking,
+        GearProgram: pallet_gear_program,
+        GearMessenger: pallet_gear_messenger,
+        GearScheduler: pallet_gear_scheduler,
+        GearBank: pallet_gear_bank,
+        Gear: pallet_gear,
+        GearGas: pallet_gear_gas,
+        GearBuiltin: pallet_gear_builtin,
+    }
+);
+
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub const ExistentialDeposit: Balance = EXISTENTIAL_DEPOSIT;
+}
+
+common::impl_pallet_system!(Test);
+common::impl_pallet_balances!(Test);
+common::impl_pallet_authorship!(Test);
+common::impl_pallet_timestamp!(Test);
+common::impl_pallet_staking!(Test, NextNewSession = Session);
+
+parameter_types! {
+    pub const BlockGasLimit: u64 = 100_000_000_000;
+    pub const OutgoingLimit: u32 = 1024;
+    pub const OutgoingBytesLimit: u32 = 64 * 1024 * 1024;
+    pub ReserveThreshold: BlockNumber = 1;
+    pub GearSchedule: pallet_gear::Schedule<Test> = <pallet_gear::Schedule<Test>>::default();
+    pub RentFreePeriod: BlockNumber = 12_000;
+    pub RentCostPerBlock: Balance = 11;
+    pub ResumeMinimalPeriod: BlockNumber = 100;
+    pub ResumeSessionDuration: BlockNumber = 1_000;
+    pub const PerformanceMultiplier: u32 = 100;
+    pub const BankAddress: AccountId = 15082001;
+    pub const GasMultiplier: common::GasMultiplier<Balance, u64> = common::GasMultiplier::ValuePerGas(25);
+}
+
+pub struct TestSessionHandler;
+impl pallet_session::SessionHandler<AccountId> for TestSessionHandler {
+    const KEY_TYPE_IDS: &'static [KeyTypeId] = &[key_types::DUMMY];
+
+    fn on_new_session<Ks: OpaqueKeys>(
+        _changed: bool,
+        _validators: &[(AccountId, Ks)],
+        _queued_validators: &[(AccountId, Ks)],
+    ) {
+    }
+
+    fn on_disabled(_validator_index: u32) {}
+
+    fn on_genesis_session<Ks: OpaqueKeys>(_validators: &[(AccountId, Ks)]) {}
+}
+
+parameter_types! {
+    pub const Period: u64 = SESSION_DURATION;
+    pub const Offset: u64 = SESSION_DURATION + 1;
+}
+
+impl pallet_session::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+    type ValidatorId = AccountId;
+    type ValidatorIdOf = pallet_staking::StashOf<Self>;
+    type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
+    type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+    type SessionManager = pallet_session_historical::NoteHistoricalRoot<Self, Staking>;
+    type SessionHandler = TestSessionHandler;
+    type Keys = UintAuthorityId;
+    type WeightInfo = ();
+}
+
+impl pallet_session_historical::Config for Test {
+    type FullIdentification = pallet_staking::Exposure<AccountId, u128>;
+    type FullIdentificationOf = pallet_staking::ExposureOf<Test>;
+}
+
+pallet_gear_bank::impl_config!(Test);
+pallet_gear_gas::impl_config!(Test);
+pallet_gear_scheduler::impl_config!(Test);
+pallet_gear_program::impl_config!(Test);
+pallet_gear_messenger::impl_config!(Test, CurrentBlockNumber = Gear);
+pallet_gear::impl_config!(
+    Test,
+    Schedule = GearSchedule,
+    BuiltinDispatcherFactory = GearBuiltin,
+);
+
+impl pallet_gear_builtin::Config for Test {
+    type RuntimeCall = RuntimeCall;
+    type Builtins = (StakingBuiltin<Self>,);
+    type WeightInfo = ();
+}
+
+// Build genesis storage according to the mock runtime.
+#[derive(Default)]
+pub struct ExtBuilder {
+    initial_authorities: Vec<(AccountId, UintAuthorityId)>,
+    endowed_accounts: Vec<AccountId>,
+    endowment: Balance,
+}
+
+impl ExtBuilder {
+    pub fn endowment(mut self, e: Balance) -> Self {
+        self.endowment = e;
+        self
+    }
+
+    pub fn endowed_accounts(mut self, accounts: Vec<AccountId>) -> Self {
+        self.endowed_accounts = accounts;
+        self
+    }
+
+    pub fn initial_authorities(mut self, authorities: Vec<(AccountId, UintAuthorityId)>) -> Self {
+        self.initial_authorities = authorities;
+        self
+    }
+
+    pub fn build(self) -> sp_io::TestExternalities {
+        let mut storage = system::GenesisConfig::<Test>::default()
+            .build_storage()
+            .unwrap();
+
+        pallet_balances::GenesisConfig::<Test> {
+            balances: self
+                .initial_authorities
+                .iter()
+                .map(|x| (x.0, self.endowment))
+                .chain(self.endowed_accounts.iter().map(|k| (*k, self.endowment)))
+                .collect(),
+        }
+        .assimilate_storage(&mut storage)
+        .unwrap();
+
+        pallet_session::GenesisConfig::<Test> {
+            keys: self
+                .initial_authorities
+                .iter()
+                .map(|x| (x.0, x.0, x.1.clone()))
+                .collect(),
+        }
+        .assimilate_storage(&mut storage)
+        .unwrap();
+
+        pallet_staking::GenesisConfig::<Test> {
+            validator_count: self.initial_authorities.len() as u32,
+            minimum_validator_count: self.initial_authorities.len() as u32,
+            stakers: self
+                .initial_authorities
+                .iter()
+                .map(|x| {
+                    (
+                        x.0,
+                        x.0,
+                        self.endowment,
+                        pallet_staking::StakerStatus::<AccountId>::Validator,
+                    )
+                })
+                .collect::<Vec<_>>(),
+            invulnerables: self.initial_authorities.iter().map(|x| x.0).collect(),
+            slash_reward_fraction: Perbill::from_percent(10),
+            ..Default::default()
+        }
+        .assimilate_storage(&mut storage)
+        .unwrap();
+
+        let mut ext: sp_io::TestExternalities = storage.into();
+
+        ext.execute_with(|| {
+            let new_blk = 1;
+            System::set_block_number(new_blk);
+            on_initialize(new_blk);
+        });
+        ext
+    }
+}
+
+pub(crate) fn run_to_next_block() {
+    run_for_n_blocks(1)
+}
+
+pub(crate) fn run_for_n_blocks(n: u64) {
+    let now = System::block_number();
+    let until = now + n;
+    for current_blk in now..until {
+        Gear::run(frame_support::dispatch::RawOrigin::None.into(), None).unwrap();
+        on_finalize(current_blk);
+
+        let new_block_number = current_blk + 1;
+        System::set_block_number(new_block_number);
+        on_initialize(new_block_number);
+    }
+}
+
+// Run on_initialize hooks in order as they appear in AllPalletsWithSystem.
+pub(crate) fn on_initialize(new_block_number: BlockNumberFor<Test>) {
+    Timestamp::set_timestamp(new_block_number.saturating_mul(MILLISECS_PER_BLOCK));
+    Authorship::on_initialize(new_block_number);
+    GearGas::on_initialize(new_block_number);
+    GearMessenger::on_initialize(new_block_number);
+    Gear::on_initialize(new_block_number);
+}
+
+// Run on_finalize hooks (in pallets reverse order, as they appear in AllPalletsWithSystem)
+pub(crate) fn on_finalize(current_blk: BlockNumberFor<Test>) {
+    Authorship::on_finalize(current_blk);
+    Gear::on_finalize(current_blk);
+    assert!(!System::events().iter().any(|e| {
+        matches!(
+            e.event,
+            RuntimeEvent::Gear(pallet_gear::Event::QueueNotProcessed)
+        )
+    }))
+}
+
+pub(crate) fn gas_price(gas: u64) -> u128 {
+    <Test as pallet_gear_bank::Config>::GasMultiplier::get().gas_to_value(gas)
+}
+
+pub(crate) fn start_transaction() {
+    sp_externalities::with_externalities(|ext| ext.storage_start_transaction())
+        .expect("externalities should exists");
+}
+
+pub(crate) fn rollback_transaction() {
+    sp_externalities::with_externalities(|ext| {
+        ext.storage_rollback_transaction()
+            .expect("ongoing transaction must be there");
+    })
+    .expect("externalities should be set");
+}
+
+pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
+    let bank_address = <Test as pallet_gear_bank::Config>::BankAddress::get();
+
+    ExtBuilder::default()
+        .initial_authorities(vec![
+            (VAL_1_STASH, VAL_1_AUTH_ID),
+            (VAL_2_STASH, VAL_2_AUTH_ID),
+            (VAL_3_STASH, VAL_3_AUTH_ID),
+        ])
+        .endowment(ENDOWMENT)
+        .endowed_accounts(vec![bank_address, SIGNER, REWARD_PAYEE])
+        .build()
+}
+
+pub(crate) fn init_logger() {
+    let _ = env_logger::Builder::from_default_env()
+        .format_module_path(false)
+        .format_level(true)
+        .try_init();
+}
+
+fn deploy_broker_contract() {
+    assert_ok!(Gear::upload_program(
+        RuntimeOrigin::signed(SIGNER),
+        WASM_BINARY.to_vec(),
+        b"contract".to_vec(),
+        Default::default(),
+        10_000_000_000,
+        EXISTENTIAL_DEPOSIT, // keep the contract's account "providing"
+        false,
+    ));
+}
+
+fn send_bond_message(contract_id: ProgramId, amount: Balance, payee: Option<RewardAccount>) {
+    assert_ok!(Gear::send_message(
+        RuntimeOrigin::signed(SIGNER),
+        contract_id,
+        Request::V1(RequestV1::Bond {
+            value: amount,
+            payee
+        })
+        .encode(),
+        10_000_000_000,
+        amount,
+        false,
+    ));
+}
+
+#[derive(PartialEq)]
+enum EventType {
+    Bonded,
+    Unbonded,
+    Withdrawn,
+}
+
+fn assert_staking_events(contract_id: AccountId, balance: Balance, t: EventType) {
+    assert!(System::events().into_iter().any(|e| {
+        match e.event {
+            RuntimeEvent::Staking(pallet_staking::Event::<Test>::Bonded { stash, amount }) => {
+                t == EventType::Bonded && stash == contract_id && balance == amount
+            }
+            RuntimeEvent::Staking(pallet_staking::Event::<Test>::Unbonded { stash, amount }) => {
+                t == EventType::Unbonded && stash == contract_id && balance == amount
+            }
+            RuntimeEvent::Staking(pallet_staking::Event::<Test>::Withdrawn { stash, amount }) => {
+                t == EventType::Withdrawn && stash == contract_id && balance == amount
+            }
+            _ => false,
+        }
+    }))
+}
+
+#[test]
+fn bonding_works() {
+    init_logger();
+
+    new_test_ext().execute_with(|| {
+        let contract_id = ProgramId::generate_from_user(CodeId::generate(WASM_BINARY), b"contract");
+        let contract_account_id = AccountId::from_origin(contract_id.into_origin());
+
+        deploy_broker_contract();
+        run_to_next_block();
+
+        let signer_current_balance_at_blk_1 = Balances::free_balance(SIGNER);
+
+        // Measure necessary gas in a transaction
+        let gas_info = |bonded: u128, value: Option<u128>| {
+            start_transaction();
+            let res = Gear::calculate_gas_info(
+                SIGNER.into_origin(),
+                pallet_gear::manager::HandleKind::Handle(contract_id),
+                Request::V1(RequestV1::Bond {
+                    value: bonded,
+                    payee: None,
+                })
+                .encode(),
+                value.unwrap_or(bonded),
+                true,
+                None,
+                None,
+            )
+            .expect("calculate_gas_info failed");
+            rollback_transaction();
+            res
+        };
+        let gas_burned = gas_info(100 * UNITS, None).burned;
+
+        // Ensure the state hasn't changed
+        assert_eq!(
+            Balances::free_balance(SIGNER),
+            signer_current_balance_at_blk_1
+        );
+
+        // Asserting success
+        send_bond_message(contract_id, 100 * UNITS, None);
+        run_to_next_block();
+
+        let signer_current_balance_at_blk_2 = Balances::free_balance(SIGNER);
+        let contract_account_data = System::account(contract_account_id).data;
+
+        // SIGNER has spent in current block:
+        // - 100 UNITS sent as value to the contract
+        // - paid for the burned gas
+        assert_eq!(
+            signer_current_balance_at_blk_2,
+            signer_current_balance_at_blk_1 - 100 * UNITS - gas_price(gas_burned)
+        );
+
+        // The contract's account has the same 10 * UNITS of free balance (the ED)
+        assert_eq!(contract_account_data.free, 110 * UNITS);
+        // and 100 * UNITS of it is frozen as bonded
+        assert_eq!(contract_account_data.frozen, 100 * UNITS);
+
+        // Asserting the expected events are present
+        assert_staking_events(contract_account_id, 100 * UNITS, EventType::Bonded);
+
+        System::reset_events();
+
+        // Measure necessary gas again as underlying runtime call should be different this time:
+        // - `bond_extra` instead of `bond`
+        let gas_burned = gas_info(50 * UNITS, Some(100 * UNITS)).burned;
+
+        // Asserting success again (the contract should be able to figure out that `bond_extra`
+        // should be called instead).
+        // Note: the actual added amount is limited by the message `value` field, that is
+        // it's going to be 50 UNITS, not 100 UNITS as encoded in the message payload.
+        assert_ok!(Gear::send_message(
+            RuntimeOrigin::signed(SIGNER),
+            contract_id,
+            Request::V1(RequestV1::Bond {
+                value: 50 * UNITS,
+                payee: None
+            })
+            .encode(),
+            10_000_000_000,
+            100 * UNITS,
+            false,
+        ));
+
+        run_to_next_block();
+
+        // SIGNER has spent since last time:
+        // - 50 UNITS sent as value to the contract
+        // - paid for gas
+        assert_eq!(
+            Balances::free_balance(SIGNER),
+            signer_current_balance_at_blk_2 - 100 * UNITS - gas_price(gas_burned)
+        );
+        // Another 50 * UNITS added to locked balance
+        assert_eq!(
+            System::account(contract_account_id).data.frozen,
+            150 * UNITS
+        );
+
+        // Asserting the expected events are present
+        assert_staking_events(contract_account_id, 50 * UNITS, EventType::Bonded);
+    });
+}
+
+#[test]
+fn unbonding_works() {
+    init_logger();
+
+    new_test_ext().execute_with(|| {
+        let contract_id = ProgramId::generate_from_user(CodeId::generate(WASM_BINARY), b"contract");
+        let contract_account_id = AccountId::from_origin(contract_id.into_origin());
+
+        deploy_broker_contract();
+        run_to_next_block();
+
+        send_bond_message(contract_id, 100 * UNITS, None);
+        run_to_next_block();
+
+        // Asserting the expected events are present
+        assert_staking_events(contract_account_id, 100 * UNITS, EventType::Bonded);
+
+        System::reset_events();
+
+        // Measure necessary gas in a transaction for `unbond` message
+        start_transaction();
+        let _gas_info = Gear::calculate_gas_info(
+            SIGNER.into_origin(),
+            pallet_gear::manager::HandleKind::Handle(contract_id),
+            Request::V1(RequestV1::Unbond { value: 200 * UNITS }).encode(),
+            0,
+            true,
+            None,
+            None,
+        )
+        .expect("calculate_gas_info failed");
+        rollback_transaction();
+
+        // Sending `unbond` message
+        assert_ok!(Gear::send_message(
+            RuntimeOrigin::signed(SIGNER),
+            contract_id,
+            // expecting to unbond only 100 UNITS despite 200 UNITS are being requested
+            Request::V1(RequestV1::Unbond { value: 200 * UNITS }).encode(),
+            10_000_000_000,
+            0,
+            false,
+        ));
+
+        run_to_next_block();
+
+        // Asserting the expected events are present
+        assert_staking_events(contract_account_id, 100 * UNITS, EventType::Unbonded);
+    });
+}
+
+#[test]
+fn nominating_works() {
+    init_logger();
+
+    new_test_ext().execute_with(|| {
+        let contract_id = ProgramId::generate_from_user(CodeId::generate(WASM_BINARY), b"contract");
+        let contract_account_id = AccountId::from_origin(contract_id.into_origin());
+
+        deploy_broker_contract();
+        run_to_next_block();
+
+        let targets: Vec<[u8; 32]> = vec![VAL_1_STASH, VAL_2_STASH]
+            .into_iter()
+            .map(|x| x.into_origin().into())
+            .collect();
+
+        // Doesn't work without bonding first
+        assert_ok!(Gear::send_message(
+            RuntimeOrigin::signed(SIGNER),
+            contract_id,
+            Request::V1(RequestV1::Nominate {
+                targets: targets.clone()
+            })
+            .encode(),
+            10_000_000_000,
+            0,
+            false,
+        ));
+
+        run_to_next_block();
+
+        System::reset_events();
+
+        send_bond_message(contract_id, 100 * UNITS, None);
+        run_to_next_block();
+        assert_staking_events(contract_account_id, 100 * UNITS, EventType::Bonded);
+
+        let targets_before = pallet_staking::Nominators::<Test>::get(contract_account_id)
+            .map_or_else(Vec::new, |x| x.targets.into_inner());
+        assert_eq!(targets_before.len(), 0);
+
+        // Now expecting nominating to work
+        assert_ok!(Gear::send_message(
+            RuntimeOrigin::signed(SIGNER),
+            contract_id,
+            Request::V1(RequestV1::Nominate {
+                targets: targets.clone()
+            })
+            .encode(),
+            10_000_000_000,
+            0,
+            false,
+        ));
+
+        run_to_next_block();
+
+        let targets_after = pallet_staking::Nominators::<Test>::get(contract_account_id)
+            .map_or_else(Vec::new, |x| x.targets.into_inner());
+        assert_eq!(targets_after.len(), targets.len());
+    });
+}
+
+#[test]
+fn withdraw_unbonded_works() {
+    init_logger();
+
+    new_test_ext().execute_with(|| {
+        let contract_id = ProgramId::generate_from_user(CodeId::generate(WASM_BINARY), b"contract");
+        let contract_account_id = AccountId::from_origin(contract_id.into_origin());
+
+        deploy_broker_contract();
+        run_to_next_block();
+
+        send_bond_message(contract_id, 500 * UNITS, None);
+        run_to_next_block();
+        assert_staking_events(contract_account_id, 500 * UNITS, EventType::Bonded);
+
+        let contract_account_data = System::account(contract_account_id).data;
+
+        // Locked 500 * UNITS as bonded on contracts's account
+        assert_eq!(contract_account_data.frozen, 500 * UNITS);
+
+        System::reset_events();
+
+        // Sending `unbond` message
+        assert_ok!(Gear::send_message(
+            RuntimeOrigin::signed(SIGNER),
+            contract_id,
+            Request::V1(RequestV1::Unbond { value: 200 * UNITS }).encode(),
+            10_000_000_000,
+            0,
+            false,
+        ));
+
+        run_to_next_block();
+        assert_staking_events(contract_account_id, 200 * UNITS, EventType::Unbonded);
+
+        // The funds are still locked
+        assert_eq!(
+            System::account(contract_account_id).data.frozen,
+            500 * UNITS
+        );
+
+        // Pretend we have run the chain for at least the `unbonding period` number of eras
+        pallet_staking::CurrentEra::<Test>::put(
+            <Test as pallet_staking::Config>::BondingDuration::get() + 1_u32,
+        );
+
+        // Sending `withdraw_unbonded` message
+        assert_ok!(Gear::send_message(
+            RuntimeOrigin::signed(SIGNER),
+            contract_id,
+            Request::V1(RequestV1::WithdrawUnbonded {
+                num_slashing_spans: 0
+            })
+            .encode(),
+            10_000_000_000,
+            0,
+            false,
+        ));
+
+        run_to_next_block();
+
+        // 200 * UNITS have been released, 300 * UNITS remain locked
+        assert_eq!(
+            System::account(contract_account_id).data.frozen,
+            300 * UNITS
+        );
+        assert_staking_events(contract_account_id, 200 * UNITS, EventType::Withdrawn);
+        let ledger = pallet_staking::Pallet::<Test>::ledger(contract_account_id).unwrap();
+        assert_eq!(ledger.active, 300 * UNITS);
+    });
+}
+
+#[test]
+fn set_payee_works() {
+    init_logger();
+
+    new_test_ext().execute_with(|| {
+        let contract_id = ProgramId::generate_from_user(CodeId::generate(WASM_BINARY), b"contract");
+        let contract_account_id = AccountId::from_origin(contract_id.into_origin());
+
+        deploy_broker_contract();
+        run_to_next_block();
+
+        // Bond funds with the `payee`` set to contract's stash (default)
+        send_bond_message(contract_id, 100 * UNITS, None);
+        run_to_next_block();
+        assert_staking_events(contract_account_id, 100 * UNITS, EventType::Bonded);
+
+        // Assert the `payee` is set to contract's stash
+        let payee = pallet_staking::Pallet::<Test>::payee(contract_account_id);
+        assert_eq!(payee, pallet_staking::RewardDestination::Stash);
+
+        // Set the `payee` to SIGNER
+        assert_ok!(Gear::send_message(
+            RuntimeOrigin::signed(SIGNER),
+            contract_id,
+            Request::V1(RequestV1::SetPayee {
+                payee: RewardAccount::Custom(REWARD_PAYEE.into_origin().into())
+            })
+            .encode(),
+            10_000_000_000,
+            0,
+            false,
+        ));
+
+        run_to_next_block();
+
+        // Assert the `payee` is now set to SIGNER
+        let payee = pallet_staking::Pallet::<Test>::payee(contract_account_id);
+        assert_eq!(
+            payee,
+            pallet_staking::RewardDestination::Account(REWARD_PAYEE)
+        );
+    });
+}
+
+#[test]
+fn rebond_works() {
+    init_logger();
+
+    new_test_ext().execute_with(|| {
+        let contract_id = ProgramId::generate_from_user(CodeId::generate(WASM_BINARY), b"contract");
+        let contract_account_id = AccountId::from_origin(contract_id.into_origin());
+
+        deploy_broker_contract();
+        run_to_next_block();
+
+        send_bond_message(contract_id, 500 * UNITS, None);
+        run_to_next_block();
+        assert_staking_events(contract_account_id, 500 * UNITS, EventType::Bonded);
+
+        let contract_account_data = System::account(contract_account_id).data;
+
+        // Locked 500 * UNITS as bonded on contracts's account
+        assert_eq!(contract_account_data.frozen, 500 * UNITS);
+
+        System::reset_events();
+
+        // Sending `unbond` message
+        assert_ok!(Gear::send_message(
+            RuntimeOrigin::signed(SIGNER),
+            contract_id,
+            Request::V1(RequestV1::Unbond { value: 400 * UNITS }).encode(),
+            10_000_000_000,
+            0,
+            false,
+        ));
+
+        run_to_next_block();
+        assert_staking_events(contract_account_id, 400 * UNITS, EventType::Unbonded);
+
+        // All the bonded funds are still locked
+        assert_eq!(
+            System::account(contract_account_id).data.frozen,
+            500 * UNITS
+        );
+
+        // However, the ledger has been updated
+        let ledger = pallet_staking::Pallet::<Test>::ledger(contract_account_id).unwrap();
+        assert_eq!(ledger.active, 100 * UNITS);
+        assert_eq!(ledger.unlocking.len(), 1);
+
+        // Sending `rebond` message
+        assert_ok!(Gear::send_message(
+            RuntimeOrigin::signed(SIGNER),
+            contract_id,
+            Request::V1(RequestV1::Rebond { value: 200 * UNITS }).encode(),
+            10_000_000_000,
+            0,
+            false,
+        ));
+
+        run_to_next_block();
+
+        // All the bonded funds are still locked
+        assert_eq!(
+            System::account(contract_account_id).data.frozen,
+            500 * UNITS
+        );
+
+        // However, the ledger has been updated again
+        let ledger = pallet_staking::Pallet::<Test>::ledger(contract_account_id).unwrap();
+        assert_eq!(ledger.active, 300 * UNITS);
+        assert_eq!(ledger.unlocking.len(), 1);
+
+        // Sending another `rebond` message, with `value` exceeding the unlocking amount
+        assert_ok!(Gear::send_message(
+            RuntimeOrigin::signed(SIGNER),
+            contract_id,
+            Request::V1(RequestV1::Rebond { value: 300 * UNITS }).encode(),
+            10_000_000_000,
+            0,
+            false,
+        ));
+
+        run_to_next_block();
+
+        // All the bonded funds are still locked
+        assert_eq!(
+            System::account(contract_account_id).data.frozen,
+            500 * UNITS
+        );
+
+        // The ledger has been updated again, however, the rebonded amount was limited
+        // by the actual unlocking amount - not the `value` sent in the message.
+        let ledger = pallet_staking::Pallet::<Test>::ledger(contract_account_id).unwrap();
+        assert_eq!(ledger.active, 500 * UNITS);
+        assert_eq!(ledger.unlocking.len(), 0);
+    });
+}
+
+#[test]
+fn payout_stakers_works() {
+    init_logger();
+
+    new_test_ext().execute_with(|| {
+        let contract_id = ProgramId::generate_from_user(CodeId::generate(WASM_BINARY), b"contract");
+        let contract_account_id = AccountId::from_origin(contract_id.into_origin());
+
+        deploy_broker_contract();
+        run_to_next_block();
+
+        // Only nominating one target
+        let targets: Vec<[u8; 32]> = vec![VAL_1_STASH.into_origin().into()];
+
+        send_bond_message(
+            contract_id,
+            800 * UNITS,
+            Some(RewardAccount::Custom(REWARD_PAYEE.into_origin().into())),
+        );
+        run_to_next_block();
+        assert_staking_events(contract_account_id, 800 * UNITS, EventType::Bonded);
+
+        // Nomintate the validator
+        assert_ok!(Gear::send_message(
+            RuntimeOrigin::signed(SIGNER),
+            contract_id,
+            Request::V1(RequestV1::Nominate {
+                targets: targets.clone()
+            })
+            .encode(),
+            10_000_000_000,
+            0,
+            false,
+        ));
+
+        run_to_next_block();
+
+        let targets = pallet_staking::Nominators::<Test>::get(contract_account_id)
+            .unwrap()
+            .targets
+            .into_inner();
+        assert_eq!(targets, vec![VAL_1_STASH]);
+
+        let rewards_payee_initial_balance = Balances::free_balance(REWARD_PAYEE);
+        assert_eq!(rewards_payee_initial_balance, ENDOWMENT);
+
+        // Run the chain for a few eras (5) to accumulate some rewards
+        run_for_n_blocks(
+            5 * SESSION_DURATION * <Test as pallet_staking::Config>::SessionsPerEra::get() as u64,
+        );
+
+        // Send `payout_stakers` message for an era for which the rewards should have been earned
+        assert_ok!(Gear::send_message(
+            RuntimeOrigin::signed(SIGNER),
+            contract_id,
+            Request::V1(RequestV1::PayoutStakers {
+                validator_stash: VAL_1_STASH.into_origin().into(),
+                era: 4
+            })
+            .encode(),
+            10_000_000_000,
+            0,
+            false,
+        ));
+
+        run_to_next_block();
+    });
+}

--- a/pallets/gear-builtin/src/tests/staking.rs
+++ b/pallets/gear-builtin/src/tests/staking.rs
@@ -18,8 +18,8 @@
 
 use frame_support::assert_ok;
 
-use util::*;
 use sp_staking::StakingAccount;
+use util::*;
 
 #[test]
 fn bonding_works() {
@@ -314,7 +314,9 @@ fn withdraw_unbonded_works() {
             300 * UNITS
         );
         assert_staking_events(contract_account_id, 200 * UNITS, EventType::Withdrawn);
-        let ledger = pallet_staking::Pallet::<Test>::ledger(StakingAccount::Stash(contract_account_id)).unwrap();
+        let ledger =
+            pallet_staking::Pallet::<Test>::ledger(StakingAccount::Stash(contract_account_id))
+                .unwrap();
         assert_eq!(ledger.active, 300 * UNITS);
     });
 }
@@ -336,7 +338,8 @@ fn set_payee_works() {
         assert_staking_events(contract_account_id, 100 * UNITS, EventType::Bonded);
 
         // Assert the `payee` is set to contract's stash
-        let payee = pallet_staking::Pallet::<Test>::payee(StakingAccount::Stash(contract_account_id));
+        let payee =
+            pallet_staking::Pallet::<Test>::payee(StakingAccount::Stash(contract_account_id));
         assert_eq!(payee, pallet_staking::RewardDestination::Stash);
 
         // Set the `payee` to SIGNER
@@ -355,7 +358,8 @@ fn set_payee_works() {
         run_to_next_block();
 
         // Assert the `payee` is now set to SIGNER
-        let payee = pallet_staking::Pallet::<Test>::payee(StakingAccount::Stash(contract_account_id));
+        let payee =
+            pallet_staking::Pallet::<Test>::payee(StakingAccount::Stash(contract_account_id));
         assert_eq!(
             payee,
             pallet_staking::RewardDestination::Account(REWARD_PAYEE)
@@ -405,7 +409,9 @@ fn rebond_works() {
         );
 
         // However, the ledger has been updated
-        let ledger = pallet_staking::Pallet::<Test>::ledger(StakingAccount::Stash(contract_account_id)).unwrap();
+        let ledger =
+            pallet_staking::Pallet::<Test>::ledger(StakingAccount::Stash(contract_account_id))
+                .unwrap();
         assert_eq!(ledger.active, 100 * UNITS);
         assert_eq!(ledger.unlocking.len(), 1);
 
@@ -428,7 +434,9 @@ fn rebond_works() {
         );
 
         // However, the ledger has been updated again
-        let ledger = pallet_staking::Pallet::<Test>::ledger(StakingAccount::Stash(contract_account_id)).unwrap();
+        let ledger =
+            pallet_staking::Pallet::<Test>::ledger(StakingAccount::Stash(contract_account_id))
+                .unwrap();
         assert_eq!(ledger.active, 300 * UNITS);
         assert_eq!(ledger.unlocking.len(), 1);
 
@@ -452,7 +460,9 @@ fn rebond_works() {
 
         // The ledger has been updated again, however, the rebonded amount was limited
         // by the actual unlocking amount - not the `value` sent in the message.
-        let ledger = pallet_staking::Pallet::<Test>::ledger(StakingAccount::Stash(contract_account_id)).unwrap();
+        let ledger =
+            pallet_staking::Pallet::<Test>::ledger(StakingAccount::Stash(contract_account_id))
+                .unwrap();
         assert_eq!(ledger.active, 500 * UNITS);
         assert_eq!(ledger.unlocking.len(), 0);
     });

--- a/pallets/gear-builtin/src/tests/staking.rs
+++ b/pallets/gear-builtin/src/tests/staking.rs
@@ -218,7 +218,7 @@ fn payload_size_matters() {
         assert_error_message_sent();
 
         // User message payload indicates the error
-        assert_payload_contains("payload too large");
+        assert_payload_contains("Failure to decode message");
     });
 }
 

--- a/pallets/gear-builtin/src/tests/staking.rs
+++ b/pallets/gear-builtin/src/tests/staking.rs
@@ -218,7 +218,7 @@ fn payload_size_matters() {
         assert_error_message_sent();
 
         // User message payload indicates the error
-        assert_payload_contains("Failure to decode message");
+        assert_payload_contains("Message decoding error");
     });
 }
 
@@ -571,7 +571,7 @@ fn payout_stakers_works() {
                 era: 1
             }
             .encode(),
-            10_000_000_000,
+            300_000_000_000,
             0,
             false,
         ));
@@ -692,7 +692,7 @@ mod util {
     );
 
     parameter_types! {
-        pub const BlockGasLimit: u64 = 100_000_000_000;
+        pub const BlockGasLimit: u64 = 350_000_000_000;
         pub const OutgoingLimit: u32 = 1024;
         pub const OutgoingBytesLimit: u32 = 64 * 1024 * 1024;
         pub ReserveThreshold: BlockNumber = 1;

--- a/pallets/gear-builtin/src/weights.rs
+++ b/pallets/gear-builtin/src/weights.rs
@@ -48,6 +48,7 @@ pub trait WeightInfo {
     fn bls12_381_mul_projective_g2(c: u32, ) -> Weight;
     fn bls12_381_aggregate_g1(c: u32, ) -> Weight;
     fn bls12_381_map_to_g2affine(c: u32, ) -> Weight;
+	fn staking_estimate_decode(l: u32, ) -> Weight;
 }
 
 /// Weights for pallet_gear_builtin using the Gear node and recommended hardware.
@@ -154,6 +155,17 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             // Standard Error: 11
             .saturating_add(Weight::from_parts(565, 0).saturating_mul(c.into()))
     }
+	/// The range of component `l` is `[1, 8388608]`.
+	fn staking_estimate_decode(l: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 0_000 picoseconds.
+		Weight::from_parts(0, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+			// Standard Error: 0
+			.saturating_add(Weight::from_parts(84, 0).saturating_mul(l.into()))
+	}
 }
 
 // For backwards compatibility and tests
@@ -259,4 +271,15 @@ impl WeightInfo for () {
             // Standard Error: 11
             .saturating_add(Weight::from_parts(565, 0).saturating_mul(c.into()))
     }
+	/// The range of component `l` is `[1, 8388608]`.
+	fn staking_estimate_decode(l: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 0_000 picoseconds.
+		Weight::from_parts(0, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+			// Standard Error: 0
+			.saturating_add(Weight::from_parts(84, 0).saturating_mul(l.into()))
+	}
 }

--- a/pallets/gear-builtin/src/weights.rs
+++ b/pallets/gear-builtin/src/weights.rs
@@ -48,7 +48,6 @@ pub trait WeightInfo {
     fn bls12_381_mul_projective_g2(c: u32, ) -> Weight;
     fn bls12_381_aggregate_g1(c: u32, ) -> Weight;
     fn bls12_381_map_to_g2affine(c: u32, ) -> Weight;
-	fn staking_estimate_decode(l: u32, ) -> Weight;
 }
 
 /// Weights for pallet_gear_builtin using the Gear node and recommended hardware.
@@ -155,17 +154,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             // Standard Error: 11
             .saturating_add(Weight::from_parts(565, 0).saturating_mul(c.into()))
     }
-	/// The range of component `l` is `[1, 8388608]`.
-	fn staking_estimate_decode(l: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 0_000 picoseconds.
-		Weight::from_parts(0, 0)
-			.saturating_add(Weight::from_parts(0, 0))
-			// Standard Error: 0
-			.saturating_add(Weight::from_parts(84, 0).saturating_mul(l.into()))
-	}
 }
 
 // For backwards compatibility and tests
@@ -271,15 +259,4 @@ impl WeightInfo for () {
             // Standard Error: 11
             .saturating_add(Weight::from_parts(565, 0).saturating_mul(c.into()))
     }
-	/// The range of component `l` is `[1, 8388608]`.
-	fn staking_estimate_decode(l: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 0_000 picoseconds.
-		Weight::from_parts(0, 0)
-			.saturating_add(Weight::from_parts(0, 0))
-			// Standard Error: 0
-			.saturating_add(Weight::from_parts(84, 0).saturating_mul(l.into()))
-	}
 }

--- a/pallets/staking-rewards/Cargo.toml
+++ b/pallets/staking-rewards/Cargo.toml
@@ -41,7 +41,6 @@ pallet-authorship = { workspace = true, features = ["std"] }
 pallet-timestamp = { workspace = true, features = ["std"] }
 pallet-session = { workspace = true, features = ["std"] }
 pallet-sudo = { workspace = true, features = ["std"] }
-pallet-bags-list = { workspace = true, features = ["std"] }
 pallet-utility = { workspace = true, features = ["std"] }
 pallet-election-provider-multi-phase = { workspace = true, features = ["std"] }
 frame-executive = { workspace = true, features = ["std"] }
@@ -55,7 +54,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"pallet-balances/std",
-    "pallet-bags-list/std",
 	"pallet-staking/std",
 	"pallet-staking-reward-fn/std",
     "parity-scale-codec/std",

--- a/runtime/vara/Cargo.toml
+++ b/runtime/vara/Cargo.toml
@@ -102,6 +102,7 @@ pallet-gear-rpc-runtime-api.workspace = true
 pallet-gear-staking-rewards-rpc-runtime-api.workspace = true
 pallet-gear-builtin-rpc-runtime-api.workspace = true
 runtime-primitives.workspace = true
+gbuiltin-staking.workspace = true
 
 [dev-dependencies]
 sp-io.workspace = true

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -1091,13 +1091,13 @@ impl pallet_gear_messenger::Config for Runtime {
 }
 
 /// Builtin actors arranged in a tuple.
-pub type BuiltinActors = (pallet_gear_builtin::bls12_381::Actor<Runtime>,);
-
-parameter_types! {
-    pub const BuiltinActorPalletId: PalletId = PalletId(*b"py/biact");
-}
+pub type BuiltinActors = (
+    pallet_gear_builtin::bls12_381::Actor<Runtime>,
+    pallet_gear_builtin::staking::Actor<Runtime>,
+);
 
 impl pallet_gear_builtin::Config for Runtime {
+    type RuntimeCall = RuntimeCall;
     type Builtins = BuiltinActors;
     type WeightInfo = pallet_gear_builtin::weights::SubstrateWeight<Runtime>;
 }


### PR DESCRIPTION
The change includes:
- another builtin actor added to the Runtime to enable staking-related logic in programs (e.g. liquid staking etc.). The actor converts incoming messages into dispatchable calls and relays the latter to the `Staking` pallet;
- a set of types facilitating interaction with the staking builtin actor collected in a crate called `gbuiltin-staking`;
- a simple example of how contracts could interact with the builtin in question - for demo purpose only as real life scenarios would require more attention to details.