### PR TITLE
chore(tests): enable RUST_LIB_BACKTRACE=1 for CI and other

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -14,6 +14,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: short
+  RUST_LIB_BACKTRACE: 1
   TERM: xterm-256color
   BINARYEN_VERSION: version_111
 

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -11,6 +11,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: short
+  RUST_LIB_BACKTRACE: 1
   TERM: xterm-256color
   BINARYEN_VERSION: version_111
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -15,6 +15,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: short
+  RUST_LIB_BACKTRACE: 1
   TERM: xterm-256color
 
 jobs:

--- a/.github/workflows/build-win-native.yml
+++ b/.github/workflows/build-win-native.yml
@@ -15,6 +15,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: short
+  RUST_LIB_BACKTRACE: 1
   TERM: xterm-256color
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ run-name: ${{ inputs.title }} ( ${{ format('#{0}', inputs.number) }} )
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: short
+  RUST_LIB_BACKTRACE: 1
   TERM: xterm-256color
   BINARYEN_VERSION: version_111
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: short
+  RUST_LIB_BACKTRACE: 1
   TERM: xterm-256color
   BINARYEN_VERSION: version_111
 

--- a/.github/workflows/crates-io.yml
+++ b/.github/workflows/crates-io.yml
@@ -15,6 +15,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: short
+  RUST_LIB_BACKTRACE: 1
   TERM: xterm-256color
 
 jobs:


### PR DESCRIPTION
In order to append additional information if tests uses anyhow for errors (tokio::tests mainly)
https://docs.rs/anyhow/latest/anyhow/#:~:text=If%20you%20want%20only%20errors%20to%20have%20backtraces%2C%20set%20RUST_LIB_BACKTRACE%3D1%3B