### PR TITLE
chore: rename WAMV to Wasm VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Gear Protocol provides a developer-friendly programming platform for decentraliz
 
 - Gear Protocol provides dApp developers with a very minimal, intuitive, and sufficient API for writing custom-logic programs in Rust and running them on Gear-powered networks, such as the Vara Network.
 - It provides a technological foundation for constructing highly scalable and rapid decentralized Layer-1 networks.
-- Reduces the computational burden on blockchains by offloading highly intensive calculations using a Vara node with WAVM, and then proving the correctness of these calculations on any blockchain.
+- Reduces the computational burden on blockchains by offloading highly intensive calculations using a Vara node with Wasm VM, and then proving the correctness of these calculations on any blockchain.
 - A Vara node can be used as a standalone instance running microservices, middleware, open API, and more.
 
 For more details refer to the **[Gear Whitepaper](https://whitepaper.gear.foundation)**.


### PR DESCRIPTION
WAMV can be interpreted as radio station or C++ wasm executor https://github.com/WAVM/WAVM