### PR TITLE
fix(gtest): allow zero balance for `exec::exit()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5233,9 +5233,9 @@ name = "gtest"
 version = "1.2.0"
 dependencies = [
  "colored",
+ "demo-constructor",
  "demo-custom",
  "demo-futures-unordered",
- "demo-meta-io",
  "demo-piggy-bank",
  "demo-ping",
  "derive_more",

--- a/gtest/Cargo.toml
+++ b/gtest/Cargo.toml
@@ -30,4 +30,4 @@ demo-custom.workspace = true
 demo-piggy-bank.workspace = true
 demo-ping.workspace = true
 demo-futures-unordered.workspace = true
-demo-meta-io.workspace = true
+demo-constructor = { workspace = true, features = ["std"] }

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -598,8 +598,8 @@ impl ExtManager {
         )
     }
 
-    pub(crate) fn mint_to(&mut self, id: &ProgramId, value: Balance) {
-        if value < crate::EXISTENTIAL_DEPOSIT {
+    pub(crate) fn mint_to(&mut self, id: &ProgramId, value: Balance, keep_alive: bool) {
+        if keep_alive && value < crate::EXISTENTIAL_DEPOSIT {
             panic!(
                 "An attempt to mint value ({}) less than existential deposit ({})",
                 value,
@@ -983,7 +983,7 @@ impl JournalHandler for ExtManager {
 
     fn exit_dispatch(&mut self, id_exited: ProgramId, value_destination: ProgramId) {
         if let Some((_, balance)) = self.actors.remove(&id_exited) {
-            self.mint_to(&value_destination, balance);
+            self.mint_to(&value_destination, balance, false);
         }
     }
 
@@ -1126,9 +1126,9 @@ impl JournalHandler for ExtManager {
                 }
             }
 
-            self.mint_to(to, value);
+            self.mint_to(to, value, true);
         } else {
-            self.mint_to(&from, value);
+            self.mint_to(&from, value, true);
         }
     }
 

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -217,6 +217,15 @@ impl Actors {
     }
 }
 
+/// Simple boolean for whether an account needs to be kept in existence.
+#[derive(PartialEq)]
+pub(crate) enum MintMode {
+    /// Operation must not result in the account going out of existence.
+    KeepAlive,
+    /// Operation may result in account going out of existence.
+    AllowDeath,
+}
+
 #[derive(Default, Debug)]
 pub(crate) struct ExtManager {
     // State metadata
@@ -598,8 +607,8 @@ impl ExtManager {
         )
     }
 
-    pub(crate) fn mint_to(&mut self, id: &ProgramId, value: Balance, keep_alive: bool) {
-        if keep_alive && value < crate::EXISTENTIAL_DEPOSIT {
+    pub(crate) fn mint_to(&mut self, id: &ProgramId, value: Balance, mint_mode: MintMode) {
+        if mint_mode == MintMode::KeepAlive && value < crate::EXISTENTIAL_DEPOSIT {
             panic!(
                 "An attempt to mint value ({}) less than existential deposit ({})",
                 value,
@@ -983,7 +992,7 @@ impl JournalHandler for ExtManager {
 
     fn exit_dispatch(&mut self, id_exited: ProgramId, value_destination: ProgramId) {
         if let Some((_, balance)) = self.actors.remove(&id_exited) {
-            self.mint_to(&value_destination, balance, false);
+            self.mint_to(&value_destination, balance, MintMode::AllowDeath);
         }
     }
 
@@ -1126,9 +1135,9 @@ impl JournalHandler for ExtManager {
                 }
             }
 
-            self.mint_to(to, value, true);
+            self.mint_to(to, value, MintMode::KeepAlive);
         } else {
-            self.mint_to(&from, value, true);
+            self.mint_to(&from, value, MintMode::KeepAlive);
         }
     }
 

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -18,7 +18,7 @@
 
 use crate::{
     log::RunResult,
-    manager::{Balance, ExtManager, Program as InnerProgram, TestActor},
+    manager::{Balance, ExtManager, MintMode, Program as InnerProgram, TestActor},
     system::System,
     Result,
 };
@@ -750,7 +750,9 @@ impl<'a> Program<'a> {
 
     /// Mint balance to the account.
     pub fn mint(&mut self, value: Balance) {
-        self.manager.borrow_mut().mint_to(&self.id(), value, true)
+        self.manager
+            .borrow_mut()
+            .mint_to(&self.id(), value, MintMode::KeepAlive)
     }
 
     /// Returns the balance of the account.

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -750,7 +750,7 @@ impl<'a> Program<'a> {
 
     /// Mint balance to the account.
     pub fn mint(&mut self, value: Balance) {
-        self.manager.borrow_mut().mint_to(&self.id(), value)
+        self.manager.borrow_mut().mint_to(&self.id(), value, true)
     }
 
     /// Returns the balance of the account.
@@ -1123,5 +1123,22 @@ mod tests {
             let result = prog.send_bytes(signer, b"send from reservation");
             assert!(!result.main_failed());
         }
+    }
+
+    #[test]
+    fn test_handle_exit_with_zero_balance() {
+        use demo_constructor::{demo_exit_handle, WASM_BINARY};
+
+        let sys = System::new();
+        sys.init_logger();
+
+        let user_id = [42; 32];
+        let prog = Program::from_opt_and_meta_code_with_id(&sys, 137, WASM_BINARY.to_vec(), None);
+
+        let run_result = prog.send(user_id, demo_exit_handle::scheme());
+        assert!(!run_result.main_failed());
+
+        let run_result = prog.send_bytes(user_id, []);
+        assert!(!run_result.main_failed());
     }
 }

--- a/gtest/src/system.rs
+++ b/gtest/src/system.rs
@@ -270,7 +270,7 @@ impl System {
     /// Mint balance to user with given `id` and `value`.
     pub fn mint_to<ID: Into<ProgramIdWrapper>>(&self, id: ID, value: Balance) {
         let actor_id = id.into().0;
-        self.0.borrow_mut().mint_to(&actor_id, value);
+        self.0.borrow_mut().mint_to(&actor_id, value, true);
     }
 
     /// Returns balance of user with given `id`.

--- a/gtest/src/system.rs
+++ b/gtest/src/system.rs
@@ -19,7 +19,7 @@
 use crate::{
     log::RunResult,
     mailbox::Mailbox,
-    manager::{Actors, Balance, ExtManager},
+    manager::{Actors, Balance, ExtManager, MintMode},
     program::{Program, ProgramIdWrapper},
     BLOCK_DURATION_IN_MSECS,
 };
@@ -270,7 +270,9 @@ impl System {
     /// Mint balance to user with given `id` and `value`.
     pub fn mint_to<ID: Into<ProgramIdWrapper>>(&self, id: ID, value: Balance) {
         let actor_id = id.into().0;
-        self.0.borrow_mut().mint_to(&actor_id, value, true);
+        self.0
+            .borrow_mut()
+            .mint_to(&actor_id, value, MintMode::KeepAlive);
     }
 
     /// Returns balance of user with given `id`.


### PR DESCRIPTION
Resolves #3847

@gear-tech/dev
