### PR TITLE
fix(gtest): Fix timestamp setting on block creation

### DIFF
--- a/gtest/src/state/blocks.rs
+++ b/gtest/src/state/blocks.rs
@@ -18,7 +18,6 @@
 
 //! Block timestamp and height management.
 
-use crate::BLOCK_DURATION_IN_MSECS;
 use core_processor::configs::BlockInfo;
 use gear_common::{auxiliary::BlockNumber, storage::GetCallback};
 use std::{

--- a/gtest/src/state/blocks.rs
+++ b/gtest/src/state/blocks.rs
@@ -84,8 +84,7 @@ impl BlocksManager {
                 panic!("instance always initialized");
             };
             block_info.height += amount;
-            let duration = BLOCK_DURATION_IN_MSECS.saturating_mul(amount as u64);
-            block_info.timestamp += duration;
+            block_info.timestamp = now();
 
             *block_info
         })


### PR DESCRIPTION
A quick fix for the `gtest` block timestamp calculation.
