### PR TITLE
feat(ethexe): Option to print only 1 key format after generation

### DIFF
--- a/ethexe/cli/src/args.rs
+++ b/ethexe/cli/src/args.rs
@@ -122,7 +122,14 @@ pub struct ArgsOnConfig {
 
 #[derive(Clone, Debug, Subcommand, Deserialize)]
 pub enum ExtraCommands {
-    GenerateKey,
+    GenerateKey {
+        /// Print only secp256k1 public key
+        #[arg(long, conflicts_with = "ethereum")]
+        secp256k1: bool,
+        /// Print only Ethereum address
+        #[arg(long, conflicts_with = "secp256k1")]
+        ethereum: bool,
+    },
     ListKeys,
     ClearKeys,
     InsertKey(InsertKeyArgs),
@@ -189,11 +196,20 @@ impl ExtraCommands {
         };
 
         match self {
-            ExtraCommands::GenerateKey => {
+            ExtraCommands::GenerateKey {
+                secp256k1,
+                ethereum,
+            } => {
                 let new_pub = signer.generate_key()?;
 
-                println!("New public key stored: {}", new_pub);
-                println!("Ethereum address: {}", new_pub.to_address());
+                if *secp256k1 {
+                    println!("{new_pub}");
+                } else if *ethereum {
+                    println!("{}", new_pub.to_address())
+                } else {
+                    println!("New public key stored: {}", new_pub);
+                    println!("Ethereum address: {}", new_pub.to_address());
+                }
             }
 
             ExtraCommands::ClearKeys => {

--- a/ethexe/cli/src/main.rs
+++ b/ethexe/cli/src/main.rs
@@ -58,15 +58,15 @@ async fn main() -> anyhow::Result<()> {
     let config =
         Config::try_from(args.clone()).with_context(|| "Failed to create configuration")?;
 
-    env_logger::Builder::from_env(Env::default().default_filter_or("info"))
-        .try_init()
-        .with_context(|| "Failed to initialize logger")?;
-
-    print_info(&config);
-
     if let Some(extra_command) = args.extra_command {
         extra_command.run(&config).await?;
     } else {
+        env_logger::Builder::from_env(Env::default().default_filter_or("info"))
+            .try_init()
+            .with_context(|| "Failed to initialize logger")?;
+
+        print_info(&config);
+
         let mut service = Some(Service::new(&config).await?);
 
         async fn run_service(service: &mut Option<Service>) -> anyhow::Result<()> {


### PR DESCRIPTION
```console
foo@bar:~$ ethexe generate-key --ethereum
0x78a361a3947f647c525dd109c7d73d04a5f4e1f2
```