### PR TITLE
fix(sandbox, lazy-pages): Increase corosensei precommited stack size to 1MiB (windows)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2754,8 +2754,7 @@ dependencies = [
 [[package]]
 name = "corosensei"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80128832c58ea9cbd041d2a759ec449224487b2c1e400453d99d244eead87a8e"
+source = "git+https://github.com/gear-tech/corosensei?branch=rmasl-precommit-1mb-stack-on-windows#6a05a1eb84e505edd68e941195221936a6f634a0"
 dependencies = [
  "autocfg",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -558,9 +558,6 @@ loom = "0.7.2"                                               # utils/gear-wasmer
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)', 'cfg(fuzz)', 'cfg(substrate_runtime)'] }
 
-[profile.dev.package.corosensei]
-opt-level = 3
-
 [profile.release]
 panic = "unwind"
 
@@ -603,3 +600,6 @@ blake3 = { git = "https://github.com/gear-tech/BLAKE3", branch = "clang-cl-cross
 
 # TODO: remove after https://github.com/pepyakin/wabt-rs/pull/84
 wabt = { git = "https://github.com/gear-tech/wabt-rs", branch = "al-win-crt" }
+
+# Attempt to fix UB on windows by increasing precommited stack size to 1 MiB, see https://github.com/gear-tech/gear/issues/4341
+corosensei = { git = "https://github.com/gear-tech/corosensei", branch = "rmasl-precommit-1mb-stack-on-windows" }


### PR DESCRIPTION
Relates #4341.

Only for Windows:

There was observed what undefined behavior (UB) don't occurs when we pre-commit `corosensei`
 stack (pre-commited stack size 1MiB). 

@reviewer-or-team
