### PR TITLE
chore(ci): set `--repeat=0` for all testing benchmarks run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,13 +117,13 @@ jobs:
         run: |
           cargo build -p gear-cli --features=runtime-benchmarks,runtime-benchmarks-checkers ${{ matrix.profiles.flags }}
           # check that perf benchmarks works. `--steps=5` need to test, that benchmarks works for different input number.
-          ./target/${{ matrix.profiles.name }}/gear benchmark pallet --chain=dev --pallet="*" --steps=5 --extrinsic="*" --heap-pages=4096
+          ./target/${{ matrix.profiles.name }}/gear benchmark pallet --chain=dev --pallet="*" --steps=5 --repeat=0 --extrinsic="*" --heap-pages=4096
           # check that read_big_state benchmarks works
-          ./target/${{ matrix.profiles.name }}/gear benchmark pallet --chain=dev --pallet=pallet_gear --extrinsic="read_big_state" --heap-pages=4096 --extra
+          ./target/${{ matrix.profiles.name }}/gear benchmark pallet --chain=dev --pallet=pallet_gear --repeat=0 --extrinsic="read_big_state" --heap-pages=4096 --extra
           # check that signal_stack_limit_exceeded_works benchmarks works
-          ./target/${{ matrix.profiles.name }}/gear benchmark pallet --chain=dev --pallet=pallet_gear --extrinsic="signal_stack_limit_exceeded_works" --heap-pages=4096 --extra
+          ./target/${{ matrix.profiles.name }}/gear benchmark pallet --chain=dev --pallet=pallet_gear --repeat=0 --extrinsic="signal_stack_limit_exceeded_works" --heap-pages=4096 --extra
           # check that check/test benchmarks works
-          ./target/${{ matrix.profiles.name }}/gear benchmark pallet --chain=dev --pallet=pallet_gear --extrinsic="check_all" --heap-pages=4096 --extra
+          ./target/${{ matrix.profiles.name }}/gear benchmark pallet --chain=dev --pallet=pallet_gear --repeat=0 --extrinsic="check_all" --heap-pages=4096 --extra
 
       - name: "Test: Syscalls Wasmi integrity"
         run: ./scripts/gear.sh test syscalls ${{ matrix.profiles.flags }}


### PR DESCRIPTION
Because now default is not 0, so increase running time. 
https://github.com/gear-tech/polkadot-sdk/blob/bab0348372b58d5106333faa597423242e831a31/substrate/utils/frame/benchmarking-cli/src/pallet/mod.rs#L57-L59

Default steps also `50` now. But steps are not taken in account for `--extra` benchmarks without steps.