### PR TITLE
fix(pallet-gear): unable to run migration `MigrateWaitingInitList` with try-runtime

### DIFF
--- a/pallets/gear/src/migrations.rs
+++ b/pallets/gear/src/migrations.rs
@@ -103,8 +103,8 @@ where
 
     #[cfg(feature = "try-runtime")]
     fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
-        let current = Pallet::<T>::current_storage_version();
-        let onchain = Pallet::<T>::on_chain_storage_version();
+        let current = pallet_gear_program::Pallet::<T>::current_storage_version();
+        let onchain = pallet_gear_program::Pallet::<T>::on_chain_storage_version();
 
         let data = if onchain == MIGRATE_FROM_VERSION {
             ensure!(


### PR DESCRIPTION
Wrong storage version check in the `pre_upgrade` hook. Affects only `try-runtime` runs.

@reviewer-or-team
