### PR TITLE
feat(gtest): Introduce gas allowance to `gtest`

### DIFF
--- a/gtest/src/gas_tree.rs
+++ b/gtest/src/gas_tree.rs
@@ -18,7 +18,7 @@
 
 //! Auxiliary (for tests) gas tree management implementation for the crate.
 
-use crate::{GAS_ALLOWANCE, GAS_MULTIPLIER};
+use crate::GAS_MULTIPLIER;
 use gear_common::{
     gas_provider::{
         AuxiliaryGasProvider, ConsumeResultOf, GasNodeId, GasTreeError, PlainNodeId, Provider, Tree,

--- a/gtest/src/gas_tree.rs
+++ b/gtest/src/gas_tree.rs
@@ -45,13 +45,13 @@ impl GasTreeManager {
         &self,
         origin: ProgramId,
         mid: MessageId,
-        amount: Option<Gas>,
+        amount: Gas,
     ) -> Result<PositiveImbalance, GasTreeError> {
         GasTree::create(
             origin.cast(),
             GAS_MULTIPLIER,
             GasNodeId::from(mid.cast::<PlainNodeId>()),
-            amount.unwrap_or(GAS_ALLOWANCE),
+            amount,
         )
     }
 

--- a/gtest/src/log.rs
+++ b/gtest/src/log.rs
@@ -23,7 +23,7 @@ use gear_core::{
     message::{Payload, StoredMessage},
 };
 use gear_core_errors::{ErrorReplyReason, ReplyCode, SimpleExecutionError, SuccessReplyReason};
-use std::{convert::TryInto, fmt::Debug};
+use std::{collections::BTreeMap, convert::TryInto, fmt::Debug};
 
 /// A log that emitted by a program, for user defined logs,
 /// see [`Log`].
@@ -371,7 +371,7 @@ pub struct RunResult {
     pub(crate) message_id: MessageId,
     pub(crate) total_processed: u32,
     pub(crate) main_gas_burned: Gas,
-    pub(crate) others_gas_burned: Gas,
+    pub(crate) others_gas_burned: BTreeMap<u32, Gas>,
 }
 
 impl RunResult {
@@ -413,8 +413,8 @@ impl RunResult {
     }
 
     /// Get the total gas burned by the other messages.
-    pub fn others_gas_burned(&self) -> Gas {
-        self.others_gas_burned
+    pub fn others_gas_burned(&self) -> &BTreeMap<u32, Gas> {
+        &self.others_gas_burned
     }
 
     /// Returns decoded logs.


### PR DESCRIPTION
Resolves #3977

- Introduce _block_ concept: gas for all generated dispatches are counted not in one single counter, but in the map `block number -> gas used`.
- If processing stopped because of the gas allowance exceed error, the block number is incremented and dispatches execution continues as if it is a new block with updated gas allowance.

