### PR TITLE
feat(runtime): Account for programs locked balance

### DIFF
--- a/gsdk/src/metadata/generated.rs
+++ b/gsdk/src/metadata/generated.rs
@@ -2576,6 +2576,10 @@ pub mod runtime_types {
                     #[doc = "Deposit of funds that will not keep bank account alive."]
                     #[doc = "**Must be unreachable in Gear main protocol.**"]
                     InsufficientDeposit,
+                    #[codec(index = 5)]
+                    #[doc = "Overflow during funds transfer."]
+                    #[doc = "**Must be unreachable in Gear main protocol.**"]
+                    Overflow,
                 }
             }
         }

--- a/pallets/gear-bank/src/tests.rs
+++ b/pallets/gear-bank/src/tests.rs
@@ -729,9 +729,23 @@ fn deposit_value_zero() {
 }
 
 #[test]
-fn deposit_value_insufficient_balance() {
+fn deposit_value_overflow() {
     new_test_ext().execute_with(|| {
         const VALUE: Balance = Balance::MAX;
+
+        assert!(VALUE > Balances::free_balance(ALICE));
+
+        assert_noop!(
+            GearBank::deposit_value(&ALICE, VALUE, false),
+            Error::<Test>::Overflow
+        );
+    })
+}
+
+#[test]
+fn deposit_value_insufficient_balance() {
+    new_test_ext().execute_with(|| {
+        const VALUE: Balance = Balance::MAX / 2;
 
         assert!(VALUE > Balances::free_balance(ALICE));
 
@@ -1464,6 +1478,7 @@ mod utils {
                 Self::InsufficientGasBalance => matches!(other, Self::InsufficientGasBalance),
                 Self::InsufficientValueBalance => matches!(other, Self::InsufficientValueBalance),
                 Self::InsufficientDeposit => matches!(other, Self::InsufficientDeposit),
+                Self::Overflow => matches!(other, Self::Overflow),
                 _ => unimplemented!(),
             }
         }

--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -72,7 +72,11 @@ use frame_support::{
     dispatch::{DispatchResultWithPostInfo, PostDispatchInfo},
     ensure,
     pallet_prelude::*,
-    traits::{ConstBool, Currency, ExistenceRequirement, Get, Randomness, StorageVersion},
+    traits::{
+        fungible,
+        tokens::{Fortitude, Preservation},
+        ConstBool, Currency, ExistenceRequirement, Get, Randomness, StorageVersion,
+    },
     weights::Weight,
 };
 use frame_system::{
@@ -1656,8 +1660,6 @@ pub mod pallet {
             let who = origin;
             let origin = who.clone().into_origin();
 
-            Self::check_gas_limit_and_value(gas_limit, value)?;
-
             let message = HandleMessage::from_packet(
                 Self::next_message_id(origin),
                 HandlePacket::new_with_gas(
@@ -1674,6 +1676,8 @@ pub mod pallet {
                     Self::is_active(&builtins, destination),
                     Error::<T>::InactiveProgram
                 );
+
+                Self::check_gas_limit_and_value(gas_limit, value)?;
 
                 // Message is not guaranteed to be executed, that's why value is not immediately transferred.
                 // That's because destination can fail to be initialized, while this dispatch message is next

--- a/pallets/gear/src/queue.rs
+++ b/pallets/gear/src/queue.rs
@@ -230,7 +230,11 @@ where
                 continue;
             }
 
-            let balance = CurrencyOf::<T>::free_balance(&program_id.cast());
+            let balance = <CurrencyOf<T> as fungible::Inspect<T::AccountId>>::reducible_balance(
+                &program_id.cast(),
+                Preservation::Expendable,
+                Fortitude::Polite,
+            );
 
             let journal = Self::run_queue_step(QueueStep {
                 block_config: &block_config,

--- a/pallets/gear/src/runtime_api.rs
+++ b/pallets/gear/src/runtime_api.rs
@@ -551,8 +551,13 @@ where
         gas: u64,
         value: BalanceOf<T>,
     ) -> RawOrigin<AccountIdOf<T>> {
-        // Querying balance of the account.
-        let origin_balance = CurrencyOf::<T>::free_balance(&origin);
+        // Querying transferrable balance of the origin taking into account a possibility of
+        // a part of its `free` balance being `frozen`.
+        let origin_balance = <CurrencyOf<T> as fungible::Inspect<_>>::reducible_balance(
+            &origin,
+            Preservation::Preserve,
+            Fortitude::Polite,
+        );
 
         // Calculating amount of value to be paid for gas.
         let value_for_gas = <T as pallet_gear_bank::Config>::GasMultiplier::get().gas_to_value(gas);
@@ -625,13 +630,20 @@ where
             block_config.forbidden_funcs = forbidden_funcs;
         }
 
+        // Program's balance that it can spend during the execution keeping its account alive.
+        let disposable_balance = <CurrencyOf<T> as fungible::Inspect<_>>::reducible_balance(
+            &destination.cast(),
+            Preservation::Preserve,
+            Fortitude::Polite,
+        );
+
         // Processing of the message, if destination is common program.
         let journal = Self::run_queue_step(QueueStep {
             block_config: &block_config,
             ext_manager,
             gas_limit,
             dispatch,
-            balance: CurrencyOf::<T>::free_balance(&destination.cast()).unique_saturated_into(),
+            balance: disposable_balance.unique_saturated_into(),
         });
 
         Ok(Some((processed, journal, false)))

--- a/pallets/staking-rewards/src/lib.rs
+++ b/pallets/staking-rewards/src/lib.rs
@@ -515,22 +515,17 @@ impl<T: Config> OnUnbalanced<NegativeImbalanceOf<T>> for OffsetPool<T> {
 pub struct OffsetPoolDust<T>(sp_std::marker::PhantomData<T>);
 impl<T: Config> OnUnbalanced<fungible::Credit<T::AccountId, CurrencyOf<T>>> for OffsetPoolDust<T>
 where
-    CurrencyOf<T>: fungible::Balanced<<T as frame_system::Config>::AccountId>,
-    <T as pallet_staking::Config>::CurrencyBalance:
-        From<<CurrencyOf<T> as fungible::Inspect<<T as frame_system::Config>::AccountId>>::Balance>,
+    CurrencyOf<T>:
+        fungible::Balanced<T::AccountId> + fungible::Inspect<T::AccountId, Balance = BalanceOf<T>>,
 {
-    fn on_nonzero_unbalanced(amount: fungible::Credit<T::AccountId, CurrencyOf<T>>)
-    where
-        CurrencyOf<T>: fungible::Balanced<<T as frame_system::Config>::AccountId>
-            + fungible::Inspect<<T as frame_system::Config>::AccountId>,
-    {
+    fn on_nonzero_unbalanced(amount: fungible::Credit<T::AccountId, CurrencyOf<T>>) {
         let numeric_amount = amount.peek();
 
         let result =
             <CurrencyOf<T> as fungible::Balanced<_>>::resolve(&Pallet::<T>::account_id(), amount);
         match result {
             Ok(()) => Pallet::deposit_event(Event::<T>::Minted {
-                amount: numeric_amount.into(),
+                amount: numeric_amount,
             }),
             Err(amount) => log::error!("Balanced::resolve() err: {:?}", amount.peek()),
         }


### PR DESCRIPTION
A necessary prerequisite for the staking builtin actor to be added. Being able to participate in staking for programs would mean they'll have part of their balances locked while bonding funds. This hasn't been accounted for so far - all checks of programs' funds availability have been based on their `free_balance` which can produce incorrect estimations and lead to errors in transfers.