### PR TITLE
fix(pallet-gear): don't charge gas in benchmarks

### DIFF
--- a/pallets/gear/src/lib.rs
+++ b/pallets/gear/src/lib.rs
@@ -550,12 +550,13 @@ pub mod pallet {
             value: BalanceOf<T>,
         ) -> DispatchResultWithPostInfo {
             use gear_core::code::TryNewCodeConfig;
+            use gear_wasm_instrument::gas_metering::CustomConstantCostRules;
 
             let who = ensure_signed(origin)?;
 
-            let code = Code::try_new_mock_const_or_no_rules(
+            let code = Code::try_new_mock_with_rules(
                 code,
-                true,
+                |_| CustomConstantCostRules::new(0, 0, 0),
                 TryNewCodeConfig {
                     // actual version to avoid re-instrumentation
                     version: T::Schedule::get().instruction_weights.version,


### PR DESCRIPTION
`CustomConstantCostRules::default()` will add some extra overhead in benchmarks

https://github.com/gear-tech/gear/blob/8ba3c6996be2c4fd060f2d9f16b292c72b201f2c/core/src/code/mod.rs#L274-L280
