### PR TITLE
feat(runtime-fuzzer): use previously waited message id as wake syscall param

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6753,6 +6753,7 @@ dependencies = [
  "indexmap 2.2.6",
  "indicatif",
  "log",
+ "nonempty",
  "proptest",
  "rand 0.8.5",
  "thiserror",

--- a/utils/runtime-fuzzer/src/generator/upload_program.rs
+++ b/utils/runtime-fuzzer/src/generator/upload_program.rs
@@ -171,7 +171,8 @@ fn config(
             actor_kind: actor_kind.clone(),
             range: EXISTENTIAL_DEPOSIT..=max_value,
         })
-        .with_ptr_rule(PtrParamAllowedValues::ReservationId);
+        .with_ptr_rule(PtrParamAllowedValues::ReservationId)
+        .with_ptr_rule(PtrParamAllowedValues::WaitedMessageId);
 
     if let Some(code_ids) = code_ids {
         params_config = params_config.with_ptr_rule(PtrParamAllowedValues::CodeIdsWithValue {

--- a/utils/wasm-gen/Cargo.toml
+++ b/utils/wasm-gen/Cargo.toml
@@ -17,6 +17,7 @@ gear-core.workspace = true
 wasmparser.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
+nonempty.workspace = true
 
 [dev-dependencies]
 rand = { workspace = true, features = ["small_rng"] }

--- a/utils/wasm-gen/src/config/syscalls.rs
+++ b/utils/wasm-gen/src/config/syscalls.rs
@@ -40,16 +40,7 @@ pub struct SyscallsConfigBuilder(SyscallsConfig);
 
 impl SyscallsConfigBuilder {
     /// Create a new builder with defined injection amounts for all syscalls.
-    pub fn new(mut injection_types: SyscallsInjectionTypes) -> Self {
-        // Enable `MessageId` syscall import if `Wake` syscall is enabled.
-        // This is done to provide a syscall `Wake` with a correct message id.
-        if matches!(
-            injection_types.get(InvocableSyscall::Loose(SyscallName::Wake)),
-            SyscallInjectionType::Function(..)
-        ) {
-            injection_types.enable_syscall_import(InvocableSyscall::Loose(SyscallName::MessageId));
-        }
-
+    pub fn new(injection_types: SyscallsInjectionTypes) -> Self {
         Self(SyscallsConfig {
             injection_types,
             params_config: SyscallsParamsConfig::default(),

--- a/utils/wasm-gen/src/config/syscalls.rs
+++ b/utils/wasm-gen/src/config/syscalls.rs
@@ -40,7 +40,16 @@ pub struct SyscallsConfigBuilder(SyscallsConfig);
 
 impl SyscallsConfigBuilder {
     /// Create a new builder with defined injection amounts for all syscalls.
-    pub fn new(injection_types: SyscallsInjectionTypes) -> Self {
+    pub fn new(mut injection_types: SyscallsInjectionTypes) -> Self {
+        // Enable `MessageId` syscall import if `Wake` syscall is enabled.
+        // This is done to provide a syscall `Wake` with a correct message id.
+        if matches!(
+            injection_types.get(InvocableSyscall::Loose(SyscallName::Wake)),
+            SyscallInjectionType::Function(..)
+        ) {
+            injection_types.enable_syscall_import(InvocableSyscall::Loose(SyscallName::MessageId));
+        }
+
         Self(SyscallsConfig {
             injection_types,
             params_config: SyscallsParamsConfig::default(),

--- a/utils/wasm-gen/src/config/syscalls/param.rs
+++ b/utils/wasm-gen/src/config/syscalls/param.rs
@@ -127,6 +127,7 @@ impl SyscallsParamsConfig {
             }
             PtrParamAllowedValues::ReservationId => Ptr::Hash(HashType::ReservationId),
             PtrParamAllowedValues::CodeIdsWithValue { .. } => Ptr::HashWithValue(HashType::CodeId),
+            PtrParamAllowedValues::WaitedMessageId => Ptr::Hash(HashType::MessageId),
         };
 
         self.ptr.insert(ptr, allowed_values);
@@ -272,6 +273,8 @@ pub enum PtrParamAllowedValues {
         code_ids: NonEmpty<CodeId>,
         range: RangeInclusive<u128>,
     },
+    /// Variant of `Ptr::Hash` pointer type, where hash is waited message id.
+    WaitedMessageId,
 }
 
 /// Actor kind, which is actually a syscall destination choice.

--- a/utils/wasm-gen/src/config/syscalls/param.rs
+++ b/utils/wasm-gen/src/config/syscalls/param.rs
@@ -97,6 +97,7 @@ impl SyscallsParamsConfig {
                 range,
             })
             .with_ptr_rule(PtrParamAllowedValues::ReservationId)
+            .with_ptr_rule(PtrParamAllowedValues::WaitedMessageId)
     }
 
     /// Set rules for a regular syscall param.

--- a/utils/wasm-gen/src/generator/syscalls.rs
+++ b/utils/wasm-gen/src/generator/syscalls.rs
@@ -214,6 +214,9 @@ impl InvocableSyscall {
                 SyscallName::SendCommitWGas,
             ],
             SyscallName::ReplyDeposit => &[SyscallName::SendInput, SyscallName::ReplyDeposit],
+            // Enable `MessageId` syscall import if `Wake` syscall is enabled.
+            // This is done to provide a syscall `Wake` with a correct message id.
+            SyscallName::Wake => &[SyscallName::MessageId],
             _ => return None,
         })
     }

--- a/utils/wasm-gen/src/generator/syscalls/invocator.rs
+++ b/utils/wasm-gen/src/generator/syscalls/invocator.rs
@@ -34,8 +34,8 @@ use gear_utils::NonEmpty;
 use gear_wasm_instrument::{
     parity_wasm::elements::{BlockType, Instruction, Internal, ValueType},
     syscalls::{
-        FallibleSyscallSignature, HashType, ParamType, Ptr, RegularParamType, SyscallName,
-        SyscallSignature, SystemSyscallSignature,
+        FallibleSyscallSignature, ParamType, Ptr, RegularParamType, SyscallName, SyscallSignature,
+        SystemSyscallSignature,
     },
 };
 use gsys::{ErrorCode, Handle, Hash};
@@ -110,9 +110,6 @@ pub(crate) fn process_syscall_params(
                 Pointer(Ptr::SizedBufferStart { .. } | Ptr::MutSizedBufferStart { .. }) => {
                     ProcessedSyscallParams::MemoryArrayPtr
                 }
-                Pointer(Ptr::Hash(HashType::MessageId)) => ProcessedSyscallParams::MemoryPtrValue {
-                    allowed_values: Some(PtrParamAllowedValues::WaitedMessageId),
-                },
                 // It's guaranteed that fallible syscall has error pointer as a last param.
                 Pointer(ptr) => ProcessedSyscallParams::MemoryPtrValue {
                     allowed_values: params_config.get_ptr_rule(ptr),

--- a/utils/wasm-gen/src/tests.rs
+++ b/utils/wasm-gen/src/tests.rs
@@ -289,7 +289,9 @@ fn test_wake_uses_stored_message_id() {
     rng.fill_bytes(&mut buf);
     let mut unstructured = Unstructured::new(&buf);
 
-    let params_config = SyscallsParamsConfig::new().with_default_regular_config();
+    let params_config = SyscallsParamsConfig::new()
+        .with_default_regular_config()
+        .with_ptr_rule(PtrParamAllowedValues::WaitedMessageId);
 
     let mut injection_types = SyscallsInjectionTypes::all_never();
     injection_types.set(InvocableSyscall::Loose(SyscallName::Wake), 1, 1);

--- a/utils/wasm-gen/src/tests.rs
+++ b/utils/wasm-gen/src/tests.rs
@@ -264,7 +264,8 @@ fn test_wait_stores_message_id() {
 
         // It's Ok, message id is 32 bytes in size, but we use u64 for testing purposes.
         let mut message_id = [0u8; 8];
-        let waited_message_id_ptr = MemoryLayout::from(0x10000).waited_message_id_ptr;
+        let waited_message_id_ptr =
+            MemoryLayout::from(WASM_PAGE_SIZE * INITIAL_PAGES).waited_message_id_ptr;
         memory
             .read(&store, waited_message_id_ptr as u32, &mut message_id)
             .unwrap();

--- a/utils/wasm-gen/src/tests.rs
+++ b/utils/wasm-gen/src/tests.rs
@@ -41,11 +41,14 @@ use gear_wasm_instrument::{
     gas_metering::CustomConstantCostRules,
     parity_wasm::{self, elements::Module},
 };
+use nonempty::nonempty;
 use proptest::prelude::*;
 use rand::{rngs::SmallRng, RngCore, SeedableRng};
 use std::num::{NonZeroU32, NonZeroUsize};
 
 const UNSTRUCTURED_SIZE: usize = 1_000_000;
+const WASM_PAGE_SIZE: u32 = 64 * 1024;
+const INITIAL_PAGES: u32 = 1;
 
 type Ext = gear_core_processor::Ext<LazyPagesNative>;
 
@@ -193,15 +196,130 @@ fn test_avoid_waits_works() {
     let backend_report = execute_wasm_with_custom_configs(
         &mut unstructured,
         syscalls_config,
-        None,
-        1024,
-        false,
-        0,
-        0,
+        ExecuteParams {
+            // This test supposed to check if waiting probability works correctly,
+            // so we have to set `init_called flag` to make wait probability code reachable.
+            // And the second, we have to set waiting probability counter to non-zero value,
+            // because the wasm check looks like this `if *wait_called_ptr % waiting_probability == 0 { orig_wait_syscall(); }`
+            initial_memory_write: nonempty![set_init_called_flag(), set_wait_called_counter(1)]
+                .into(),
+            ..Default::default()
+        },
     );
 
     assert_eq!(
         backend_report.termination_reason,
+        TerminationReason::Actor(ActorTerminationReason::Success)
+    );
+}
+
+#[test]
+fn test_wait_stores_message_id() {
+    gear_utils::init_default_logger();
+
+    const EXPECTED_MSG_ID: u64 = 12345678;
+
+    let mut rng = SmallRng::seed_from_u64(123);
+    let mut buf = vec![0; UNSTRUCTURED_SIZE];
+    rng.fill_bytes(&mut buf);
+    let mut unstructured = Unstructured::new(&buf);
+
+    let params_config = SyscallsParamsConfig::new().with_default_regular_config();
+
+    let mut injection_types = SyscallsInjectionTypes::all_never();
+    injection_types.set(InvocableSyscall::Loose(SyscallName::Wait), 1, 1);
+    // Only for test, syscall `message_id` import added automatically when `wake` syscall is enabled in config.
+    injection_types.enable_syscall_import(InvocableSyscall::Loose(SyscallName::MessageId));
+
+    let syscalls_config_with_waiting_probabilty =
+        SyscallsConfigBuilder::new(injection_types.clone())
+            .with_params_config(params_config.clone())
+            .with_waiting_probability(NonZeroU32::new(4).unwrap())
+            .build();
+
+    let syscalls_config_wo_waiting_probabilty = SyscallsConfigBuilder::new(injection_types)
+        .with_params_config(params_config)
+        .build();
+
+    // Test both configs:
+    for syscalls_config in [
+        syscalls_config_with_waiting_probabilty,
+        syscalls_config_wo_waiting_probabilty,
+    ] {
+        let BackendReport {
+            termination_reason,
+            store,
+            memory,
+            ..
+        } = execute_wasm_with_custom_configs(
+            &mut unstructured,
+            syscalls_config,
+            ExecuteParams {
+                initial_memory_write: nonempty![set_init_called_flag(), set_wait_called_counter(0)]
+                    .into(),
+                message_id: EXPECTED_MSG_ID,
+                ..Default::default()
+            },
+        );
+
+        // It's Ok, message id is 32 bytes in size, but we use u64 for testing purposes.
+        let mut message_id = [0u8; 8];
+        let waited_message_id_ptr = MemoryLayout::from(0x10000).waited_message_id_ptr;
+        memory
+            .read(&store, waited_message_id_ptr as u32, &mut message_id)
+            .unwrap();
+        assert_eq!(u64::from_le_bytes(message_id), EXPECTED_MSG_ID);
+
+        assert!(matches!(
+            termination_reason,
+            TerminationReason::Actor(ActorTerminationReason::Wait(..))
+        ));
+    }
+}
+
+#[test]
+fn test_wake_uses_stored_message_id() {
+    gear_utils::init_default_logger();
+
+    const EXPECTED_MSG_ID: u64 = 12345678;
+
+    let mut rng = SmallRng::seed_from_u64(123);
+    let mut buf = vec![0; UNSTRUCTURED_SIZE];
+    rng.fill_bytes(&mut buf);
+    let mut unstructured = Unstructured::new(&buf);
+
+    let params_config = SyscallsParamsConfig::new().with_default_regular_config();
+
+    let mut injection_types = SyscallsInjectionTypes::all_never();
+    injection_types.set(InvocableSyscall::Loose(SyscallName::Wake), 1, 1);
+    let syscalls_config = SyscallsConfigBuilder::new(injection_types)
+        .with_params_config(params_config)
+        .build();
+
+    let BackendReport {
+        termination_reason,
+        mut store,
+        memory,
+        ext,
+    } = execute_wasm_with_custom_configs(
+        &mut unstructured,
+        syscalls_config,
+        ExecuteParams {
+            initial_memory_write: nonempty![set_waited_message_id(EXPECTED_MSG_ID)].into(),
+            ..Default::default()
+        },
+    );
+
+    let info = ext.into_ext_info(&mut store, &memory).unwrap();
+    let msg_id = info.awakening.first().unwrap().0;
+    let msg_id_bytes = msg_id.into_bytes();
+    assert_eq!(
+        u64::from_le_bytes(msg_id_bytes[..8].try_into().unwrap()),
+        EXPECTED_MSG_ID
+    );
+
+    assert_eq!(
+        termination_reason,
         TerminationReason::Actor(ActorTerminationReason::Success)
     );
 }
@@ -226,15 +344,8 @@ fn test_source_as_address_param() {
         .with_error_processing_config(ErrorProcessingConfig::All)
         .build();
 
-    let backend_report = execute_wasm_with_custom_configs(
-        &mut unstructured,
-        syscalls_config,
-        None,
-        1024,
-        false,
-        0,
-        0,
-    );
+    let backend_report =
+        execute_wasm_with_custom_configs(&mut unstructured, syscalls_config, Default::default());
 
     assert_eq!(
         backend_report.termination_reason,
@@ -266,15 +377,8 @@ fn test_existing_address_as_address_param() {
         .with_error_processing_config(ErrorProcessingConfig::All)
         .build();
 
-    let backend_report = execute_wasm_with_custom_configs(
-        &mut unstructured,
-        syscalls_config,
-        None,
-        1024,
-        false,
-        0,
-        0,
-    );
+    let backend_report =
+        execute_wasm_with_custom_configs(&mut unstructured, syscalls_config, Default::default());
 
     assert_eq!(
         backend_report.termination_reason,
@@ -325,11 +429,10 @@ fn test_msg_value_ptr() {
     let backend_report = execute_wasm_with_custom_configs(
         &mut unstructured,
         syscalls_config,
-        None,
-        1024,
-        false,
-        INITIAL_BALANCE,
-        0,
+        ExecuteParams {
+            value: INITIAL_BALANCE,
+            ..Default::default()
+        },
     );
 
     assert_eq!(
@@ -393,11 +496,10 @@ fn test_msg_value_ptr_dest() {
             let backend_report = execute_wasm_with_custom_configs(
                 &mut unstructured,
                 syscalls_config,
-                None,
-                1024,
-                false,
-                INITIAL_BALANCE,
-                0,
+                ExecuteParams {
+                    value: INITIAL_BALANCE,
+                    ..Default::default()
+                },
             );
 
             assert_eq!(
@@ -464,15 +566,8 @@ fn test_send_init_with_send() {
         .with_keeping_insertion_order(true)
         .build();
 
-    let backend_report = execute_wasm_with_custom_configs(
-        &mut unstructured,
-        syscalls_config,
-        None,
-        1024,
-        false,
-        0,
-        0,
-    );
+    let backend_report =
+        execute_wasm_with_custom_configs(&mut unstructured, syscalls_config, Default::default());
 
     assert_eq!(
         backend_report.termination_reason,
@@ -505,11 +600,10 @@ fn test_reservation_id_with_value_ptr() {
     let backend_report = execute_wasm_with_custom_configs(
         &mut unstructured,
         syscalls_config,
-        None,
-        1024,
-        false,
-        0,
-        250_000_000_000,
+        ExecuteParams {
+            gas: 250_000_000_000,
+            ..Default::default()
+        },
     );
 
     assert_eq!(
@@ -553,11 +647,10 @@ fn test_reservation_id_with_actor_id_and_value_ptr() {
     let backend_report = execute_wasm_with_custom_configs(
         &mut unstructured,
         syscalls_config,
-        None,
-        1024,
-        false,
-        0,
-        250_000_000_000,
+        ExecuteParams {
+            gas: 250_000_000_000,
+            ..Default::default()
+        },
     );
 
     assert_eq!(
@@ -591,11 +684,10 @@ fn test_reservation_id_ptr() {
     let backend_report = execute_wasm_with_custom_configs(
         &mut unstructured,
         syscalls_config,
-        None,
-        1024,
-        false,
-        0,
-        250_000_000_000,
+        ExecuteParams {
+            gas: 250_000_000_000,
+            ..Default::default()
+        },
     );
 
     assert_eq!(
@@ -642,11 +734,10 @@ fn test_code_id_with_value_ptr() {
         let backend_report = execute_wasm_with_custom_configs(
             &mut unstructured,
             syscalls_config,
-            None,
-            1024,
-            false,
-            INITIAL_BALANCE,
-            0,
+            ExecuteParams {
+                value: INITIAL_BALANCE,
+                ..Default::default()
+            },
         );
 
         assert_eq!(
@@ -698,11 +789,12 @@ fn error_processing_works_for_fallible_syscalls() {
                 .clone()
                 .with_error_processing_config(ErrorProcessingConfig::All)
                 .build(),
-            initial_memory_write.clone(),
-            0,
-            true,
-            0,
-            0,
+            ExecuteParams {
+                initial_memory_write: initial_memory_write.clone(),
+                outgoing_limit: 0,
+                imitate_reply: true,
+                ..Default::default()
+            },
         )
         .termination_reason;
 
@@ -717,11 +809,12 @@ fn error_processing_works_for_fallible_syscalls() {
         let termination_reason = execute_wasm_with_custom_configs(
             &mut unstructured2,
             syscalls_config_builder.build(),
-            initial_memory_write.clone(),
-            0,
-            true,
-            0,
-            0,
+            ExecuteParams {
+                initial_memory_write: initial_memory_write.clone(),
+                outgoing_limit: 0,
+                imitate_reply: true,
+                ..Default::default()
+            },
         )
         .termination_reason;
 
@@ -769,11 +862,7 @@ fn precise_syscalls_works() {
                 .with_precise_syscalls_config(PreciseSyscallsConfig::new(3..=3, 3..=3))
                 .with_error_processing_config(ErrorProcessingConfig::All)
                 .build(),
-            None,
-            1024,
-            false,
-            0,
-            0,
+            Default::default(),
         )
         .termination_reason;
 
@@ -794,24 +883,72 @@ struct MemoryWrite {
 
 fn get_params_for_syscall_to_fail(
     _syscall: InvocableSyscall,
-) -> (SyscallsParamsConfig, Option<MemoryWrite>) {
+) -> (SyscallsParamsConfig, Option<NonEmpty<MemoryWrite>>) {
     (
         SyscallsParamsConfig::const_regular_params(i32::MAX as i64),
         None,
     )
 }
 
-fn execute_wasm_with_custom_configs(
-    unstructured: &mut Unstructured,
-    syscalls_config: SyscallsConfig,
-    initial_memory_write: Option<MemoryWrite>,
+fn set_init_called_flag() -> MemoryWrite {
+    let mem_layout = MemoryLayout::from(WASM_PAGE_SIZE * INITIAL_PAGES);
+    let offset = mem_layout.init_called_ptr as u32;
+    let content = 0x01u32.to_le_bytes().to_vec();
+
+    MemoryWrite { offset, content }
+}
+
+fn set_wait_called_counter(counter: u8) -> MemoryWrite {
+    let mem_layout = MemoryLayout::from(WASM_PAGE_SIZE * INITIAL_PAGES);
+    let offset = mem_layout.wait_called_ptr as u32;
+    let content = vec![counter];
+
+    MemoryWrite { offset, content }
+}
+
+fn set_waited_message_id(message_id: u64) -> MemoryWrite {
+    let mem_layout = MemoryLayout::from(WASM_PAGE_SIZE * INITIAL_PAGES);
+    let offset = mem_layout.waited_message_id_ptr as u32;
+    let content = message_id.to_le_bytes().to_vec();
+
+    MemoryWrite { offset, content }
+}
+
+struct ExecuteParams {
+    initial_memory_write: Option<NonEmpty<MemoryWrite>>,
     outgoing_limit: u32,
     imitate_reply: bool,
     value: u128,
     gas: u64,
+    message_id: u64,
+}
+
+impl Default for ExecuteParams {
+    fn default() -> Self {
+        Self {
+            initial_memory_write: None,
+            outgoing_limit: 1024,
+            imitate_reply: false,
+            value: 0,
+            gas: 0,
+            message_id: 0,
+        }
+    }
+}
+
+fn execute_wasm_with_custom_configs(
+    unstructured: &mut Unstructured,
+    syscalls_config: SyscallsConfig,
+    ExecuteParams {
+        initial_memory_write,
+        outgoing_limit,
+        imitate_reply,
+        value,
+        gas,
+        message_id,
+    }: ExecuteParams,
 ) -> BackendReport<Ext> {
     const PROGRAM_STORAGE_PREFIX: [u8; 32] = *b"execute_wasm_with_custom_configs";
-    const INITIAL_PAGES: u16 = 1;
 
     gear_lazy_pages::init(
         LazyPagesVersion::Version1,
@@ -823,7 +960,7 @@ fn execute_wasm_with_custom_configs(
     let gear_config = (
         GearWasmGeneratorConfigBuilder::new()
             .with_memory_config(MemoryPagesConfig {
-                initial_size: INITIAL_PAGES as u32,
+                initial_size: INITIAL_PAGES,
                 ..MemoryPagesConfig::default()
             })
             .with_syscalls_config(syscalls_config)
@@ -853,7 +990,7 @@ fn execute_wasm_with_custom_configs(
     let program_id = ProgramId::generate_from_user(code_id, b"");
 
     let incoming_message = IncomingMessage::new(
-        Default::default(),
+        message_id.into(),
         message_sender(),
         Default::default(),
         Default::default(),
@@ -886,7 +1023,7 @@ fn execute_wasm_with_custom_configs(
         code.code(),
         DispatchKind::Init,
         vec![DispatchKind::Init].into_iter().collect(),
-        INITIAL_PAGES.into(),
+        (INITIAL_PAGES as u16).into(),
     )
     .expect("Failed to create environment");
 
@@ -905,9 +1042,11 @@ fn execute_wasm_with_custom_configs(
             Default::default(),
         );
 
-        if let Some(mem_write) = initial_memory_write {
-            mem.write(ctx, mem_write.offset, &mem_write.content)
-                .expect("Failed to write to memory");
+        if let Some(mem_writes) = initial_memory_write {
+            for mem_write in mem_writes {
+                mem.write(ctx, mem_write.offset, &mem_write.content)
+                    .expect("Failed to write to memory");
+            }
         };
     })
     .expect("Failed to execute WASM module")

--- a/utils/wasm-gen/src/wasm.rs
+++ b/utils/wasm-gen/src/wasm.rs
@@ -270,6 +270,7 @@ def_memory_layout! {
         reservation_temp2_ptr: u32,
         reservation_flags_ptr: u32,
         reservation_array_ptr: [Hash; MemoryLayout::AMOUNT_OF_RESERVATIONS as _],
+        waited_message_id_ptr: Hash,
     }
 }
 


### PR DESCRIPTION
In the runtime fuzzer:

- When generating a syscall from wait-family, it stores the current message ID in the specified Wasm memory storage for later use.
- When `wake` syscall is called, this previously stored/waited message ID is used as a parameter for the wake syscall.



@reviewer-or-team
