### PR TITLE
fix(gtest): Fix gas tree ops to avoid `split`/`split_with_value` when both reply is sent and reply deposit exists

### DIFF
--- a/gtest/src/manager/journal.rs
+++ b/gtest/src/manager/journal.rs
@@ -164,15 +164,15 @@ impl JournalHandler for ExtManager {
             match (gas_limit, reservation) {
                 (Some(gas_limit), None) => self
                     .gas_tree
-                    .split_with_value(false, message_id, dispatch.id(), gas_limit)
+                    .split_with_value(dispatch.is_reply(), message_id, dispatch.id(), gas_limit)
                     .unwrap_or_else(|e| unreachable!("GasTree corrupted! {:?}", e)),
                 (None, None) => self
                     .gas_tree
-                    .split(false, message_id, dispatch.id())
+                    .split(dispatch.is_reply(), message_id, dispatch.id())
                     .unwrap_or_else(|e| unreachable!("GasTree corrupted! {:?}", e)),
                 (None, Some(reservation)) => {
                     self.gas_tree
-                        .split(false, reservation, dispatch.id())
+                        .split(dispatch.is_reply(), reservation, dispatch.id())
                         .unwrap_or_else(|e| unreachable!("GasTree corrupted! {:?}", e));
                     self.remove_gas_reservation_with_task(dispatch.source(), reservation);
                 }

--- a/gtest/src/state/gas_tree.rs
+++ b/gtest/src/state/gas_tree.rs
@@ -88,7 +88,7 @@ impl GasTreeManager {
         new_mid: MessageId,
         amount: Gas,
     ) -> Result<(), GasTreeError> {
-        if !is_reply && !GasTree::exists_and_deposit(GasNodeId::from(new_mid.cast::<PlainNodeId>()))
+        if !is_reply || !GasTree::exists_and_deposit(GasNodeId::from(new_mid.cast::<PlainNodeId>()))
         {
             return GasTree::split_with_value(
                 GasNodeId::from(original_mid.cast::<PlainNodeId>()),
@@ -107,7 +107,7 @@ impl GasTreeManager {
         original_node: impl Origin,
         new_mid: MessageId,
     ) -> Result<(), GasTreeError> {
-        if !is_reply && !GasTree::exists_and_deposit(GasNodeId::from(new_mid.cast::<PlainNodeId>()))
+        if !is_reply || !GasTree::exists_and_deposit(GasNodeId::from(new_mid.cast::<PlainNodeId>()))
         {
             return GasTree::split(
                 GasNodeId::from(original_node.cast::<PlainNodeId>()),


### PR DESCRIPTION
Fixing issue submitted by @MedovTimur https://github.com/MedovTimur/send-value
