### PR TITLE
feat(gstd): stabilize program logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3437,6 +3437,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "demo-log"
+version = "0.1.0"
+dependencies = [
+ "gstd",
+ "gtest",
+]
+
+[[package]]
 name = "demo-messenger"
 version = "0.1.0"
 dependencies = [
@@ -3547,7 +3555,6 @@ dependencies = [
 name = "demo-ping"
 version = "0.1.0"
 dependencies = [
- "gear-wasm-builder",
  "gstd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3555,6 +3555,7 @@ dependencies = [
 name = "demo-ping"
 version = "0.1.0"
 dependencies = [
+ "gear-wasm-builder",
  "gstd",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
     "examples/init-fail-sender",
     "examples/init-wait",
     "examples/init-wait-reply-exit",
+    "examples/log",
     "examples/messenger",
     "examples/mul-by-const",
     "examples/ncompose",

--- a/examples/ping/Cargo.toml
+++ b/examples/ping/Cargo.toml
@@ -10,9 +10,6 @@ repository.workspace = true
 [dependencies]
 gstd.workspace = true
 
-[build-dependencies]
-gear-wasm-builder.workspace = true
-
 [features]
 debug = ["gstd/debug"]
 default = ["std"]

--- a/examples/ping/Cargo.toml
+++ b/examples/ping/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 [dependencies]
 gstd.workspace = true
 
+[build-dependencies]
+gear-wasm-builder.workspace = true
+
 [features]
 debug = ["gstd/debug"]
 default = ["std"]

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -175,6 +175,8 @@ pub use gcore::{
     ReservationId, Ss58Address, Value,
 };
 pub use gstd_codegen::{actor_id, async_init, async_main};
+pub use hex;
+pub use macros::log::LOG_DATA_PREFIX;
 pub use prelude::*;
 pub use reservations::*;
 

--- a/gstd/src/lib.rs
+++ b/gstd/src/lib.rs
@@ -176,7 +176,6 @@ pub use gcore::{
 };
 pub use gstd_codegen::{actor_id, async_init, async_main};
 pub use hex;
-pub use macros::log::LOG_DATA_PREFIX;
 pub use prelude::*;
 pub use reservations::*;
 

--- a/gstd/src/macros/log.rs
+++ b/gstd/src/macros/log.rs
@@ -1,0 +1,87 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2024 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+/// Prints a string to the log.
+///
+/// For the internal logic, this macro sends messages to empty program
+/// which results as logging, the sent logs can be extracted from the
+/// chain event `pallet_gear::Event::UserMessageSent`.
+///
+/// ```no_run
+/// let GearEvent::UserMessageSent {
+///   message: UserMessage {
+///     // The payload here is the log you sent with the method.
+///     payload,
+///     destination: ActorId::zero(),
+///     ...
+///   },
+///   ...
+/// } = event;
+/// ```
+///
+/// # Example
+///
+/// ```no_run
+/// // in program
+/// gstd::log!("the anwser is {value}");
+///
+/// // on client side, after extracting payload from events.
+/// assert_eq!(String::from_utf8_lossy(payload), format!("the anwser is {value}"));
+/// ```
+#[macro_export]
+macro_rules! log {
+    ($($arg:tt)*) => {{
+        gcore::msg::send(ActorId::zero(), format!($($arg:tt)*).as_ref(), 0)
+    }};
+}
+
+/// Prints some slices as hex
+///
+/// Similar to [`log`], but hex encode the input slice with [`LOG_DATA_PREFIX`]
+/// in the output string.
+///
+/// # Example
+///
+/// ```no_run
+/// // in program
+/// #[derive(Encode, Decode)]
+/// struct Data {
+///   value: u64,
+/// }
+///
+/// gstd::log_data!(Data { value: 42 }.encode());
+///
+/// // on client side, after extracting payload from events.
+/// assert_eq!(
+///   Ok(Data { value: 42 }),
+///   Data::decode(&mut hex::decode(
+///     String::from_utf8_lossy(payload).trim_start_matches(gstd::LOG_DATA_PREFIX)
+///   )?.as_ref())?
+/// );
+/// ```
+#[macro_export]
+macro_rules! log_data {
+    ($data:tt) => {{
+        let mut log: String = $crate::macros::LOG_DATA_PREFIX;
+        log += $crate::hex::encode($bytes);
+        gcore::msg::send(ActorId::zero(), log, 0)
+    }};
+}
+
+/// Prefix for log data, see [`log_data`]
+pub const LOG_DATA_PREFIX: &str = "data: ";

--- a/gstd/src/macros/log.rs
+++ b/gstd/src/macros/log.rs
@@ -29,7 +29,7 @@
 /// // on client side, after extracting payload from events.
 /// assert_eq!(
 ///     String::from_utf8_lossy(payload),
-///     format!("the answer is 42")
+///     "the answer is 42".into()
 /// );
 /// ```
 #[macro_export]

--- a/gstd/src/macros/log.rs
+++ b/gstd/src/macros/log.rs
@@ -18,21 +18,7 @@
 
 /// Prints a string to the log.
 ///
-/// For the internal logic, this macro sends messages to empty program
-/// which results as logging, the sent logs can be extracted from the
-/// chain event `pallet_gear::Event::UserMessageSent`.
-///
-/// ```no_run
-/// let GearEvent::UserMessageSent {
-///   message: UserMessage {
-///     // The payload here is the log you sent with the method.
-///     payload,
-///     destination: ActorId::zero(),
-///     ...
-///   },
-///   ...
-/// } = event;
-/// ```
+/// Shortcut of [`gstd::msg::log`] with formatter.
 ///
 /// # Example
 ///
@@ -46,42 +32,6 @@
 #[macro_export]
 macro_rules! log {
     ($($arg:tt)*) => {{
-        gcore::msg::send(ActorId::zero(), format!($($arg:tt)*).as_ref(), 0)
+        $crate::msg::log_str($crate::format!($($arg)*))
     }};
 }
-
-/// Prints some slices as hex
-///
-/// Similar to [`log`], but hex encode the input slice with [`LOG_DATA_PREFIX`]
-/// in the output string.
-///
-/// # Example
-///
-/// ```no_run
-/// // in program
-/// #[derive(Encode, Decode)]
-/// struct Data {
-///   value: u64,
-/// }
-///
-/// gstd::log_data!(Data { value: 42 }.encode());
-///
-/// // on client side, after extracting payload from events.
-/// assert_eq!(
-///   Ok(Data { value: 42 }),
-///   Data::decode(&mut hex::decode(
-///     String::from_utf8_lossy(payload).trim_start_matches(gstd::LOG_DATA_PREFIX)
-///   )?.as_ref())?
-/// );
-/// ```
-#[macro_export]
-macro_rules! log_data {
-    ($data:tt) => {{
-        let mut log: String = $crate::macros::LOG_DATA_PREFIX;
-        log += $crate::hex::encode($bytes);
-        gcore::msg::send(ActorId::zero(), log, 0)
-    }};
-}
-
-/// Prefix for log data, see [`log_data`]
-pub const LOG_DATA_PREFIX: &str = "data: ";

--- a/gstd/src/macros/log.rs
+++ b/gstd/src/macros/log.rs
@@ -18,16 +18,19 @@
 
 /// Prints a string to the log.
 ///
-/// Shortcut of [`gstd::msg::log`] with formatter.
+/// Shortcut of [`gstd::msg::log_str`] with formatter.
 ///
 /// # Example
 ///
 /// ```no_run
 /// // in program
-/// gstd::log!("the anwser is {value}");
+/// gstd::log!("the answer is {}", 42);
 ///
 /// // on client side, after extracting payload from events.
-/// assert_eq!(String::from_utf8_lossy(payload), format!("the anwser is {value}"));
+/// assert_eq!(
+///     String::from_utf8_lossy(payload),
+///     format!("the answer is 42")
+/// );
 /// ```
 #[macro_export]
 macro_rules! log {

--- a/gstd/src/macros/mod.rs
+++ b/gstd/src/macros/mod.rs
@@ -18,3 +18,4 @@
 
 mod bail;
 mod debug;
+pub(crate) mod log;

--- a/gstd/src/msg/log.rs
+++ b/gstd/src/msg/log.rs
@@ -40,7 +40,7 @@ use gcore::{errors::Result, ActorId, MessageId};
 ///
 /// ```no_run
 /// // program side
-/// let log = "the anwser is 42";
+/// let log = "the answer is 42";
 /// gstd::msg::log_str(log);
 ///
 /// // client side, after extracting payload from events.

--- a/gstd/src/msg/log.rs
+++ b/gstd/src/msg/log.rs
@@ -1,0 +1,68 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2024 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use gcore::{errors::Result, ActorId, MessageId};
+
+/// Prints a string to the log.
+///
+/// For the internal logic, this macro sends messages to empty program
+/// which results as logging, the sent logs can be extracted from the
+/// chain event `pallet_gear::Event::UserMessageSent`.
+///
+/// ```no_run
+/// let GearEvent::UserMessageSent {
+///   message: UserMessage {
+///     // The payload here is the log you sent with the method.
+///     payload,
+///     destination: ActorId::zero(),
+///     ...
+///   },
+///   ...
+/// } = event;
+/// ```
+///
+/// # Example
+///
+/// ```no_run
+/// // program side
+/// let log = "the anwser is 42";
+/// gstd::msg::log_str(log);
+///
+/// // client side, after extracting payload from events.
+/// assert_eq!(String::from_utf8_lossy(payload), log.into());
+/// ```
+pub fn log_str(s: impl AsRef<str>) -> Result<MessageId> {
+    log(s.as_ref().as_bytes())
+}
+
+/// Log raw bytes.
+///
+/// Similar to [`log_str`], but without any encoding.
+///
+/// # Example
+///
+/// ```no_run
+/// // program side
+/// gstd::msg::log(b"42");
+///
+/// // client side, after extracting payload from events.
+/// assert_eq!(payload, b"42".into());
+/// ```
+pub fn log(data: impl AsRef<[u8]>) -> Result<MessageId> {
+    crate::msg::send_bytes(ActorId::zero(), data.as_ref(), 0)
+}

--- a/gstd/src/msg/mod.rs
+++ b/gstd/src/msg/mod.rs
@@ -56,4 +56,7 @@ pub use basic::*;
 mod encoded;
 pub use encoded::*;
 
+mod log;
+pub use log::*;
+
 mod utils;

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -861,8 +861,13 @@ pub mod gbuild {
     }
 
     /// Ensure the current project has been built by `cargo-gbuild`.
-    pub fn ensure_gbuild() {
+    pub fn ensure_gbuild(rebuild: bool) {
+        let mut build = false || rebuild;
         if wasm_path().is_err() {
+            build = true;
+        }
+
+        if build {
             let manifest = etc::find_up("Cargo.toml").expect("Unable to find project manifest.");
             if !Command::new("cargo")
                 .args(["gbuild", "-m"])

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -862,7 +862,7 @@ pub mod gbuild {
 
     /// Ensure the current project has been built by `cargo-gbuild`.
     pub fn ensure_gbuild(rebuild: bool) {
-        let mut build = false || rebuild;
+        let mut build = rebuild;
         if wasm_path().is_err() {
             build = true;
         }

--- a/utils/cargo-gbuild/src/bin/cargo-gbuild.rs
+++ b/utils/cargo-gbuild/src/bin/cargo-gbuild.rs
@@ -16,11 +16,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::env;
-
 use anyhow::Result;
 use cargo_gbuild::GBuild;
 use clap::Parser;
+use std::env;
 use tracing_subscriber::filter::EnvFilter;
 
 const CUSTOM_COMMAND_NAME: &str = "gbuild";
@@ -55,7 +54,7 @@ fn main() -> Result<()> {
     let env = EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new(match app.verbose {
         0 => format!("{name}=info"),
         1 => format!("{name}=debug"),
-        2 => "debug".into(),
+        2 => format!("{name}=trace"),
         _ => "trace".into(),
     }));
 

--- a/utils/cargo-gbuild/test-program/src/lib.rs
+++ b/utils/cargo-gbuild/test-program/src/lib.rs
@@ -44,7 +44,7 @@ mod tests {
 
     #[test]
     fn test_init() {
-        gtest::ensure_gbuild();
+        gtest::ensure_gbuild(false);
 
         // Initialize system environment
         let system = System::new();


### PR DESCRIPTION
Resolves # .

Different from `gstd::debug!`, developers may have `log` requirements while building programs in production, e.g. using an indexer to fetch the historical events.

The demand is similar to `log{n}` in EVM's instructions, but since our pallet haven't had an event just for program logging atm (_this is also an option_), our current implementation could be more closed to solana's logs, sending messages to another program, this PR uses `Actor::zero` as a logger program

@gear-tech/dev 
