### PR TITLE
chore(docs): disable `ethexe` feature on docs.rs, improve docs.gear.rs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,9 +277,11 @@ doc:
 	@ RUSTDOCFLAGS="--enable-index-page --generate-link-to-definition -Zunstable-options -D warnings" cargo doc --no-deps \
 		-p galloc -p gclient -p gcore -p gear-core-backend \
 		-p gear-core -p gear-core-processor -p gear-lazy-pages -p gear-core-errors \
-		-p gmeta -p gstd -p gtest -p gear-wasm-builder -p gear-common \
+		-p gmeta -p gtest -p gear-wasm-builder -p gear-common \
 		-p pallet-gear -p pallet-gear-gas -p pallet-gear-messenger -p pallet-gear-payment \
 		-p pallet-gear-program -p pallet-gear-rpc-runtime-api -p pallet-gear-rpc -p pallet-gear-scheduler -p gsdk
+	@ RUSTDOCFLAGS="--enable-index-page --generate-link-to-definition -Zunstable-options -D warnings" cargo doc --no-deps \
+		-p gstd -F document-features
 	@ cp -f images/logo.svg target/doc/rust-logo.svg
 
 .PHONY: kill-gear

--- a/gstd/Cargo.toml
+++ b/gstd/Cargo.toml
@@ -28,7 +28,8 @@ futures = { workspace = true, features = ["alloc"] }
 waker-fn = "1.2.0"
 
 [features]
-#! ## Default features
+#! ## Default features:
+#! - `panic-message`
 
 default = ["panic-message"]
 
@@ -82,4 +83,4 @@ debug = ["galloc/debug", "gcore/debug"]
 #! [rust-51540]: https://github.com/rust-lang/rust/issues/51540
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["document-features"]


### PR DESCRIPTION
This PR fixes missing functions (send with reservations, etc.) in gstd documentation. Rendered: https://docs.gear.rs/pr-4278/gstd/index.html