### PR TITLE
fix(benchmarks): Create files with weights beforehand

### DIFF
--- a/.github/workflows/test-measurements.yaml
+++ b/.github/workflows/test-measurements.yaml
@@ -55,14 +55,15 @@ jobs:
           --output-file ./target/action-pallet-output.json
 
       - name: "Collect: pallet-gear benches"
-        run: >-
+        run: |
+          touch ./target/weights.json
           ./target/release/gear benchmark pallet --pallet=pallet_gear
           --steps=50
           --repeat=20
           --chain=dev
           --extrinsic=*
           --heap-pages=4096
-          --json-file ./target/weights.json
+          --output ./target/weights.json
           --template ./.maintain/regression-analysis-weight-template.hbs
 
       - name: "Generate report: pallet-gear benches"

--- a/.github/workflows/test-measurements.yaml
+++ b/.github/workflows/test-measurements.yaml
@@ -57,14 +57,7 @@ jobs:
       - name: "Collect: pallet-gear benches"
         run: |
           touch ./target/weights.json
-          ./target/release/gear benchmark pallet --pallet=pallet_gear
-          --steps=50
-          --repeat=20
-          --chain=dev
-          --extrinsic=*
-          --heap-pages=4096
-          --output ./target/weights.json
-          --template ./.maintain/regression-analysis-weight-template.hbs
+          ./target/release/gear benchmark pallet --pallet=pallet_gear --steps=50 --repeat=20 --chain=dev --extrinsic=* --heap-pages=4096 --output ./target/weights.json --template ./.maintain/regression-analysis-weight-template.hbs
 
       - name: "Generate report: pallet-gear benches"
         run: |

--- a/scripts/benchmarking/run_all_benchmarks.sh
+++ b/scripts/benchmarking/run_all_benchmarks.sh
@@ -181,6 +181,7 @@ for PALLET in "${PALLETS[@]}"; do
   fi
 
   WEIGHT_FILE="./${WEIGHTS_OUTPUT}/${PALLET}.rs"
+  touch "$WEIGHT_FILE"
   echo "[+] Benchmarking $PALLET with weight file $WEIGHT_FILE";
 
   OUTPUT=$(
@@ -204,6 +205,7 @@ for PALLET in "${PALLETS[@]}"; do
   if [ "$PALLET" == "pallet_gear" ]
   then
     echo "[+] Benchmarking $PALLET one-time syscalls with weight file ./${WEIGHTS_OUTPUT}/${PALLET}_onetime.rs";
+    touch "./${WEIGHTS_OUTPUT}/${PALLET}_onetime.rs"
     OUTPUT=$(
         $TASKSET_CMD $GEAR benchmark pallet \
         --chain="$chain_spec" \


### PR DESCRIPTION
to avoid an errors like `Error: Input("Could not get absolute path for: \"./scripts/benchmarking/weights-output/frame_system.rs\". Error: Os { code: 2, kind: NotFound, message: \"No such file or directory\" }")`

@gear-tech/dev 
