### PR TITLE
fix(crates-io): fix late partial publishing 

### DIFF
--- a/scripts/src/init.sh
+++ b/scripts/src/init.sh
@@ -25,6 +25,7 @@ wasm_init() {
     rustup update stable
   fi
 
+  rustup target add wasm32v1-none --toolchain stable
   rustup target add wasm32v1-none --toolchain nightly
 }
 

--- a/utils/crates-io/src/handler.rs
+++ b/utils/crates-io/src/handler.rs
@@ -38,8 +38,8 @@ pub fn crates_io_name(pkg: &str) -> &str {
 }
 
 /// Patch specified manifest by provided name.
-pub fn patch(pkg: &Package, is_published: bool) -> Result<Manifest> {
-    let mut manifest = Manifest::new(pkg, is_published)?;
+pub fn patch(pkg: &Package, is_published: bool, is_actualized: bool) -> Result<Manifest> {
+    let mut manifest = Manifest::new(pkg, is_published, is_actualized)?;
     let doc = &mut manifest.mutable_manifest;
 
     match manifest.name.as_str() {

--- a/utils/crates-io/src/manifest.rs
+++ b/utils/crates-io/src/manifest.rs
@@ -53,6 +53,7 @@ impl Workspace {
                 mutable_manifest,
                 path,
                 is_published: true,
+                is_actualized: true,
             },
             lock_file: LockFile {
                 content,
@@ -190,12 +191,14 @@ pub struct Manifest {
     pub path: PathBuf,
     /// Whether the crate is published
     pub is_published: bool,
+    /// Whether the current version is published
+    pub is_actualized: bool,
 }
 
 impl Manifest {
     /// Complete the manifest of the specified crate from
     /// the workspace manifest
-    pub fn new(pkg: &Package, is_published: bool) -> Result<Self> {
+    pub fn new(pkg: &Package, is_published: bool, is_actualized: bool) -> Result<Self> {
         let original_manifest: DocumentMut = fs::read_to_string(&pkg.manifest_path)?.parse()?;
         let mut mutable_manifest = original_manifest.clone();
 
@@ -210,6 +213,7 @@ impl Manifest {
             mutable_manifest,
             path: pkg.manifest_path.clone().into(),
             is_published,
+            is_actualized,
         })
     }
 


### PR DESCRIPTION
Changes:
* Manifest.is_actualized is bool field defining if current version is already published
* rustup toolchain adds wasm target for stable toolchain on `make init`
