### PR TITLE
fix(ethexe): correct numeric cast function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5102,6 +5102,7 @@ dependencies = [
  "gprimitives",
  "log",
  "parity-scale-codec",
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/ethexe/ethereum/Cargo.toml
+++ b/ethexe/ethereum/Cargo.toml
@@ -32,3 +32,6 @@ alloy = { workspace = true, features = [
 futures.workspace = true
 log.workspace = true
 parity-scale-codec = { workspace = true, features = ["std", "derive"] }
+
+[dev-dependencies]
+rand.workspace = true

--- a/ethexe/ethereum/src/abi.rs
+++ b/ethexe/ethereum/src/abi.rs
@@ -54,7 +54,7 @@ sol!(
 );
 
 pub(crate) fn uint256_to_u128_lossy(value: AlloyU256) -> u128 {
-    let [.., high, low] = value.into_limbs();
+    let [low, high, ..] = value.into_limbs();
 
     ((high as u128) << 64) | (low as u128)
 }
@@ -319,5 +319,13 @@ impl From<IWrappedVara::Approval> for wvara::Event {
             spender: (*event.spender.into_word()).into(),
             value: U256(event.value.into_limbs()),
         }
+    }
+}
+
+#[test]
+fn cast_is_correct() {
+    for _ in 0..10 {
+        let res: u128 = rand::random();
+        assert_eq!(uint256_to_u128_lossy(AlloyU256::from(res)), res);
     }
 }


### PR DESCRIPTION
> Limbs are least significant first.

```rust
/// Convert to a array of limbs.
///
/// Limbs are least significant first.
#[inline(always)]
#[must_use]
pub const fn into_limbs(self) -> [u64; LIMBS] {
    self.limbs
}
```