### PR TITLE
chore: Update rust nightly to 2024-06-04

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom 0.2.10",
  "once_cell",
@@ -5446,7 +5446,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.6",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -5455,7 +5455,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.6",
+ "ahash 0.7.8",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,9 +2922,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derivative"
@@ -7672,6 +7675,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-format"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9359,6 +9368,12 @@ name = "portable-atomic"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -13529,12 +13544,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.27"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb39ee79a6d8de55f48f2293a830e040392f1c5f16e336bdd1788cd0aadce07"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -13542,16 +13559,17 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.13"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733d258752e9303d392b94b75230d07b0b9c489350c69b851fc6c065fde3e8f9"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2141,9 +2141,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f711ade317dd348950a9910f81c5947e3d8907ebd2b83f76203ff1807e6a2bc2"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3247,7 +3247,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
 dependencies = [
- "curve25519-dalek 4.0.0",
+ "curve25519-dalek 4.1.2",
  "ed25519",
  "rand_core 0.6.4",
  "serde",
@@ -3574,9 +3574,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.20"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "file-per-thread-logger"
@@ -7247,7 +7247,7 @@ dependencies = [
  "bitflags 1.3.2",
  "blake2 0.10.6",
  "c2-chacha",
- "curve25519-dalek 4.0.0",
+ "curve25519-dalek 4.1.2",
  "either",
  "hashlink",
  "lioness",
@@ -12100,7 +12100,7 @@ dependencies = [
  "aes-gcm 0.9.4",
  "blake2 0.10.6",
  "chacha20poly1305",
- "curve25519-dalek 4.0.0",
+ "curve25519-dalek 4.1.2",
  "rand_core 0.6.4",
  "ring 0.16.20",
  "rustc_version",
@@ -12734,7 +12734,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/gear-tech/polkadot-sdk.git?branch=gear-v1.3.0#8c76964cc3c2debb09a81f8b85976bb3a43f766b"
 dependencies = [
  "aes-gcm 0.10.3",
- "curve25519-dalek 4.0.0",
+ "curve25519-dalek 4.1.2",
  "ed25519-dalek",
  "hkdf 0.12.4",
  "parity-scale-codec",
@@ -15725,7 +15725,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek 4.0.0",
+ "curve25519-dalek 4.1.2",
  "rand_core 0.6.4",
  "serde",
  "zeroize",

--- a/common/numerated/src/numerated.rs
+++ b/common/numerated/src/numerated.rs
@@ -29,7 +29,7 @@ use num_traits::{One, PrimInt, Unsigned};
 ///
 /// # Examples
 /// 1) For any `T`, which max value can be get by calling some static live time function,
-/// `Option<T>`` can be used as `Bound<T>`. `None` is __upper__. Mapping: Some(t) -> t, t -> Some(t).
+///    `Option<T>`` can be used as `Bound<T>`. `None` is __upper__. Mapping: Some(t) -> t, t -> Some(t).
 ///
 /// 2) When `inner` field max value is always smaller than `inner` type max value, then we can use this variant:
 /// ```
@@ -77,14 +77,14 @@ pub trait Numerated: Copy + Sized + Ord + Eq {
     /// # Guaranties
     /// - iff `self + num` is enclosed by `self` and `other`, then returns `Some(_)`.
     /// - iff `self.add_if_enclosed_by(num, other) == Some(a)`,
-    /// then `a.sub_if_enclosed_by(num, self) == Some(self)`.
+    ///   then `a.sub_if_enclosed_by(num, self) == Some(self)`.
     fn add_if_enclosed_by(self, num: Self::Distance, other: Self) -> Option<Self>;
     /// Subtracts `num` from `self`, if `self - num` is enclosed by `self` and `other`.
     ///
     /// # Guaranties
     /// - iff `self - num` is enclosed by `self` and `other`, then returns `Some(_)`.
     /// - iff `self.sub_if_enclosed_by(num, other) == Some(a)`,
-    /// then `a.add_if_enclosed_by(num, self) == Some(self)`.
+    ///   then `a.add_if_enclosed_by(num, self) == Some(self)`.
     fn sub_if_enclosed_by(self, num: Self::Distance, other: Self) -> Option<Self>;
     /// Returns a distance between `self` and `other`
     ///

--- a/common/src/gas_provider/internal.rs
+++ b/common/src/gas_provider/internal.rs
@@ -250,7 +250,7 @@ where
     /// 1. If `catch_value` call ended up with `CatchValueOutput::Missed` in
     ///    `consume`, all the calls of catch_value on ancestor nodes will be
     ///    `CatchValueOutput::Missed` as well.
-    /// 
+    ///
     /// That's because if there is an existing ancestor patron on the path from
     /// the `key` node to the root, catching value on all the nodes before that
     /// patron on this same path will give the same `CatchValueOutput::Missed`
@@ -263,7 +263,7 @@ where
     /// 3. If `catch_value` call ended up with `CatchValueOutput::Caught(x)` in
     ///    `consume`, all the calls of `catch_value` on ancestor nodes will be
     ///    `CatchValueOutput::Caught(0)`.
-    /// 
+    ///
     /// That's due to the 12-th invariant stated in [`super::property_tests`]
     ///   module docs. When node becomes consumed without unspec refs (i.e.,
     ///   stops being a patron) `consume` procedure call on such node either
@@ -271,7 +271,7 @@ where
     ///   value to the origin. So any repetitive `catch_value` call on such
     ///   nodes results in `CatchValueOutput::Caught(0)` (if there is an
     ///   ancestor patron).
-    /// 
+    ///
     /// So if `consume` procedure on the node with `key` id resulted in value
     ///    being caught, it means that there are no ancestor patrons, so none of
     ///    `catch_value` calls on the node's ancestors will return

--- a/common/src/gas_provider/internal.rs
+++ b/common/src/gas_provider/internal.rs
@@ -248,8 +248,9 @@ where
     /// Internal invariant of the procedure:
     ///
     /// 1. If `catch_value` call ended up with `CatchValueOutput::Missed` in
-    /// `consume`, all the calls of catch_value on ancestor nodes will be
-    /// `CatchValueOutput::Missed` as well.
+    ///    `consume`, all the calls of catch_value on ancestor nodes will be
+    ///    `CatchValueOutput::Missed` as well.
+    /// 
     /// That's because if there is an existing ancestor patron on the path from
     /// the `key` node to the root, catching value on all the nodes before that
     /// patron on this same path will give the same `CatchValueOutput::Missed`
@@ -257,23 +258,25 @@ where
     /// will receive their values.
     ///
     /// 2. Also in that case cascade ancestors consumption will last until
-    /// either the patron node or the first ancestor with specified child found.
+    ///    either the patron node or the first ancestor with specified child found.
     ///
     /// 3. If `catch_value` call ended up with `CatchValueOutput::Caught(x)` in
-    /// `consume`, all the calls of `catch_value` on ancestor nodes will be
-    /// `CatchValueOutput::Caught(0)`.
+    ///    `consume`, all the calls of `catch_value` on ancestor nodes will be
+    ///    `CatchValueOutput::Caught(0)`.
+    /// 
     /// That's due to the 12-th invariant stated in [`super::property_tests`]
-    /// module docs. When node becomes consumed without unspec refs (i.e.,
-    /// stops being a patron) `consume` procedure call on such node either
-    /// moves value upstream (if there is an ancestor patron) or returns
-    /// value to the origin. So any repetitive `catch_value` call on such
-    /// nodes results in `CatchValueOutput::Caught(0)` (if there is an
-    /// ancestor patron).
+    ///   module docs. When node becomes consumed without unspec refs (i.e.,
+    ///   stops being a patron) `consume` procedure call on such node either
+    ///   moves value upstream (if there is an ancestor patron) or returns
+    ///   value to the origin. So any repetitive `catch_value` call on such
+    ///   nodes results in `CatchValueOutput::Caught(0)` (if there is an
+    ///   ancestor patron).
+    /// 
     /// So if `consume` procedure on the node with `key` id resulted in value
-    /// being caught, it means that there are no ancestor patrons, so none of
-    /// `catch_value` calls on the node's ancestors will return
-    /// `CatchValueOutput::Missed`, but will return
-    /// `CatchValueOutput::Caught(0)`.
+    ///    being caught, it means that there are no ancestor patrons, so none of
+    ///    `catch_value` calls on the node's ancestors will return
+    ///    `CatchValueOutput::Missed`, but will return
+    ///    `CatchValueOutput::Caught(0)`.
     fn try_remove_consumed_ancestors(
         key: NodeId,
         descendant_catch_output: CatchValueOutput<Balance>,

--- a/common/src/gas_provider/property_tests/mod.rs
+++ b/common/src/gas_provider/property_tests/mod.rs
@@ -41,7 +41,7 @@
 //! 6. All non-external nodes have ancestor with value (for example,
 //!    [`TreeImpl::node_with_value`] procedure always return `Ok`),
 //!    however this value can be equal to 0.
-//! 
+//!
 //! This ancestor is either a parent or the node itself.
 //!
 //! 7. All nodes can't have consumed parent with zero refs (there can't be any

--- a/common/src/gas_provider/property_tests/mod.rs
+++ b/common/src/gas_provider/property_tests/mod.rs
@@ -21,57 +21,58 @@
 //! 1. Nodes can become consumed only after [`Tree::consume`] call.
 //!
 //! 2. Unspec refs counter for the current node is incremented only after
-//! [`Tree::split`] which creates a node with [`GasNode::UnspecifiedLocal`]
-//! type.
+//!    [`Tree::split`] which creates a node with [`GasNode::UnspecifiedLocal`]
+//!    type.
 //!
 //! 3. Spec refs counter for the current node is incremented only after
-//! [`GasNode::split_with_value`], which creates a node with
-//! [`GasNode::SpecifiedLocal`] type.
+//!    [`GasNode::split_with_value`], which creates a node with
+//!    [`GasNode::SpecifiedLocal`] type.
 //!
 //! 4. All nodes, except for [`GasNode::Cut`], [`GasNode::Reserve`] and
-//! [`GasNode::External`] have a parent in GasTree storage.
+//!    [`GasNode::External`] have a parent in GasTree storage.
 //!
 //! 5. All nodes with parent point to a parent with value. So if a `key` is an
-//! id of [`GasNode::SpecifiedLocal`], [`GasNode::Reserved`] or [`GasNode::External`] node,
-//! the node under this `key` will always be a parent of the newly generated node
-//! after [`Tree::split`]/[`Tree::split_with_value`] call.
-//! However, there is no such guarantee if key is an id of the
-//! [`GasNode::UnspecifiedLocal`] nodes.
+//!    id of [`GasNode::SpecifiedLocal`], [`GasNode::Reserved`] or [`GasNode::External`] node,
+//!    the node under this `key` will always be a parent of the newly generated node
+//!    after [`Tree::split`]/[`Tree::split_with_value`] call.
+//!    However, there is no such guarantee if key is an id of the
+//!    [`GasNode::UnspecifiedLocal`] nodes.
 //!
 //! 6. All non-external nodes have ancestor with value (for example,
-//! [`TreeImpl::node_with_value`] procedure always return `Ok`),
-//! however this value can be equal to 0.
+//!    [`TreeImpl::node_with_value`] procedure always return `Ok`),
+//!    however this value can be equal to 0.
+//! 
 //! This ancestor is either a parent or the node itself.
 //!
 //! 7. All nodes can't have consumed parent with zero refs (there can't be any
-//! nodes like that in storage) between calls to [`Tree::consume`]. Therefore,
-//! if node is deleted, it is consumed and has zero refs (and zero value).
+//!    nodes like that in storage) between calls to [`Tree::consume`]. Therefore,
+//!    if node is deleted, it is consumed and has zero refs (and zero value).
 //!
 //! 8. [`GasNode::UnspecifiedLocal`] nodes are always leaves in the tree (they
-//! have no children), so they are always deleted after consume call. The same
-//! rule is for [`GasNode::Cut`] nodes. So there can't be any
-//! [`GasNode::UnspecifiedLocal`] node in the tree with consumed field
-//! set to true. So if there is an **existing consumed** node, then it
-//! has non-zero refs counter and a value >= 0 (between calls to
-//! [`Tree::consume`]).
+//!    have no children), so they are always deleted after consume call. The same
+//!    rule is for [`GasNode::Cut`] nodes. So there can't be any
+//!    [`GasNode::UnspecifiedLocal`] node in the tree with consumed field
+//!    set to true. So if there is an **existing consumed** node, then it
+//!    has non-zero refs counter and a value >= 0 (between calls to
+//!    [`Tree::consume`]).
 //!
 //! 9. In a tree a root with [`GasNode::External`] or [`GasNode::Reserved`]
-//! type is always deleted last.
+//!    type is always deleted last.
 //!
 //! 10. If node wasn't removed after `consume` it's [`GasNode::SpecifiedLocal`],
-//! [`GasNode::Reserved`] or [`GasNode::External`] node. Similar to the previous invariant, but
-//! focuses more on [`Tree::consume`] procedure, while the other focuses
-//! on the all tree invariant. (checked in `consume` call assertions).
+//!      [`GasNode::Reserved`] or [`GasNode::External`] node. Similar to the previous invariant, but
+//!      focuses more on [`Tree::consume`] procedure, while the other focuses
+//!      on the all tree invariant. (checked in `consume` call assertions).
 //!
 //! 11. [`GasNode::UnspecifiedLocal`] and [`GasNode::Cut`] nodes can't
-//! be removed, nor mutated during cascade removal. So after [`Tree::consume`]
-//! call not more than one node is of [`GasNode::UnspecifiedLocal`] type.
+//!      be removed, nor mutated during cascade removal. So after [`Tree::consume`]
+//!      call not more than one node is of [`GasNode::UnspecifiedLocal`] type.
 //!
 //! 12. Between calls to [`Tree::consume`] if node is consumed and has no unspec
-//! refs, it's internal gas value is zero.
+//!     refs, it's internal gas value is zero.
 //!
 //! 13. Between calls to [`Tree::consume`] if node has value, it's either not
-//! consumed or it has unspecified children.
+//!     consumed or it has unspecified children.
 //!
 //! 14. Value catch can be performed only on consumed nodes (not tested).
 

--- a/common/src/storage/complex/messenger.rs
+++ b/common/src/storage/complex/messenger.rs
@@ -81,7 +81,7 @@ pub trait Messenger {
     type DispatchStashKey;
 
     /// Amount of messages sent from outside (from users)
-    /// within the current block.
+    ///    within the current block.
     ///
     /// Used as local counter for `MessageId` generation.
     type Sent: Counter<Value = Self::Capacity>;
@@ -138,16 +138,16 @@ pub trait Messenger {
     ///
     /// Message can be inserted into waitlist only in these cases:
     /// 1. Destination program called `gr_wait` while was executing
-    /// this message, so only this program can remove and
-    /// requeue it by `gr_wake` call in any execution.
+    ///    this message, so only this program can remove and
+    ///    requeue it by `gr_wake` call in any execution.
     /// 2. The message sent to program, that hadn't finished its
-    /// initialization, and will be automatically removed once
-    /// result of initialization would be available.
+    ///    initialization, and will be automatically removed once
+    ///    result of initialization would be available.
     /// 3. Restored after resuming paused programs. On pause we
-    /// collect waitlist content addressed to the program,
-    /// removing it afterwards. On resume, user should provide
-    /// the same content to be able to unpause program, which
-    /// gonna be added into waitlist again.
+    ///    collect waitlist content addressed to the program,
+    ///    removing it afterwards. On resume, user should provide
+    ///    the same content to be able to unpause program, which
+    ///    gonna be added into waitlist again.
     ///
     /// More cases may be considered in future.
     ///

--- a/common/src/storage/complicated/dequeue.rs
+++ b/common/src/storage/complicated/dequeue.rs
@@ -22,11 +22,11 @@
 //! This dequeue algorithm has main invariants:
 //! - If dequeue is empty, it's head and tail should be empty.
 //! - If dequeue contains the only one elements, is'ts head and tail
-//! should equal this element's key.
+//!    should equal this element's key.
 //! - Based on above specified points, head and tail should
-//! both be set or be empty.
+//!    both be set or be empty.
 //! - Inner map should contain values under keys, set in head and tail,
-//! if they present.
+//!    if they present.
 
 use crate::storage::{Callback, Counted, EmptyCallback, IterableMap, MapStorage, ValueStorage};
 use core::marker::PhantomData;

--- a/core-processor/src/lib.rs
+++ b/core-processor/src/lib.rs
@@ -20,7 +20,6 @@
 
 #![no_std]
 #![warn(missing_docs)]
-#![cfg_attr(feature = "strict", deny(warnings))]
 #![doc(html_logo_url = "https://docs.gear.rs/logo.svg")]
 #![doc(html_favicon_url = "https://gear-tech.io/favicons/favicon.ico")]
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -22,7 +22,6 @@
 //! To be used primary in Gear Substrate node implementation, but it is not limited to that.
 #![no_std]
 #![warn(missing_docs)]
-#![cfg_attr(feature = "strict", deny(warnings))]
 #![doc(html_logo_url = "https://docs.gear.rs/logo.svg")]
 #![doc(html_favicon_url = "https://gear-tech.io/favicons/favicon.ico")]
 

--- a/examples/constructor/src/builder.rs
+++ b/examples/constructor/src/builder.rs
@@ -47,7 +47,7 @@ impl Calls {
     }
 
     pub fn add_from_iter(mut self, calls: impl Iterator<Item = Call>) -> Self {
-        self.0.extend(calls.into_iter());
+        self.0.extend(calls);
         self
     }
 

--- a/examples/distributor/src/lib.rs
+++ b/examples/distributor/src/lib.rs
@@ -46,6 +46,7 @@ pub enum Reply {
     Amount(u64),
 }
 
+#[allow(dead_code)]
 #[derive(Eq, Ord, PartialEq, PartialOrd)]
 struct Program {
     handle: ActorId,

--- a/galloc/src/lib.rs
+++ b/galloc/src/lib.rs
@@ -17,7 +17,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 #![no_std]
-#![cfg_attr(feature = "strict", deny(warnings))]
 #![doc(html_logo_url = "https://docs.gear.rs/logo.svg")]
 #![doc(html_favicon_url = "https://gear-tech.io/favicons/favicon.ico")]
 

--- a/gcli/src/cmd/config.rs
+++ b/gcli/src/cmd/config.rs
@@ -135,9 +135,9 @@ impl AsRef<str> for Network {
     }
 }
 
-impl ToString for Network {
-    fn to_string(&self) -> String {
-        self.as_ref().into()
+impl fmt::Display for Network {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 

--- a/gcli/src/meta/registry.rs
+++ b/gcli/src/meta/registry.rs
@@ -129,6 +129,7 @@ impl<'t, T: Form<Type = UntrackedSymbol<TypeId>>> fmt::Display for LocalType<'t,
 
 /// Local type registry
 pub trait LocalRegistry: Sized + Clone {
+    #[allow(dead_code)]
     fn from_hex(hex: &str) -> Result<Self>;
 
     /// Get type from identity

--- a/gclient/src/lib.rs
+++ b/gclient/src/lib.rs
@@ -127,7 +127,6 @@
 //! ```
 
 #![warn(missing_docs)]
-#![cfg_attr(feature = "strict", deny(warnings))]
 #![doc(html_logo_url = "https://docs.gear.rs/logo.svg")]
 #![doc(html_favicon_url = "https://gear-tech.io/favicons/favicon.ico")]
 

--- a/gcore/src/lib.rs
+++ b/gcore/src/lib.rs
@@ -48,13 +48,13 @@
 //!     }
 //! }
 //!
-//! # #[cfg(target = "wasm32")]
+//! # #[cfg(target_arch = "wasm32")]
 //! #[alloc_error_handler]
 //! pub fn oom(_: core::alloc::Layout) -> ! {
 //!     core::arch::wasm32::unreachable()
 //! }
 //!
-//! # #[cfg(target = "wasm32")]
+//! # #[cfg(target_arch = "wasm32")]
 //! #[panic_handler]
 //! fn panic(_: &core::panic::PanicInfo) -> ! {
 //!     core::arch::wasm32::unreachable()

--- a/gcore/src/lib.rs
+++ b/gcore/src/lib.rs
@@ -64,7 +64,6 @@
 
 #![no_std]
 #![warn(missing_docs)]
-#![cfg_attr(feature = "strict", deny(warnings))]
 #![doc(html_logo_url = "https://docs.gear.rs/logo.svg")]
 #![doc(html_favicon_url = "https://gear-tech.io/favicons/favicon.ico")]
 #![doc(test(attr(deny(warnings), allow(unused_variables, unused_assignments))))]

--- a/gmeta/codegen/src/lib.rs
+++ b/gmeta/codegen/src/lib.rs
@@ -115,10 +115,10 @@ fn validate_if_has_no_attributes(
 /// # Syntax
 ///
 /// - This attribute **must** be used on the `pub`lic `mod` container with the
-/// `metafns` identifier.
+///   `metafns` identifier.
 /// - The first item in the module **must** be a `pub`lic `type` alias with the
-/// `State` identifier. The type for which `State` will be an alias **must**
-/// implement [`Decode`] trait.
+///   `State` identifier. The type for which `State` will be an alias **must**
+///   implement [`Decode`] trait.
 ///
 /// Usually the state type should be imported from the implemented associated
 /// [`Metadata::State`](../gmeta/trait.Metadata.html#associatedtype.State) type
@@ -127,19 +127,19 @@ fn validate_if_has_no_attributes(
 /// - The rest of items **must** be `pub`lic functions.
 /// - The first argument's type of metafunctions **must** be `State`.
 /// - If the first argument uses
-/// [the identifier pattern](https://doc.rust-lang.org/stable/reference/patterns.html#identifier-patterns),
-/// the identifier **must** be `state` or `_state`.
+///   [the identifier pattern](https://doc.rust-lang.org/stable/reference/patterns.html#identifier-patterns),
+///   the identifier **must** be `state` or `_state`.
 ///
 /// In addition to the mandatory first argument, functions can have additional
 /// ones.
 ///
 /// - The maximum amount of additional arguments is 18 due restrictions of the
-/// SCALE codec.
+///   SCALE codec.
 /// - All additional arguments **must** implement the [`Decode`] &
-/// [`TypeInfo`] traits.
+///   [`TypeInfo`] traits.
 /// - A function **mustn't** return `()` or nothing.
 /// - A returned type **must** implement the
-/// [`Encode`](../gmeta/trait.Encode.html) & [`TypeInfo`] traits.
+///   [`Encode`](../gmeta/trait.Encode.html) & [`TypeInfo`] traits.
 ///
 /// [`Decode`]: ../gmeta/trait.Decode.html
 /// [`TypeInfo`]: ../gmeta/trait.TypeInfo.html
@@ -166,7 +166,7 @@ fn validate_if_has_no_attributes(
 /// - For `some_function` an argument must be [`None`].
 /// - For `another_function_but_with_arg` an argument must be `Some(SomeArg)`.
 /// - For `function_with_multiple_args` an argument must be
-/// `Some((SomeArg, u16, u32))`.
+///   `Some((SomeArg, u16, u32))`.
 #[proc_macro_attribute]
 pub fn metawasm(_: TokenStream, item: TokenStream) -> TokenStream {
     process(parse_macro_input!(item)).unwrap_or_else(|error| error.into_compile_error().into())

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -148,6 +148,8 @@
 #![doc(html_favicon_url = "https://gear-tech.io/favicons/favicon.ico")]
 #![doc(test(attr(deny(warnings), allow(unused_variables, unused_assignments))))]
 
+#![allow(ambiguous_glob_reexports)]
+
 extern crate alloc;
 
 #[cfg(target_arch = "wasm32")]

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -147,7 +147,6 @@
 #![doc(html_logo_url = "https://docs.gear.rs/logo.svg")]
 #![doc(html_favicon_url = "https://gear-tech.io/favicons/favicon.ico")]
 #![doc(test(attr(deny(warnings), allow(unused_variables, unused_assignments))))]
-
 #![allow(ambiguous_glob_reexports)]
 
 extern crate alloc;

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -144,7 +144,6 @@
     all(target_arch = "wasm32", feature = "oom-handler"),
     feature(alloc_error_handler)
 )]
-#![cfg_attr(feature = "strict", deny(warnings))]
 #![doc(html_logo_url = "https://docs.gear.rs/logo.svg")]
 #![doc(html_favicon_url = "https://gear-tech.io/favicons/favicon.ico")]
 #![doc(test(attr(deny(warnings), allow(unused_variables, unused_assignments))))]

--- a/gstd/src/reservations.rs
+++ b/gstd/src/reservations.rs
@@ -136,8 +136,8 @@ impl Reservation {
 /// ```
 ///
 /// # See also
-/// - [`ReservationId`](ReservationId) is used to reserve and unreserve gas
-///   for program execution later.
+/// - [`ReservationId`](ReservationId) is used to reserve and unreserve gas for
+///   program execution later.
 /// - [`Reservation`] stores some additional data along with `ReservationId`.
 #[derive(Default, Clone, Debug, TypeInfo, Hash, Encode, Decode)]
 pub struct Reservations(Vec<Reservation>);
@@ -218,8 +218,8 @@ impl Reservations {
     /// reservations that were found in process of search are cleaned out.
     ///
     /// # See also
-    /// - [`ReservationId`] is used to reserve and unreserve gas amount
-    ///   for program execution later.
+    /// - [`ReservationId`] is used to reserve and unreserve gas amount for
+    ///   program execution later.
     /// - [`Reservation`] stores some additional data along with
     ///   `ReservationId`.
     pub fn try_take_reservation(&mut self, amount: u64) -> Option<Reservation> {

--- a/gstd/src/reservations.rs
+++ b/gstd/src/reservations.rs
@@ -137,7 +137,7 @@ impl Reservation {
 ///
 /// # See also
 /// - [`ReservationId`](ReservationId) is used to reserve and unreserve gas
-/// for program execution later.
+///   for program execution later.
 /// - [`Reservation`] stores some additional data along with `ReservationId`.
 #[derive(Default, Clone, Debug, TypeInfo, Hash, Encode, Decode)]
 pub struct Reservations(Vec<Reservation>);
@@ -219,7 +219,7 @@ impl Reservations {
     ///
     /// # See also
     /// - [`ReservationId`] is used to reserve and unreserve gas amount
-    /// for program execution later.
+    ///   for program execution later.
     /// - [`Reservation`] stores some additional data along with
     ///   `ReservationId`.
     pub fn try_take_reservation(&mut self, amount: u64) -> Option<Reservation> {

--- a/gstd/src/util.rs
+++ b/gstd/src/util.rs
@@ -45,7 +45,9 @@ pub(crate) fn with_optimized_encode<T, E: Encode>(payload: E, f: impl FnOnce(&[u
             // &[MaybeUninit<T>]` is written to uninitialized memory via `copy_from_slice`.
             let end_offset = self.offset + bytes.len();
             let this = unsafe { self.buffer.get_unchecked_mut(self.offset..end_offset) };
-            this.copy_from_slice(unsafe { transmute::<&[u8], &[core::mem::MaybeUninit<u8>]>(bytes) });
+            this.copy_from_slice(unsafe {
+                transmute::<&[u8], &[core::mem::MaybeUninit<u8>]>(bytes)
+            });
             self.offset = end_offset;
         }
     }

--- a/gstd/src/util.rs
+++ b/gstd/src/util.rs
@@ -45,7 +45,7 @@ pub(crate) fn with_optimized_encode<T, E: Encode>(payload: E, f: impl FnOnce(&[u
             // &[MaybeUninit<T>]` is written to uninitialized memory via `copy_from_slice`.
             let end_offset = self.offset + bytes.len();
             let this = unsafe { self.buffer.get_unchecked_mut(self.offset..end_offset) };
-            this.copy_from_slice(unsafe { transmute(bytes) });
+            this.copy_from_slice(unsafe { transmute::<&[u8], &[core::mem::MaybeUninit<u8>]>(bytes) });
             self.offset = end_offset;
         }
     }

--- a/gtest/src/lib.rs
+++ b/gtest/src/lib.rs
@@ -208,7 +208,7 @@
 //!     ```
 //!
 //!     Every place in this lib, where you need to specify some ids, it requires
-//! generic type `ID`, which implements ``Into<ProgramIdWrapper>``.
+//!   generic type `ID`, which implements ``Into<ProgramIdWrapper>``.
 //!
 //!     `ProgramIdWrapper` may be built from:
 //!     - `u64`

--- a/lazy-pages/src/common.rs
+++ b/lazy-pages/src/common.rs
@@ -251,8 +251,9 @@ impl LazyPagesExecutionContext {
 /// Key consists of two parts:
 /// 1) current program prefix in storage
 /// 2) page number in little endian bytes order
+/// 
 /// First part is always the same, so we can copy it to buffer
-/// once and then use it for all pages.
+///    once and then use it for all pages.
 #[derive(Debug)]
 pub(crate) struct PagePrefix {
     buffer: Vec<u8>,

--- a/lazy-pages/src/common.rs
+++ b/lazy-pages/src/common.rs
@@ -251,7 +251,7 @@ impl LazyPagesExecutionContext {
 /// Key consists of two parts:
 /// 1) current program prefix in storage
 /// 2) page number in little endian bytes order
-/// 
+///
 /// First part is always the same, so we can copy it to buffer
 ///    once and then use it for all pages.
 #[derive(Debug)]

--- a/lazy-pages/src/process.rs
+++ b/lazy-pages/src/process.rs
@@ -79,7 +79,7 @@ pub(crate) trait AccessHandler {
 /// for all gear pages from accessed native page.
 /// 1) Set new access pages protection accordingly it is read or write access.
 /// 2) If some page contains data in storage, then load this data and place it in
-/// program's wasm memory.
+///    program's wasm memory.
 /// 3) Charge gas for access and data loading.
 pub(crate) fn process_lazy_pages<H: AccessHandler>(
     rt_ctx: &mut LazyPagesRuntimeContext,

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -318,12 +318,6 @@ pub fn run() -> sc_cli::Result<()> {
                 }
             })
         }
-        #[cfg(feature = "try-runtime")]
-        Some(Subcommand::TryRuntime) => Err(try_runtime_cli::DEPRECATION_NOTICE.to_owned().into()),
-        #[cfg(not(feature = "try-runtime"))]
-        Some(Subcommand::TryRuntime) => Err("TryRuntime wasn't enabled when building the node. \
-                You can enable it with `--features try-runtime`."
-            .into()),
         Some(Subcommand::ChainInfo(cmd)) => {
             let runner = cli.create_runner(cmd)?;
             runner.sync_run(|config| cmd.run::<Block>(&config))
@@ -357,5 +351,6 @@ pub fn run() -> sc_cli::Result<()> {
                 .map_err(sc_cli::Error::Service)
             })
         }
+        _ => Err("Unknown command.".into()),
     }
 }

--- a/pallets/gas/src/lib.rs
+++ b/pallets/gas/src/lib.rs
@@ -27,13 +27,13 @@
 //! ## Overview
 //!
 //! The Gear Gas Pallet's main aim is to separate message's associated gas tree nodes storages out
-//! of Gear's execution logic and provide soft functionality to manage them.
+//!    of Gear's execution logic and provide soft functionality to manage them.
 //!
 //! The Gear Gas Pallet provides functions for:
 //! - Obtaining maximum gas amount available within one block of execution.
 //! - Managing number of remaining gas, i.e. gas allowance.
 //! - Managing gas tree: create, split, cut, etc new nodes determining
-//! execution resources of messages.
+//!    execution resources of messages.
 //!
 //! ## Interface
 //!
@@ -58,7 +58,7 @@
 //! ```
 //!
 //! 2. Provide associated type for your pallet's `Config`, which implements
-//! `gear_common::GasProvider` trait, specifying associated types if needed.
+//!    `gear_common::GasProvider` trait, specifying associated types if needed.
 //!
 //! ```ignore
 //! // `some_pallet/src/lib.rs`
@@ -116,7 +116,7 @@
 //! ```
 //!
 //! 5. Work with Gear Gas Pallet in your pallet with provided
-//! associated type interface.
+//!    associated type interface.
 //!
 //! ## Genesis config
 //!

--- a/pallets/gear-messenger/src/lib.rs
+++ b/pallets/gear-messenger/src/lib.rs
@@ -30,14 +30,14 @@
 //!
 //! The Gear Messenger Pallet provides functions for:
 //! - Counting amount of messages sent from outside (from extrinsics)
-//! within the current block.
+//!    within the current block.
 //! - Counting amount of messages removed from queue to be processed
-//! or skipped within the current block.
+//!    or skipped within the current block.
 //! - Managing continuation of queue processing within the current block.
 //! - Storing and managing message queue, it's pushing and popping algorithms.
 //! - Storing and managing mailbox, it's insertion and removal algorithms,
-//! including the value claiming with Balances Pallet as `Currency`
-//! `Config`'s associated type.
+//!    including the value claiming with Balances Pallet as `Currency`
+//!    `Config`'s associated type.
 //!
 //! ## Interface
 //!
@@ -62,8 +62,8 @@
 //! ```
 //!
 //! 2. Provide associated type for your pallet's `Config`, which implements
-//! `gear_common::storage::Messenger` trait,
-//! specifying associated types if needed.
+//!    `gear_common::storage::Messenger` trait,
+//!    specifying associated types if needed.
 //!
 //! ```ignore
 //! // `some_pallet/src/lib.rs`
@@ -121,7 +121,7 @@
 //! ```
 //!
 //! 5. Work with Gear Messenger Pallet in your pallet with provided
-//! associated type interface.
+//!    associated type interface.
 //!
 //! ## Genesis config
 //!
@@ -130,7 +130,7 @@
 //! ## Assumptions
 //!
 //! * You should manually control storage load from queue and mailbox
-//! length overflow (see Gear Payment Pallet).
+//!    length overflow (see Gear Payment Pallet).
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![doc(html_logo_url = "https://docs.gear.rs/logo.svg")]

--- a/pallets/gear-program/src/lib.rs
+++ b/pallets/gear-program/src/lib.rs
@@ -59,8 +59,8 @@
 //! ```
 //!
 //! 2. Provide associated type for your pallet's `Config`, which implements
-//! `gear_common::{CodeStorage, ProgramStorage}` traits,
-//! specifying associated types if needed.
+//!    `gear_common::{CodeStorage, ProgramStorage}` traits,
+//!    specifying associated types if needed.
 //!
 //! ```ignore
 //! // `some_pallet/src/lib.rs`
@@ -121,7 +121,7 @@
 //! ```
 //!
 //! 5. Work with Gear Program Pallet in your pallet with provided
-//! associated type interface.
+//!    associated type interface.
 //!
 //! ## Genesis config
 //!

--- a/pallets/gear/src/benchmarking/code.rs
+++ b/pallets/gear/src/benchmarking/code.rs
@@ -816,7 +816,7 @@ pub mod body {
 }
 
 /// The maximum amount of pages any program is allowed to have according to the current `Schedule`.
-pub fn max_pages<T: Config>() -> u16
+pub fn max_pages<T>() -> u16
 where
     T: Config,
 {

--- a/pallets/gear/src/benchmarking/mod.rs
+++ b/pallets/gear/src/benchmarking/mod.rs
@@ -32,8 +32,6 @@
 //! the only thing they do - wasmer take them in account, when compiles wasm code.
 //! So, we suppose this instruction have weight 0.
 
-#![cfg(feature = "runtime-benchmarks")]
-
 #[allow(dead_code)]
 mod code;
 mod sandbox;

--- a/pallets/gear/src/manager/mod.rs
+++ b/pallets/gear/src/manager/mod.rs
@@ -21,27 +21,28 @@
 //! Should be mentioned, that if message contains value we have a guarantee that it will be sent further in case of successful execution,
 //! or sent back in case execution ends up with an error. This guarantee is reached by the following conditions:
 //! 1. **Reserve/unreserve model for transferring values**.
-//! Ownership over message value is moved not by simple transfer operation, which decreases **free** balance of sender. That is done by
-//! reserving value before message is executed and repatriating reserved in favor of beneficiary in case of successful execution, or unreserving
-//! in case of execution resulting in a trap. So, it gives us a guarantee that regardless of the result of message execution, there is **always some
-//! value** to perform asset management, i.e move tokens further to the recipient or give back to sender. The guarantee is implemented by using
-//! corresponding `pallet_balances` functions (`reserve`, `repatriate_reserved`, `unreserve` along with `transfer`) in `pallet_gear` extrinsics,
-//! [`JournalHandler::send_dispatch`](core_processor::common::JournalHandler::send_dispatch) and
-//! [`JournalHandler::send_value`](core_processor::common::JournalHandler::send_value) procedures.
+//!    Ownership over message value is moved not by simple transfer operation, which decreases **free** balance of sender. That is done by
+//!    reserving value before message is executed and repatriating reserved in favor of beneficiary in case of successful execution, or unreserving
+//!    in case of execution resulting in a trap. So, it gives us a guarantee that regardless of the result of message execution, there is **always some
+//!    value** to perform asset management, i.e move tokens further to the recipient or give back to sender. The guarantee is implemented by using
+//!    corresponding `pallet_balances` functions (`reserve`, `repatriate_reserved`, `unreserve` along with `transfer`) in `pallet_gear` extrinsics,
+//!    [`JournalHandler::send_dispatch`](core_processor::common::JournalHandler::send_dispatch) and
+//!    [`JournalHandler::send_value`](core_processor::common::JournalHandler::send_value) procedures.
 //!
 //! 2. **Balance sufficiency before adding message with value to the queue**.
-//! Before message is added to the queue, sender's balance is checked for having adequate amount of assets to send desired value. For actors, who
-//! can sign transactions, these checks are done in extrinsic calls. For programs these checks are done on core backend level during execution. In details,
-//! when a message is executed, it has some context, which is set from the pallet level, and a part of the context data is program's actual balance (current balance +
-//! value sent within the executing message). So if during execution of the original message some other messages were sent, message send call is followed
-//! by program's balance checks. The check gives guarantee that value reservation call in
+//!    Before message is added to the queue, sender's balance is checked for having adequate amount of assets to send desired value. For actors, who
+//!    can sign transactions, these checks are done in extrinsic calls. For programs these checks are done on core backend level during execution. In details,
+//!    when a message is executed, it has some context, which is set from the pallet level, and a part of the context data is program's actual balance (current balance +
+//!    value sent within the executing message). So if during execution of the original message some other messages were sent, message send call is followed
+//!    by program's balance checks. The check gives guarantee that value reservation call in
+//! 
 //! [`JournalHandler::send_dispatch`](core_processor::common::JournalHandler::send_dispatch) for program's messages won't fail, because there is always a
 //! sufficient balance for the call.
 //!
 //! 3. **Messages's value management considers existential deposit rule**.
-//! It means that before message with value is added to the queue, value is checked to be in the valid range - `{0} ∪ [existential_deposit; +inf)`. This is
-//! crucial for programs. The check gives guarantee that if funds were moved to the program, the program will definitely have an account in `pallet_balances`
-//! registry and will be able then to manage these funds. Without this check, program could receive funds, but won't be able to use them.
+//!    It means that before message with value is added to the queue, value is checked to be in the valid range - `{0} ∪ [existential_deposit; +inf)`. This is
+//!    crucial for programs. The check gives guarantee that if funds were moved to the program, the program will definitely have an account in `pallet_balances`
+//!    registry and will be able then to manage these funds. Without this check, program could receive funds, but won't be able to use them.
 //!
 //! Due to these 3 conditions implemented in `pallet_gear`, we have a guarantee that value management calls, performed by user or program, won't fail.
 

--- a/pallets/gear/src/manager/mod.rs
+++ b/pallets/gear/src/manager/mod.rs
@@ -35,7 +35,7 @@
 //!    when a message is executed, it has some context, which is set from the pallet level, and a part of the context data is program's actual balance (current balance +
 //!    value sent within the executing message). So if during execution of the original message some other messages were sent, message send call is followed
 //!    by program's balance checks. The check gives guarantee that value reservation call in
-//! 
+//!
 //! [`JournalHandler::send_dispatch`](core_processor::common::JournalHandler::send_dispatch) for program's messages won't fail, because there is always a
 //! sufficient balance for the call.
 //!

--- a/pallets/staking-rewards/src/tests.rs
+++ b/pallets/staking-rewards/src/tests.rs
@@ -18,8 +18,6 @@
 
 //! Staking rewards pallet tests.
 
-#![cfg(test)]
-
 use crate::{mock::*, *};
 use frame_support::{assert_noop, assert_ok, assert_storage_noop, traits::EstimateNextNewSession};
 use sp_runtime::{traits::Convert, DispatchError, PerThing, Perbill};

--- a/runtime-interface/src/gear_sandbox/detail.rs
+++ b/runtime-interface/src/gear_sandbox/detail.rs
@@ -67,6 +67,7 @@ struct SandboxContext<'a, 'b> {
 }
 
 impl<'a, 'b> sandbox_env::SandboxContext for SandboxContext<'a, 'b> {
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn invoke(
         &mut self,
         invoke_args_ptr: Pointer<u8>,
@@ -464,6 +465,7 @@ pub fn memory_new(context: &mut dyn FunctionContext, initial: u32, maximum: u32)
     method_result
 }
 
+#[allow(clippy::needless_borrows_for_generic_args)]
 pub fn memory_set(
     context: &mut dyn FunctionContext,
     memory_idx: u32,

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -20,6 +20,8 @@
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
 #![allow(clippy::items_after_test_module)]
+#![allow(clippy::legacy_numeric_constants)]
+#![allow(non_local_definitions)]
 
 // Make the WASM binary available.
 #[cfg(all(feature = "std", not(feature = "fuzz")))]
@@ -1551,7 +1553,7 @@ where
 
     fn from_parts(call: &C, params: Self::Params) -> Self {
         Self {
-            call: unsafe { std::mem::transmute(call) },
+            call: unsafe { std::mem::transmute::<&C, &C>(call) },
             transaction_depth: params.0.into(),
             changes: core::cell::RefCell::new(params.1),
             recorder: params.2,

--- a/runtime/vara/src/weights/mod.rs
+++ b/runtime/vara/src/weights/mod.rs
@@ -18,6 +18,8 @@
 
 //! A list of the different weight modules for our runtime.
 
+#![allow(dead_code)]
+
 pub mod frame_system;
 pub mod pallet_balances;
 pub mod pallet_gear;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2024-06-04"
+channel = "nightly-2024-05-01"
 components = [ "llvm-tools" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "default"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2024-01-25"
+channel = "nightly-2024-06-04"
 components = [ "llvm-tools" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "default"

--- a/sandbox/sandbox/src/lib.rs
+++ b/sandbox/sandbox/src/lib.rs
@@ -37,6 +37,7 @@
 //! - executing a wasm substrate runtime inside of a wasm parachain
 
 #![warn(missing_docs)]
+#![allow(clippy::needless_borrows_for_generic_args)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/scripts/src/clippy.sh
+++ b/scripts/src/clippy.sh
@@ -28,5 +28,5 @@ gear_clippy() {
 }
 
 examples_clippy() {
-  __GEAR_WASM_BUILDER_NO_BUILD=1 SKIP_WASM_BUILD=1 SKIP_VARA_RUNTIME_WASM_BUILD=1 cargo clippy -p "demo-*" -p test-syscalls --no-default-features "$@" -- --no-deps -D warnings -A static_mut_ref
+  __GEAR_WASM_BUILDER_NO_BUILD=1 SKIP_WASM_BUILD=1 SKIP_VARA_RUNTIME_WASM_BUILD=1 cargo clippy -p "demo-*" -p test-syscalls --no-default-features "$@" -- --no-deps -D warnings -A static_mut_refs
 }

--- a/utils/gear-replay-cli/src/lib.rs
+++ b/utils/gear-replay-cli/src/lib.rs
@@ -149,7 +149,7 @@ pub(crate) fn build_executor<H: HostFunctions>(shared: &SharedParams) -> WasmExe
         .build()
 }
 
-pub(crate) async fn fetch_block<Block: BlockT>(
+pub(crate) async fn fetch_block<Block>(
     rpc: &WsClient,
     hash: Option<HashFor<Block>>,
 ) -> sc_cli::Result<Block>

--- a/utils/gring/src/keyring.rs
+++ b/utils/gring/src/keyring.rs
@@ -76,6 +76,7 @@ impl Keyring {
     }
 
     /// Update and get the primary key.
+    #[allow(clippy::assigning_clones)]
     pub fn primary(&mut self) -> Result<Keystore> {
         if self.ring.is_empty() {
             return Err(anyhow::anyhow!(

--- a/utils/gring/src/keystore.rs
+++ b/utils/gring/src/keystore.rs
@@ -137,6 +137,7 @@ impl Keystore {
     }
 
     /// Returns self with the given name in meta.
+    #[allow(clippy::assigning_clones)]
     pub fn with_name(mut self, name: &str) -> Self {
         self.meta.name = name.to_owned();
         self

--- a/utils/node-loader/src/batch_pool/report.rs
+++ b/utils/node-loader/src/batch_pool/report.rs
@@ -61,6 +61,7 @@ impl From<BTreeSet<MessageId>> for MailboxReport {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Default)]
 pub struct BatchRunReport {
     /// Seed of the batch is the id.

--- a/utils/wasm-builder/src/cargo_toolchain.rs
+++ b/utils/wasm-builder/src/cargo_toolchain.rs
@@ -36,7 +36,7 @@ pub(crate) struct Toolchain(String);
 
 impl Toolchain {
     /// This is a version of nightly toolchain, tested on our CI.
-    const PINNED_NIGHTLY_TOOLCHAIN: &'static str = "nightly-2024-06-04";
+    const PINNED_NIGHTLY_TOOLCHAIN: &'static str = "nightly-2024-05-01";
 
     /// Returns `Toolchain` representing the recommended nightly version.
     pub fn recommended_nightly() -> Self {

--- a/utils/wasm-builder/src/cargo_toolchain.rs
+++ b/utils/wasm-builder/src/cargo_toolchain.rs
@@ -36,7 +36,7 @@ pub(crate) struct Toolchain(String);
 
 impl Toolchain {
     /// This is a version of nightly toolchain, tested on our CI.
-    const PINNED_NIGHTLY_TOOLCHAIN: &'static str = "nightly-2024-01-25";
+    const PINNED_NIGHTLY_TOOLCHAIN: &'static str = "nightly-2024-06-04";
 
     /// Returns `Toolchain` representing the recommended nightly version.
     pub fn recommended_nightly() -> Self {

--- a/utils/wasm-builder/src/code_validator.rs
+++ b/utils/wasm-builder/src/code_validator.rs
@@ -220,7 +220,7 @@ impl TryFrom<(&Module, &ImportError)> for ImportErrorWithContext {
 
         let Some(import_entry) = module
             .import_section()
-            .and_then(|section| section.entries().iter().nth(*idx as usize))
+            .and_then(|section| section.entries().get(*idx as usize))
         else {
             bail!("failed to get import entry by index");
         };

--- a/utils/wasm-builder/src/lib.rs
+++ b/utils/wasm-builder/src/lib.rs
@@ -16,7 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#![cfg_attr(feature = "strict", deny(warnings))]
 #![doc(html_logo_url = "https://docs.gear.rs/logo.svg")]
 #![doc(html_favicon_url = "https://gear-tech.io/favicons/favicon.ico")]
 

--- a/utils/wasm-builder/src/stack_end.rs
+++ b/utils/wasm-builder/src/stack_end.rs
@@ -49,8 +49,7 @@ pub fn insert_stack_end_export(module: &mut Module) -> Result<(), &'static str> 
         .ok_or("Cannot find globals section")?;
     let global = glob_section
         .entries()
-        .iter()
-        .nth(stack_pointer_index as usize)
+        .get(stack_pointer_index as usize)
         .ok_or("there is no globals")?;
     if global.global_type().content_type() != ValueType::I32 {
         return Err("has no i32 global 0");

--- a/utils/wasm-gen/src/config.rs
+++ b/utils/wasm-gen/src/config.rs
@@ -20,7 +20,7 @@
 //!
 //! Configs, possibly, can be instantiated 3 different ways:
 //! 1. From scratch by settings fields to corresponding values sometimes using
-//! related to these fields builders. For example, wasm module configs:
+//!    related to these fields builders. For example, wasm module configs:
 //! ```rust
 //! # use std::num::NonZeroUsize;
 //! use gear_wasm_gen::*;
@@ -68,7 +68,7 @@
 //! ```
 //!
 //! 2. By using `Default` trait.
-//! For example:
+//!    For example:
 //! ```rust
 //! use gear_wasm_gen::*;
 //! let wasm_gen_config = GearWasmGeneratorConfig::default();

--- a/utils/wasm-gen/src/generator.rs
+++ b/utils/wasm-gen/src/generator.rs
@@ -22,9 +22,9 @@
 //! 1. Every generator has a disabled version of itself.
 //! 2. Almost all disabled generators can be converted to [`ModuleWithCallIndexes`], from which the wasm module can be retrieved.
 //! 3. Every generator has a "main" function, after finishing which a transition to another generator is available (either directly or through disabled
-//! version of the generator).
+//!    version of the generator).
 //! 4. Almost all generators are instantiated from the disabled generator worked on the previous generation step (see [`GearWasmGenerator::generate`]). This is how
-//! generator form a state-machine.
+//!    generator form a state-machine.
 //!
 //! Transitions paths:
 //! ```text

--- a/utils/wasm-gen/src/generator/entry_points.rs
+++ b/utils/wasm-gen/src/generator/entry_points.rs
@@ -143,14 +143,14 @@ impl<'a, 'b> EntryPointsGenerator<'a, 'b> {
     /// Generates an export function with a `name`.
     ///
     /// Actually generating a new export function doesn't mean generating it's body
-    /// from scratch. This function chooses random internal function and calls it
-    /// from the body of the newly generated export.
+    ///    from scratch. This function chooses random internal function and calls it
+    ///    from the body of the newly generated export.
     ///
     /// # Note:
     /// 1. The method is intended to generate just exports, not only gear entry points.
     /// 2. If the generator was used to generate some export with a custom name (not gear entry point)
-    /// and then disabled, that export index can be retrieved from [`DisabledEntryPointsGenerator`], by
-    /// accessing the underlying `parity_wasm::module::Module` and iterating over it's export section.
+    ///    and then disabled, that export index can be retrieved from [`DisabledEntryPointsGenerator`], by
+    ///    accessing the underlying `parity_wasm::module::Module` and iterating over it's export section.
     pub fn generate_export(&mut self, name: &str) -> Result<GearEntryPointGenerationProof> {
         log::trace!(
             "Random data before generating {name} export - {}",

--- a/utils/wasm-gen/src/generator/syscalls/invocator.rs
+++ b/utils/wasm-gen/src/generator/syscalls/invocator.rs
@@ -189,7 +189,7 @@ impl<'a, 'b> SyscallsInvocator<'a, 'b> {
                         .injection_types()
                         .order()
                         .into_iter()
-                        .filter(|syscall| self.syscalls_imports.get(syscall).is_some())
+                        .filter(|syscall| self.syscalls_imports.contains_key(syscall))
                         .flat_map(|syscall1| {
                             iter::repeat(syscall1)
                                 .take(


### PR DESCRIPTION
Resolves # .

- update nightly to `2024-06-04`
- Fix doc indentation
- Remove `strict` feature
- Resolve some clippy lints

@reviewer-or-team
