### PR TITLE
fix(cargo-gbuild): optional metadata field

### DIFF
--- a/utils/cargo-gbuild/src/metadata.rs
+++ b/utils/cargo-gbuild/src/metadata.rs
@@ -52,10 +52,14 @@ impl Metadata {
         command.manifest_path(&manifest);
 
         let inner = command.exec()?;
-        let mut gbuild =
-            serde_json::from_value::<MetadataField>(inner.workspace_metadata.clone())?.gbuild;
-        gbuild.programs.dedup();
-        gbuild.metas.dedup();
+        let gbuild = serde_json::from_value::<MetadataField>(inner.workspace_metadata.clone())
+            .map(|m| {
+                let mut gbuild = m.gbuild;
+                gbuild.programs.dedup();
+                gbuild.metas.dedup();
+                gbuild
+            })
+            .unwrap_or_default();
 
         Ok(Self {
             inner,

--- a/utils/cargo-gbuild/src/metadata.rs
+++ b/utils/cargo-gbuild/src/metadata.rs
@@ -53,11 +53,10 @@ impl Metadata {
 
         let inner = command.exec()?;
         let gbuild = serde_json::from_value::<MetadataField>(inner.workspace_metadata.clone())
-            .map(|m| {
-                let mut gbuild = m.gbuild;
-                gbuild.programs.dedup();
-                gbuild.metas.dedup();
-                gbuild
+            .map(|mut m| {
+                m.gbuild.programs.dedup();
+                m.gbuild.metas.dedup();
+                m.gbuild
             })
             .unwrap_or_default();
 


### PR DESCRIPTION
Resolves #4006 

- [x] make the metadata parsing optional

@gear-tech/dev 
