### PR TITLE
chore(gbuild): specify stable toolchain installation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   linux:
-    runs-on: [ kuberunner, github-runner-01 ]
+    runs-on: [kuberunner, github-runner-01]
     env:
       RUSTUP_HOME: /tmp/rustup_home
     steps:
@@ -68,12 +68,13 @@ jobs:
         run: |
           cargo +stable check -p gstd --target wasm32-unknown-unknown
           cargo +stable check --manifest-path utils/wasm-builder/test-program/Cargo.toml
+          cargo +stable check --manifest-path utils/cargo-gbuild/test-program/Cargo.toml --workspace --target wasm32-unknown-unknown
 
       - name: "Check: crates-io packages"
         run: cargo +stable run --release -p crates-io check
 
   fuzzer:
-    runs-on: [ kuberunner, github-runner-01 ]
+    runs-on: [kuberunner, github-runner-01]
     env:
       RUSTUP_HOME: /tmp/rustup_home
     steps:

--- a/utils/cargo-gbuild/tests/smoke.rs
+++ b/utils/cargo-gbuild/tests/smoke.rs
@@ -76,14 +76,14 @@ fn test_program_tests() {
     // This is momently only for adapting the environment (nightly)
     // of our CI.
     {
-        let toolchains = Command::new("rustup")
-            .args(["toolchain", "list"])
+        let targets = Command::new("rustup")
+            .args(["target", "list", "--toolchain", "stable"])
             .output()
             .expect("Failed to list rust toolchains")
             .stdout;
 
-        if !String::from_utf8_lossy(&toolchains).contains("stable") {
-            Command::new("rustup")
+        if !String::from_utf8_lossy(&targets).contains("wasm32-unknown-unknown") {
+            assert!(Command::new("rustup")
                 .args([
                     "toolchain",
                     "install",
@@ -94,7 +94,8 @@ fn test_program_tests() {
                     "wasm32-unknown-unknown",
                 ])
                 .status()
-                .expect("Failed to install stable toolchain");
+                .expect("Failed to install stable toolchain")
+                .success());
         }
     }
 

--- a/utils/cargo-gbuild/tests/smoke.rs
+++ b/utils/cargo-gbuild/tests/smoke.rs
@@ -84,7 +84,15 @@ fn test_program_tests() {
 
         if !String::from_utf8_lossy(&toolchains).contains("stable") {
             Command::new("rustup")
-                .args(["install", "stable"])
+                .args([
+                    "toolchain",
+                    "install",
+                    "stable",
+                    "--component",
+                    "llvm-tools",
+                    "--target",
+                    "wasm32-unknown-unknown",
+                ])
                 .status()
                 .expect("Failed to install stable toolchain");
         }

--- a/utils/cargo-gbuild/tests/smoke.rs
+++ b/utils/cargo-gbuild/tests/smoke.rs
@@ -82,7 +82,7 @@ fn test_program_tests() {
             .expect("Failed to list rust toolchains")
             .stdout;
 
-        if !String::from_utf8_lossy(&targets).contains("wasm32-unknown-unknown") {
+        if !String::from_utf8_lossy(&targets).contains("wasm32-unknown-unknown (installed)") {
             assert!(Command::new("rustup")
                 .args([
                     "toolchain",


### PR DESCRIPTION
https://github.com/gear-tech/gear/actions/runs/9512048719/job/26219320973

The stable toolchain is not installed correctly every time, specify to `toolchain installation`

similar implementations: 

- [the smoke tests in wasm-builder](https://github.com/gear-tech/gear/blob/master/utils/wasm-builder/tests/smoke.rs#L52)
- [stable checks in our ci](https://github.com/gear-tech/gear/blob/master/.github/workflows/check.yml#L61)

@gear-tech/dev 
