### PR TITLE
chore(crates-io): skip not tracked substrate dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ gpu-pre-commit:
 	@ echo " > Formatting eGPU" && cargo +nightly fmt --all -- --config imports_granularity=Crate,edition=2021
 	@ echo " >> Clippy checking eGPU" && cargo clippy -p "ethexe-*" --all-targets --all-features -- --no-deps -D warnings
 
-# Bulding contracts
+# Building contracts
 .PHONY: gpu-contracts-pre-commit
 gpu-contracts-pre-commit:
 	@ echo " > Cleaning contracts" && forge clean --root ethexe/contracts
@@ -23,7 +23,7 @@ show:
 	@ ./scripts/gear.sh show
 
 .PHONY: pre-commit # Here should be no release builds to keep checks fast.
-pre-commit: fmt clippy test check-runtime-imports # TODO: fix typos
+pre-commit: fmt typos clippy test check-runtime-imports
 
 .PHONY: check-spec
 check-spec:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ show:
 	@ ./scripts/gear.sh show
 
 .PHONY: pre-commit # Here should be no release builds to keep checks fast.
-pre-commit: fmt typos clippy test check-runtime-imports
+pre-commit: fmt clippy test check-runtime-imports # TODO: fix typos
 
 .PHONY: check-spec
 check-spec:

--- a/_typos.toml
+++ b/_typos.toml
@@ -5,7 +5,10 @@ extend-ignore-re = [
 ]
 
 [files]
-extend-exclude = ["gsdk/src/metadata/generated.rs"]
+extend-exclude = [
+  "gsdk/src/metadata/generated.rs",
+  "ethexe/ethereum/*.json"
+]
 
 [default.extend-words]
 overlayed = "overlayed" # typo in sp-state-machine, won't fix.

--- a/utils/crates-io/src/handler.rs
+++ b/utils/crates-io/src/handler.rs
@@ -286,7 +286,7 @@ mod substrate {
             "sp-crypto-ec-utils" => {
                 table.insert("package", "gp-crypto-ec-utils".into());
             }
-            _ => {}
+            _ => return,
         }
 
         table.remove("branch");


### PR DESCRIPTION
Resolves # .

- [x] skip not tracked dependencies
- [x] ignore eth abis in typos check
-

@gear-tech/dev 
