### PR TITLE
chore(cargo-gbuild): soft link rust-toolchain from the root workspace

### DIFF
--- a/utils/cargo-gbuild/test-program/rust-toolchain.toml
+++ b/utils/cargo-gbuild/test-program/rust-toolchain.toml
@@ -1,0 +1,1 @@
+../../../rust-toolchain.toml


### PR DESCRIPTION
Resolves # .

introduce a soft link for the root rust-toolchain in the smoke tests of `cargo-gbuild`

@techraed 
