### PR TITLE
fix(pallet-gear-program): Migrations version

### DIFF
--- a/pallets/gear-program/src/lib.rs
+++ b/pallets/gear-program/src/lib.rs
@@ -168,7 +168,7 @@ pub mod pallet {
     use sp_runtime::DispatchError;
 
     /// The current storage version.
-    pub(crate) const PROGRAM_STORAGE_VERSION: StorageVersion = StorageVersion::new(4);
+    pub(crate) const PROGRAM_STORAGE_VERSION: StorageVersion = StorageVersion::new(5);
 
     #[pallet::config]
     pub trait Config: frame_system::Config {

--- a/pallets/gear-program/src/migration.rs
+++ b/pallets/gear-program/src/migration.rs
@@ -48,7 +48,7 @@ impl<T: Config> OnRuntimeUpgrade for AppendStackEndMigration<T> {
         let mut weight = T::DbWeight::get().reads(1);
         let mut counter = 0;
 
-        // NOTE: in 1.3.0 release, current storage version == `UPDATE_TO_VERSION` is checked,
+        // NOTE: in 1.3.0 release, current storage version == `MIGRATE_TO_VERSION` is checked,
         // but we need to skip this check now, because storage version was increased.
         if onchain == MIGRATE_FROM_VERSION {
             let current = Pallet::<T>::current_storage_version();

--- a/pallets/gear-program/src/migration.rs
+++ b/pallets/gear-program/src/migration.rs
@@ -34,8 +34,8 @@ use {
     sp_std::vec::Vec,
 };
 
-const UPDATE_FROM_VERSION: u16 = 3;
-const UPDATE_TO_VERSION: u16 = 4;
+const MIGRATE_FROM_VERSION: u16 = 3;
+const MIGRATE_TO_VERSION: u16 = 4;
 const ALLOWED_CURRENT_STORAGE_VERSION: u16 = 5;
 
 pub struct AppendStackEndMigration<T: Config>(PhantomData<T>);
@@ -50,14 +50,14 @@ impl<T: Config> OnRuntimeUpgrade for AppendStackEndMigration<T> {
 
         // NOTE: in 1.3.0 release, current storage version == `UPDATE_TO_VERSION` is checked,
         // but we need to skip this check now, because storage version was increased.
-        if onchain == UPDATE_FROM_VERSION {
+        if onchain == MIGRATE_FROM_VERSION {
             let current = Pallet::<T>::current_storage_version();
             if current != ALLOWED_CURRENT_STORAGE_VERSION {
                 log::error!("❌ Migration is not allowed for current storage version {current:?}.");
                 return weight;
             }
 
-            let update_to = StorageVersion::new(UPDATE_TO_VERSION);
+            let update_to = StorageVersion::new(MIGRATE_TO_VERSION);
             log::info!("🚚 Running migration from {onchain:?} to {update_to:?}, current storage version is {current:?}.");
 
             CodeStorage::<T>::translate(|_, code: onchain::InstrumentedCode| {
@@ -86,7 +86,7 @@ impl<T: Config> OnRuntimeUpgrade for AppendStackEndMigration<T> {
 
             log::info!("✅ Successfully migrates storage. {counter} codes have been migrated");
         } else {
-            log::info!("🟠 Migration requires onchain version {UPDATE_FROM_VERSION}, so was skipped for {onchain:?}");
+            log::info!("🟠 Migration requires onchain version {MIGRATE_FROM_VERSION}, so was skipped for {onchain:?}");
         }
 
         weight
@@ -97,7 +97,7 @@ impl<T: Config> OnRuntimeUpgrade for AppendStackEndMigration<T> {
         let current = Pallet::<T>::current_storage_version();
         let onchain = Pallet::<T>::on_chain_storage_version();
 
-        let res = if onchain == UPDATE_FROM_VERSION {
+        let res = if onchain == MIGRATE_FROM_VERSION {
             ensure!(
                 current == ALLOWED_CURRENT_STORAGE_VERSION,
                 "Current storage version is not allowed for migration, check migration code in order to allow it."

--- a/pallets/gear-program/src/migration.rs
+++ b/pallets/gear-program/src/migration.rs
@@ -84,7 +84,7 @@ impl<T: Config> OnRuntimeUpgrade for AppendStackEndMigration<T> {
 
             update_to.put::<Pallet<T>>();
 
-            log::info!("Successfully migrated storage. {counter} codes has been migrated");
+            log::info!("✅ Successfully migrates storage. {counter} codes have been migrated");
         } else {
             log::info!("🟠 Migration requires onchain version {UPDATE_FROM_VERSION}, so was skipped for {onchain:?}");
         }

--- a/pallets/gear-program/src/migration.rs
+++ b/pallets/gear-program/src/migration.rs
@@ -34,17 +34,15 @@ use {
     sp_std::vec::Vec,
 };
 
-const SUITABLE_ONCHAIN_STORAGE_VERSION: u16 = 3;
+const UPDATE_FROM_VERSION: u16 = 3;
+const UPDATE_TO_VERSION: u16 = 4;
+const ALLOWED_CURRENT_STORAGE_VERSION: u16 = 5;
 
 pub struct AppendStackEndMigration<T: Config>(PhantomData<T>);
 
 impl<T: Config> OnRuntimeUpgrade for AppendStackEndMigration<T> {
     fn on_runtime_upgrade() -> Weight {
-        const UPDATE_TO_VERSION: u16 = 4;
-        let update_to = StorageVersion::new(UPDATE_TO_VERSION);
         let onchain = Pallet::<T>::on_chain_storage_version();
-
-        log::info!("🚚 Running migration: update from {onchain:?} to {update_to:?}");
 
         // 1 read for onchain storage version
         let mut weight = T::DbWeight::get().reads(1);
@@ -52,7 +50,16 @@ impl<T: Config> OnRuntimeUpgrade for AppendStackEndMigration<T> {
 
         // NOTE: in 1.3.0 release, current storage version == `UPDATE_TO_VERSION` is checked,
         // but we need to skip this check now, because storage version was increased.
-        if onchain == SUITABLE_ONCHAIN_STORAGE_VERSION {
+        if onchain == UPDATE_FROM_VERSION {
+            let current = Pallet::<T>::current_storage_version();
+            if current != ALLOWED_CURRENT_STORAGE_VERSION {
+                log::error!("❌ Migration is not allowed for current storage version {current:?}.");
+                return weight;
+            }
+
+            let update_to = StorageVersion::new(UPDATE_TO_VERSION);
+            log::info!("🚚 Running migration from {onchain:?} to {update_to:?}, current storage version is {current:?}.");
+
             CodeStorage::<T>::translate(|_, code: onchain::InstrumentedCode| {
                 weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
                 counter += 1;
@@ -79,7 +86,7 @@ impl<T: Config> OnRuntimeUpgrade for AppendStackEndMigration<T> {
 
             log::info!("Successfully migrated storage. {counter} codes has been migrated");
         } else {
-            log::info!("❌ Migration did not execute. This probably should be removed");
+            log::info!("🟠 Migration requires onchain version {UPDATE_FROM_VERSION}, so was skipped for {onchain:?}");
         }
 
         weight
@@ -87,10 +94,19 @@ impl<T: Config> OnRuntimeUpgrade for AppendStackEndMigration<T> {
 
     #[cfg(feature = "try-runtime")]
     fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+        let current = Pallet::<T>::current_storage_version();
         let onchain = Pallet::<T>::on_chain_storage_version();
 
-        let res = (onchain == SUITABLE_ONCHAIN_STORAGE_VERSION)
-            .then(|| onchain::CodeStorage::<T>::iter().count() as u64);
+        let res = if onchain == UPDATE_FROM_VERSION {
+            ensure!(
+                current == ALLOWED_CURRENT_STORAGE_VERSION,
+                "Current storage version is not allowed for migration, check migration code in order to allow it."
+            );
+
+            Some(onchain::CodeStorage::<T>::iter().count() as u64)
+        } else {
+            None
+        };
 
         Ok(res.encode())
     }

--- a/pallets/gear-program/src/migration.rs
+++ b/pallets/gear-program/src/migration.rs
@@ -84,7 +84,7 @@ impl<T: Config> OnRuntimeUpgrade for AppendStackEndMigration<T> {
 
             update_to.put::<Pallet<T>>();
 
-            log::info!("✅ Successfully migrates storage. {counter} codes have been migrated");
+            log::info!("✅ Successfully migrated storage. {counter} codes have been migrated");
         } else {
             log::info!("🟠 Migration requires onchain version {MIGRATE_FROM_VERSION}, so was skipped for {onchain:?}");
         }

--- a/pallets/gear-program/src/migration.rs
+++ b/pallets/gear-program/src/migration.rs
@@ -18,7 +18,7 @@
 
 use crate::{CodeStorage, Config, Pallet};
 use frame_support::{
-    traits::{Get, GetStorageVersion, OnRuntimeUpgrade},
+    traits::{Get, GetStorageVersion, OnRuntimeUpgrade, StorageVersion},
     weights::Weight,
 };
 use gear_core::code::InstrumentedCode;

--- a/pallets/gear/src/migrations.rs
+++ b/pallets/gear/src/migrations.rs
@@ -54,7 +54,7 @@ where
         // 1 read for the on-chain storage version
         let mut weight = T::DbWeight::get().reads(1);
 
-        if current == 4 && onchain == 3 {
+        if current == 5 && onchain == 4 {
             waiting_init_list::WaitingInitStorage::<T>::translate(
                 |program_id, messages: Vec<MessageId>| {
                     // read and remove an element

--- a/pallets/gear/src/migrations.rs
+++ b/pallets/gear/src/migrations.rs
@@ -93,7 +93,7 @@ where
 
             update_to.put::<pallet_gear_program::Pallet<T>>();
 
-            log::info!("✅ Successfully migrates storage");
+            log::info!("✅ Successfully migrated storage");
         } else {
             log::info!("🟠 Migration requires onchain version {MIGRATE_FROM_VERSION}, so was skipped for {onchain:?}");
         }

--- a/pallets/gear/src/migrations.rs
+++ b/pallets/gear/src/migrations.rs
@@ -23,7 +23,7 @@ use common::{
     Origin,
 };
 use frame_support::{
-    traits::{Get, GetStorageVersion, OnRuntimeUpgrade},
+    traits::{Get, GetStorageVersion, OnRuntimeUpgrade, StorageVersion},
     weights::Weight,
 };
 use gear_core::ids::MessageId;
@@ -32,11 +32,16 @@ use sp_std::{marker::PhantomData, vec::Vec};
 #[cfg(feature = "try-runtime")]
 use {
     common::storage::IterableMap,
+    frame_support::ensure,
     parity_scale_codec::{Decode, Encode},
     sp_runtime::TryRuntimeError,
 };
 
 pub struct MigrateWaitingInitList<T>(PhantomData<T>);
+
+const UPDATE_FROM_VERSION: u16 = 4;
+const UPDATE_TO_VERSION: u16 = 5;
+const ALLOWED_CURRENT_STORAGE_VERSION: u16 = 5;
 
 impl<T> OnRuntimeUpgrade for MigrateWaitingInitList<T>
 where
@@ -44,17 +49,21 @@ where
     T::AccountId: Origin,
 {
     fn on_runtime_upgrade() -> Weight {
-        let current = pallet_gear_program::Pallet::<T>::current_storage_version();
         let onchain = pallet_gear_program::Pallet::<T>::on_chain_storage_version();
-
-        log::info!(
-            "🚚 Running migration with current storage version {current:?} / onchain {onchain:?}"
-        );
 
         // 1 read for the on-chain storage version
         let mut weight = T::DbWeight::get().reads(1);
 
-        if current == 5 && onchain == 4 {
+        if onchain == UPDATE_FROM_VERSION {
+            let current = pallet_gear_program::Pallet::<T>::current_storage_version();
+            if current != ALLOWED_CURRENT_STORAGE_VERSION {
+                log::error!("❌ Migration is not allowed for current storage version {current:?}.");
+                return weight;
+            }
+
+            let update_to = StorageVersion::new(UPDATE_TO_VERSION);
+            log::info!("🚚 Running migration from {onchain:?} to {update_to:?}, current storage version is {current:?}.");
+
             waiting_init_list::WaitingInitStorage::<T>::translate(
                 |program_id, messages: Vec<MessageId>| {
                     // read and remove an element
@@ -82,11 +91,11 @@ where
                 },
             );
 
-            current.put::<pallet_gear_program::Pallet<T>>();
+            update_to.put::<pallet_gear_program::Pallet<T>>();
 
-            log::info!("Successfully migrated storage");
+            log::info!("✅ Successfully migrates storage");
         } else {
-            log::info!("❌ Migration did not execute. This probably should be removed");
+            log::info!("🟠 Migration requires onchain version {UPDATE_FROM_VERSION}, so was skipped for {onchain:?}");
         }
 
         weight
@@ -94,9 +103,15 @@ where
 
     #[cfg(feature = "try-runtime")]
     fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+        let current = Pallet::<T>::current_storage_version();
         let onchain = Pallet::<T>::on_chain_storage_version();
 
-        let data = if onchain == 4 {
+        let data = if onchain == UPDATE_FROM_VERSION {
+            ensure!(
+                current == ALLOWED_CURRENT_STORAGE_VERSION,
+                "Current storage version is not allowed for migration, check migration code in order to allow it."
+            );
+
             let init_msgs: usize = waiting_init_list::WaitingInitStorage::<T>::iter_values()
                 .map(|d| d.len())
                 .sum();
@@ -256,7 +271,7 @@ mod tests {
         init_logger();
 
         new_test_ext().execute_with(|| {
-            StorageVersion::new(4).put::<GearProgram>();
+            StorageVersion::new(UPDATE_FROM_VERSION).put::<GearProgram>();
 
             let multiplier = <Test as pallet_gear_bank::Config>::GasMultiplier::get();
 
@@ -329,7 +344,7 @@ mod tests {
             assert!(!weight.is_zero());
             MigrateWaitingInitList::<Test>::post_upgrade(state).unwrap();
 
-            assert_eq!(StorageVersion::get::<GearProgram>(), 5);
+            assert_eq!(StorageVersion::get::<GearProgram>(), UPDATE_TO_VERSION);
 
             assert_eq!(
                 waiting_init_list::WaitingInitStorage::<Test>::iter().count(),

--- a/pallets/gear/src/migrations.rs
+++ b/pallets/gear/src/migrations.rs
@@ -39,8 +39,8 @@ use {
 
 pub struct MigrateWaitingInitList<T>(PhantomData<T>);
 
-const UPDATE_FROM_VERSION: u16 = 4;
-const UPDATE_TO_VERSION: u16 = 5;
+const MIGRATE_FROM_VERSION: u16 = 4;
+const MIGRATE_TO_VERSION: u16 = 5;
 const ALLOWED_CURRENT_STORAGE_VERSION: u16 = 5;
 
 impl<T> OnRuntimeUpgrade for MigrateWaitingInitList<T>
@@ -54,14 +54,14 @@ where
         // 1 read for the on-chain storage version
         let mut weight = T::DbWeight::get().reads(1);
 
-        if onchain == UPDATE_FROM_VERSION {
+        if onchain == MIGRATE_FROM_VERSION {
             let current = pallet_gear_program::Pallet::<T>::current_storage_version();
             if current != ALLOWED_CURRENT_STORAGE_VERSION {
                 log::error!("❌ Migration is not allowed for current storage version {current:?}.");
                 return weight;
             }
 
-            let update_to = StorageVersion::new(UPDATE_TO_VERSION);
+            let update_to = StorageVersion::new(MIGRATE_TO_VERSION);
             log::info!("🚚 Running migration from {onchain:?} to {update_to:?}, current storage version is {current:?}.");
 
             waiting_init_list::WaitingInitStorage::<T>::translate(
@@ -95,7 +95,7 @@ where
 
             log::info!("✅ Successfully migrates storage");
         } else {
-            log::info!("🟠 Migration requires onchain version {UPDATE_FROM_VERSION}, so was skipped for {onchain:?}");
+            log::info!("🟠 Migration requires onchain version {MIGRATE_FROM_VERSION}, so was skipped for {onchain:?}");
         }
 
         weight
@@ -106,7 +106,7 @@ where
         let current = Pallet::<T>::current_storage_version();
         let onchain = Pallet::<T>::on_chain_storage_version();
 
-        let data = if onchain == UPDATE_FROM_VERSION {
+        let data = if onchain == MIGRATE_FROM_VERSION {
             ensure!(
                 current == ALLOWED_CURRENT_STORAGE_VERSION,
                 "Current storage version is not allowed for migration, check migration code in order to allow it."
@@ -271,7 +271,7 @@ mod tests {
         init_logger();
 
         new_test_ext().execute_with(|| {
-            StorageVersion::new(UPDATE_FROM_VERSION).put::<GearProgram>();
+            StorageVersion::new(MIGRATE_FROM_VERSION).put::<GearProgram>();
 
             let multiplier = <Test as pallet_gear_bank::Config>::GasMultiplier::get();
 
@@ -344,7 +344,7 @@ mod tests {
             assert!(!weight.is_zero());
             MigrateWaitingInitList::<Test>::post_upgrade(state).unwrap();
 
-            assert_eq!(StorageVersion::get::<GearProgram>(), UPDATE_TO_VERSION);
+            assert_eq!(StorageVersion::get::<GearProgram>(), MIGRATE_TO_VERSION);
 
             assert_eq!(
                 waiting_init_list::WaitingInitStorage::<Test>::iter().count(),

--- a/pallets/gear/src/migrations.rs
+++ b/pallets/gear/src/migrations.rs
@@ -96,7 +96,7 @@ where
     fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
         let onchain = Pallet::<T>::on_chain_storage_version();
 
-        let data = if onchain == 3 {
+        let data = if onchain == 4 {
             let init_msgs: usize = waiting_init_list::WaitingInitStorage::<T>::iter_values()
                 .map(|d| d.len())
                 .sum();
@@ -256,7 +256,7 @@ mod tests {
         init_logger();
 
         new_test_ext().execute_with(|| {
-            StorageVersion::new(3).put::<GearProgram>();
+            StorageVersion::new(4).put::<GearProgram>();
 
             let multiplier = <Test as pallet_gear_bank::Config>::GasMultiplier::get();
 
@@ -329,7 +329,7 @@ mod tests {
             assert!(!weight.is_zero());
             MigrateWaitingInitList::<Test>::post_upgrade(state).unwrap();
 
-            assert_eq!(StorageVersion::get::<GearProgram>(), 4);
+            assert_eq!(StorageVersion::get::<GearProgram>(), 5);
 
             assert_eq!(
                 waiting_init_list::WaitingInitStorage::<Test>::iter().count(),


### PR DESCRIPTION
Without this changes migration for waiting init list is not applied in `try-runtime` tests. Even more we need to increase storage version, so that this migration can be applied in future.
```bash
[2024-04-18T12:01:32Z INFO  pallet_gear_program::migration] 🚚 Running migration with current storage version StorageVersion(4) / onchain StorageVersion(3)                      
[2024-04-18T12:01:33Z INFO  pallet_gear_program::migration] Successfully migrated storage. 1862 codes has been migrated                                                          
[2024-04-18T12:01:33Z INFO  pallet_gear::migrations] 🚚 Running migration with current storage version StorageVersion(4) / onchain StorageVersion(4)                             
[2024-04-18T12:01:33Z INFO  pallet_gear::migrations] ❌ Migration did not execute. This probably should be removed                                                               
[2024-04-18T12:01:36Z INFO  pallet_gear_program::migration] 🚚 Running migration with current storage version StorageVersion(4) / onchain StorageVersion(3)                      
[2024-04-18T12:01:36Z INFO  pallet_gear_program::migration] Successfully migrated storage. 1862 codes has been migrated                                                          
[2024-04-18T12:01:36Z INFO  pallet_gear::migrations] 🚚 Running migration with current storage version StorageVersion(4) / onchain StorageVersion(4)                             
[2024-04-18T12:01:36Z INFO  pallet_gear::migrations] ❌ Migration did not execute. This probably should be removed                                                               
[2024-04-18T12:01:39Z INFO  pallet_gear_program::migration] 🚚 Running migration with current storage version StorageVersion(4) / onchain StorageVersion(4)                      
[2024-04-18T12:01:39Z INFO  pallet_gear_program::migration] ❌ Migration did not execute. This probably should be removed                                                        
[2024-04-18T12:01:39Z INFO  pallet_gear::migrations] 🚚 Running migration with current storage version StorageVersion(4) / onchain StorageVersion(4)                             
[2024-04-18T12:01:39Z INFO  pallet_gear::migrations] ❌ Migration did not execute. This probably should be removed                                                  
```

After fixing:
```
[2024-04-19T07:54:49Z INFO  pallet_gear_program::migration] 🚚 Running migration from StorageVersion(3) to StorageVersion(4), current storage version is StorageVersion(5).
[2024-04-19T07:54:50Z INFO  pallet_gear_program::migration] ✅ Successfully migrated storage. 1866 codes have been migrated
[2024-04-19T07:54:50Z INFO  pallet_gear::migrations] 🚚 Running migration from StorageVersion(4) to StorageVersion(5), current storage version is StorageVersion(5).
[2024-04-19T07:54:50Z DEBUG pallet_gear_scheduler::pallet] TaskPool::OnChange; weight = Weight(ref_time: 100000000, proof_size: 0), GasAllowance = 998156119826
[2024-04-19T07:54:50Z DEBUG pallet_gear_scheduler::pallet] TaskPool::OnChange; weight = Weight(ref_time: 100000000, proof_size: 0), GasAllowance = 998056119826
[2024-04-19T07:54:50Z INFO  pallet_gear::migrations] ✅ Successfully migrated storage
[2024-04-19T07:54:54Z INFO  pallet_gear_program::migration] 🚚 Running migration from StorageVersion(3) to StorageVersion(4), current storage version is StorageVersion(5).
[2024-04-19T07:54:54Z INFO  pallet_gear_program::migration] ✅ Successfully migrated storage. 1866 codes have been migrated
[2024-04-19T07:54:54Z INFO  pallet_gear::migrations] 🚚 Running migration from StorageVersion(4) to StorageVersion(5), current storage version is StorageVersion(5).
[2024-04-19T07:54:54Z DEBUG pallet_gear_scheduler::pallet] TaskPool::OnChange; weight = Weight(ref_time: 100000000, proof_size: 0), GasAllowance = 998156119826
[2024-04-19T07:54:54Z DEBUG pallet_gear_scheduler::pallet] TaskPool::OnChange; weight = Weight(ref_time: 100000000, proof_size: 0), GasAllowance = 998056119826
[2024-04-19T07:54:54Z INFO  pallet_gear::migrations] ✅ Successfully migrated storage
[2024-04-19T07:54:57Z INFO  pallet_gear_program::migration] 🟠 Migration requires onchain version 3, so was skipped for StorageVersion(5)
[2024-04-19T07:54:57Z INFO  pallet_gear::migrations] 🟠 Migration requires onchain version 4, so was skipped for StorageVersion(5)
```