### PR TITLE
fix(gear-wasm-builder): Support 1.79.0 nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4863,6 +4863,7 @@ dependencies = [
  "parity-wasm",
  "pathdiff",
  "regex",
+ "rustc_version",
  "thiserror",
  "toml 0.8.12",
  "wabt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -454,11 +454,12 @@ libfuzzer-sys = "0.4"                                                     # util
 page_size = { version = "0.6", default-features = false }                 # pallets/gear
 pathdiff = { version = "0.2.1", default-features = false }                # utils/wasm-builder
 rand_pcg = "0.3.1"                                                        # pallets/gear
+rustc_version = "0.4.0"                                                   # utils/wasm-builder
 schnorrkel = "0.9.1"                                                      # gcli
 scopeguard = { version = "1.2.0", default-features = false }              # pallets/gear
 tabled = "0.10.0"                                                         # utils/regression-analysis
 thousands = "0.2.0"                                                       # utils/regression-analysis
-toml = "0.8.12"                                                            # utils/wasm-builder
+toml = "0.8.12"                                                           # utils/wasm-builder
 tracing = "0.1.40"                                                        # utils/node-loader
 tracing-appender = "0.2"                                                  # utils/node-loader
 tracing-subscriber = "0.3.18"                                             # utils/node-loader

--- a/utils/wasm-builder/Cargo.toml
+++ b/utils/wasm-builder/Cargo.toml
@@ -27,6 +27,7 @@ gear-wasm-instrument.workspace = true
 wasm-opt = { workspace = true, optional = true }
 wasmparser.workspace = true
 regex.workspace = true
+rustc_version.workspace = true
 
 [dev-dependencies]
 wabt.workspace = true

--- a/utils/wasm-builder/src/crate_info.rs
+++ b/utils/wasm-builder/src/crate_info.rs
@@ -18,7 +18,7 @@
 
 use anyhow::{Context, Result};
 use cargo_metadata::{Metadata, MetadataCommand, Package};
-use rustc_version::{version, version_meta, Channel, Version};
+use rustc_version::{version, Version};
 use std::{collections::BTreeMap, path::Path};
 
 use crate::builder_error::BuilderError;
@@ -87,16 +87,19 @@ impl CrateInfo {
         //
         // see also https://doc.rust-lang.org/reference/linkage.html
         let validated_lib = |ty: &String| ty == "lib" || ty == "rlib";
+        let pkg_snake_case_name = pkg.name.replace('-', "_");
+        let rustc_version = Version::parse("1.79.0").unwrap();
+
         let _ = pkg
             .targets
             .iter()
             .find(|target| {
                 // Check for rustc version. See https://github.com/rust-lang/cargo/pull/12783
-                if version().unwrap() >= Version::parse("1.78.0").unwrap() {
-                    let pkg_snake_case_name = pkg.name.replace('-', "_");
-                    target.name.eq(&pkg_snake_case_name) && target.crate_types.iter().any(validated_lib)
-                } else {
+                if version().unwrap() < rustc_version {
                     target.name.eq(&pkg.name) && target.crate_types.iter().any(validated_lib)
+                } else {
+                    target.name.eq(&pkg_snake_case_name)
+                        && target.crate_types.iter().any(validated_lib)
                 }
             })
             .ok_or(BuilderError::CrateTypeInvalid)?;


### PR DESCRIPTION
cargo-metadata output for target names changes with Rust 1.79 due to PR https://github.com/rust-lang/cargo/pull/12783 fixing issue https://github.com/rust-lang/cargo/issues/12780. (TLDR: dashes in target names are replaced with underscores starting with Rust 1.79)

Currently, if a user tries to build a program where the package name contains a dash, they will receive an error message:
```bash
error: failed to run custom build command for `gear-guessing-game v0.1.0 (/projects/gear-guessing-game)`

Caused by:
  process didn't exit successfully: `/projects/gear-guessing-game/target/release/build/gear-guessing-game-f6620258e346ef1d/build-script-build` (exit status: 1)
  --- stderr
  error: please add "rlib" to [lib.crate-type]
```

@gear-tech/dev 
