### PR TITLE
refactor(core): Clear ContextStore state created by *_commit syscalls

### DIFF
--- a/core/src/message/context.rs
+++ b/core/src/message/context.rs
@@ -198,6 +198,13 @@ impl ContextStore {
     pub fn system_reservation(&self) -> Option<u64> {
         self.system_reservation
     }
+
+    /// Clear state created by `*_commit` syscalls. This function is part of #4284
+    /// and will be removed once migration to a runtime without `*_commit` syscalls is done.
+    pub fn clear_commit_state(&mut self) {
+        self.outgoing.clear();
+        self.reply = None;
+    }
 }
 
 /// Context of currently processing incoming message.

--- a/core/src/message/incoming.rs
+++ b/core/src/message/incoming.rs
@@ -158,7 +158,11 @@ impl IncomingDispatch {
     }
 
     /// Convert IncomingDispatch into gasless StoredDispatch with updated (or recently set) context.
-    pub fn into_stored(self, destination: ProgramId, context: ContextStore) -> StoredDispatch {
+    pub fn into_stored(self, destination: ProgramId, mut context: ContextStore) -> StoredDispatch {
+        // clear outgoing messages in context, we don't want to keep them.
+        // See: #4284
+        context.clear_commit_state();
+
         StoredDispatch::new(
             self.kind,
             self.message.into_stored(destination),

--- a/core/src/message/incoming.rs
+++ b/core/src/message/incoming.rs
@@ -158,11 +158,7 @@ impl IncomingDispatch {
     }
 
     /// Convert IncomingDispatch into gasless StoredDispatch with updated (or recently set) context.
-    pub fn into_stored(self, destination: ProgramId, mut context: ContextStore) -> StoredDispatch {
-        // clear outgoing messages in context, we don't want to keep them.
-        // See: #4284
-        context.clear_commit_state();
-
+    pub fn into_stored(self, destination: ProgramId, context: ContextStore) -> StoredDispatch {
         StoredDispatch::new(
             self.kind,
             self.message.into_stored(destination),

--- a/gsdk/src/metadata/generated.rs
+++ b/gsdk/src/metadata/generated.rs
@@ -698,27 +698,13 @@ pub mod runtime_types {
                         Debug, crate::gp::Decode, crate::gp::DecodeAsType, crate::gp::Encode,
                     )]
                     pub struct ContextStore {
-                        pub outgoing: ::subxt::ext::subxt_core::utils::KeyedVec<
-                            ::core::primitive::u32,
-                            ::core::option::Option<
-                                runtime_types::gear_core::buffer::LimitedVec<
-                                    ::core::primitive::u8,
-                                    runtime_types::gear_core::message::PayloadSizeError,
-                                >,
-                            >,
-                        >,
-                        pub reply: ::core::option::Option<
-                            runtime_types::gear_core::buffer::LimitedVec<
-                                ::core::primitive::u8,
-                                runtime_types::gear_core::message::PayloadSizeError,
-                            >,
-                        >,
                         pub initialized: ::subxt::ext::subxt_core::alloc::vec::Vec<
                             runtime_types::gprimitives::ActorId,
                         >,
                         pub reservation_nonce:
                             runtime_types::gear_core::reservation::ReservationNonce,
                         pub system_reservation: ::core::option::Option<::core::primitive::u64>,
+                        pub outgoing_nonce: ::core::primitive::u32,
                     }
                 }
                 pub mod stored {

--- a/pallets/gear-messenger/src/lib.rs
+++ b/pallets/gear-messenger/src/lib.rs
@@ -145,6 +145,7 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
+pub mod migrations;
 pub mod pallet_tests;
 
 // Public exports from pallet.

--- a/pallets/gear-messenger/src/migrations/context_store.rs
+++ b/pallets/gear-messenger/src/migrations/context_store.rs
@@ -126,7 +126,8 @@ mod v3 {
         scale::{Decode, Encode},
         TypeInfo,
     };
-    use std::collections::{BTreeMap, BTreeSet};
+
+    use sp_std::collections::{btree_map::BTreeMap, btree_set::BTreeSet};
 
     #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Decode, Encode, TypeInfo)]
     pub struct StoredDispatch {

--- a/pallets/gear-messenger/src/migrations/context_store.rs
+++ b/pallets/gear-messenger/src/migrations/context_store.rs
@@ -9,6 +9,7 @@ use common::{
 #[cfg(feature = "try-runtime")]
 use {
     frame_support::ensure,
+    parity_scale_codec::Decode,
     sp_runtime::{
         codec::{Decode, Encode},
         TryRuntimeError,
@@ -112,7 +113,7 @@ impl<T: Config> OnRuntimeUpgrade for RemoveCommitStorage<T> {
 
     #[cfg(feature = "try-runtime")]
     fn post_upgrade(state: Vec<u8>) -> Result<(), TryRuntimeError> {
-        if let Some(x) = Option::<u64>::decode(&mut state.as_ref())
+        if let Some(x) = Option::<bool>::decode(&mut state.as_ref())
             .map_err(|_| "`pre_upgrade` provided an invalid state")?
         {
             ensure!(x, "pre_upgrade failed",);

--- a/pallets/gear-messenger/src/migrations/context_store.rs
+++ b/pallets/gear-messenger/src/migrations/context_store.rs
@@ -7,14 +7,7 @@ use common::{
 };
 
 #[cfg(feature = "try-runtime")]
-use {
-    frame_support::ensure,
-    sp_runtime::{
-        codec::{Decode, Encode},
-        TryRuntimeError,
-    },
-    sp_std::vec::Vec,
-};
+use {frame_support::ensure, sp_runtime::TryRuntimeError, sp_std::vec::Vec};
 
 use frame_support::{
     traits::{GetStorageVersion, OnRuntimeUpgrade, StorageVersion},
@@ -101,6 +94,10 @@ impl<T: Config> OnRuntimeUpgrade for RemoveCommitStorage<T> {
                 current == ALLOWED_CURRENT_STORAGE_VERSION,
                 "Current storage version is not allowed for migration, check migration code in order to allow it."
             );
+
+            Ok(vec![1])
+        } else {
+            Ok(vec![0])
         }
 
         Ok(vec![])
@@ -108,10 +105,12 @@ impl<T: Config> OnRuntimeUpgrade for RemoveCommitStorage<T> {
 
     #[cfg(feature = "try-runtime")]
     fn post_upgrade(state: Vec<u8>) -> Result<(), TryRuntimeError> {
-        ensure!(
-            Pallet::<T>::on_chain_storage_version() == MIGRATE_TO_VERSION,
-            "incorrect storage version after migration"
-        );
+        if state[0] == 1 {
+            ensure!(
+                Pallet::<T>::on_chain_storage_version() == MIGRATE_TO_VERSION,
+                "incorrect storage version after migration"
+            );
+        }
 
         Ok(())
     }

--- a/pallets/gear-messenger/src/migrations/context_store.rs
+++ b/pallets/gear-messenger/src/migrations/context_store.rs
@@ -9,7 +9,6 @@ use common::{
 #[cfg(feature = "try-runtime")]
 use {
     frame_support::ensure,
-    parity_scale_codec::Decode,
     sp_runtime::{
         codec::{Decode, Encode},
         TryRuntimeError,
@@ -97,31 +96,22 @@ impl<T: Config> OnRuntimeUpgrade for RemoveCommitStorage<T> {
         let current = Pallet::<T>::current_storage_version();
         let onchain = Pallet::<T>::on_chain_storage_version();
 
-        let res = if onchain == MIGRATE_FROM_VERSION {
+        if onchain == MIGRATE_FROM_VERSION {
             ensure!(
                 current == ALLOWED_CURRENT_STORAGE_VERSION,
                 "Current storage version is not allowed for migration, check migration code in order to allow it."
             );
+        }
 
-            Some(true)
-        } else {
-            None
-        };
-
-        Ok(res.encode())
+        Ok(vec![])
     }
 
     #[cfg(feature = "try-runtime")]
     fn post_upgrade(state: Vec<u8>) -> Result<(), TryRuntimeError> {
-        if let Some(x) = Option::<bool>::decode(&mut state.as_ref())
-            .map_err(|_| "`pre_upgrade` provided an invalid state")?
-        {
-            ensure!(x, "pre_upgrade failed",);
-            ensure!(
-                Pallet::<T>::on_chain_storage_version() == MIGRATE_TO_VERSION,
-                "incorrect storage version after migration"
-            );
-        }
+        ensure!(
+            Pallet::<T>::on_chain_storage_version() == MIGRATE_TO_VERSION,
+            "incorrect storage version after migration"
+        );
 
         Ok(())
     }

--- a/pallets/gear-messenger/src/migrations/context_store.rs
+++ b/pallets/gear-messenger/src/migrations/context_store.rs
@@ -1,0 +1,119 @@
+use core::marker::PhantomData;
+
+use crate::{Config, Pallet, Waitlist};
+use common::{
+    storage::{Interval, LinkedNode, Queue},
+    MessageId,
+};
+use frame_support::{
+    traits::{GetStorageVersion, OnRuntimeUpgrade, StorageVersion},
+    weights::Weight,
+};
+use frame_system::pallet_prelude::BlockNumberFor;
+use gear_core::message::{ContextStore, StoredDispatch};
+
+use crate::Dispatches;
+use sp_runtime::traits::Get;
+pub struct RemoveCommitStorage<T: Config>(PhantomData<T>);
+
+const MIGRATE_FROM_VERSION: u16 = 10;
+const MIGRATE_TO_VERSION: u16 = 11;
+const ALLOWED_CURRENT_STORAGE_VERSION: u16 = 10;
+
+fn translate_dispatch(dispatch: v10::StoredDispatch) -> StoredDispatch {
+    StoredDispatch::new(
+        dispatch.kind,
+        dispatch.message,
+        dispatch.context.map(|ctx| {
+            ContextStore::new(
+                ctx.initialized,
+                ctx.reservation_nonce,
+                ctx.system_reservation,
+            )
+        }),
+    )
+}
+
+impl<T: Config> OnRuntimeUpgrade for RemoveCommitStorage<T> {
+    fn on_runtime_upgrade() -> Weight {
+        let onchain = Pallet::<T>::on_chain_storage_version();
+
+        let mut weight = T::DbWeight::get().reads(1);
+        let mut counter = 0;
+
+        if onchain == MIGRATE_FROM_VERSION {
+            let current = Pallet::<T>::current_storage_version();
+            if current != ALLOWED_CURRENT_STORAGE_VERSION {
+                log::error!("❌ Migration is not allowed for current storage version {current:?}.");
+                return weight;
+            }
+
+            let update_to = StorageVersion::new(MIGRATE_TO_VERSION);
+            log::info!("🚚 Running migration from {onchain:?} to {update_to:?}, current storage version is {current:?}.");
+
+            Dispatches::<T>::translate(|_, value: LinkedNode<MessageId, v10::StoredDispatch>| {
+                counter += 1;
+                Some(LinkedNode {
+                    next: value.next,
+                    value: translate_dispatch(value.value),
+                })
+            });
+
+            Waitlist::<T>::translate(
+                |_, _, (dispatch, interval): (v10::StoredDispatch, Interval<BlockNumberFor<T>>)| {
+                    counter += 1;
+                    Some((translate_dispatch(dispatch), interval))
+                },
+            );
+            // each `translate` call results in read to DB to fetch dispatch and then write to DB to update it.
+            weight = weight.saturating_add(T::DbWeight::get().reads_writes(counter, counter));
+
+            weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+            update_to.put::<Pallet<T>>();
+
+            log::info!("✅ Successfully migrated storage. {counter} codes have been migrated");
+        } else {
+            log::info!("🟠 Migration requires onchain version {MIGRATE_FROM_VERSION}, so was skipped for {onchain:?}");
+        }
+
+        weight
+    }
+}
+
+mod v10 {
+    use common::{storage::LinkedNode, MessageId, ProgramId};
+    use core::marker::PhantomData;
+    use frame_support::{
+        pallet_prelude::CountedStorageMap, storage::types::CountedStorageMapInstance,
+        traits::StorageInstance, Identity,
+    };
+    use frame_system::Config;
+    use gear_core::{
+        message::{DispatchKind, Payload, StoredMessage},
+        reservation::ReservationNonce,
+    };
+
+    use scale_info::{
+        scale::{Decode, Encode},
+        TypeInfo,
+    };
+    use std::collections::{BTreeMap, BTreeSet};
+
+    #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Decode, Encode, TypeInfo)]
+    pub struct StoredDispatch {
+        pub kind: DispatchKind,
+        pub message: StoredMessage,
+        pub context: Option<ContextStore>,
+    }
+    #[derive(
+        Clone, Default, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Decode, Encode, TypeInfo,
+    )]
+    pub struct ContextStore {
+        pub outgoing: BTreeMap<u32, Option<Payload>>,
+        pub reply: Option<Payload>,
+        pub initialized: BTreeSet<ProgramId>,
+        pub reservation_nonce: ReservationNonce,
+        pub system_reservation: Option<u64>,
+    }
+}

--- a/pallets/gear-messenger/src/migrations/context_store.rs
+++ b/pallets/gear-messenger/src/migrations/context_store.rs
@@ -5,6 +5,17 @@ use common::{
     storage::{Interval, LinkedNode},
     MessageId,
 };
+
+#[cfg(feature = "try-runtime")]
+use {
+    frame_support::ensure,
+    sp_runtime::{
+        codec::{Decode, Encode},
+        TryRuntimeError,
+    },
+    sp_std::vec::Vec,
+};
+
 use frame_support::{
     traits::{GetStorageVersion, OnRuntimeUpgrade, StorageVersion},
     weights::Weight,
@@ -104,7 +115,6 @@ impl<T: Config> OnRuntimeUpgrade for RemoveCommitStorage<T> {
         if let Some(x) = Option::<u64>::decode(&mut state.as_ref())
             .map_err(|_| "`pre_upgrade` provided an invalid state")?
         {
-            let count = ProgramStorage::<T>::iter().count() as u64;
             ensure!(x, "pre_upgrade failed",);
             ensure!(
                 Pallet::<T>::on_chain_storage_version() == MIGRATE_TO_VERSION,

--- a/pallets/gear-messenger/src/migrations/context_store.rs
+++ b/pallets/gear-messenger/src/migrations/context_store.rs
@@ -99,8 +99,6 @@ impl<T: Config> OnRuntimeUpgrade for RemoveCommitStorage<T> {
         } else {
             Ok(vec![0])
         }
-
-        Ok(vec![])
     }
 
     #[cfg(feature = "try-runtime")]

--- a/pallets/gear-messenger/src/migrations/mod.rs
+++ b/pallets/gear-messenger/src/migrations/mod.rs
@@ -1,0 +1,1 @@
+pub mod context_store;

--- a/pallets/gear/src/migrations/mod.rs
+++ b/pallets/gear/src/migrations/mod.rs
@@ -19,24 +19,17 @@
 #[cfg(test)]
 #[cfg(feature = "try-runtime")]
 mod tests {
-    use crate::{mock::*, QueueOf};
-    use common::ProgramId;
+    use crate::mock::*;
+
     use frame_support::traits::{OnRuntimeUpgrade, StorageVersion};
-    use gear_core::{
-        ids::CodeId,
-        message::{DispatchKind, Payload, StoredDispatch, StoredMessage},
-    };
-    use gstd::MessageId;
-    use pallet_gear_messenger::migrations::context_store::*;
-    use sp_runtime::traits::Zero;
 
     #[test]
     fn test_context_store_migration_works() {
         new_test_ext().execute_with(|| {
-            StorageVersion::new(MIGRATE_FROM_VERSION).put::<GearMessenger>();
+            StorageVersion::new(3).put::<GearMessenger>();
             let state = pallet_gear_messenger::migrations::context_store::RemoveCommitStorage::<Test>::pre_upgrade().unwrap();
-            let w = pallet_gear_messenger::migrations::context_store::RemoveCommitStorage::on_runtime_upgrade();
-            pallet_gear_messenger::migrations::<Test>::post_upgrade(state).unwrap();
+            let _w = pallet_gear_messenger::migrations::context_store::RemoveCommitStorage::<Test>::on_runtime_upgrade();
+            pallet_gear_messenger::migrations::context_store::RemoveCommitStorage::<Test>::post_upgrade(state).unwrap();
 
         });
     }

--- a/pallets/gear/src/migrations/mod.rs
+++ b/pallets/gear/src/migrations/mod.rs
@@ -15,3 +15,29 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#[cfg(test)]
+#[cfg(feature = "try-runtime")]
+mod tests {
+    use crate::{mock::*, QueueOf};
+    use common::ProgramId;
+    use frame_support::traits::{OnRuntimeUpgrade, StorageVersion};
+    use gear_core::{
+        ids::CodeId,
+        message::{DispatchKind, Payload, StoredDispatch, StoredMessage},
+    };
+    use gstd::MessageId;
+    use pallet_gear_messenger::migrations::context_store::*;
+    use sp_runtime::traits::Zero;
+
+    #[test]
+    fn test_context_store_migration_works() {
+        new_test_ext().execute_with(|| {
+            StorageVersion::new(MIGRATE_FROM_VERSION).put::<GearMessenger>();
+            let state = pallet_gear_messenger::migrations::context_store::RemoveCommitStorage::<Test>::pre_upgrade().unwrap();
+            let w = pallet_gear_messenger::migrations::context_store::RemoveCommitStorage::on_runtime_upgrade();
+            pallet_gear_messenger::migrations::<Test>::post_upgrade(state).unwrap();
+
+        });
+    }
+}

--- a/runtime/vara/src/migrations.rs
+++ b/runtime/vara/src/migrations.rs
@@ -27,6 +27,8 @@ pub type Migrations = (
     pallet_grandpa::migrations::MigrateV4ToV5<Runtime>,
     // move allocations to a separate storage item and remove pages_with_data field from program
     pallet_gear_program::migrations::allocations::MigrateAllocations<Runtime>,
+    // remove commit state in context-store
+    pallet_gear_messenger::migrations::context_store::RemoveCommitStorage<Runtime>,
 );
 
 mod staking {


### PR DESCRIPTION
First commit before implementing actual migrations to clear all data creates by `_commit` syscalls family. 