### PR TITLE
refactor(core): move `validate_memory_params` to `AllocationsCotntext…

### DIFF
--- a/core-processor/src/common.rs
+++ b/core-processor/src/common.rs
@@ -28,7 +28,7 @@ use alloc::{
 use gear_core::{
     gas::{GasAllowanceCounter, GasAmount, GasCounter},
     ids::{CodeId, MessageId, ProgramId, ReservationId},
-    memory::{MemoryError, PageBuf},
+    memory::{MemoryError, MemorySetupError, PageBuf},
     message::{
         ContextStore, Dispatch, DispatchKind, IncomingDispatch, MessageWaitedType, StoredDispatch,
     },
@@ -472,47 +472,6 @@ impl ActorExecutionErrorReplyReason {
             Self::Environment | Self::UnsupportedMessage => SimpleExecutionError::Unsupported,
         }
     }
-}
-
-/// Inconsistency in memory parameters provided for wasm execution.
-#[derive(Debug, PartialEq, Eq, derive_more::Display)]
-pub enum MemorySetupError {
-    /// Memory size exceeds max pages
-    #[display(fmt = "Memory size {memory_size:?} must be less than or equal to {max_pages:?}")]
-    MemorySizeExceedsMaxPages {
-        /// Memory size
-        memory_size: WasmPagesAmount,
-        /// Max allowed memory size
-        max_pages: WasmPagesAmount,
-    },
-    /// Insufficient memory size
-    #[display(fmt = "Memory size {memory_size:?} must be at least {static_pages:?}")]
-    InsufficientMemorySize {
-        /// Memory size
-        memory_size: WasmPagesAmount,
-        /// Static memory size
-        static_pages: WasmPagesAmount,
-    },
-    /// Stack end is out of static memory
-    #[display(fmt = "Stack end {stack_end:?} is out of static memory 0..{static_pages:?}")]
-    StackEndOutOfStaticMemory {
-        /// Stack end
-        stack_end: WasmPage,
-        /// Static memory size
-        static_pages: WasmPagesAmount,
-    },
-    /// Allocated page is out of allowed memory interval
-    #[display(
-        fmt = "Allocated page {page:?} is out of allowed memory interval {static_pages:?}..{memory_size:?}"
-    )]
-    AllocatedPageOutOfAllowedInterval {
-        /// Allocated page
-        page: WasmPage,
-        /// Static memory size
-        static_pages: WasmPagesAmount,
-        /// Memory size
-        memory_size: WasmPagesAmount,
-    },
 }
 
 /// System execution error

--- a/core-processor/src/executor.rs
+++ b/core-processor/src/executor.rs
@@ -19,7 +19,7 @@
 use crate::{
     common::{
         ActorExecutionError, ActorExecutionErrorReplyReason, DispatchResult, DispatchResultKind,
-        ExecutionError, MemorySetupError, SystemExecutionError, WasmExecutionContext,
+        ExecutionError, SystemExecutionError, WasmExecutionContext,
     },
     configs::{BlockInfo, ExecutionSettings},
     ext::{ProcessorContext, ProcessorExternalities},
@@ -35,7 +35,7 @@ use gear_core::{
         ContextSettings, DispatchKind, IncomingDispatch, IncomingMessage, MessageContext,
         WasmEntryPoint,
     },
-    pages::{WasmPage, WasmPagesAmount},
+    pages::WasmPage,
     program::{MemoryInfix, Program},
     reservation::GasReserver,
 };
@@ -47,60 +47,6 @@ use gear_core_backend::{
     },
     BackendExternalities,
 };
-
-/// Checks memory parameters, that are provided for wasm execution.
-/// NOTE: this params partially checked in `Code::try_new` in `gear-core`.
-fn validate_memory_params(
-    memory_size: WasmPagesAmount,
-    static_pages: WasmPagesAmount,
-    stack_end: Option<WasmPage>,
-    allocations: &BTreeSet<WasmPage>,
-    max_pages: WasmPagesAmount,
-) -> Result<(), MemorySetupError> {
-    if memory_size > max_pages {
-        return Err(MemorySetupError::MemorySizeExceedsMaxPages {
-            memory_size,
-            max_pages,
-        });
-    }
-
-    if static_pages > memory_size {
-        return Err(MemorySetupError::InsufficientMemorySize {
-            memory_size,
-            static_pages,
-        });
-    }
-
-    if let Some(stack_end) = stack_end {
-        if stack_end > static_pages {
-            return Err(MemorySetupError::StackEndOutOfStaticMemory {
-                stack_end,
-                static_pages,
-            });
-        }
-    }
-
-    if let Some(&page) = allocations.last() {
-        if page >= memory_size {
-            return Err(MemorySetupError::AllocatedPageOutOfAllowedInterval {
-                page,
-                static_pages,
-                memory_size,
-            });
-        }
-    }
-    if let Some(&page) = allocations.first() {
-        if page < static_pages {
-            return Err(MemorySetupError::AllocatedPageOutOfAllowedInterval {
-                page,
-                static_pages,
-                memory_size,
-            });
-        }
-    }
-
-    Ok(())
-}
 
 /// Execute wasm with dispatch and return dispatch result.
 pub(crate) fn execute_wasm<Ext>(
@@ -131,22 +77,15 @@ where
     log::debug!("Executing program {}", program_id);
     log::debug!("Executing dispatch {:?}", dispatch);
 
-    // TODO: move to `AllocationsContext::new` #3813
-    validate_memory_params(
+    // Creating allocations context.
+    let allocations_context = AllocationsContext::try_new(
         memory_size,
+        program.allocations().clone(),
         program.static_pages(),
         program.stack_end(),
-        program.allocations(),
         settings.max_pages,
     )
     .map_err(SystemExecutionError::from)?;
-
-    // Creating allocations context.
-    let allocations_context = AllocationsContext::new(
-        program.allocations().clone(),
-        program.static_pages(),
-        settings.max_pages,
-    );
 
     // Creating message context.
     let Some(message_context) = MessageContext::new(dispatch.clone(), program_id, msg_ctx_settings)
@@ -353,7 +292,14 @@ where
         gas_allowance_counter: GasAllowanceCounter::new(gas_limit),
         gas_reserver: GasReserver::new(&Default::default(), Default::default(), Default::default()),
         value_counter: ValueCounter::new(Default::default()),
-        allocations_context: AllocationsContext::new(allocations, static_pages, 512.into()),
+        allocations_context: AllocationsContext::try_new(
+            memory_size,
+            allocations,
+            static_pages,
+            program.stack_end(),
+            512.into(),
+        )
+        .map_err(|e| format!("Failed to create alloc ctx: {e:?}"))?,
         message_context,
         block_info,
         performance_multiplier: gsys::Percent::new(100),
@@ -444,96 +390,4 @@ where
     }
 
     Err("Reply not found".into())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use core::iter;
-
-    #[test]
-    fn memory_params_validation() {
-        assert_eq!(
-            validate_memory_params(
-                4.into(),
-                2.into(),
-                Some(2.into()),
-                &iter::once(WasmPage::from(2)).collect(),
-                4.into(),
-            ),
-            Ok(())
-        );
-
-        assert_eq!(
-            validate_memory_params(
-                4.into(),
-                2.into(),
-                Some(2.into()),
-                &BTreeSet::new(),
-                3.into(),
-            ),
-            Err(MemorySetupError::MemorySizeExceedsMaxPages {
-                memory_size: 4.into(),
-                max_pages: 3.into()
-            })
-        );
-
-        assert_eq!(
-            validate_memory_params(
-                1.into(),
-                2.into(),
-                Some(1.into()),
-                &BTreeSet::new(),
-                4.into(),
-            ),
-            Err(MemorySetupError::InsufficientMemorySize {
-                memory_size: 1.into(),
-                static_pages: 2.into()
-            })
-        );
-
-        assert_eq!(
-            validate_memory_params(
-                4.into(),
-                2.into(),
-                Some(3.into()),
-                &BTreeSet::new(),
-                4.into(),
-            ),
-            Err(MemorySetupError::StackEndOutOfStaticMemory {
-                stack_end: 3.into(),
-                static_pages: 2.into()
-            })
-        );
-
-        assert_eq!(
-            validate_memory_params(
-                4.into(),
-                2.into(),
-                Some(2.into()),
-                &iter::once(WasmPage::from(1)).collect(),
-                4.into(),
-            ),
-            Err(MemorySetupError::AllocatedPageOutOfAllowedInterval {
-                page: 1.into(),
-                static_pages: 2.into(),
-                memory_size: 4.into()
-            })
-        );
-
-        assert_eq!(
-            validate_memory_params(
-                4.into(),
-                2.into(),
-                Some(2.into()),
-                &iter::once(WasmPage::from(4)).collect(),
-                4.into(),
-            ),
-            Err(MemorySetupError::AllocatedPageOutOfAllowedInterval {
-                page: 4.into(),
-                static_pages: 2.into(),
-                memory_size: 4.into()
-            })
-        );
-    }
 }

--- a/core-processor/src/ext.rs
+++ b/core-processor/src/ext.rs
@@ -116,11 +116,14 @@ impl ProcessorContext {
             ),
             system_reservation: None,
             value_counter: ValueCounter::new(0),
-            allocations_context: AllocationsContext::new(
+            allocations_context: AllocationsContext::try_new(
                 Default::default(),
                 Default::default(),
                 Default::default(),
-            ),
+                Default::default(),
+                Default::default(),
+            )
+            .unwrap(),
             message_context: MessageContext::new(
                 Default::default(),
                 Default::default(),
@@ -1328,8 +1331,14 @@ mod tests {
         let existing_page = 99.into();
         let non_existing_page = 100.into();
 
-        let allocations_context =
-            AllocationsContext::new(BTreeSet::from([existing_page]), 1.into(), 512.into());
+        let allocations_context = AllocationsContext::try_new(
+            512.into(),
+            BTreeSet::from([existing_page]),
+            1.into(),
+            None,
+            512.into(),
+        )
+        .unwrap();
 
         let mut ext = Ext::new(
             ProcessorContextBuilder::new()

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -253,6 +253,48 @@ impl GrowHandler for NoopGrowHandler {
     fn after_grow_action(self, _mem: &mut impl Memory) {}
 }
 
+/// Inconsistency in memory parameters provided for wasm execution.
+#[derive(Debug, Clone, PartialEq, Eq, derive_more::Display)]
+pub enum MemorySetupError {
+    /// Memory size exceeds max pages
+    #[display(fmt = "Memory size {memory_size:?} must be less than or equal to {max_pages:?}")]
+    MemorySizeExceedsMaxPages {
+        /// Memory size
+        memory_size: WasmPagesAmount,
+        /// Max allowed memory size
+        max_pages: WasmPagesAmount,
+    },
+    /// Insufficient memory size
+    #[display(fmt = "Memory size {memory_size:?} must be at least {static_pages:?}")]
+    InsufficientMemorySize {
+        /// Memory size
+        memory_size: WasmPagesAmount,
+        /// Static memory size
+        static_pages: WasmPagesAmount,
+    },
+    /// Stack end is out of static memory
+    #[display(fmt = "Stack end {stack_end:?} is out of static memory 0..{static_pages:?}")]
+    StackEndOutOfStaticMemory {
+        /// Stack end
+        stack_end: WasmPage,
+        /// Static memory size
+        static_pages: WasmPagesAmount,
+    },
+    /// Allocated page is out of allowed memory interval
+    #[display(
+        fmt = "Allocated page {page:?} is out of allowed memory interval {static_pages:?}..{memory_size:?}"
+    )]
+    AllocatedPageOutOfAllowedInterval {
+        /// Allocated page
+        page: WasmPage,
+        /// Static memory size
+        static_pages: WasmPagesAmount,
+        /// Memory size
+        memory_size: WasmPagesAmount,
+    },
+}
+
+// TODO: This error type used for temporary solution, should be removed in #3791.
 /// Incorrect allocation data error
 #[derive(Debug, Clone, Eq, PartialEq, derive_more::Display)]
 #[display(fmt = "Allocated memory pages or memory size are incorrect")]
@@ -288,17 +330,83 @@ impl AllocationsContext {
     /// Provide currently running `program_id`, boxed memory abstraction
     /// and allocation manager. Also configurable `static_pages` and `max_pages`
     /// are set.
-    pub fn new(
+    ///
+    /// Returns `MemorySetupError` on incorrect memory params.
+    pub fn try_new(
+        memory_size: WasmPagesAmount,
         allocations: BTreeSet<WasmPage>,
         static_pages: WasmPagesAmount,
+        stack_end: Option<WasmPage>,
         max_pages: WasmPagesAmount,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, MemorySetupError> {
+        Self::validate_memory_params(
+            memory_size,
+            &allocations,
+            static_pages,
+            stack_end,
+            max_pages,
+        )?;
+
+        Ok(Self {
             init_allocations: allocations.clone(),
             allocations,
             max_pages,
             static_pages,
+        })
+    }
+
+    /// Checks memory parameters, that are provided for wasm execution.
+    /// NOTE: this params partially checked in `Code::try_new` in `gear-core`.
+    fn validate_memory_params(
+        memory_size: WasmPagesAmount,
+        allocations: &BTreeSet<WasmPage>,
+        static_pages: WasmPagesAmount,
+        stack_end: Option<WasmPage>,
+        max_pages: WasmPagesAmount,
+    ) -> Result<(), MemorySetupError> {
+        if memory_size > max_pages {
+            return Err(MemorySetupError::MemorySizeExceedsMaxPages {
+                memory_size,
+                max_pages,
+            });
         }
+
+        if static_pages > memory_size {
+            return Err(MemorySetupError::InsufficientMemorySize {
+                memory_size,
+                static_pages,
+            });
+        }
+
+        if let Some(stack_end) = stack_end {
+            if stack_end > static_pages {
+                return Err(MemorySetupError::StackEndOutOfStaticMemory {
+                    stack_end,
+                    static_pages,
+                });
+            }
+        }
+
+        if let Some(&page) = allocations.last() {
+            if page >= memory_size {
+                return Err(MemorySetupError::AllocatedPageOutOfAllowedInterval {
+                    page,
+                    static_pages,
+                    memory_size,
+                });
+            }
+        }
+        if let Some(&page) = allocations.first() {
+            if page < static_pages {
+                return Err(MemorySetupError::AllocatedPageOutOfAllowedInterval {
+                    page,
+                    static_pages,
+                    memory_size,
+                });
+            }
+        }
+
+        Ok(())
     }
 
     /// Return `true` if the page is the initial page,
@@ -329,7 +437,9 @@ impl AllocationsContext {
             match Interval::<WasmPage>::try_from(start..end) {
                 Ok(interval) if interval.len() >= pages => break,
                 Err(TryFromRangeError::IncorrectRange) => {
-                    return Err(IncorrectAllocationDataError.into())
+                    unreachable!(
+                        "Allocated memory pages or memory size are incorrect, but we checked it in validate memory param, start: {start:?}, end: {end:?}"
+                    )
                 }
                 Ok(_) | Err(TryFromRangeError::EmptyRange) => {}
             };
@@ -406,6 +516,7 @@ impl AllocationsContext {
 mod tests {
     use super::*;
     use alloc::vec::Vec;
+    use core::iter;
 
     struct TestMemory(WasmPagesAmount);
 
@@ -446,24 +557,29 @@ mod tests {
 
     #[test]
     fn free_fails() {
-        let mut ctx = AllocationsContext::new(Default::default(), 0.into(), 0.into());
+        let mut ctx =
+            AllocationsContext::try_new(0.into(), Default::default(), 0.into(), None, 0.into())
+                .unwrap();
         assert_eq!(ctx.free(1.into()), Err(AllocError::InvalidFree(1.into())));
 
-        let mut ctx = AllocationsContext::new(Default::default(), 1.into(), 0.into());
-        assert_eq!(ctx.free(0.into()), Err(AllocError::InvalidFree(0.into())));
-
-        let mut ctx = AllocationsContext::new(
+        let mut ctx = AllocationsContext::try_new(
+            1.into(),
             [WasmPage::from(0)].into_iter().collect(),
+            0.into(),
+            None,
             1.into(),
-            1.into(),
-        );
+        )
+        .unwrap();
         assert_eq!(ctx.free(1.into()), Err(AllocError::InvalidFree(1.into())));
 
-        let mut ctx = AllocationsContext::new(
+        let mut ctx = AllocationsContext::try_new(
+            4.into(),
             [WasmPage::from(1), WasmPage::from(3)].into_iter().collect(),
             1.into(),
+            None,
             4.into(),
-        );
+        )
+        .unwrap();
         let interval = Interval::<WasmPage>::try_from(1u16..4).unwrap();
         assert_eq!(ctx.free_range(interval), Ok(()));
     }
@@ -484,7 +600,14 @@ mod tests {
     fn alloc() {
         let _ = env_logger::try_init();
 
-        let mut ctx = AllocationsContext::new(Default::default(), 16.into(), 256.into());
+        let mut ctx = AllocationsContext::try_new(
+            256.into(),
+            Default::default(),
+            16.into(),
+            None,
+            256.into(),
+        )
+        .unwrap();
         let mut mem = TestMemory(16.into());
         alloc_ok(&mut ctx, &mut mem, 16, 16);
         alloc_ok(&mut ctx, &mut mem, 0, 16);
@@ -519,27 +642,155 @@ mod tests {
     fn alloc_incorrect_data() {
         let _ = env_logger::try_init();
 
-        let allocations: BTreeSet<WasmPage> = [1.into()].into_iter().collect();
-
-        let mut ctx = AllocationsContext::new(allocations.clone(), 10.into(), 13.into());
-        let mut mem = TestMemory(0.into());
+        let mut ctx = AllocationsContext::try_new(
+            2.into(),
+            iter::once(1.into()).collect(),
+            1.into(),
+            None,
+            2.into(),
+        )
+        .unwrap();
+        let mut mem = TestMemory(WasmPagesAmount::UPPER);
         alloc_err(&mut ctx, &mut mem, 1, IncorrectAllocationDataError.into());
+    }
 
-        let mut ctx =
-            AllocationsContext::new(allocations.clone(), WasmPagesAmount::UPPER, 13.into());
-        let mut mem = TestMemory(0.into());
-        alloc_err(&mut ctx, &mut mem, 1, IncorrectAllocationDataError.into());
+    #[test]
+    fn memory_params_validation() {
+        assert_eq!(
+            AllocationsContext::validate_memory_params(
+                4.into(),
+                &iter::once(2.into()).collect(),
+                2.into(),
+                Some(2.into()),
+                4.into(),
+            ),
+            Ok(())
+        );
 
-        let mut ctx =
-            AllocationsContext::new(allocations.clone(), 10.into(), WasmPagesAmount::UPPER);
-        let mut mem = TestMemory(0.into());
-        alloc_err(&mut ctx, &mut mem, 1, IncorrectAllocationDataError.into());
+        assert_eq!(
+            AllocationsContext::validate_memory_params(
+                4.into(),
+                &BTreeSet::new(),
+                2.into(),
+                Some(2.into()),
+                3.into(),
+            ),
+            Err(MemorySetupError::MemorySizeExceedsMaxPages {
+                memory_size: 4.into(),
+                max_pages: 3.into()
+            })
+        );
+
+        assert_eq!(
+            AllocationsContext::validate_memory_params(
+                1.into(),
+                &BTreeSet::new(),
+                2.into(),
+                Some(1.into()),
+                4.into(),
+            ),
+            Err(MemorySetupError::InsufficientMemorySize {
+                memory_size: 1.into(),
+                static_pages: 2.into()
+            })
+        );
+
+        assert_eq!(
+            AllocationsContext::validate_memory_params(
+                4.into(),
+                &BTreeSet::new(),
+                2.into(),
+                Some(3.into()),
+                4.into(),
+            ),
+            Err(MemorySetupError::StackEndOutOfStaticMemory {
+                stack_end: 3.into(),
+                static_pages: 2.into()
+            })
+        );
+
+        assert_eq!(
+            AllocationsContext::validate_memory_params(
+                4.into(),
+                &iter::once(1.into()).collect(),
+                2.into(),
+                Some(2.into()),
+                4.into(),
+            ),
+            Err(MemorySetupError::AllocatedPageOutOfAllowedInterval {
+                page: 1.into(),
+                static_pages: 2.into(),
+                memory_size: 4.into()
+            })
+        );
+
+        assert_eq!(
+            AllocationsContext::validate_memory_params(
+                4.into(),
+                &iter::once(4.into()).collect(),
+                2.into(),
+                Some(2.into()),
+                4.into(),
+            ),
+            Err(MemorySetupError::AllocatedPageOutOfAllowedInterval {
+                page: 4.into(),
+                static_pages: 2.into(),
+                memory_size: 4.into()
+            })
+        );
+
+        assert_eq!(
+            AllocationsContext::validate_memory_params(
+                13.into(),
+                &iter::once(1.into()).collect(),
+                10.into(),
+                None,
+                13.into()
+            ),
+            Err(MemorySetupError::AllocatedPageOutOfAllowedInterval {
+                page: 1.into(),
+                static_pages: 10.into(),
+                memory_size: 13.into()
+            })
+        );
+
+        assert_eq!(
+            AllocationsContext::validate_memory_params(
+                13.into(),
+                &iter::once(1.into()).collect(),
+                WasmPagesAmount::UPPER,
+                None,
+                13.into()
+            ),
+            Err(MemorySetupError::InsufficientMemorySize {
+                memory_size: 13.into(),
+                static_pages: WasmPagesAmount::UPPER
+            })
+        );
+
+        assert_eq!(
+            AllocationsContext::validate_memory_params(
+                WasmPagesAmount::UPPER,
+                &iter::once(1.into()).collect(),
+                10.into(),
+                None,
+                WasmPagesAmount::UPPER,
+            ),
+            Err(MemorySetupError::AllocatedPageOutOfAllowedInterval {
+                page: 1.into(),
+                static_pages: 10.into(),
+                memory_size: WasmPagesAmount::UPPER
+            })
+        );
     }
 
     mod property_tests {
         use super::*;
         use proptest::{
-            arbitrary::any, collection::size_range, prop_oneof, proptest, strategy::Strategy,
+            arbitrary::any,
+            collection::size_range,
+            prop_oneof, proptest,
+            strategy::{Just, Strategy},
             test_runner::Config as ProptestConfig,
         };
 
@@ -552,7 +803,8 @@ mod tests {
 
         fn actions() -> impl Strategy<Value = Vec<Action>> {
             let action = prop_oneof![
-                wasm_pages_amount().prop_map(|pages| Action::Alloc { pages }),
+                // Allocate smaller number (0..32) of pages due to `BTree::extend` significantly slows down prop-test.
+                wasm_pages_amount_with_range(0, 32).prop_map(|pages| Action::Alloc { pages }),
                 wasm_page().prop_map(|page| Action::Free { page }),
                 (wasm_page(), any::<u8>())
                     .prop_map(|(page, size)| Action::FreeRange { page, size }),
@@ -560,22 +812,68 @@ mod tests {
             proptest::collection::vec(action, 0..1024)
         }
 
-        fn allocations() -> impl Strategy<Value = BTreeSet<WasmPage>> {
-            proptest::collection::btree_set(wasm_page(), size_range(0..1024))
+        fn allocations(start: u16, end: u16) -> impl Strategy<Value = BTreeSet<WasmPage>> {
+            proptest::collection::btree_set(wasm_page_with_range(start, end), size_range(0..1024))
+        }
+
+        fn wasm_page_with_range(start: u16, end: u16) -> impl Strategy<Value = WasmPage> {
+            (start..=end).prop_map(WasmPage::from)
         }
 
         fn wasm_page() -> impl Strategy<Value = WasmPage> {
-            any::<u16>().prop_map(WasmPage::from)
+            wasm_page_with_range(0, u16::MAX)
         }
 
-        fn wasm_pages_amount() -> impl Strategy<Value = WasmPagesAmount> {
-            (0..u16::MAX as u32 + 1).prop_map(|x| {
+        fn wasm_pages_amount_with_range(
+            start: u32,
+            end: u32,
+        ) -> impl Strategy<Value = WasmPagesAmount> {
+            (start..=end).prop_map(|x| {
                 if x == u16::MAX as u32 + 1 {
                     WasmPagesAmount::UPPER
                 } else {
                     WasmPagesAmount::from(x as u16)
                 }
             })
+        }
+
+        fn wasm_pages_amount() -> impl Strategy<Value = WasmPagesAmount> {
+            wasm_pages_amount_with_range(0, u16::MAX as u32 + 1)
+        }
+
+        // This high-order strategy generates valid memory parameters in a specific way that allows passing `AllocationContext::validate_memory_params` checks.
+        fn combined_memory_params() -> impl Strategy<
+            // TODO: change strategy Value to struct MemoryParams #3906
+            Value = (
+                WasmPagesAmount,
+                WasmPagesAmount,
+                WasmPagesAmount,
+                BTreeSet<WasmPage>,
+            ),
+        > {
+            wasm_pages_amount()
+                .prop_flat_map(|max_pages| {
+                    let mem_size = wasm_pages_amount_with_range(0, u32::from(max_pages));
+                    (Just(max_pages), mem_size)
+                })
+                .prop_flat_map(|(max_pages, mem_size)| {
+                    let static_pages = wasm_pages_amount_with_range(0, u32::from(mem_size));
+                    (Just(max_pages), Just(mem_size), static_pages)
+                })
+                .prop_filter(
+                    "filter out cases where allocation region has zero size",
+                    |(_max_pages, mem_size, static_pages)| static_pages < mem_size,
+                )
+                .prop_flat_map(|(max_pages, mem_size, static_pages)| {
+                    // Last allocated page should be < `mem_size`.
+                    let end_exclusive = u32::from(mem_size) - 1;
+                    (
+                        Just(max_pages),
+                        Just(mem_size),
+                        Just(static_pages),
+                        allocations(u32::from(static_pages) as u16, end_exclusive as u16),
+                    )
+                })
         }
 
         fn proptest_config() -> ProptestConfig {
@@ -588,7 +886,7 @@ mod tests {
         #[track_caller]
         fn assert_alloc_error(err: AllocError) {
             match err {
-                AllocError::IncorrectAllocationData(_) | AllocError::ProgramAllocOutOfBounds => {}
+                AllocError::ProgramAllocOutOfBounds => {}
                 err => panic!("{err:?}"),
             }
         }
@@ -606,15 +904,14 @@ mod tests {
             #![proptest_config(proptest_config())]
             #[test]
             fn alloc(
-                static_pages in wasm_pages_amount(),
-                allocations in allocations(),
-                max_pages in wasm_pages_amount(),
-                mem_size in wasm_pages_amount(),
+                mem_params in combined_memory_params(),
                 actions in actions(),
             ) {
                 let _ = env_logger::try_init();
 
-                let mut ctx = AllocationsContext::new(allocations, static_pages, max_pages);
+                let (max_pages, mem_size, static_pages, allocations) = mem_params;
+                let mut ctx = AllocationsContext::try_new(mem_size, allocations, static_pages, None, max_pages).unwrap();
+
                 let mut mem = TestMemory(mem_size);
 
                 for action in actions {


### PR DESCRIPTION
Resolves #3813 .

Move `validate_memory_params` into `AllocationsContext` constructor and make it capable of failing.

Some tests in core/src/memory.rs were updated due to new invariants established by the validation of memory parameters upon `AllocationsContext` creation.



@reviewer-or-team
