### PR TITLE
chore(ci): Disable spec_version check in try-runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
           echo "---------- Building vara runtime ----------"
           time cargo build -p vara-runtime -F std,try-runtime --locked ${{ matrix.profiles.flags }}
           echo "---------- Executing on-runtime-upgrade for Vara ----------"
-          time ./try-runtime --runtime ./target/${{ matrix.profiles.name }}/wbuild/vara-runtime/vara_runtime.wasm on-runtime-upgrade --checks=all --no-weight-warnings live --uri ws://rpc-private.vara-network.io:9944
+          time ./try-runtime --runtime ./target/${{ matrix.profiles.name }}/wbuild/vara-runtime/vara_runtime.wasm on-runtime-upgrade --checks=all --no-weight-warnings --disable-spec-version-check live --uri ws://rpc-private.vara-network.io:9944
           sleep 5
         env:
           RUST_LOG: info,remote-ext=debug,runtime=debug


### PR DESCRIPTION
When on-chain runtime is updated, the try-runtime job fails with an error, but the development cycle does not have to depend on the on-chain.

related to https://github.com/gear-tech/gear/actions/runs/8900419011/job/24441943523?pr=3921

@gear-tech/dev 
