### PR TITLE
testnet: rotate bootnodes keys

### DIFF
--- a/node/res/vara_testnet.json
+++ b/node/res/vara_testnet.json
@@ -3,8 +3,8 @@
   "id": "vara_network_testnet",
   "chainType": "Live",
   "bootNodes": [
-    "/dns4/testnet-connect-1.vara-network.io/tcp/30333/p2p/12D3KooWPosEb8NoKNswzrU79YFcjD6FSVjubbawNbG9gEHEg5vn",
-    "/dns4/testnet-connect-2.vara-network.io/tcp/30333/p2p/12D3KooWAWEPAd5AD6TSYizF4FWc34rCvUhDKvyCNqQSkSRCLfMn"
+    "/dns4/testnet-connect-1.vara-network.io/tcp/30333/p2p/12D3KooWN13WbLwnFB9V9oZftpo49EvA5cABFi8CJVuczf1Py5wP",
+    "/dns4/testnet-connect-2.vara-network.io/tcp/30333/p2p/12D3KooWBExHKKuDq5nktbHHVhmwimfrbvmez2xd5UaEPhgQjVqu"
   ],
   "telemetryEndpoints": null,
   "protocolId": null,


### PR DESCRIPTION
rotate keys after migrate to gcloud

synchronization is working:
2024-10-13 12:09:02 ⚙️  Syncing, target=#11008097 (14 peers), best: #8705 (0x8d9f…d6bd), finalized #8704 (0x7fc3…9c27), ⬇ 294.3kiB/s ⬆ 10.6kiB/s    
