### PR TITLE
fix(ci): use stable toolchain for ecosystem

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -70,7 +70,7 @@ jobs:
           cargo +stable check --manifest-path utils/wasm-builder/test-program/Cargo.toml
 
       - name: "Check: crates-io packages"
-        run: cargo run --release -p crates-io check
+        run: cargo +stable run --release -p crates-io check
 
   fuzzer:
     runs-on: [ kuberunner, github-runner-01 ]

--- a/.github/workflows/crates-io.yml
+++ b/.github/workflows/crates-io.yml
@@ -26,13 +26,16 @@ jobs:
       - name: "ACTIONS: Checkout"
         uses: actions/checkout@v4
 
-      - name: "Install: Rust toolchain"
-        uses: dsherret/rust-toolchain-file@v1
+      - name: "Install: Rust stable toolchain"
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: llvm-tools
 
       - name: "Check packages"
         if: ${{ !inputs.publish }}
-        run: cargo run -p crates-io check
+        run: cargo +stable run -p crates-io check
 
       - name: "Publish packages"
         if: ${{ inputs.publish }}
-        run: cargo run -p crates-io publish -v ${{ inputs.version }}
+        run: cargo +stable run -p crates-io publish -v ${{ inputs.version }}

--- a/.github/workflows/crates-io.yml
+++ b/.github/workflows/crates-io.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: [kuberunner]
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:

--- a/.github/workflows/time-consuming-tests.yml
+++ b/.github/workflows/time-consuming-tests.yml
@@ -31,4 +31,4 @@ jobs:
         run: ./scripts/gear.sh build node --release --locked
 
       - name: "Test: Time consuming tests"
-        run: ./scripts/gear.sh test time-consuming --release
+        run: ./scripts/gear.sh test time-consuming

--- a/common/numerated/Cargo.toml
+++ b/common/numerated/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "numerated"
 description = "A library for working with intervals and sets of numerated values"
-keywords = ["gear", "tree", "interval", "numerated", "no-std", "math"]
+keywords = ["gear", "tree", "interval", "numerated", "no-std"]
 categories = ["mathematics", "no-std"]
 version.workspace = true
 authors.workspace = true

--- a/scripts/src/test.sh
+++ b/scripts/src/test.sh
@@ -120,7 +120,7 @@ doc_test() {
 }
 
 time_consuming_tests() {
-  $CARGO test -p demo-fungible-token --no-fail-fast "$@" -- --nocapture --ignored
+  $CARGO test -p demo-fungible-token --no-fail-fast --release -- --nocapture --ignored
   $CARGO test -p gear-wasm-builder --no-fail-fast "$@" -- --nocapture --ignored
 }
 

--- a/utils/crates-io/src/lib.rs
+++ b/utils/crates-io/src/lib.rs
@@ -29,7 +29,7 @@ use anyhow::Result;
 use std::process::{Command, ExitStatus};
 
 /// Required Packages without local dependencies.
-pub const SAFE_DEPENDENCIES: [&str; 12] = [
+pub const SAFE_DEPENDENCIES: [&str; 13] = [
     "actor-system-error",
     "galloc",
     "gear-stack-buffer",
@@ -42,6 +42,7 @@ pub const SAFE_DEPENDENCIES: [&str; 12] = [
     "gsdk-codegen",
     "gstd-codegen",
     "gsys",
+    "numerated",
 ];
 
 /// Required packages with local dependencies.

--- a/utils/crates-io/src/lib.rs
+++ b/utils/crates-io/src/lib.rs
@@ -85,7 +85,7 @@ pub const PACKAGE_ALIAS: [(&str, &str); 2] = [
 /// Check the input package
 pub fn check(manifest: &str) -> Result<ExitStatus> {
     Command::new("cargo")
-        .args(["check", "--lib", "--manifest-path", manifest])
+        .args(["+stable", "check", "--lib", "--manifest-path", manifest])
         .status()
         .map_err(Into::into)
 }
@@ -93,7 +93,7 @@ pub fn check(manifest: &str) -> Result<ExitStatus> {
 /// Test the input package
 pub fn test(package: &str, test: &str) -> Result<ExitStatus> {
     Command::new("cargo")
-        .args(["test", "-p", package, "--", test])
+        .args(["+stable", "test", "-p", package, "--", test])
         .status()
         .map_err(Into::into)
 }
@@ -101,7 +101,13 @@ pub fn test(package: &str, test: &str) -> Result<ExitStatus> {
 /// Publish the input package
 pub fn publish(manifest: &str) -> Result<ExitStatus> {
     Command::new("cargo")
-        .args(["publish", "--manifest-path", manifest, "--allow-dirty"])
+        .args([
+            "+stable",
+            "publish",
+            "--manifest-path",
+            manifest,
+            "--allow-dirty",
+        ])
         .status()
         .map_err(Into::into)
 }

--- a/utils/crates-io/src/manifest.rs
+++ b/utils/crates-io/src/manifest.rs
@@ -26,7 +26,7 @@ use std::{
     ops::{Deref, DerefMut},
     path::PathBuf,
 };
-use toml_edit::Document;
+use toml_edit::{Document, Item};
 
 const WORKSPACE_NAME: &str = "__gear_workspace";
 
@@ -62,6 +62,8 @@ impl Workspace {
 
             workspace.manifest["workspace"]["package"]["version"] = toml_edit::value(version);
         }
+
+        workspace.manifest["workspace"]["dependencies"]["gstd"]["features"] = Item::None;
 
         Ok(workspace)
     }

--- a/utils/wasm-builder/tests/smoke.rs
+++ b/utils/wasm-builder/tests/smoke.rs
@@ -72,6 +72,8 @@ fn install_stable_toolchain() {
 fn test_debug() {
     install_stable_toolchain();
 
+    //TODO: uncomment after solving issue #3915
+    //CargoRunner::new().args(["test"]).run();
     CargoRunner::stable().args(["test"]).run();
 }
 
@@ -89,6 +91,8 @@ fn build_debug() {
 fn test_release() {
     install_stable_toolchain();
 
+    //TODO: uncomment after solving issue #3915
+    //CargoRunner::new().args(["test", "--release"]).run();
     CargoRunner::stable().args(["test", "--release"]).run();
 }
 

--- a/utils/wasm-builder/tests/smoke.rs
+++ b/utils/wasm-builder/tests/smoke.rs
@@ -72,7 +72,7 @@ fn install_stable_toolchain() {
 fn test_debug() {
     install_stable_toolchain();
 
-    CargoRunner::new().args(["test"]).run();
+    //CargoRunner::new().args(["test"]).run();
     CargoRunner::stable().args(["test"]).run();
 }
 
@@ -90,7 +90,7 @@ fn build_debug() {
 fn test_release() {
     install_stable_toolchain();
 
-    CargoRunner::new().args(["test", "--release"]).run();
+    //CargoRunner::new().args(["test", "--release"]).run();
     CargoRunner::stable().args(["test", "--release"]).run();
 }
 

--- a/utils/wasm-builder/tests/smoke.rs
+++ b/utils/wasm-builder/tests/smoke.rs
@@ -72,7 +72,6 @@ fn install_stable_toolchain() {
 fn test_debug() {
     install_stable_toolchain();
 
-    //CargoRunner::new().args(["test"]).run();
     CargoRunner::stable().args(["test"]).run();
 }
 
@@ -90,7 +89,6 @@ fn build_debug() {
 fn test_release() {
     install_stable_toolchain();
 
-    //CargoRunner::new().args(["test", "--release"]).run();
     CargoRunner::stable().args(["test", "--release"]).run();
 }
 


### PR DESCRIPTION
Resolves #3899 by migrating the ecosystem and publishing packages to stable toolchain. 

We still have problems with the nightly version, since `stdsimd` was split into `stdarch_x86_avx512` and we have many old versions of crates (polkadot-sdk, wasmer) that work on our version of the compiler, but are broken on the newer one.