### PR TITLE
ci(build): pin foundry to 2.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       - name: "Install: Foundry"
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: "nightly-de596a4db781933f0c95805bd1c8c05e65f03d4f" # https://github.com/foundry-rs/foundry/releases/tag/nightly-de596a4db781933f0c95805bd1c8c05e65f03d4f
+          version: "nightly-d75318c9c7a1c6af5404fe96f63ca890dcdd588d" # https://github.com/foundry-rs/foundry/releases/tag/nightly-d75318c9c7a1c6af5404fe96f63ca890dcdd588d
 
       - name: "Show: Versioning"
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       - name: "Install: Foundry"
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: "2.0.0"
 
       - name: "Show: Versioning"
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       - name: "Install: Foundry"
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: "2.0.0"
+          version: "nightly-de596a4db781933f0c95805bd1c8c05e65f03d4f" # https://github.com/foundry-rs/foundry/releases/tag/nightly-de596a4db781933f0c95805bd1c8c05e65f03d4f
 
       - name: "Show: Versioning"
         run: |


### PR DESCRIPTION
Resolves # .

The foundry toolchain used in CI currently don't have version management, different from rust updates, foundry updates could cause unrecovered problems frequently

@gear-tech/dev 
