### PR TITLE
refactor!(core): change `ActorId`s implementation of `From<u64>`

### DIFF
--- a/common/numerated/src/tree.rs
+++ b/common/numerated/src/tree.rs
@@ -391,7 +391,7 @@ impl<T: Numerated> IntervalsTree<T> {
     /// Iterating complexity: `O(n + m)`, where
     /// - `n` is amount of intervals in `self`
     /// - `m` is amount of intervals in `other`
-    pub fn difference<'a>(&'a self, other: &'a Self) -> impl Iterator<Item = Interval<T>> + '_ {
+    pub fn difference<'a>(&'a self, other: &'a Self) -> impl Iterator<Item = Interval<T>> + 'a {
         DifferenceIterator {
             iter1: self.iter(),
             iter2: other.iter(),

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -77,6 +77,7 @@ pub use gas_provider::{
 /// Type alias for gas entity.
 pub type Gas = u64;
 
+/// NOTE: Implementation of this for `u64` places bytes from idx=0.
 pub trait Origin: Sized {
     fn into_origin(self) -> H256;
     fn from_origin(val: H256) -> Self;

--- a/gprimitives/src/lib.rs
+++ b/gprimitives/src/lib.rs
@@ -80,13 +80,15 @@ pub struct MessageHandle(u32);
 /// struct. The source `ActorId` for a message being processed can be obtained
 /// using `gstd::msg::source()` function. Also, each send function has a target
 /// `ActorId` as one of the arguments.
+///
+/// NOTE: Implementation of `From<u64>` places bytes from idx=12 for Eth compatibility.
 #[derive(Clone, Copy, Default, Hash, Ord, PartialEq, PartialOrd, Eq, From, Into, AsRef, AsMut)]
 #[as_ref(forward)]
 #[as_mut(forward)]
 #[cfg_attr(feature = "codec", derive(TypeInfo, Encode, Decode, MaxEncodedLen), codec(crate = scale))]
 pub struct ActorId([u8; 32]);
 
-macros::impl_primitive!(new zero into_bytes from_u64 from_h256 into_h256 try_from_slice debug, ActorId);
+macros::impl_primitive!(new zero into_bytes from_h256 into_h256 try_from_slice debug, ActorId);
 
 impl ActorId {
     /// Returns the ss58-check address with default ss58 version.
@@ -108,6 +110,14 @@ impl ActorId {
         let mut h160 = H160::zero();
         h160.0.copy_from_slice(&self.into_bytes()[12..]);
         h160
+    }
+}
+
+impl From<u64> for ActorId {
+    fn from(value: u64) -> Self {
+        let mut id = Self::zero();
+        id.0[12..20].copy_from_slice(&value.to_le_bytes()[..]);
+        id
     }
 }
 

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -867,11 +867,8 @@ pub mod gbuild {
 #[cfg(test)]
 mod tests {
     use super::Program;
-
     use crate::{Log, ProgramIdWrapper, System, Value, DEFAULT_USER_ALICE, EXISTENTIAL_DEPOSIT};
     use demo_constructor::{Arg, Scheme};
-    use gear_common::Origin;
-
     use gear_core::ids::ActorId;
     use gear_core_errors::{ErrorReplyReason, ReplyCode, SimpleExecutionError};
 
@@ -1085,7 +1082,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "Insufficient balance: user (0x0500000000000000000000000000000000000000000000000000000000000000) \
+        expected = "Insufficient balance: user (0x0000000000000000000000000500000000000000000000000000000000000000) \
     tries to send (1000000000001) value, (4500000000000) gas and ED (1000000000000), while his balance (1000000000000)"
     )]
     fn fails_on_insufficient_balance() {
@@ -1446,7 +1443,12 @@ mod tests {
         let handle = Calls::builder()
             .reserve_gas(10_000_000_000, 5)
             .store("reservation")
-            .reservation_send_value("reservation", user_id.into_origin().0, payload.clone(), 0);
+            .reservation_send_value(
+                "reservation",
+                ActorId::from(user_id).into_bytes(),
+                payload.clone(),
+                0,
+            );
         let msg_id = prog.send(user_id, handle);
         let res = sys.run_next_block();
         assert!(res.succeed.contains(&msg_id));
@@ -1459,7 +1461,7 @@ mod tests {
         let new_prog_id = 4343;
         let new_program = Program::from_binary_with_id(&sys, new_prog_id, WASM_BINARY);
         let payload = b"sup!".to_vec();
-        let handle = Calls::builder().send(user_id.into_origin().0, payload.clone());
+        let handle = Calls::builder().send(ActorId::from(user_id).into_bytes(), payload.clone());
         let scheme = Scheme::predefined(
             Calls::builder().noop(),
             handle,
@@ -1474,7 +1476,12 @@ mod tests {
         let handle = Calls::builder()
             .reserve_gas(10_000_000_000, 5)
             .store("reservation")
-            .reservation_send_value("reservation", new_prog_id.into_origin().0, [], 0);
+            .reservation_send_value(
+                "reservation",
+                ActorId::from(new_prog_id).into_bytes(),
+                [],
+                0,
+            );
         let msg_id = prog.send(user_id, handle);
         let res = sys.run_next_block();
         assert!(res.succeed.contains(&msg_id));

--- a/pallets/gear-builtin/src/tests/basic.rs
+++ b/pallets/gear-builtin/src/tests/basic.rs
@@ -237,7 +237,7 @@ fn calculate_gas_info_works() {
         // An error reply should have been sent.
         assert!(System::events().into_iter().any(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                message.destination() == ProgramId::from(SIGNER) && message.details().is_some() && {
+                message.destination() == SIGNER.cast() && message.details().is_some() && {
                     let details = message.details().expect("Value checked above");
                     details.to_reply_code()
                         == ReplyCode::Error(ErrorReplyReason::Execution(

--- a/pallets/gear-builtin/src/tests/bls381.rs
+++ b/pallets/gear-builtin/src/tests/bls381.rs
@@ -95,7 +95,7 @@ fn decoding_error() {
         // An error reply should have been sent.
         assert!(System::events().into_iter().any(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                message.destination() == ProgramId::from(SIGNER)
+                message.destination() == SIGNER.cast()
                     && matches!(message.details(), Some(details) if details.to_reply_code()
                     == ReplyCode::Error(ErrorReplyReason::Execution(
                         SimpleExecutionError::UserspacePanic,
@@ -137,7 +137,7 @@ fn multi_miller_loop() {
 
         assert!(System::events().into_iter().any(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                message.destination() == ProgramId::from(SIGNER)
+                message.destination() == SIGNER.cast()
                     && matches!(message.details(), Some(details) if details.to_reply_code()
                     == ReplyCode::Error(ErrorReplyReason::Execution(
                         SimpleExecutionError::UserspacePanic,
@@ -172,7 +172,7 @@ fn multi_miller_loop() {
         // An error reply should have been sent.
         assert!(System::events().into_iter().any(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                message.destination() == ProgramId::from(SIGNER)
+                message.destination() == SIGNER.cast()
                     && matches!(message.details(), Some(details) if details.to_reply_code()
                     == ReplyCode::Error(ErrorReplyReason::Execution(
                         SimpleExecutionError::RanOutOfGas,
@@ -197,7 +197,7 @@ fn multi_miller_loop() {
 
         let response = match System::events().into_iter().find_map(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                assert_eq!(message.destination(), ProgramId::from(SIGNER));
+                assert_eq!(message.destination(), SIGNER.cast());
                 assert!(matches!(message.details(), Some(details) if matches!(details.to_reply_code(), ReplyCode::Success(..))));
 
                 Some(message.payload_bytes().to_vec())
@@ -256,7 +256,7 @@ fn final_exponentiation() {
         // An error reply should have been sent.
         assert!(System::events().into_iter().any(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                message.destination() == ProgramId::from(SIGNER)
+                message.destination() == SIGNER.cast()
                     && matches!(message.details(), Some(details) if details.to_reply_code()
                     == ReplyCode::Error(ErrorReplyReason::Execution(
                         SimpleExecutionError::RanOutOfGas,
@@ -281,7 +281,7 @@ fn final_exponentiation() {
 
         let response = match System::events().into_iter().find_map(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                assert_eq!(message.destination(), ProgramId::from(SIGNER));
+                assert_eq!(message.destination(), SIGNER.cast());
                 assert!(matches!(message.details(), Some(details) if matches!(details.to_reply_code(), ReplyCode::Success(..))));
 
                 Some(message.payload_bytes().to_vec())
@@ -339,7 +339,7 @@ fn msm_g1() {
 
         assert!(System::events().into_iter().any(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                message.destination() == ProgramId::from(SIGNER)
+                message.destination() == SIGNER.cast()
                     && matches!(message.details(), Some(details) if details.to_reply_code()
                     == ReplyCode::Error(ErrorReplyReason::Execution(
                         SimpleExecutionError::UserspacePanic,
@@ -374,7 +374,7 @@ fn msm_g1() {
         // An error reply should have been sent.
         assert!(System::events().into_iter().any(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                message.destination() == ProgramId::from(SIGNER)
+                message.destination() == SIGNER.cast()
                     && matches!(message.details(), Some(details) if details.to_reply_code()
                     == ReplyCode::Error(ErrorReplyReason::Execution(
                         SimpleExecutionError::RanOutOfGas,
@@ -399,7 +399,7 @@ fn msm_g1() {
 
         let response = match System::events().into_iter().find_map(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                assert_eq!(message.destination(), ProgramId::from(SIGNER));
+                assert_eq!(message.destination(), SIGNER.cast());
                 assert!(matches!(message.details(), Some(details) if matches!(details.to_reply_code(), ReplyCode::Success(..))));
 
                 Some(message.payload_bytes().to_vec())
@@ -457,7 +457,7 @@ fn msm_g2() {
 
         assert!(System::events().into_iter().any(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                message.destination() == ProgramId::from(SIGNER)
+                message.destination() == SIGNER.cast()
                     && matches!(message.details(), Some(details) if details.to_reply_code()
                     == ReplyCode::Error(ErrorReplyReason::Execution(
                         SimpleExecutionError::UserspacePanic,
@@ -492,7 +492,7 @@ fn msm_g2() {
         // An error reply should have been sent.
         assert!(System::events().into_iter().any(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                message.destination() == ProgramId::from(SIGNER)
+                message.destination() == SIGNER.cast()
                     && matches!(message.details(), Some(details) if details.to_reply_code()
                     == ReplyCode::Error(ErrorReplyReason::Execution(
                         SimpleExecutionError::RanOutOfGas,
@@ -517,7 +517,7 @@ fn msm_g2() {
 
         let response = match System::events().into_iter().find_map(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                assert_eq!(message.destination(), ProgramId::from(SIGNER));
+                assert_eq!(message.destination(), SIGNER.cast());
                 assert!(matches!(message.details(), Some(details) if matches!(details.to_reply_code(), ReplyCode::Success(..))));
 
                 Some(message.payload_bytes().to_vec())
@@ -574,7 +574,7 @@ fn mul_projective_g1() {
         // An error reply should have been sent.
         assert!(System::events().into_iter().any(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                message.destination() == ProgramId::from(SIGNER)
+                message.destination() == SIGNER.cast()
                     && matches!(message.details(), Some(details) if details.to_reply_code()
                     == ReplyCode::Error(ErrorReplyReason::Execution(
                         SimpleExecutionError::RanOutOfGas,
@@ -599,7 +599,7 @@ fn mul_projective_g1() {
 
         let response = match System::events().into_iter().find_map(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                assert_eq!(message.destination(), ProgramId::from(SIGNER));
+                assert_eq!(message.destination(), SIGNER.cast());
                 assert!(matches!(message.details(), Some(details) if matches!(details.to_reply_code(), ReplyCode::Success(..))));
 
                 Some(message.payload_bytes().to_vec())
@@ -656,7 +656,7 @@ fn mul_projective_g2() {
         // An error reply should have been sent.
         assert!(System::events().into_iter().any(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                message.destination() == ProgramId::from(SIGNER)
+                message.destination() == SIGNER.cast()
                     && matches!(message.details(), Some(details) if details.to_reply_code()
                     == ReplyCode::Error(ErrorReplyReason::Execution(
                         SimpleExecutionError::RanOutOfGas,
@@ -681,7 +681,7 @@ fn mul_projective_g2() {
 
         let response = match System::events().into_iter().find_map(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                assert_eq!(message.destination(), ProgramId::from(SIGNER));
+                assert_eq!(message.destination(), SIGNER.cast());
                 assert!(matches!(message.details(), Some(details) if matches!(details.to_reply_code(), ReplyCode::Success(..))));
 
                 Some(message.payload_bytes().to_vec())
@@ -717,7 +717,7 @@ fn aggregate_g1() {
         let encoded_points = ark_points.encode();
 
         let payload = Request::AggregateG1 { points: encoded_points }.encode();
-        let builtin_actor_id: ProgramId = H256::from(ACTOR_ID).cast();
+        let builtin_actor_id = ACTOR_ID.into();
         let gas_info = get_gas_info(builtin_actor_id, payload.clone());
 
         // Check the case of insufficient gas
@@ -736,7 +736,7 @@ fn aggregate_g1() {
         // An error reply should have been sent.
         assert!(System::events().into_iter().any(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                message.destination() == ProgramId::from(SIGNER)
+                message.destination() == SIGNER.cast()
                     && matches!(message.details(), Some(details) if details.to_reply_code()
                     == ReplyCode::Error(ErrorReplyReason::Execution(
                         SimpleExecutionError::RanOutOfGas,
@@ -761,7 +761,7 @@ fn aggregate_g1() {
 
         let response = match System::events().into_iter().find_map(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                assert_eq!(message.destination(), ProgramId::from(SIGNER));
+                assert_eq!(message.destination(), SIGNER.cast());
                 assert!(matches!(message.details(), Some(details) if matches!(details.to_reply_code(), ReplyCode::Success(..))));
 
                 Some(message.payload_bytes().to_vec())
@@ -816,7 +816,7 @@ fn map_to_g2affine() {
         // An error reply should have been sent.
         assert!(System::events().into_iter().any(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                message.destination() == ProgramId::from(SIGNER)
+                message.destination() == SIGNER.cast()
                     && matches!(message.details(), Some(details) if details.to_reply_code()
                     == ReplyCode::Error(ErrorReplyReason::Execution(
                         SimpleExecutionError::RanOutOfGas,
@@ -841,7 +841,7 @@ fn map_to_g2affine() {
 
         let response = match System::events().into_iter().find_map(|e| match e.event {
             RuntimeEvent::Gear(pallet_gear::Event::<Test>::UserMessageSent { message, .. }) => {
-                assert_eq!(message.destination(), ProgramId::from(SIGNER));
+                assert_eq!(message.destination(), SIGNER.cast());
                 assert!(matches!(message.details(), Some(details) if matches!(details.to_reply_code(), ReplyCode::Success(..))));
 
                 Some(message.payload_bytes().to_vec())

--- a/pallets/gear-debug/src/tests/mod.rs
+++ b/pallets/gear-debug/src/tests/mod.rs
@@ -18,7 +18,7 @@
 
 use super::*;
 use crate::mock::*;
-use common::{self, event::MessageEntry, CodeStorage, Origin as _};
+use common::{self, event::MessageEntry, CodeStorage, Origin};
 use frame_support::assert_ok;
 use gear_core::{
     ids::{prelude::*, CodeId, MessageId, ProgramId},
@@ -251,7 +251,7 @@ fn debug_mode_works() {
                         DispatchKind::Handle,
                         StoredMessage::new(
                             message_id_1,
-                            1.into(),
+                            1.cast(),
                             program_id_1,
                             Default::default(),
                             0,
@@ -263,7 +263,7 @@ fn debug_mode_works() {
                         DispatchKind::Handle,
                         StoredMessage::new(
                             message_id_2,
-                            1.into(),
+                            1.cast(),
                             program_id_2,
                             Default::default(),
                             0,
@@ -356,10 +356,12 @@ fn get_last_program_id() -> ProgramId {
 }
 
 #[track_caller]
-fn maybe_last_message(account: u64) -> Option<UserMessage> {
+fn maybe_last_message(account: impl Origin) -> Option<UserMessage> {
+    let account = account.cast();
+
     System::events().into_iter().rev().find_map(|e| {
         if let super::mock::RuntimeEvent::Gear(Event::UserMessageSent { message, .. }) = e.event {
-            if message.destination() == account.into() {
+            if message.destination() == account {
                 Some(message)
             } else {
                 None

--- a/pallets/gear-scheduler/src/tests.rs
+++ b/pallets/gear-scheduler/src/tests.rs
@@ -48,12 +48,12 @@ fn wl_cost_for(amount_of_blocks: u64) -> u128 {
     gas_price(<Pallet<Test> as Scheduler>::CostsPerBlock::waitlist() * amount_of_blocks)
 }
 
-fn dispatch_from(src: impl Into<ProgramId>) -> StoredDispatch {
+fn dispatch_from(src: impl Origin) -> StoredDispatch {
     StoredDispatch::new(
         DispatchKind::Handle,
         StoredMessage::new(
             H256::random().cast(),
-            src.into(),
+            src.cast(),
             H256::random().cast(),
             Default::default(),
             0,

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -374,7 +374,7 @@ fn test_failing_delayed_reservation_send() {
 
         let message = maybe_any_last_message().expect("Should be");
         assert_eq!(message.id(), err_reply);
-        assert_eq!(message.destination(), USER_1.into());
+        assert_eq!(message.destination(), USER_1.cast());
     });
 }
 
@@ -2137,7 +2137,7 @@ fn delayed_send_user_message_with_reservation() {
             PROXY_WGAS_WASM_BINARY.to_vec(),
             DEFAULT_SALT.to_vec(),
             InputArgs {
-                destination: USER_2.into(),
+                destination: USER_2.cast(),
                 delay: delay.saturated_into(),
                 reservation_amount,
             }
@@ -3220,7 +3220,7 @@ fn send_message_works() {
 
         assert_ok!(Gear::send_message(
             RuntimeOrigin::signed(USER_1),
-            USER_2.into(),
+            USER_2.cast(),
             EMPTY_PAYLOAD.to_vec(),
             DEFAULT_GAS_LIMIT,
             mail_value,
@@ -3417,7 +3417,7 @@ fn send_message_expected_failure() {
         MailboxOf::<Test>::clear();
         assert_ok!(Gear::send_message(
             RuntimeOrigin::signed(LOW_BALANCE_USER),
-            USER_1.into(),
+            USER_1.cast(),
             EMPTY_PAYLOAD.to_vec(),
             10,
             value,
@@ -3465,7 +3465,7 @@ fn messages_processing_works() {
 
         assert_last_dequeued(2);
 
-        assert_ok!(send_default_message(USER_1, USER_2.into()));
+        assert_ok!(send_default_message(USER_1, USER_2.cast()));
         assert_ok!(send_default_message(USER_1, program_id));
 
         run_to_block(3, None);
@@ -6010,7 +6010,7 @@ fn test_wait_timeout() {
         //
         // Emits error when locks are timeout
         let duration = 10u64;
-        let payload = Command::SendTimeout(USER_1.into(), duration.saturated_into()).encode();
+        let payload = Command::SendTimeout(USER_1.cast(), duration.saturated_into()).encode();
         assert_ok!(Gear::send_message(
             RuntimeOrigin::signed(USER_1),
             program_id,
@@ -6070,7 +6070,7 @@ fn test_join_wait_timeout() {
         let duration_a: BlockNumber = 5;
         let duration_b: BlockNumber = 10;
         let payload = Command::JoinTimeout(
-            USER_1.into(),
+            USER_1.cast(),
             duration_a.saturated_into(),
             duration_b.saturated_into(),
         )
@@ -6135,7 +6135,7 @@ fn test_select_wait_timeout() {
         let duration_a: BlockNumber = 5;
         let duration_b: BlockNumber = 10;
         let payload = Command::SelectTimeout(
-            USER_1.into(),
+            USER_1.cast(),
             duration_a.saturated_into(),
             duration_b.saturated_into(),
         )
@@ -6186,7 +6186,7 @@ fn test_wait_lost() {
 
         let duration_a: BlockNumber = 5;
         let duration_b: BlockNumber = 10;
-        let payload = Command::WaitLost(USER_1.into()).encode();
+        let payload = Command::WaitLost(USER_1.cast()).encode();
         assert_ok!(Gear::send_message(
             RuntimeOrigin::signed(USER_1),
             program_id,
@@ -6819,7 +6819,7 @@ fn test_sequence_inheritor_of() {
         // serial inheritance
         let mut programs = vec![];
         for i in 1000..1100 {
-            let program_id = ProgramId::from(i);
+            let program_id = i.cast();
             manager.set_program(
                 program_id,
                 &code_info,
@@ -6828,7 +6828,7 @@ fn test_sequence_inheritor_of() {
             );
 
             ProgramStorageOf::<Test>::update_program_if_active(program_id, |program, _bn| {
-                let inheritor = programs.last().copied().unwrap_or_else(|| USER_1.into());
+                let inheritor = programs.last().copied().unwrap_or_else(|| USER_1.cast());
                 if i % 2 == 0 {
                     *program = Program::Exited(inheritor);
                 } else {
@@ -6856,23 +6856,23 @@ fn test_sequence_inheritor_of() {
             (inheritor, holders)
         };
 
-        let res = Gear::inheritor_for(USER_1.into(), NonZero::<usize>::MAX);
+        let res = Gear::inheritor_for(USER_1.cast(), NonZero::<usize>::MAX);
         assert_eq!(res, Err(InheritorForError::NotFound));
 
         let (inheritor, holders) = inheritor_for(programs[99], usize::MAX);
-        assert_eq!(inheritor, USER_1.into());
+        assert_eq!(inheritor, USER_1.cast());
         assert_eq!(holders, indexed_programs);
 
         let (inheritor, holders) = inheritor_for(programs[49], usize::MAX);
-        assert_eq!(inheritor, USER_1.into());
+        assert_eq!(inheritor, USER_1.cast());
         assert_eq!(holders, indexed_programs[..=49]);
 
         let (inheritor, holders) = inheritor_for(programs[0], usize::MAX);
-        assert_eq!(inheritor, USER_1.into());
+        assert_eq!(inheritor, USER_1.cast());
         assert_eq!(holders, indexed_programs[..=0]);
 
         let (inheritor, holders) = inheritor_for(programs[0], 1);
-        assert_eq!(inheritor, USER_1.into());
+        assert_eq!(inheritor, USER_1.cast());
         assert_eq!(holders, indexed_programs[..=0]);
 
         let (inheritor, holders) = inheritor_for(programs[99], 10);
@@ -6884,7 +6884,7 @@ fn test_sequence_inheritor_of() {
         assert_eq!(holders, indexed_programs[50..]);
 
         let (inheritor, holders) = inheritor_for(programs[99], 100);
-        assert_eq!(inheritor, USER_1.into());
+        assert_eq!(inheritor, USER_1.cast());
         assert_eq!(holders, indexed_programs);
 
         let (inheritor, holders) = inheritor_for(programs[99], 99);
@@ -13417,7 +13417,7 @@ fn relay_messages() {
             RelayCall::ResendPush(vec![
                 // "Hi, USER_2!"
                 ResendPushData {
-                    destination: USER_2.into(),
+                    destination: USER_2.cast(),
                     start: None,
                     end: Some((10, true)),
                 },
@@ -13431,7 +13431,7 @@ fn relay_messages() {
             RelayCall::ResendPush(vec![
                 // the same but end index specified in another way
                 ResendPushData {
-                    destination: USER_2.into(),
+                    destination: USER_2.cast(),
                     start: None,
                     end: Some((11, false)),
                 },
@@ -13445,7 +13445,7 @@ fn relay_messages() {
             RelayCall::ResendPush(vec![
                 // "Ping USER_3."
                 ResendPushData {
-                    destination: USER_3.into(),
+                    destination: USER_3.cast(),
                     start: Some(12),
                     end: None,
                 },
@@ -13459,7 +13459,7 @@ fn relay_messages() {
             RelayCall::ResendPush(vec![
                 // invalid range
                 ResendPushData {
-                    destination: USER_3.into(),
+                    destination: USER_3.cast(),
                     start: Some(2),
                     end: Some((0, true)),
                 },
@@ -13476,7 +13476,7 @@ fn relay_messages() {
     }
 
     test(
-        RelayCall::Resend(USER_3.into()),
+        RelayCall::Resend(USER_3.cast()),
         payload,
         vec![Expected {
             user: USER_3,
@@ -13484,7 +13484,7 @@ fn relay_messages() {
         }],
     );
     test(
-        RelayCall::ResendWithGas(USER_3.into(), 50_000),
+        RelayCall::ResendWithGas(USER_3.cast(), 50_000),
         payload,
         vec![Expected {
             user: USER_3,
@@ -16520,10 +16520,12 @@ pub(crate) mod utils {
     }
 
     #[track_caller]
-    pub(super) fn maybe_last_message(account: AccountId) -> Option<UserMessage> {
+    pub(super) fn maybe_last_message(account: impl Origin) -> Option<UserMessage> {
+        let account = account.cast();
+
         System::events().into_iter().rev().find_map(|e| {
             if let MockRuntimeEvent::Gear(Event::UserMessageSent { message, .. }) = e.event {
-                if message.destination() == account.into() {
+                if message.destination() == account {
                     Some(message)
                 } else {
                     None
@@ -16560,8 +16562,8 @@ pub(crate) mod utils {
     }
 
     #[track_caller]
-    pub(super) fn get_last_mail(account: AccountId) -> UserStoredMessage {
-        MailboxOf::<Test>::iter_key(account)
+    pub(super) fn get_last_mail(account: impl Origin) -> UserStoredMessage {
+        MailboxOf::<Test>::iter_key(account.cast())
             .last()
             .map(|(msg, _bn)| msg)
             .expect("Element should be")
@@ -16727,7 +16729,9 @@ pub(crate) mod utils {
     }
 
     #[track_caller]
-    pub(crate) fn assert_responses_to_user(user_id: AccountId, assertions: Vec<Assertion>) {
+    pub(crate) fn assert_responses_to_user(user_id: impl Origin, assertions: Vec<Assertion>) {
+        let user_id = user_id.cast();
+
         let messages: Vec<UserMessage> = System::events()
             .into_iter()
             .filter_map(|e| {
@@ -16737,7 +16741,7 @@ pub(crate) mod utils {
                     None
                 }
             })
-            .filter(|message| message.destination() == user_id.into())
+            .filter(|message| message.destination() == user_id)
             .collect();
 
         if messages.len() != assertions.len() {
@@ -16838,12 +16842,14 @@ pub(crate) mod utils {
 
     // Collect all messages by account in chronological order (oldest first)
     #[track_caller]
-    pub(super) fn all_user_messages(user_id: AccountId) -> Vec<UserMessage> {
+    pub(super) fn all_user_messages(user_id: impl Origin) -> Vec<UserMessage> {
+        let user_id = user_id.cast();
+
         System::events()
             .into_iter()
             .filter_map(|e| {
                 if let MockRuntimeEvent::Gear(Event::UserMessageSent { message, .. }) = e.event {
-                    if message.destination() == user_id.into() {
+                    if message.destination() == user_id {
                         Some(message)
                     } else {
                         None


### PR DESCRIPTION
Motivation: gear.exes development requires test coverage. Currently, in tests it's impossible to use this implementation, since if u64 takes place of the very beginning of the resulting bytes array, it will be stripped by `ActorId::to_address_lossy`, which starts from idx=12.