### PR TITLE
feat(crates-io): check owners before publishing

### DIFF
--- a/.github/workflows/crates-io.yml
+++ b/.github/workflows/crates-io.yml
@@ -30,7 +30,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-          components: llvm-tools
+          components: llvm-tools, rust-src
 
       - name: "Publish packages (simulate)"
         if: ${{ !inputs.publish }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6227,8 +6227,8 @@ dependencies = [
 name = "gbuiltin-proxy"
 version = "1.6.2"
 dependencies = [
- "derive_more 0.99.18",
  "gprimitives",
+ "parity-scale-codec",
  "scale-info",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13013,7 +13013,6 @@ checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.1.0",

--- a/docker/runtime-fuzzer/scripts/fuzzer.sh
+++ b/docker/runtime-fuzzer/scripts/fuzzer.sh
@@ -67,8 +67,8 @@ function start_container_post {
      	--workdir /gear/utils/runtime-fuzzer \
      	--name ${CONTAINER_NAME_GEAR} ${IMAGE} \
      	-c "cargo install cargo-binutils && \
-		rustup component add llvm-tools-preview && \
-		rustup component add --toolchain nightly llvm-tools-preview && \
+		rustup component add llvm-tools && \
+		rustup component add --toolchain nightly llvm-tools && \
 		cargo fuzz coverage --release --sanitizer=none main /corpus/main -- \
         -rss_limit_mb=8192 -max_len=450000 -len_control=0 && \
 		cargo cov -- show target/x86_64-unknown-linux-gnu/coverage/x86_64-unknown-linux-gnu/release/main \

--- a/gbuiltins/proxy/Cargo.toml
+++ b/gbuiltins/proxy/Cargo.toml
@@ -9,6 +9,6 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-gprimitives.workspace = true
-derive_more.workspace = true
+parity-scale-codec = { workspace = true, features = ["derive"] }
 scale-info = { workspace = true, features = ["derive"] }
+gprimitives = { workspace = true, features = ["codec"] }

--- a/gbuiltins/proxy/src/lib.rs
+++ b/gbuiltins/proxy/src/lib.rs
@@ -21,14 +21,13 @@
 #![no_std]
 
 use gprimitives::ActorId;
-use scale_info::scale::{self, Decode, Encode};
+use parity_scale_codec::{Decode, Encode};
 
 /// Request that can be handled by the proxy builtin.
 ///
 /// Currently all proxies aren't required to send announcement,
 /// i.e. no delays for the delegate actions.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Encode, Decode)]
-#[codec(crate = scale)]
 pub enum Request {
     /// Add proxy request.
     ///
@@ -53,7 +52,6 @@ pub enum Request {
 ///
 /// The mirror enum for the one defined in vara-runtime crate.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Encode, Decode)]
-#[codec(crate = scale)]
 pub enum ProxyType {
     Any,
     NonTransfer,

--- a/scripts/pin-rust-nightly.sh
+++ b/scripts/pin-rust-nightly.sh
@@ -12,7 +12,7 @@ fi
 pin_date=$1
 os_name="$(uname)"
 suffix=$(rustc -Vv | grep "host: " | sed "s/^host: \(.*\)$/\1/")
-rustup toolchain install nightly-$pin_date --component llvm-tools-preview
+rustup toolchain install nightly-$pin_date --component llvm-tools --component rust-src
 rustup target add wasm32-unknown-unknown --toolchain nightly-$pin_date
 rm -rf ~/.rustup/toolchains/nightly-$suffix
 ln -s ~/.rustup/toolchains/nightly-$pin_date-$suffix ~/.rustup/toolchains/nightly-$suffix

--- a/utils/crates-io/Cargo.toml
+++ b/utils/crates-io/Cargo.toml
@@ -9,7 +9,7 @@ cargo-http-registry.workspace = true
 cargo_metadata.workspace = true
 clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
-reqwest = { workspace = true, features = ["blocking", "json", "default-tls"] }
+reqwest = { workspace = true, features = ["json", "default-tls"] }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 toml_edit.workspace = true

--- a/utils/crates-io/src/handler.rs
+++ b/utils/crates-io/src/handler.rs
@@ -38,8 +38,8 @@ pub fn crates_io_name(pkg: &str) -> &str {
 }
 
 /// Patch specified manifest by provided name.
-pub fn patch(pkg: &Package) -> Result<Manifest> {
-    let mut manifest = Manifest::new(pkg)?;
+pub fn patch(pkg: &Package, is_published: bool) -> Result<Manifest> {
+    let mut manifest = Manifest::new(pkg, is_published)?;
     let doc = &mut manifest.mutable_manifest;
 
     match manifest.name.as_str() {

--- a/utils/crates-io/src/lib.rs
+++ b/utils/crates-io/src/lib.rs
@@ -29,7 +29,7 @@ pub use self::{
     manifest::{LockFile, Manifest, Workspace},
     publisher::Publisher,
     simulator::Simulator,
-    version::verify,
+    version::{verify, verify_ownership},
 };
 use anyhow::Result;
 use std::process::{Command, ExitStatus};
@@ -60,6 +60,7 @@ pub const SAFE_DEPENDENCIES: &[&str] = &[
 pub const STACKED_DEPENDENCIES: &[&str] = &[
     "gprimitives",
     "gbuiltin-eth-bridge",
+    "gbuiltin-proxy",
     "gbuiltin-staking",
     "gstd-codegen",
     "gcore",

--- a/utils/crates-io/src/lib.rs
+++ b/utils/crates-io/src/lib.rs
@@ -29,7 +29,7 @@ pub use self::{
     manifest::{LockFile, Manifest, Workspace},
     publisher::Publisher,
     simulator::Simulator,
-    version::{verify, verify_ownership},
+    version::{verify, verify_owners},
 };
 use anyhow::Result;
 use std::process::{Command, ExitStatus};
@@ -106,14 +106,6 @@ pub const PACKAGE_ALIAS: [(&str, &str); 2] = [
 
 /// Name for temporary cargo registry.
 pub const CARGO_REGISTRY_NAME: &str = "cargo-http-registry";
-
-/// Check the input package
-pub fn check(manifest: &str) -> Result<ExitStatus> {
-    Command::new("cargo")
-        .args(["+stable", "check", "--manifest-path", manifest])
-        .status()
-        .map_err(Into::into)
-}
 
 /// Test the input package
 pub fn test(package: &str, test: &str) -> Result<ExitStatus> {

--- a/utils/crates-io/src/lib.rs
+++ b/utils/crates-io/src/lib.rs
@@ -29,10 +29,19 @@ pub use self::{
     manifest::{LockFile, Manifest, Workspace},
     publisher::Publisher,
     simulator::Simulator,
-    version::{verify, verify_owners},
+    version::{verify, verify_owners, PackageStatus},
 };
 use anyhow::Result;
 use std::process::{Command, ExitStatus};
+
+/// Username that owns crates.
+pub const USER_OWNER: &str = "breathx";
+
+/// Team that owns crates.
+pub const TEAM_OWNER: &str = "github:gear-tech:dev";
+
+/// Expected owners of crates.
+pub const EXPECTED_OWNERS: [&str; 2] = [USER_OWNER, TEAM_OWNER];
 
 /// Required Packages without local dependencies.
 pub const SAFE_DEPENDENCIES: &[&str] = &[
@@ -125,6 +134,14 @@ pub fn publish(manifest: &str) -> Result<ExitStatus> {
             manifest,
             "--allow-dirty",
         ])
+        .status()
+        .map_err(Into::into)
+}
+
+/// Add owner to the input package
+pub fn add_owner(package: &str, owner: &str) -> Result<ExitStatus> {
+    Command::new("cargo")
+        .args(["+stable", "owner", "--add", owner, package])
         .status()
         .map_err(Into::into)
 }

--- a/utils/crates-io/src/main.rs
+++ b/utils/crates-io/src/main.rs
@@ -62,14 +62,15 @@ async fn main() -> Result<()> {
             simulate,
             registry_path,
         } => {
-            let publisher =
-                Publisher::with_simulation(simulate, registry_path)?.build(true, version)?;
+            let publisher = Publisher::with_simulation(simulate, registry_path)?
+                .build(true, version)
+                .await?;
             let result = publisher.publish();
             publisher.restore()?;
             result
         }
         Command::Build => {
-            Publisher::new()?.build(false, None)?;
+            Publisher::new()?.build(false, None).await?;
             Ok(())
         }
     }

--- a/utils/crates-io/src/main.rs
+++ b/utils/crates-io/src/main.rs
@@ -64,7 +64,8 @@ async fn main() -> Result<()> {
         } => {
             let publisher = Publisher::with_simulation(simulate, registry_path)?
                 .build(true, version)
-                .await?;
+                .await?
+                .check()?;
             let result = publisher.publish();
             publisher.restore()?;
             result

--- a/utils/crates-io/src/manifest.rs
+++ b/utils/crates-io/src/manifest.rs
@@ -52,6 +52,7 @@ impl Workspace {
                 original_manifest,
                 mutable_manifest,
                 path,
+                is_published: true,
             },
             lock_file: LockFile {
                 content,
@@ -187,12 +188,14 @@ pub struct Manifest {
     pub mutable_manifest: DocumentMut,
     /// Path of the manifest
     pub path: PathBuf,
+    /// Whether the crate is published
+    pub is_published: bool,
 }
 
 impl Manifest {
     /// Complete the manifest of the specified crate from
     /// the workspace manifest
-    pub fn new(pkg: &Package) -> Result<Self> {
+    pub fn new(pkg: &Package, is_published: bool) -> Result<Self> {
         let original_manifest: DocumentMut = fs::read_to_string(&pkg.manifest_path)?.parse()?;
         let mut mutable_manifest = original_manifest.clone();
 
@@ -206,6 +209,7 @@ impl Manifest {
             original_manifest,
             mutable_manifest,
             path: pkg.manifest_path.clone().into(),
+            is_published,
         })
     }
 

--- a/utils/crates-io/src/publisher.rs
+++ b/utils/crates-io/src/publisher.rs
@@ -68,8 +68,8 @@ impl Publisher {
                 continue;
             };
 
-            if verify && !crate::verify_ownership(name).await? {
-                bail!("Package {name} has an invalid owner!");
+            if verify && !crate::verify_owners(name).await? {
+                bail!("Package {name} has invalid owners!");
             }
 
             if verify && crate::verify(name, &version, self.simulator.as_ref()).await? {
@@ -125,26 +125,7 @@ impl Publisher {
     }
 
     /// Check the to-be-published packages
-    ///
-    /// TODO: Complete the check process (#3565)
-    pub fn check(&self) -> Result<()> {
-        let mut failed = Vec::new();
-        for Manifest { path, name, .. } in self.graph.iter() {
-            if !PACKAGES.contains(&name.as_str()) {
-                continue;
-            }
-
-            println!("Checking {path:?}");
-            let status = crate::check(&path.to_string_lossy())?;
-            if !status.success() {
-                failed.push(path);
-            }
-        }
-
-        if !failed.is_empty() {
-            bail!("Packages {failed:?} failed to pass the check ...");
-        }
-
+    pub fn check(self) -> Result<Self> {
         // Post tests for gtest and gclient
         for (pkg, test) in [
             ("demo-syscall-error", "program_can_be_initialized"),
@@ -155,7 +136,7 @@ impl Publisher {
             }
         }
 
-        Ok(())
+        Ok(self)
     }
 
     /// Publish packages

--- a/utils/crates-io/src/version.rs
+++ b/utils/crates-io/src/version.rs
@@ -85,7 +85,7 @@ struct User {
 }
 
 /// Verify if the package has valid owners.
-pub async fn verify_ownership(name: &str) -> Result<bool> {
+pub async fn verify_owners(name: &str) -> Result<bool> {
     println!("Verifying {name} ownership ...");
 
     let client = Client::builder()

--- a/utils/runtime-fuzzer/README.md
+++ b/utils/runtime-fuzzer/README.md
@@ -6,7 +6,7 @@ This is an internal product that is used to find panics that may occur in our ru
 
 Pre-requirements:
 
-- llvm-tools: `rustup component add llvm-tools-preview`
+- llvm-tools: `rustup component add llvm-tools`
 - [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz): `cargo install cargo-fuzz`
 - [cargo-binutils](https://github.com/rust-embedded/cargo-binutils): `cargo install cargo-binutils`
 - [rustfilt](https://github.com/luser/rustfilt): `cargo install rustfilt`

--- a/utils/wasm-builder/test-program/src/lib.rs
+++ b/utils/wasm-builder/test-program/src/lib.rs
@@ -27,12 +27,13 @@ extern "C" fn init() {
 mod gtest_tests {
     extern crate std;
 
-    use gtest::{Log, Program, System};
+    use gtest::{constants::UNITS, Log, Program, System};
 
     #[test]
     fn init_self() {
         let system = System::new();
         system.init_logger();
+        system.mint_to(123, UNITS * 100);
 
         let this_program = Program::current(&system);
 

--- a/utils/wasm-builder/tests/smoke.rs
+++ b/utils/wasm-builder/tests/smoke.rs
@@ -74,8 +74,7 @@ fn install_stable_toolchain() {
 fn test_debug() {
     install_stable_toolchain();
 
-    //TODO: uncomment after solving issue #3915
-    //CargoRunner::new().args(["test"]).run();
+    CargoRunner::new().args(["test"]).run();
     CargoRunner::stable().args(["test"]).run();
 }
 
@@ -93,8 +92,7 @@ fn build_debug() {
 fn test_release() {
     install_stable_toolchain();
 
-    //TODO: uncomment after solving issue #3915
-    //CargoRunner::new().args(["test", "--release"]).run();
+    CargoRunner::new().args(["test", "--release"]).run();
     CargoRunner::stable().args(["test", "--release"]).run();
 }
 
@@ -168,6 +166,6 @@ fn build_release_for_target_deny_duplicate_crate() {
     cmd.arg("--manifest-path=test-program/Cargo.toml");
     cmd.arg("--config=env.GEAR_WASM_BUILDER_DENIED_DUPLICATE_CRATES=\'syn\'");
 
-    let status = cmd.status().expect("cargo run error");
-    assert!(!status.success())
+    let _status = cmd.status().expect("cargo run error");
+    //assert!(!status.success())
 }

--- a/utils/wasm-builder/tests/smoke.rs
+++ b/utils/wasm-builder/tests/smoke.rs
@@ -59,6 +59,8 @@ fn install_stable_toolchain() {
             .arg("stable")
             .arg("--component")
             .arg("llvm-tools")
+            .arg("--component")
+            .arg("rust-src")
             .arg("--target")
             .arg("wasm32-unknown-unknown")
             .status()

--- a/utils/wasm-builder/tests/smoke.rs
+++ b/utils/wasm-builder/tests/smoke.rs
@@ -164,8 +164,8 @@ fn build_release_for_target_deny_duplicate_crate() {
         .0;
     cmd.arg("--color=always");
     cmd.arg("--manifest-path=test-program/Cargo.toml");
-    cmd.arg("--config=env.GEAR_WASM_BUILDER_DENIED_DUPLICATE_CRATES=\'syn\'");
+    cmd.env("__GEAR_WASM_BUILDER_DENIED_DUPLICATE_CRATES", "syn");
 
-    let _status = cmd.status().expect("cargo run error");
-    //assert!(!status.success())
+    let status = cmd.status().expect("cargo run error");
+    assert!(!status.success())
 }


### PR DESCRIPTION
Resolves #4315

- [x] if package is not on crates.io, then owner check is skipped
- [x] fix #4315
- [x] add `github:gear-tech:dev` to owners when publishing new crates