### PR TITLE
fix(gstd): parse panic message correctly

### DIFF
--- a/gstd/src/common/handlers.rs
+++ b/gstd/src/common/handlers.rs
@@ -152,7 +152,7 @@ mod panic_handler {
                 }
 
                 if !self.found_delimiter {
-                    if s == ":\n" {
+                    if s == ":\n" || s == "\n" {
                         self.found_delimiter = true;
                         return Ok(());
                     }


### PR DESCRIPTION
rust 1.79.0 - 1.80.1 has different panic format and our parser does not work: https://github.com/rust-lang/rust/commit/fc257fae3c6d4adc6effb2535fb9130d8c15e3ff
