### PR TITLE
feat(gsdk): Print SCALE metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5265,6 +5265,7 @@ dependencies = [
  "gear-runtime-interface",
  "gear-utils",
  "heck 0.5.0",
+ "hex",
  "parity-scale-codec",
  "proc-macro2",
  "quote",

--- a/gsdk/api-gen/Cargo.toml
+++ b/gsdk/api-gen/Cargo.toml
@@ -17,6 +17,7 @@ quote.workspace = true
 parity-scale-codec.workspace = true
 scale-info.workspace = true
 heck.workspace = true
+hex.workspace = true
 # NOTE: only required by this package.
 #
 # Same version from `/Cargo.lock`

--- a/gsdk/api-gen/src/main.rs
+++ b/gsdk/api-gen/src/main.rs
@@ -51,7 +51,7 @@ fn main() -> Result<()> {
         panic!("Invalid metadata, doesn't even have enough bytes for the magic number.");
     }
 
-    if let Ok(_) = env::var(PRINT_SCALE) {
+    if env::var(PRINT_SCALE).is_ok() {
         io::stdout().write_all(("0x".to_owned() + &hex::encode(&encoded[4..])).as_bytes())?;
         return Ok(());
     }

--- a/gsdk/api-gen/src/main.rs
+++ b/gsdk/api-gen/src/main.rs
@@ -32,6 +32,7 @@ use subxt_metadata::Metadata;
 use syn::{parse_quote, Fields, ItemEnum, ItemImpl, ItemMod, Variant};
 
 const RUNTIME_WASM: &str = "RUNTIME_WASM";
+const PRINT_SCALE: &str = "PRINT_SCALE";
 const USAGE: &str = r#"
 Usage: RUNTIME_WASM=<path> generate-client-api
 "#;
@@ -39,7 +40,7 @@ Usage: RUNTIME_WASM=<path> generate-client-api
 fn main() -> Result<()> {
     color_eyre::install()?;
 
-    if env::args().len() != 1 {
+    if env::args().len() < 1 {
         println!("{}", USAGE.trim());
         return Ok(());
     }
@@ -48,6 +49,11 @@ fn main() -> Result<()> {
     let encoded = metadata();
     if encoded.len() < 4 {
         panic!("Invalid metadata, doesn't even have enough bytes for the magic number.");
+    }
+
+    if let Ok(_) = env::var(PRINT_SCALE) {
+        io::stdout().write_all(("0x".to_owned() + &hex::encode(&encoded[4..])).as_bytes())?;
+        return Ok(());
     }
 
     // NOTE: [4..] here for removing the magic number.


### PR DESCRIPTION
Add `PRINT_SCALE` env var.

Useful for updating backend/frontend before the upgrade. Publish `metadata.scale` to release artifacts.

Usage:
```bash
RUNTIME_WASM=production_vara_runtime_v1400.wasm PRINT_SCALE=1 cargo run -p gsdk-api-gen --release > meta.txt
```

@gear-tech/dev 
