### PR TITLE
feat(gtest): Introduce auxiliary waitlist impl to `gtest`

### DIFF
--- a/common/src/auxiliary/mod.rs
+++ b/common/src/auxiliary/mod.rs
@@ -23,6 +23,7 @@
 pub mod gas_provider;
 pub mod mailbox;
 pub mod task_pool;
+pub mod waitlist;
 
 use crate::storage::{
     Counted, CountedByKey, DoubleMapStorage, GetFirstPos, GetSecondPos, IterableByKeyMap,

--- a/common/src/auxiliary/waitlist.rs
+++ b/common/src/auxiliary/waitlist.rs
@@ -1,0 +1,84 @@
+// This file is part of Gear.
+
+// Copyright (C) 2021-2024 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Auxiliary implementation of the waitlist.
+
+use super::{AuxiliaryDoubleStorageWrap, BlockNumber, DoubleBTreeMap};
+use crate::storage::{Interval, WaitlistError, WaitlistImpl, WaitlistKeyGen};
+use core::cell::RefCell;
+use gear_core::{
+    ids::{MessageId, ProgramId},
+    message::StoredDispatch,
+};
+
+/// Waitlist implementation that can be used in a native, non-wasm runtimes.
+pub type AuxiliaryWaitlist<WaitListCallbacks> = WaitlistImpl<
+    WaitlistStorageWrap,
+    WaitlistedMessage,
+    BlockNumber,
+    WaitlistErrorImpl,
+    WaitlistErrorImpl,
+    WaitListCallbacks,
+    WaitlistKeyGen,
+>;
+/// Type represents message stored in the waitlist.
+pub type WaitlistedMessage = StoredDispatch;
+
+std::thread_local! {
+    // Definition of the mailbox (`StorageDoubleMap`) global storage, accessed by the `Mailbox` trait implementor.
+    pub(crate) static WAITLIST_STORAGE: RefCell<DoubleBTreeMap<ProgramId, MessageId, (WaitlistedMessage, Interval<BlockNumber>)>> = const { RefCell::new(DoubleBTreeMap::new()) };
+}
+
+/// `Waitlist` double storage map manager.
+pub struct WaitlistStorageWrap;
+
+impl AuxiliaryDoubleStorageWrap for WaitlistStorageWrap {
+    type Key1 = ProgramId;
+    type Key2 = MessageId;
+    type Value = (WaitlistedMessage, Interval<BlockNumber>);
+
+    fn with_storage<F, R>(f: F) -> R
+    where
+        F: FnOnce(&DoubleBTreeMap<Self::Key1, Self::Key2, Self::Value>) -> R,
+    {
+        WAITLIST_STORAGE.with_borrow(f)
+    }
+
+    fn with_storage_mut<F, R>(f: F) -> R
+    where
+        F: FnOnce(&mut DoubleBTreeMap<Self::Key1, Self::Key2, Self::Value>) -> R,
+    {
+        WAITLIST_STORAGE.with_borrow_mut(f)
+    }
+}
+
+/// An implementor of the error returned from calling `Waitlist` trait functions
+pub enum WaitlistErrorImpl {
+    DuplicateKey,
+    ElementNotFound,
+}
+
+impl WaitlistError for WaitlistErrorImpl {
+    fn duplicate_key() -> Self {
+        Self::DuplicateKey
+    }
+
+    fn element_not_found() -> Self {
+        Self::ElementNotFound
+    }
+}

--- a/common/src/auxiliary/waitlist.rs
+++ b/common/src/auxiliary/waitlist.rs
@@ -40,7 +40,7 @@ pub type AuxiliaryWaitlist<WaitListCallbacks> = WaitlistImpl<
 pub type WaitlistedMessage = StoredDispatch;
 
 std::thread_local! {
-    // Definition of the mailbox (`StorageDoubleMap`) global storage, accessed by the `Mailbox` trait implementor.
+    // Definition of the waitlist (`StorageDoubleMap`) global storage, accessed by the `Waitlist` trait implementor.
     pub(crate) static WAITLIST_STORAGE: RefCell<DoubleBTreeMap<ProgramId, MessageId, (WaitlistedMessage, Interval<BlockNumber>)>> = const { RefCell::new(DoubleBTreeMap::new()) };
 }
 

--- a/gtest/src/blocks.rs
+++ b/gtest/src/blocks.rs
@@ -18,14 +18,14 @@
 
 //! Block timestamp and height management.
 
+use crate::BLOCK_DURATION_IN_MSECS;
 use core_processor::configs::BlockInfo;
+use gear_common::{auxiliary::BlockNumber, storage::GetCallback};
 use std::{
     cell::RefCell,
     rc::Rc,
     time::{SystemTime, UNIX_EPOCH},
 };
-
-use crate::BLOCK_DURATION_IN_MSECS;
 
 type BlockInfoStorageInner = Rc<RefCell<Option<BlockInfo>>>;
 
@@ -113,6 +113,18 @@ fn now() -> u64 {
         .duration_since(UNIX_EPOCH)
         .expect("Time went backwards")
         .as_millis() as u64
+}
+
+/// Block number getter.
+///
+/// Used to get block number for auxiliary complex storage managers,
+/// like auxiliary maibox, waitlist and etc.
+pub(crate) struct GetBlockNumberImpl;
+
+impl GetCallback<BlockNumber> for GetBlockNumberImpl {
+    fn call() -> BlockNumber {
+        BlocksManager::new().get().height
+    }
 }
 
 #[cfg(test)]

--- a/gtest/src/gas_tree.rs
+++ b/gtest/src/gas_tree.rs
@@ -36,7 +36,7 @@ pub type OriginNodeDataOf = (
 type GasTree = <AuxiliaryGasProvider as Provider>::GasTree;
 
 /// Gas tree manager which operates under the hood over
-/// [`gear_common::AuxiliaryGasProvider`].
+/// [`gear_common::auxiliary::gas_provider::AuxiliaryGasProvider`].
 ///
 /// Manager is needed mainly to adapt arguments of the gas tree methods to the
 /// crate.

--- a/gtest/src/lib.rs
+++ b/gtest/src/lib.rs
@@ -504,6 +504,7 @@ mod manager;
 mod program;
 mod system;
 mod task_pool;
+mod waitlist;
 
 pub use crate::log::{BlockRunResult, CoreLog, Log};
 pub use codec;

--- a/gtest/src/mailbox/manager.rs
+++ b/gtest/src/mailbox/manager.rs
@@ -18,15 +18,15 @@
 
 //! Mailbox manager.
 
-use crate::blocks::BlocksManager;
+use crate::blocks::GetBlockNumberImpl;
 use gear_common::{
     auxiliary::{mailbox::*, BlockNumber},
-    storage::{GetCallback, Interval, IterableByKeyMap, Mailbox, MailboxCallbacks},
+    storage::{Interval, IterableByKeyMap, Mailbox, MailboxCallbacks},
 };
 use gear_core::ids::{MessageId, ProgramId};
 
 /// Mailbox manager which operates under the hood over
-/// [`gear_common::AuxiliaryMailbox`].
+/// [`gear_common::auxiliary::mailbox::AuxiliaryMailbox`].
 #[derive(Debug, Default)]
 pub(crate) struct MailboxManager;
 
@@ -79,15 +79,4 @@ impl MailboxCallbacks<MailboxErrorImpl> for MailboxCallbacksImpl {
 
     type OnInsert = ();
     type OnRemove = ();
-}
-
-/// Block number getter.
-///
-/// Used to get block number to insert message into mailbox.
-pub(crate) struct GetBlockNumberImpl;
-
-impl GetCallback<BlockNumber> for GetBlockNumberImpl {
-    fn call() -> BlockNumber {
-        BlocksManager::new().get().height
-    }
 }

--- a/gtest/src/task_pool.rs
+++ b/gtest/src/task_pool.rs
@@ -29,7 +29,7 @@ use gear_common::{
 };
 
 /// Task pool manager which operates under the hood over
-/// [`gear_common::AuxiliaryTaskpool`].
+/// [`gear_common::auxiliary::task_pool::AuxiliaryTaskpool`].
 ///
 /// Manager is needed mainly to adapt arguments of the task pool methods to the
 /// crate.

--- a/gtest/src/waitlist.rs
+++ b/gtest/src/waitlist.rs
@@ -20,15 +20,15 @@
 
 #![allow(unused)]
 
-use crate::blocks::BlocksManager;
+use crate::blocks::GetBlockNumberImpl;
 use gear_common::{
     auxiliary::{waitlist::*, BlockNumber},
-    storage::{GetCallback, Interval, IterableByKeyMap, Waitlist, WaitlistCallbacks},
+    storage::{Interval, IterableByKeyMap, Waitlist, WaitlistCallbacks},
 };
 use gear_core::ids::{MessageId, ProgramId};
 
 /// Waitlist manager which operates under the hood over
-/// [`gear_common::AuxiliaryWaitlist`].
+/// [`gear_common::auxiliary::waitlist::AuxiliaryWaitlist`].
 #[derive(Debug, Default)]
 pub(crate) struct WaitlistManager;
 
@@ -78,15 +78,4 @@ impl WaitlistCallbacks for WaitlistCallbacksImpl {
 
     type OnInsert = ();
     type OnRemove = ();
-}
-
-/// Block number getter.
-///
-/// Used to get block number to insert message into mailbox.
-pub(crate) struct GetBlockNumberImpl;
-
-impl GetCallback<BlockNumber> for GetBlockNumberImpl {
-    fn call() -> BlockNumber {
-        BlocksManager::new().get().height
-    }
 }

--- a/gtest/src/waitlist.rs
+++ b/gtest/src/waitlist.rs
@@ -1,0 +1,92 @@
+// This file is part of Gear.
+
+// Copyright (C) 2024 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Waitlist manager.
+
+#![allow(unused)]
+
+use crate::blocks::BlocksManager;
+use gear_common::{
+    auxiliary::{waitlist::*, BlockNumber},
+    storage::{GetCallback, Interval, IterableByKeyMap, Waitlist, WaitlistCallbacks},
+};
+use gear_core::ids::{MessageId, ProgramId};
+
+/// Waitlist manager which operates under the hood over
+/// [`gear_common::AuxiliaryWaitlist`].
+#[derive(Debug, Default)]
+pub(crate) struct WaitlistManager;
+
+impl WaitlistManager {
+    /// Check if message with `message_id` to a program with `program_id` is in
+    /// the waitlist.
+    pub(crate) fn contains(program_id: ProgramId, message_id: MessageId) -> bool {
+        <AuxiliaryWaitlist<WaitlistCallbacksImpl> as Waitlist>::contains(&program_id, &message_id)
+    }
+
+    /// Insert message into waitlist.
+    pub(crate) fn insert(
+        &self,
+        message: WaitlistedMessage,
+        expected: BlockNumber,
+    ) -> Result<(), WaitlistErrorImpl> {
+        <AuxiliaryWaitlist<WaitlistCallbacksImpl> as Waitlist>::insert(message, expected)
+    }
+
+    /// Remove message from the waitlist.
+    pub(crate) fn remove(
+        &self,
+        program_id: ProgramId,
+        message_id: MessageId,
+    ) -> Result<(WaitlistedMessage, Interval<BlockNumber>), WaitlistErrorImpl> {
+        <AuxiliaryWaitlist<WaitlistCallbacksImpl> as Waitlist>::remove(program_id, message_id)
+    }
+
+    /// Fully reset waitlist.
+    ///
+    /// # Note:
+    /// Must be called by `WaitlistManager` owner to reset waitlist
+    /// when the owner is dropped.
+    pub(crate) fn reset(&self) {
+        <AuxiliaryWaitlist<WaitlistCallbacksImpl> as Waitlist>::clear();
+    }
+}
+
+/// Waitlist callbacks implementor.
+pub(crate) struct WaitlistCallbacksImpl;
+
+impl WaitlistCallbacks for WaitlistCallbacksImpl {
+    type Value = WaitlistedMessage;
+    type BlockNumber = BlockNumber;
+
+    type GetBlockNumber = GetBlockNumberImpl;
+
+    type OnInsert = ();
+    type OnRemove = ();
+}
+
+/// Block number getter.
+///
+/// Used to get block number to insert message into mailbox.
+pub(crate) struct GetBlockNumberImpl;
+
+impl GetCallback<BlockNumber> for GetBlockNumberImpl {
+    fn call() -> BlockNumber {
+        BlocksManager::new().get().height
+    }
+}


### PR DESCRIPTION
Defines auxiliary waitlist in `common` crate and ports full implementation of the auxiliary waitlist to `gtest`, without actually using it (next PR).
