### PR TITLE
feat(ethexe): Add more context to returned errors

### DIFF
--- a/ethexe/cli/src/commands/run.rs
+++ b/ethexe/cli/src/commands/run.rs
@@ -54,18 +54,15 @@ impl RunCommand {
             .filter_module("wasmtime_cranelift", LevelFilter::Off)
             .filter_module("cranelift", LevelFilter::Off)
             .try_init()
-            .with_context(|| "failed to initialize logger")?;
+            .context("failed to initialize logger")?;
 
-        let config = self
-            .params
-            .into_config()
-            .with_context(|| "invalid configuration")?;
+        let config = self.params.into_config().context("invalid configuration")?;
 
         config.log_info();
 
         let service = Service::new(&config)
             .await
-            .with_context(|| "failed to create ethexe primary service")?;
+            .context("failed to create ethexe primary service")?;
 
         tokio::select! {
             res = service.run() => res,

--- a/ethexe/cli/src/lib.rs
+++ b/ethexe/cli/src/lib.rs
@@ -44,7 +44,7 @@ impl Cli {
     pub async fn run(self) -> Result<()> {
         let params = self
             .file_params()
-            .with_context(|| "failed to read params from file")?
+            .context("failed to read params from file")?
             .unwrap_or_default();
 
         self.command.run(params).await

--- a/ethexe/cli/src/params/ethereum.rs
+++ b/ethexe/cli/src/params/ethereum.rs
@@ -66,7 +66,7 @@ impl EthereumParams {
                 .ethereum_router
                 .ok_or_else(|| anyhow!("missing `ethereum-router`"))?
                 .parse()
-                .with_context(|| "invalid `ethereum-router`")?,
+                .context("invalid `ethereum-router`")?,
             block_time: Duration::from_secs(Self::BLOCK_TIME as u64),
         })
     }

--- a/ethexe/cli/src/params/mod.rs
+++ b/ethexe/cli/src/params/mod.rs
@@ -64,10 +64,8 @@ pub struct Params {
 impl Params {
     /// Load the parameters from a TOML file.
     pub fn from_file(path: PathBuf) -> Result<Self> {
-        let content =
-            std::fs::read_to_string(path).with_context(|| "failed to read params file")?;
-        let params =
-            toml::from_str(&content).with_context(|| "failed to parse toml params file")?;
+        let content = std::fs::read_to_string(path).context("failed to read params file")?;
+        let params = toml::from_str(&content).context("failed to parse toml params file")?;
 
         Ok(params)
     }

--- a/ethexe/cli/src/params/network.rs
+++ b/ethexe/cli/src/params/network.rs
@@ -75,7 +75,7 @@ impl NetworkParams {
             .network_key
             .map(|k| k.parse())
             .transpose()
-            .with_context(|| "invalid `network-key`")?;
+            .context("invalid `network-key`")?;
 
         let external_addresses = self
             .network_public_addr

--- a/ethexe/cli/src/params/node.rs
+++ b/ethexe/cli/src/params/node.rs
@@ -77,10 +77,8 @@ impl NodeParams {
         Ok(NodeConfig {
             database_path: self.db_dir(),
             key_path: self.keys_dir(),
-            sequencer: ConfigPublicKey::new(&self.sequencer)
-                .with_context(|| "invalid `sequencer` key")?,
-            validator: ConfigPublicKey::new(&self.validator)
-                .with_context(|| "invalid `validator` key")?,
+            sequencer: ConfigPublicKey::new(&self.sequencer).context("invalid `sequencer` key")?,
+            validator: ConfigPublicKey::new(&self.validator).context("invalid `validator` key")?,
             max_commitment_depth: self.max_depth.unwrap_or(Self::DEFAULT_MAX_DEPTH).get(),
             worker_threads_override: self.physical_threads.map(|v| v.get() as usize),
             virtual_threads: self

--- a/ethexe/processor/src/handling/events.rs
+++ b/ethexe/processor/src/handling/events.rs
@@ -116,10 +116,9 @@ impl ProcessingHandler {
                     });
 
                     let task = ScheduledTask::RemoveFromMailbox((actor_id, source), replied_to);
-                    transitions.remove_task(
-                        expiry,
-                        &task,
-                    ).with_context(|| format!("failed removing task {task:#?} from transitions"))?;
+                    transitions.remove_task(expiry, &task).with_context(|| {
+                        format!("failed removing task {task:#?} from transitions")
+                    })?;
 
                     let reply = Dispatch::new_reply(storage, replied_to, source, payload, value)?;
 
@@ -147,11 +146,9 @@ impl ProcessingHandler {
                     });
 
                     let task = ScheduledTask::RemoveFromMailbox((actor_id, source), claimed_id);
-                    transitions.remove_task(
-                        expiry,
-                        &task
-                    )
-                    .with_context(|| format!("failed removing task {task:#?} from transitions"))?;
+                    transitions.remove_task(expiry, &task).with_context(|| {
+                        format!("failed removing task {task:#?} from transitions")
+                    })?;
 
                     let reply = Dispatch::reply(
                         claimed_id,

--- a/ethexe/processor/src/handling/mod.rs
+++ b/ethexe/processor/src/handling/mod.rs
@@ -82,11 +82,17 @@ impl Processor {
         &mut self,
         original_code: impl AsRef<[u8]>,
     ) -> Result<Option<CodeId>> {
-        let mut executor = self.creator.instantiate().context("failed creating instance wrapper")?;
+        let mut executor = self
+            .creator
+            .instantiate()
+            .context("failed creating instance wrapper")?;
 
         let original_code = original_code.as_ref();
 
-        let Some(instrumented_code) = executor.instrument(original_code).context("failed instrumenting the code")? else {
+        let Some(instrumented_code) = executor
+            .instrument(original_code)
+            .context("failed instrumenting the code")?
+        else {
             return Ok(None);
         };
 

--- a/ethexe/processor/src/handling/mod.rs
+++ b/ethexe/processor/src/handling/mod.rs
@@ -17,7 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::Processor;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use ethexe_db::{BlockMetaStorage, CodesStorage, Database};
 use ethexe_runtime_common::{
     state::ProgramState, InBlockTransitions, ScheduleHandler, TransitionController,
@@ -82,11 +82,11 @@ impl Processor {
         &mut self,
         original_code: impl AsRef<[u8]>,
     ) -> Result<Option<CodeId>> {
-        let mut executor = self.creator.instantiate()?;
+        let mut executor = self.creator.instantiate().context("failed creating instance wrapper")?;
 
         let original_code = original_code.as_ref();
 
-        let Some(instrumented_code) = executor.instrument(original_code)? else {
+        let Some(instrumented_code) = executor.instrument(original_code).context("failed instrumenting the code")? else {
             return Ok(None);
         };
 

--- a/ethexe/processor/src/host/mod.rs
+++ b/ethexe/processor/src/host/mod.rs
@@ -78,7 +78,10 @@ impl InstanceCreator {
     pub fn instantiate(&self) -> Result<InstanceWrapper> {
         let mut store = Store::new(&self.engine, Default::default());
 
-        let instance = self.instance_pre.instantiate(&mut store).context("failed instantiating wasm module from pre-instantiation state")?;
+        let instance = self
+            .instance_pre
+            .instantiate(&mut store)
+            .context("failed instantiating wasm module from pre-instantiation state")?;
 
         let mut instance_wrapper = InstanceWrapper {
             instance,

--- a/ethexe/processor/src/host/mod.rs
+++ b/ethexe/processor/src/host/mod.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use core_processor::common::JournalNote;
 use gear_core::{code::InstrumentedCode, ids::ProgramId};
 use gprimitives::{CodeId, H256};
@@ -78,7 +78,7 @@ impl InstanceCreator {
     pub fn instantiate(&self) -> Result<InstanceWrapper> {
         let mut store = Store::new(&self.engine, Default::default());
 
-        let instance = self.instance_pre.instantiate(&mut store)?;
+        let instance = self.instance_pre.instantiate(&mut store).context("failed instantiating wasm module from pre-instantiation state")?;
 
         let mut instance_wrapper = InstanceWrapper {
             instance,

--- a/ethexe/processor/src/lib.rs
+++ b/ethexe/processor/src/lib.rs
@@ -18,7 +18,7 @@
 
 //! Program's execution service for eGPU.
 
-use anyhow::{anyhow, ensure, Result};
+use anyhow::{anyhow, ensure, Context, Result};
 use ethexe_common::events::{BlockRequestEvent, MirrorRequestEvent};
 use ethexe_db::{BlockMetaStorage, CodesStorage, Database};
 use ethexe_runtime_common::state::Storage;
@@ -93,7 +93,7 @@ impl Processor {
     ) -> Result<Vec<LocalOutcome>> {
         log::debug!("Processing upload code {code_id:?}");
 
-        let valid = code_id == CodeId::generate(code) && self.handle_new_code(code)?.is_some();
+        let valid = code_id == CodeId::generate(code) && self.handle_new_code(code).context("failed handling new code")?.is_some();
 
         self.db.set_code_valid(code_id, valid);
         Ok(vec![LocalOutcome::CodeValidated { id: code_id, valid }])
@@ -106,15 +106,15 @@ impl Processor {
     ) -> Result<Vec<LocalOutcome>> {
         log::debug!("Processing events for {block_hash:?}: {events:#?}");
 
-        let mut handler = self.handler(block_hash)?;
+        let mut handler = self.handler(block_hash).context("failed creating processing handler")?;
 
         for event in events {
             match event {
                 BlockRequestEvent::Router(event) => {
-                    handler.handle_router_event(event)?;
+                    handler.handle_router_event(event).context("failed handling router event")?;
                 }
                 BlockRequestEvent::Mirror { actor_id, event } => {
-                    handler.handle_mirror_event(actor_id, event)?;
+                    handler.handle_mirror_event(actor_id, event).context("failed handling mirror event")?;
                 }
                 BlockRequestEvent::WVara(event) => {
                     handler.handle_wvara_event(event);

--- a/ethexe/processor/src/lib.rs
+++ b/ethexe/processor/src/lib.rs
@@ -93,7 +93,11 @@ impl Processor {
     ) -> Result<Vec<LocalOutcome>> {
         log::debug!("Processing upload code {code_id:?}");
 
-        let valid = code_id == CodeId::generate(code) && self.handle_new_code(code).context("failed handling new code")?.is_some();
+        let valid = code_id == CodeId::generate(code)
+            && self
+                .handle_new_code(code)
+                .context("failed handling new code")?
+                .is_some();
 
         self.db.set_code_valid(code_id, valid);
         Ok(vec![LocalOutcome::CodeValidated { id: code_id, valid }])
@@ -106,15 +110,21 @@ impl Processor {
     ) -> Result<Vec<LocalOutcome>> {
         log::debug!("Processing events for {block_hash:?}: {events:#?}");
 
-        let mut handler = self.handler(block_hash).context("failed creating processing handler")?;
+        let mut handler = self
+            .handler(block_hash)
+            .context("failed creating processing handler")?;
 
         for event in events {
             match event {
                 BlockRequestEvent::Router(event) => {
-                    handler.handle_router_event(event).context("failed handling router event")?;
+                    handler
+                        .handle_router_event(event)
+                        .context("failed handling router event")?;
                 }
                 BlockRequestEvent::Mirror { actor_id, event } => {
-                    handler.handle_mirror_event(actor_id, event).context("failed handling mirror event")?;
+                    handler
+                        .handle_mirror_event(actor_id, event)
+                        .context("failed handling mirror event")?;
                 }
                 BlockRequestEvent::WVara(event) => {
                     handler.handle_wvara_event(event);

--- a/ethexe/rpc/src/util.rs
+++ b/ethexe/rpc/src/util.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use hyper::header::HeaderValue;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 
@@ -25,7 +25,9 @@ pub(crate) fn try_into_cors(maybe_cors: Option<Vec<String>>) -> Result<CorsLayer
         let mut list = Vec::new();
 
         for origin in cors {
-            list.push(HeaderValue::from_str(&origin)?)
+            let v = HeaderValue::from_str(&origin)
+                .with_context(|| format!("invalid cors value - {origin}"))?;
+            list.push(v);
         }
 
         Ok(CorsLayer::new().allow_origin(AllowOrigin::list(list)))

--- a/ethexe/signer/src/signature.rs
+++ b/ethexe/signer/src/signature.rs
@@ -84,12 +84,14 @@ impl Signature {
     pub fn recover_from_digest(&self, digest: Digest) -> Result<PublicKey> {
         let sig = (*self).try_into()?;
         let public_key = secp256k1::global::SECP256K1
-            .recover_ecdsa(&Message::from_digest(digest.into()), &sig)?;
+            .recover_ecdsa(&Message::from_digest(digest.into()), &sig)
+            .context("failed to recover public key from ecdsa signature")?;
         Ok(PublicKey::from_bytes(public_key.serialize()))
     }
 
     pub fn create_for_digest(private_key: PrivateKey, digest: Digest) -> Result<Signature> {
-        let raw_signature = RawSignature::create_for_digest(private_key, digest)?;
+        let raw_signature = RawSignature::create_for_digest(private_key, digest)
+            .context("failed creating raw signature for digest")?;
         Ok(raw_signature.into())
     }
 }

--- a/ethexe/signer/src/signature.rs
+++ b/ethexe/signer/src/signature.rs
@@ -33,7 +33,7 @@ pub struct RawSignature([u8; 65]);
 impl RawSignature {
     pub fn create_for_digest(private_key: PrivateKey, digest: Digest) -> Result<RawSignature> {
         let secp_secret_key = secp256k1::SecretKey::from_slice(&private_key.0)
-            .with_context(|| "Invalid secret key format")?;
+            .context("Invalid secret key format")?;
 
         let message = Message::from_digest(digest.into());
 


### PR DESCRIPTION
Adds `anyhow::Context::context` calls to errors returned from the most important crates and fns (`ethexe-cli` and 2-3 nested levels)