### PR TITLE
chore: add testing encode/decode for ReplyCode and SignalCode

### DIFF
--- a/core-errors/src/simple.rs
+++ b/core-errors/src/simple.rs
@@ -419,54 +419,14 @@ impl SignalCode {
     }
 }
 
+#[cfg(feature = "codec")]
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{ReplyCode, SignalCode};
 
     #[test]
     fn test_reply_code_encode_decode() {
-        let reply_codes: [ReplyCode; 16] = [
-            // Success
-            ReplyCode::Success(SuccessReplyReason::Auto),
-            ReplyCode::Success(SuccessReplyReason::Manual),
-            ReplyCode::Success(SuccessReplyReason::Unsupported),
-            // Error SimpleExecutionError
-            ReplyCode::Error(ErrorReplyReason::Execution(
-                SimpleExecutionError::RanOutOfGas,
-            )),
-            ReplyCode::Error(ErrorReplyReason::Execution(
-                SimpleExecutionError::MemoryOverflow,
-            )),
-            ReplyCode::Error(ErrorReplyReason::Execution(
-                SimpleExecutionError::BackendError,
-            )),
-            ReplyCode::Error(ErrorReplyReason::Execution(
-                SimpleExecutionError::UserspacePanic,
-            )),
-            ReplyCode::Error(ErrorReplyReason::Execution(
-                SimpleExecutionError::UnreachableInstruction,
-            )),
-            ReplyCode::Error(ErrorReplyReason::Execution(
-                SimpleExecutionError::StackLimitExceeded,
-            )),
-            ReplyCode::Error(ErrorReplyReason::Execution(
-                SimpleExecutionError::Unsupported,
-            )),
-            // SimpleProgramCreationError
-            ReplyCode::Error(ErrorReplyReason::FailedToCreateProgram(
-                SimpleProgramCreationError::CodeNotExists,
-            )),
-            ReplyCode::Error(ErrorReplyReason::FailedToCreateProgram(
-                SimpleProgramCreationError::Unsupported,
-            )),
-            // Other ErrorReplyReason
-            ReplyCode::Error(ErrorReplyReason::InactiveActor),
-            ReplyCode::Error(ErrorReplyReason::RemovedFromWaitlist),
-            ReplyCode::Error(ErrorReplyReason::ReinstrumentationFailure),
-            ReplyCode::Error(ErrorReplyReason::Unsupported),
-        ];
-
-        for code in reply_codes {
+        for code in enum_iterator::all::<ReplyCode>() {
             let bytes = code.to_bytes();
             assert_eq!(code, ReplyCode::from_bytes(bytes));
         }
@@ -474,18 +434,7 @@ mod tests {
 
     #[test]
     fn test_signal_code_encode_decode() {
-        let signal_codes: [SignalCode; 8] = [
-            SignalCode::Execution(SimpleExecutionError::RanOutOfGas),
-            SignalCode::Execution(SimpleExecutionError::MemoryOverflow),
-            SignalCode::Execution(SimpleExecutionError::BackendError),
-            SignalCode::Execution(SimpleExecutionError::UserspacePanic),
-            SignalCode::Execution(SimpleExecutionError::UnreachableInstruction),
-            SignalCode::Execution(SimpleExecutionError::StackLimitExceeded),
-            SignalCode::Execution(SimpleExecutionError::Unsupported),
-            SignalCode::RemovedFromWaitlist,
-        ];
-
-        for signal in signal_codes {
+        for signal in enum_iterator::all::<SignalCode>() {
             let code = signal.to_u32();
             assert_eq!(signal, SignalCode::from_u32(code).unwrap());
         }

--- a/core-errors/src/simple.rs
+++ b/core-errors/src/simple.rs
@@ -225,7 +225,6 @@ impl ErrorReplyReason {
         bytes
     }
 
-    // TODO: add test this method works correctly for all possible variants #3715
     fn from_bytes(bytes: [u8; 3]) -> Self {
         match bytes[0] {
             b if Self::Execution(Default::default()).discriminant() == b => {

--- a/core-errors/src/simple.rs
+++ b/core-errors/src/simple.rs
@@ -409,10 +409,86 @@ impl SignalCode {
             v if Self::Execution(SimpleExecutionError::StackLimitExceeded).to_u32() == v => {
                 Self::Execution(SimpleExecutionError::StackLimitExceeded)
             }
+            v if Self::Execution(SimpleExecutionError::Unsupported).to_u32() == v => {
+                Self::Execution(SimpleExecutionError::Unsupported)
+            }
             v if Self::RemovedFromWaitlist.to_u32() == v => Self::RemovedFromWaitlist,
             _ => return None,
         };
 
         Some(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reply_code_encode_decode() {
+        let reply_codes: [ReplyCode; 16] = [
+            // Success
+            ReplyCode::Success(SuccessReplyReason::Auto),
+            ReplyCode::Success(SuccessReplyReason::Manual),
+            ReplyCode::Success(SuccessReplyReason::Unsupported),
+            // Error SimpleExecutionError
+            ReplyCode::Error(ErrorReplyReason::Execution(
+                SimpleExecutionError::RanOutOfGas,
+            )),
+            ReplyCode::Error(ErrorReplyReason::Execution(
+                SimpleExecutionError::MemoryOverflow,
+            )),
+            ReplyCode::Error(ErrorReplyReason::Execution(
+                SimpleExecutionError::BackendError,
+            )),
+            ReplyCode::Error(ErrorReplyReason::Execution(
+                SimpleExecutionError::UserspacePanic,
+            )),
+            ReplyCode::Error(ErrorReplyReason::Execution(
+                SimpleExecutionError::UnreachableInstruction,
+            )),
+            ReplyCode::Error(ErrorReplyReason::Execution(
+                SimpleExecutionError::StackLimitExceeded,
+            )),
+            ReplyCode::Error(ErrorReplyReason::Execution(
+                SimpleExecutionError::Unsupported,
+            )),
+            // SimpleProgramCreationError
+            ReplyCode::Error(ErrorReplyReason::FailedToCreateProgram(
+                SimpleProgramCreationError::CodeNotExists,
+            )),
+            ReplyCode::Error(ErrorReplyReason::FailedToCreateProgram(
+                SimpleProgramCreationError::Unsupported,
+            )),
+            // Other ErrorReplyReason
+            ReplyCode::Error(ErrorReplyReason::InactiveActor),
+            ReplyCode::Error(ErrorReplyReason::RemovedFromWaitlist),
+            ReplyCode::Error(ErrorReplyReason::ReinstrumentationFailure),
+            ReplyCode::Error(ErrorReplyReason::Unsupported),
+        ];
+
+        for code in reply_codes {
+            let bytes = code.to_bytes();
+            assert_eq!(code, ReplyCode::from_bytes(bytes));
+        }
+    }
+
+    #[test]
+    fn test_signal_code_encode_decode() {
+        let signal_codes: [SignalCode; 8] = [
+            SignalCode::Execution(SimpleExecutionError::RanOutOfGas),
+            SignalCode::Execution(SimpleExecutionError::MemoryOverflow),
+            SignalCode::Execution(SimpleExecutionError::BackendError),
+            SignalCode::Execution(SimpleExecutionError::UserspacePanic),
+            SignalCode::Execution(SimpleExecutionError::UnreachableInstruction),
+            SignalCode::Execution(SimpleExecutionError::StackLimitExceeded),
+            SignalCode::Execution(SimpleExecutionError::Unsupported),
+            SignalCode::RemovedFromWaitlist,
+        ];
+
+        for signal in signal_codes {
+            let code = signal.to_u32();
+            assert_eq!(signal, SignalCode::from_u32(code).unwrap());
+        }
     }
 }


### PR DESCRIPTION
Resolves #3715 

- adding tests for `ReplyCode` and `SignalCode` enums

@grishasobol 
