### PR TITLE
chore(ci): clear npm cache, install `@openzeppelin/upgrades-core`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,6 +43,10 @@ jobs:
 
       - name: "Check: ethexe contracts"
         run: |
+          npm cache clean --force
+          # version from ethexe/contracts/lib/openzeppelin-foundry-upgrades/src/internal/Versions.sol
+          npx @openzeppelin/upgrades-core@^1.32.3
+
           cd ethexe/contracts
           forge fmt --check
           forge build --sizes


### PR DESCRIPTION
at least this should help debug `npx @openzeppelin/upgrades-core@^1.32.3`. if it fails, it won't happen during `forge test`.