### PR TITLE
feat(gtest): Introduce reservations for the `gtest`

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -54,7 +54,7 @@ use frame_support::{
     traits::Get,
 };
 pub use gear_core::{
-    ids::{CodeId, MessageId, ProgramId},
+    ids::{CodeId, MessageId, ProgramId, ReservationId},
     memory::PageBuf,
     pages::GearPage,
     program::{ActiveProgram, MemoryInfix, Program},
@@ -141,6 +141,16 @@ impl Origin for ProgramId {
 }
 
 impl Origin for CodeId {
+    fn into_origin(self) -> H256 {
+        H256(self.into())
+    }
+
+    fn from_origin(val: H256) -> Self {
+        val.to_fixed_bytes().into()
+    }
+}
+
+impl Origin for ReservationId {
     fn into_origin(self) -> H256 {
         H256(self.into())
     }

--- a/examples/constructor/src/builder.rs
+++ b/examples/constructor/src/builder.rs
@@ -321,6 +321,14 @@ impl Calls {
         self.add_call(Call::SystemReserveGas(gas.into()))
     }
 
+    pub fn reserve_gas(self, gas: impl Into<Arg<u64>>, duration: impl Into<Arg<u32>>) -> Self {
+        self.add_call(Call::ReserveGas(gas.into(), duration.into()))
+    }
+
+    pub fn unreserve_gas(self, reservation_id: impl Into<Arg<[u8; 32]>>) -> Self {
+        self.add_call(Call::UnreserveGas(reservation_id.into()))
+    }
+
     pub fn write_in_loop(self, count: impl Into<Arg<u64>>) -> Self {
         self.add_call(Call::WriteN(count.into()))
     }

--- a/gtest/src/gas_tree.rs
+++ b/gtest/src/gas_tree.rs
@@ -21,10 +21,10 @@
 use crate::GAS_MULTIPLIER;
 use gear_common::{
     auxiliary::gas_provider::{AuxiliaryGasProvider, GasTreeError, PlainNodeId},
-    gas_provider::{ConsumeResultOf, GasNodeId, Provider, Tree},
+    gas_provider::{ConsumeResultOf, GasNodeId, Provider, ReservableTree, Tree},
     Gas, Origin,
 };
-use gear_core::ids::{MessageId, ProgramId};
+use gear_core::ids::{MessageId, ProgramId, ReservationId};
 
 pub(crate) type PositiveImbalance = <GasTree as Tree>::PositiveImbalance;
 pub(crate) type NegativeImbalance = <GasTree as Tree>::NegativeImbalance;
@@ -137,8 +137,26 @@ impl GasTreeManager {
     }
 
     /// Adapted by argument types version of the gas tree `consume` method.
-    pub(crate) fn consume(&self, mid: MessageId) -> ConsumeResultOf<GasTree> {
+    pub(crate) fn consume(&self, mid: impl Origin) -> ConsumeResultOf<GasTree> {
         GasTree::consume(GasNodeId::from(mid.cast::<PlainNodeId>()))
+    }
+
+    pub(crate) fn reserve_gas(
+        &self,
+        original_mid: MessageId,
+        reservation_id: ReservationId,
+        amount: Gas,
+    ) -> Result<(), GasTreeError> {
+        GasTree::reserve(
+            GasNodeId::from(original_mid.cast::<PlainNodeId>()),
+            GasNodeId::from(reservation_id.cast::<PlainNodeId>()),
+            amount,
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn exists(&self, node_id: impl Origin) -> bool {
+        GasTree::exists(GasNodeId::from(node_id.cast::<PlainNodeId>()))
     }
 
     /// Adapted by argument types version of the gas tree `reset` method.


### PR DESCRIPTION
Release notes: introducing gas reservations creation/deletion and usage for message sending on `gtest`.

TODO:
- [ ] implement `reserve_gas`
- [ ] implement `unreserve_gas`
- [ ] implement message sending from reservations
