### PR TITLE
feat(crates-io): simulate packages publishing

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -94,8 +94,8 @@ jobs:
           cargo +stable check --manifest-path utils/wasm-builder/test-program/Cargo.toml
           cargo +stable check --manifest-path utils/cargo-gbuild/test-program/Cargo.toml --workspace --target wasm32-unknown-unknown
 
-      - name: "Check: crates-io packages"
-        run: cargo +stable run --release -p crates-io check
+      - name: "Check: crates-io packages publishing"
+        run: cargo +stable run --release -p crates-io publish --simulate --registry-path /tmp/cargo-http-registry
 
   fuzzer:
     runs-on: [kuberunner, github-runner-01]

--- a/.github/workflows/crates-io.yml
+++ b/.github/workflows/crates-io.yml
@@ -32,10 +32,10 @@ jobs:
           targets: wasm32-unknown-unknown
           components: llvm-tools
 
-      - name: "Check packages"
+      - name: "Publish packages (simulate)"
         if: ${{ !inputs.publish }}
-        run: cargo +stable run -p crates-io check
+        run: cargo +stable run --release -p crates-io publish -v ${{ inputs.version }} --simulate --registry-path /tmp/cargo-http-registry
 
       - name: "Publish packages"
         if: ${{ inputs.publish }}
-        run: cargo +stable run -p crates-io publish -v ${{ inputs.version }}
+        run: cargo +stable run --release -p crates-io publish -v ${{ inputs.version }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,8 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-http-registry"
-version = "0.1.5"
-source = "git+https://github.com/d-e-s-o/cargo-http-registry.git#a4ce5f366c308c20c95567f1f0ce030499bf2fb0"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af9bc973d36c91202e71827f8644c6cd976eda51ad6d7cd2fcb5b9b049bfd02"
 dependencies = [
  "anyhow",
  "git2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2148,6 +2148,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-http-registry"
+version = "0.1.5"
+source = "git+https://github.com/d-e-s-o/cargo-http-registry.git#a4ce5f366c308c20c95567f1f0ce030499bf2fb0"
+dependencies = [
+ "anyhow",
+ "git2",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "structopt",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.18",
+ "warp",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2338,6 +2355,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags 1.3.2",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
@@ -2350,7 +2382,7 @@ dependencies = [
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "textwrap",
+ "textwrap 0.16.0",
 ]
 
 [[package]]
@@ -2916,10 +2948,13 @@ name = "crates-io"
 version = "1.5.0"
 dependencies = [
  "anyhow",
+ "cargo-http-registry",
  "cargo_metadata 0.18.1",
  "clap 4.5.9",
  "reqwest 0.11.27",
  "serde",
+ "tempfile",
+ "tokio",
  "toml_edit 0.22.14",
 ]
 
@@ -6154,7 +6189,6 @@ dependencies = [
  "gprimitives",
  "gsys",
  "hex-literal",
- "parity-scale-codec",
 ]
 
 [[package]]
@@ -7032,6 +7066,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
+name = "git2"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b989d6a7ca95a362cf2cfc5ad688b3a467be1f87e480b8dad07fee8c79b0044"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7409,6 +7458,39 @@ checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
  "byteorder",
  "num-traits",
+]
+
+[[package]]
+name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core",
+ "http 0.2.9",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http 0.2.9",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -8695,6 +8777,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.15.2+1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9582,12 +9678,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -9968,6 +10079,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -16792,6 +16913,12 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -16801,6 +16928,30 @@ name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap 2.34.0",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "strum"
@@ -17307,6 +17458,15 @@ dependencies = [
  "gear-wasm-builder",
  "gstd",
  "parity-scale-codec",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -18112,6 +18272,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18328,6 +18494,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18416,6 +18588,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "http 0.2.9",
+ "hyper 0.14.27",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -498,6 +498,7 @@ demo-wat = { path = "examples/wat" }
 # TODO: remove these dependencies (from this file?) or add more docs.
 
 cfg-if = "1.0.0"                                             # gear-lazy-pages
+cargo-http-registry = "0.1.5"                                # crates-io
 errno = "0.3"                                                # gear-lazy-pages
 nix = "0.26.4"                                               # gear-lazy-pages
 indexmap = "2.2.6"                                           # utils/weight-diff
@@ -579,3 +580,6 @@ blake3 = { git = "https://github.com/gear-tech/BLAKE3", branch = "fix-clang-cl-c
 
 # TODO: remove after https://github.com/pepyakin/wabt-rs/pull/84
 wabt = { git = "https://github.com/gear-tech/wabt-rs", branch = "al-win-crt" }
+
+# TODO: remove after release
+cargo-http-registry = { git = "https://github.com/d-e-s-o/cargo-http-registry.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -498,7 +498,7 @@ demo-wat = { path = "examples/wat" }
 # TODO: remove these dependencies (from this file?) or add more docs.
 
 cfg-if = "1.0.0"                                             # gear-lazy-pages
-cargo-http-registry = "0.1.5"                                # crates-io
+cargo-http-registry = "0.1.6"                                # crates-io
 errno = "0.3"                                                # gear-lazy-pages
 nix = "0.26.4"                                               # gear-lazy-pages
 indexmap = "2.2.6"                                           # utils/weight-diff
@@ -580,6 +580,3 @@ blake3 = { git = "https://github.com/gear-tech/BLAKE3", branch = "fix-clang-cl-c
 
 # TODO: remove after https://github.com/pepyakin/wabt-rs/pull/84
 wabt = { git = "https://github.com/gear-tech/wabt-rs", branch = "al-win-crt" }
-
-# TODO: remove after release
-cargo-http-registry = { git = "https://github.com/d-e-s-o/cargo-http-registry.git" }

--- a/gcore/Cargo.toml
+++ b/gcore/Cargo.toml
@@ -13,13 +13,12 @@ gsys.workspace = true
 gprimitives.workspace = true
 gear-core-errors.workspace = true
 gear-stack-buffer.workspace = true
-codec = { workspace = true, optional = true }
 
 [dev-dependencies]
 hex-literal.workspace = true
 galloc.workspace = true
 
 [features]
-codec = ["dep:codec", "gear-core-errors/codec", "gprimitives/codec"]
+codec = ["gear-core-errors/codec", "gprimitives/codec"]
 debug = []
 ethexe = ["gsys/ethexe"]

--- a/utils/crates-io/Cargo.toml
+++ b/utils/crates-io/Cargo.toml
@@ -5,8 +5,11 @@ edition.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+cargo-http-registry.workspace = true
 cargo_metadata.workspace = true
 clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 reqwest = { workspace = true, features = ["blocking", "json", "default-tls"] }
+tempfile.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 toml_edit.workspace = true

--- a/utils/crates-io/src/handler.rs
+++ b/utils/crates-io/src/handler.rs
@@ -40,7 +40,7 @@ pub fn crates_io_name(pkg: &str) -> &str {
 /// Patch specified manifest by provided name.
 pub fn patch(pkg: &Package) -> Result<Manifest> {
     let mut manifest = Manifest::new(pkg)?;
-    let doc = &mut manifest.manifest;
+    let doc = &mut manifest.mutable_manifest;
 
     match manifest.name.as_str() {
         "gear-core-processor" => core_processor::patch(doc),

--- a/utils/crates-io/src/lib.rs
+++ b/utils/crates-io/src/lib.rs
@@ -26,7 +26,7 @@ mod simulator;
 mod version;
 
 pub use self::{
-    manifest::{Manifest, Workspace},
+    manifest::{LockFile, Manifest, Workspace},
     publisher::Publisher,
     simulator::Simulator,
     version::verify,

--- a/utils/crates-io/src/lib.rs
+++ b/utils/crates-io/src/lib.rs
@@ -22,14 +22,20 @@
 mod handler;
 mod manifest;
 mod publisher;
+mod simulator;
 mod version;
 
-pub use self::{manifest::Manifest, publisher::Publisher, version::verify};
+pub use self::{
+    manifest::{Manifest, Workspace},
+    publisher::Publisher,
+    simulator::Simulator,
+    version::verify,
+};
 use anyhow::Result;
 use std::process::{Command, ExitStatus};
 
 /// Required Packages without local dependencies.
-pub const SAFE_DEPENDENCIES: [&str; 13] = [
+pub const SAFE_DEPENDENCIES: &[&str] = &[
     "actor-system-error",
     "galloc",
     "gear-ss58",
@@ -50,7 +56,7 @@ pub const SAFE_DEPENDENCIES: [&str; 13] = [
 /// NOTE: Each package in this array could possibly depend
 /// on the previous one, please be cautious about changing
 /// the order.
-pub const STACKED_DEPENDENCIES: [&str; 15] = [
+pub const STACKED_DEPENDENCIES: &[&str] = &[
     "gprimitives",
     "gstd-codegen",
     "gcore",
@@ -73,7 +79,7 @@ pub const STACKED_DEPENDENCIES: [&str; 15] = [
 /// NOTE: Each package in this array could possibly depend
 /// on the previous one, please be cautious about changing
 /// the order.
-pub const PACKAGES: [&str; 11] = [
+pub const PACKAGES: &[&str] = &[
     "gring",
     "gear-wasm-optimizer",
     "gear-wasm-builder",
@@ -92,6 +98,9 @@ pub const PACKAGE_ALIAS: [(&str, &str); 2] = [
     ("gear-core-processor", "core-processor"),
     ("gear-runtime-primitives", "runtime-primitives"),
 ];
+
+/// Name for temporary cargo registry.
+pub const CARGO_REGISTRY_NAME: &str = "cargo-http-registry";
 
 /// Check the input package
 pub fn check(manifest: &str) -> Result<ExitStatus> {

--- a/utils/crates-io/src/main.rs
+++ b/utils/crates-io/src/main.rs
@@ -28,8 +28,6 @@ use std::path::PathBuf;
 enum Command {
     /// Build manifests for packages that to be published.
     Build,
-    /// Check packages that to be published.
-    Check,
     /// Publish packages.
     Publish {
         /// The version to publish.
@@ -59,12 +57,6 @@ async fn main() -> Result<()> {
     let Opt { command } = Opt::parse();
 
     match command {
-        Command::Check => {
-            let publisher = Publisher::new()?.build(false, None)?;
-            let result = publisher.check();
-            publisher.restore()?;
-            result
-        }
         Command::Publish {
             version,
             simulate,

--- a/utils/crates-io/src/main.rs
+++ b/utils/crates-io/src/main.rs
@@ -21,6 +21,7 @@
 use anyhow::Result;
 use clap::Parser;
 use crates_io::Publisher;
+use std::path::PathBuf;
 
 /// The command to run.
 #[derive(Clone, Debug, Parser)]
@@ -34,6 +35,12 @@ enum Command {
         /// The version to publish.
         #[clap(long, short)]
         version: Option<String>,
+        /// Simulates publishing of packages.
+        #[clap(long, short)]
+        simulate: bool,
+        /// Path to registry for simulation.
+        #[arg(short, long)]
+        registry_path: Option<PathBuf>,
     },
 }
 
@@ -47,15 +54,30 @@ pub struct Opt {
     command: Command,
 }
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     let Opt { command } = Opt::parse();
 
-    let publisher = Publisher::new()?;
     match command {
-        Command::Check => publisher.build(false, None)?.check(),
-        Command::Publish { version } => publisher.build(true, version)?.publish(),
+        Command::Check => {
+            let publisher = Publisher::new()?.build(false, None)?;
+            let result = publisher.check();
+            publisher.restore()?;
+            result
+        }
+        Command::Publish {
+            version,
+            simulate,
+            registry_path,
+        } => {
+            let publisher =
+                Publisher::with_simulation(simulate, registry_path)?.build(true, version)?;
+            let result = publisher.publish();
+            publisher.restore()?;
+            result
+        }
         Command::Build => {
-            publisher.build(false, None)?;
+            Publisher::new()?.build(false, None)?;
             Ok(())
         }
     }

--- a/utils/crates-io/src/publisher.rs
+++ b/utils/crates-io/src/publisher.rs
@@ -68,11 +68,6 @@ impl Publisher {
                 continue;
             };
 
-            // TODO: remove this check
-            /*if !["gear-ss58", "gprimitives"].contains(name) {
-                continue;
-            }*/
-
             if verify && crate::verify(name, &version, self.simulator.as_ref())? {
                 println!("Package {name}@{version} already published!");
                 continue;

--- a/utils/crates-io/src/publisher.rs
+++ b/utils/crates-io/src/publisher.rs
@@ -19,40 +19,37 @@
 //! Packages publisher
 
 use crate::{
-    handler, manifest::Workspace, Manifest, PACKAGES, SAFE_DEPENDENCIES, STACKED_DEPENDENCIES,
+    handler, Manifest, Simulator, Workspace, PACKAGES, SAFE_DEPENDENCIES, STACKED_DEPENDENCIES,
 };
-use anyhow::Result;
+use anyhow::{bail, Result};
 use cargo_metadata::{Metadata, MetadataCommand};
-use std::collections::{BTreeMap, HashMap};
+use std::{iter, path::PathBuf};
 
 /// crates-io packages publisher.
 pub struct Publisher {
     metadata: Metadata,
-    graph: BTreeMap<Option<usize>, Manifest>,
-    index: HashMap<String, usize>,
+    graph: Vec<Manifest>,
+    index: Vec<&'static str>,
+    workspace: Option<Workspace>,
+    simulator: Option<Simulator>,
 }
 
 impl Publisher {
     /// Create a new publisher.
     pub fn new() -> Result<Self> {
-        let metadata = MetadataCommand::new().no_deps().exec()?;
-        let graph = BTreeMap::new();
-        let index = HashMap::<String, usize>::from_iter(
-            [
-                SAFE_DEPENDENCIES.to_vec(),
-                STACKED_DEPENDENCIES.into(),
-                PACKAGES.into(),
-            ]
-            .concat()
-            .into_iter()
-            .enumerate()
-            .map(|(i, p)| (p.into(), i)),
-        );
+        Self::with_simulation(false, None)
+    }
 
+    /// Create a new publisher with simulation.
+    pub fn with_simulation(simulate: bool, registry_path: Option<PathBuf>) -> Result<Self> {
         Ok(Self {
-            metadata,
-            graph,
-            index,
+            metadata: MetadataCommand::new().no_deps().exec()?,
+            graph: vec![],
+            index: [SAFE_DEPENDENCIES, STACKED_DEPENDENCIES, PACKAGES].concat(),
+            workspace: None,
+            simulator: simulate
+                .then(|| Simulator::new(registry_path))
+                .transpose()?,
         })
     }
 
@@ -62,44 +59,74 @@ impl Publisher {
     /// 2. Rename version of all local packages
     /// 3. Patch dependencies if needed
     pub fn build(mut self, verify: bool, version: Option<String>) -> Result<Self> {
-        let mut index = self
-            .index
-            .iter()
-            .map(|(k, &v)| (k.clone(), v))
-            .collect::<Vec<_>>();
-
-        index.sort_by_key(|(_, v)| *v);
-
         let mut workspace = Workspace::lookup(version)?;
         let version = workspace.version()?;
 
-        for (name, _) in &index {
+        for name in self.index.iter() {
             let Some(pkg) = self.metadata.packages.iter().find(|pkg| pkg.name == *name) else {
+                println!("Package {name}@{version} not found in cargo metadata!");
                 continue;
             };
 
-            if verify && crate::verify(name, &version)? {
-                println!("Package {}@{} already published .", &name, &version);
+            // TODO: remove this check
+            /*if !["gear-ss58", "gprimitives"].contains(name) {
+                continue;
+            }*/
+
+            if verify && crate::verify(name, &version, self.simulator.as_ref())? {
+                println!("Package {name}@{version} already published!");
                 continue;
             }
 
-            self.graph
-                .insert(self.index.get(name).cloned(), handler::patch(pkg)?);
+            self.graph.push(handler::patch(pkg)?);
         }
 
-        let index = index.iter().map(|(k, _)| k.as_ref()).collect();
+        workspace.complete(self.index.clone(), self.simulator.is_some())?;
 
-        workspace.complete(index)?;
+        self.workspace = Some(workspace);
 
-        // write manifests to disk.
-        let manifest = workspace.into();
-        let manifests = [self.graph.values().collect::<Vec<_>>(), vec![&manifest]].concat();
-        manifests
-            .iter()
-            .map(|m| m.write())
-            .collect::<Result<Vec<_>>>()?;
+        self.patch()?;
 
         Ok(self)
+    }
+
+    /// Restore local files
+    pub fn restore(&self) -> Result<()> {
+        if let Some(manifests) = self.manifests() {
+            manifests
+                .map(|manifest| manifest.restore())
+                .collect::<Result<Vec<_>>>()?;
+        }
+
+        if let Some(simulator) = self.simulator.as_ref() {
+            simulator.restore()?;
+        }
+
+        Ok(())
+    }
+
+    /// Patch local files
+    fn patch(&self) -> Result<()> {
+        if let Some(manifests) = self.manifests() {
+            manifests
+                .map(|manifest| manifest.patch())
+                .collect::<Result<Vec<_>>>()?;
+        }
+
+        if let Some(simulator) = self.simulator.as_ref() {
+            simulator.patch()?;
+        }
+
+        Ok(())
+    }
+
+    /// Returns an iterator of manifests that have been potentially patched
+    fn manifests(&self) -> Option<impl Iterator<Item = &Manifest>> {
+        Some(
+            self.graph
+                .iter()
+                .chain(iter::once(self.workspace.as_deref()?)),
+        )
     }
 
     /// Check the to-be-published packages
@@ -107,7 +134,7 @@ impl Publisher {
     /// TODO: Complete the check process (#3565)
     pub fn check(&self) -> Result<()> {
         let mut failed = Vec::new();
-        for Manifest { path, name, .. } in self.graph.values() {
+        for Manifest { path, name, .. } in self.graph.iter() {
             if !PACKAGES.contains(&name.as_str()) {
                 continue;
             }
@@ -120,7 +147,7 @@ impl Publisher {
         }
 
         if !failed.is_empty() {
-            panic!("Packages {failed:?} failed to pass the check ...");
+            bail!("Packages {failed:?} failed to pass the check ...");
         }
 
         // Post tests for gtest and gclient
@@ -129,7 +156,7 @@ impl Publisher {
             ("gsdk", "timeout"),
         ] {
             if !crate::test(pkg, test)?.success() {
-                panic!("{pkg}:{test} failed to pass the test ...");
+                bail!("{pkg}:{test} failed to pass the test ...");
             }
         }
 
@@ -138,11 +165,11 @@ impl Publisher {
 
     /// Publish packages
     pub fn publish(&self) -> Result<()> {
-        for Manifest { path, .. } in self.graph.values() {
+        for Manifest { path, .. } in self.graph.iter() {
             println!("Publishing {path:?}");
             let status = crate::publish(&path.to_string_lossy())?;
             if !status.success() {
-                panic!("Failed to publish package {path:?} ...");
+                bail!("Failed to publish package {path:?} ...");
             }
         }
 

--- a/utils/crates-io/src/simulator.rs
+++ b/utils/crates-io/src/simulator.rs
@@ -1,0 +1,105 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2024 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Packages publishing simulator
+
+use crate::{Workspace, CARGO_REGISTRY_NAME};
+use anyhow::Result;
+use std::{
+    fs,
+    net::SocketAddr,
+    ops::Deref,
+    path::{Path, PathBuf},
+};
+use tempfile::TempDir;
+use tokio::task::{self, JoinHandle};
+use toml_edit::DocumentMut;
+
+enum RegistryPath {
+    Dir(PathBuf),
+    TempDir(TempDir),
+}
+
+impl Deref for RegistryPath {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            RegistryPath::Dir(path) => path,
+            RegistryPath::TempDir(temp_dir) => temp_dir.path(),
+        }
+    }
+}
+
+/// crates-io packages publishing simulator.
+#[allow(dead_code)]
+pub struct Simulator {
+    path: RegistryPath,
+    addr: SocketAddr,
+    handle: JoinHandle<()>,
+    config_path: PathBuf,
+    original_config: DocumentMut,
+    mutable_config: DocumentMut,
+}
+
+impl Simulator {
+    /// Create a new simulator.
+    pub fn new(registry_path: Option<PathBuf>) -> Result<Self> {
+        let path = match registry_path {
+            Some(path) => RegistryPath::Dir(path),
+            None => RegistryPath::TempDir(TempDir::new()?),
+        };
+        let (future, addr) = cargo_http_registry::serve(&path, "127.0.0.1:35503".parse()?)?;
+        let handle = task::spawn(future);
+
+        let config_path = Workspace::resolve_path(".cargo/config.toml")?;
+        let original_config: DocumentMut = fs::read_to_string(&config_path)?.parse()?;
+        let mut mutable_config = original_config.clone();
+
+        // Patch `.cargo/config.toml` according to https://github.com/d-e-s-o/cargo-http-registry/blob/main/README.md#usage
+        mutable_config["registry"]["default"] = toml_edit::value(CARGO_REGISTRY_NAME);
+        mutable_config["registries"][CARGO_REGISTRY_NAME]["index"] =
+            toml_edit::value(format!("http://{addr}/git"));
+        mutable_config["registries"][CARGO_REGISTRY_NAME]["token"] = toml_edit::value("token");
+        mutable_config["net"]["git-fetch-with-cli"] = toml_edit::value(true);
+
+        Ok(Self {
+            path,
+            addr,
+            handle,
+            config_path,
+            original_config,
+            mutable_config,
+        })
+    }
+
+    /// Returns socket addr
+    pub fn addr(&self) -> &SocketAddr {
+        &self.addr
+    }
+
+    /// Restore cargo config
+    pub fn restore(&self) -> Result<()> {
+        fs::write(&self.config_path, self.original_config.to_string()).map_err(Into::into)
+    }
+
+    /// Patch cargo config
+    pub fn patch(&self) -> Result<()> {
+        fs::write(&self.config_path, self.mutable_config.to_string()).map_err(Into::into)
+    }
+}


### PR DESCRIPTION
Resolves #4142

This PR is aimed at simplifying debugging of package publishing. Package publishing will be checked on temporary cargo registry, which will allow make additional check on CI.

TODO:
- [x] refactor the code, add rollback of patched files
- [x] use [cargo-http-registry](https://github.com/d-e-s-o/cargo-http-registry), use their api or just write bash script
- [x] write github workflow
