### PR TITLE
fix(lazy-pages-fuzzer, ci): add error output on lazy pages fuzzer's smoke test fail

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -111,6 +111,11 @@ jobs:
       - name: "ACTIONS: Checkout"
         uses: actions/checkout@v4
 
+      - name: "Install deps"
+        run: |
+          sudo apt update
+          sudo apt install -y xxd
+
       - name: "MOUNT: Logs path"
         run: |
           FUZZER_LOGS_PATH=/mnt/fuzzer_logs

--- a/scripts/check-lazy-pages-fuzzer.sh
+++ b/scripts/check-lazy-pages-fuzzer.sh
@@ -8,14 +8,15 @@ SCRIPTS="$(cd "$(dirname "$SELF")"/ && pwd)"
 RUN_DURATION_SECS=10
 PROCESS_NAME="lazy-pages-fuzzer-fuzz"
 OUTPUT_FILE="lazy_pages_fuzz_run"
+# Don't need big input for smoke test
+INITIAL_INPUT_SIZE=1000
+FUZZER_INPUT_FILE=utils/lazy-pages-fuzzer/fuzz/corpus/main/check-fuzzer-bytes
 
 main() {
     echo " >> Checking lazy pages fuzzer"
     echo " >> Getting random bytes from /dev/urandom"
-    # Fuzzer expects a minimal input size of 350 KiB. Without providing a corpus of the same or larger
-    # size fuzzer will stuck for a long time with trying to test the target using 0..100 bytes.
     mkdir -p utils/lazy-pages-fuzzer/fuzz/corpus/main
-    dd if=/dev/urandom of=utils/lazy-pages-fuzzer/fuzz/corpus/main/check-fuzzer-bytes bs=1 count="$INITIAL_INPUT_SIZE"
+    dd if=/dev/urandom of=$FUZZER_INPUT_FILE bs=1 count="$INITIAL_INPUT_SIZE"
 
     # Remove lazy pages fuzzer run file
     rm -f $OUTPUT_FILE
@@ -29,7 +30,7 @@ main() {
     ( RUST_LOG="error,lazy_pages_fuzzer::lazy_pages=trace" RUST_BACKTRACE=1 ./scripts/gear.sh test lazy-pages-fuzz "" > $OUTPUT_FILE 2>&1 ) & \
         sleep ${RUN_DURATION_SECS} ; \
         kill -s KILL $(pidof $PROCESS_NAME) 2> /dev/null ; \
-        echo " >> Lazy pages fuzzer run completed" ;
+        echo " >> Lazy pages fuzzer run finished" ;
 
     # Trim output after SIGKILL backtrace
     OUTPUT=$(sed '/SIGKILL/,$d' $OUTPUT_FILE)
@@ -37,12 +38,20 @@ main() {
     if echo $OUTPUT | grep -q 'SIG: Unprotect WASM memory at address' && \
         ! echo $OUTPUT | grep -iq "ERROR"
     then
-        echo "Success"
+        echo -e "\nSuccess"
         exit 0
     else
-        echo "Failed"
+        cat $OUTPUT_FILE
+        echo -e "\nFailure"
+        print_seed
         exit 1
     fi
+}
+
+print_seed() {
+    echo -e "\n Seed start: \""
+    xxd -p $FUZZER_INPUT_FILE | tr --delete '\n'
+    echo -e "\n\" seed end."
 }
 
 main


### PR DESCRIPTION
Resolves # .

Output the lazy pages fuzzer's smoke test result and seed in case of failure.

@reviewer-or-team
