### PR TITLE
fix(gtest): Allow program creation from code obtained from `System`

### DIFF
--- a/examples/program-factory/src/lib.rs
+++ b/examples/program-factory/src/lib.rs
@@ -163,9 +163,19 @@ mod tests {
     #[should_panic(expected = "Failed to create Program from provided code")]
     fn test_invalid_wasm_child() {
         let sys = System::new();
+        sys.init_logger();
+        let factory = prepare_factory(&sys);
 
         let invalid_wasm = [10u8; 32];
         let invalid_wasm_path_buf = create_tmp_file_with_data(&invalid_wasm);
-        let _ = sys.submit_local_code_file(invalid_wasm_path_buf);
+        let invalid_wasm_code_hash = sys.submit_local_code_file(invalid_wasm_path_buf);
+
+        let payload = CreateProgram::Custom(vec![(
+            invalid_wasm_code_hash.into(),
+            b"some_salt".to_vec(),
+            100_000,
+        )]);
+        factory.send_bytes(DEFAULT_USER_ALICE, payload.encode());
+        let _ = sys.run_next_block();
     }
 }

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -95,7 +95,7 @@ pub(crate) struct ExtManager {
 
     // State
     pub(crate) bank: Bank,
-    pub(crate) opt_binaries: BTreeMap<CodeId, InstrumentedCode>,
+    pub(crate) opt_binaries: BTreeMap<CodeId, Vec<u8>>,
     pub(crate) meta_binaries: BTreeMap<CodeId, Vec<u8>>,
     pub(crate) dispatches: VecDeque<StoredDispatch>,
     pub(crate) mailbox: MailboxManager,
@@ -145,23 +145,15 @@ impl ExtManager {
         program: Program,
         init_message_id: Option<MessageId>,
     ) -> Option<TestActor> {
-        if let Program::Genuine(GenuineProgram {
-            ref code, code_id, ..
-        }) = program
-        {
-            if self.read_code(code_id).is_none() {
-                self.store_new_code(code_id, code.clone());
-            }
-        }
         Actors::insert(program_id, TestActor::new(init_message_id, program))
     }
 
-    pub(crate) fn store_new_code(&mut self, code_id: CodeId, code: InstrumentedCode) {
+    pub(crate) fn store_new_code(&mut self, code_id: CodeId, code: Vec<u8>) {
         self.opt_binaries.insert(code_id, code);
     }
 
     pub(crate) fn read_code(&self, code_id: CodeId) -> Option<&[u8]> {
-        self.opt_binaries.get(&code_id).map(|code| code.code())
+        self.opt_binaries.get(&code_id).map(|code| code.as_ref())
     }
 
     pub(crate) fn fetch_inc_message_nonce(&mut self) -> u64 {

--- a/gtest/src/manager/journal.rs
+++ b/gtest/src/manager/journal.rs
@@ -21,6 +21,7 @@
 use super::{ExtManager, Gas, GenuineProgram, Program, TestActor};
 use crate::{
     manager::hold_bound::HoldBoundBuilder,
+    program::ProgramBuilder,
     state::{accounts::Accounts, actors::Actors},
     Value, EXISTENTIAL_DEPOSIT,
 };
@@ -294,10 +295,12 @@ impl JournalHandler for ExtManager {
         if let Some(code) = self.opt_binaries.get(&code_id).cloned() {
             for (init_message_id, candidate_id) in candidates {
                 if !Actors::contains_key(candidate_id) {
+                    let (instrumented, _) =
+                        ProgramBuilder::build_instrumented_code_and_id(code.clone());
                     self.store_new_actor(
                         candidate_id,
                         Program::Genuine(GenuineProgram {
-                            code: code.clone(),
+                            code: instrumented,
                             code_id,
                             allocations: Default::default(),
                             pages_data: Default::default(),

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -331,8 +331,9 @@ impl ProgramBuilder {
             .id
             .unwrap_or_else(|| system.0.borrow_mut().free_id_nonce().into());
 
-        let (code, code_id) = Self::build_instrumented_code_and_id(self.code);
+        let (code, code_id) = Self::build_instrumented_code_and_id(self.code.clone());
 
+        system.0.borrow_mut().store_new_code(code_id, self.code);
         if let Some(metadata) = self.meta {
             system
                 .0
@@ -368,8 +369,7 @@ impl ProgramBuilder {
         )
         .expect("Failed to create Program from provided code");
 
-        let c: InstrumentedCodeAndId = CodeAndId::new(code).into();
-        c.into_parts()
+        InstrumentedCodeAndId::from(CodeAndId::new(code)).into_parts()
     }
 }
 

--- a/gtest/src/system.rs
+++ b/gtest/src/system.rs
@@ -22,13 +22,13 @@ use crate::{
     manager::ExtManager,
     program::{Program, ProgramIdWrapper},
     state::{accounts::Accounts, actors::Actors, mailbox::ActorMailbox},
-    Gas, ProgramBuilder, Value, GAS_ALLOWANCE,
+    Gas, Value, GAS_ALLOWANCE,
 };
 use codec::{Decode, DecodeAll};
 use colored::Colorize;
 use env_logger::{Builder, Env};
 use gear_core::{
-    ids::{CodeId, ProgramId},
+    ids::{prelude::CodeIdExt, CodeId, ProgramId},
     pages::GearPage,
 };
 use gear_lazy_pages::{LazyPagesStorage, LazyPagesVersion};
@@ -352,7 +352,8 @@ impl System {
     /// must be in storage at the time of the function call. So this method
     /// stores the code in storage.
     pub fn submit_code(&self, binary: impl Into<Vec<u8>>) -> CodeId {
-        let (code, code_id) = ProgramBuilder::build_instrumented_code_and_id(binary.into());
+        let code = binary.into();
+        let code_id = CodeId::generate(code.as_ref());
         self.0.borrow_mut().store_new_code(code_id, code);
 
         code_id


### PR DESCRIPTION
Calling `System::submitted_code` returns instrumented code which can't be used to create a `Program`, as all the API expects the original code. Instrumented code is only needed for the underlying logic in `manager`, so removing it from the `ExtManager` seems reasonable, as it can always be calculated from the original one.
