### PR TITLE
refactor: Lower panic data restriction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3603,6 +3603,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "demo-panic-payload"
+version = "0.1.0"
+dependencies = [
+ "gear-core",
+ "gear-wasm-builder",
+ "gstd",
+ "gtest",
+]
+
+[[package]]
 name = "demo-piggy-bank"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ members = [
     "examples/ncompose",
     "examples/node",
     "examples/out-of-memory",
+    "examples/panic-payload",
     "examples/piggy-bank",
     "examples/ping",
     "examples/program-factory",

--- a/core-backend/src/error.rs
+++ b/core-backend/src/error.rs
@@ -21,8 +21,7 @@ use codec::{Decode, Encode};
 use gear_core::{
     gas::{ChargeError, CounterType},
     ids::ProgramId,
-    message::MessageWaitedType,
-    str::LimitedStr,
+    message::{MessageWaitedType, PanicBuffer},
 };
 use gear_core_errors::ExtError as FallibleExtError;
 
@@ -226,7 +225,7 @@ pub enum TrapExplanation {
     #[display(fmt = "Syscall unrecoverable error: {_0}")]
     UnrecoverableExt(UnrecoverableExtError),
     #[display(fmt = "Panic occurred: {_0}")]
-    Panic(LimitedStr<'static>),
+    Panic(PanicBuffer),
     #[display(fmt = "Stack limit exceeded")]
     StackLimitExceeded,
     #[display(fmt = "Reason is unknown. Possibly `unreachable` instruction is occurred")]

--- a/core-backend/src/funcs.rs
+++ b/core-backend/src/funcs.rs
@@ -32,10 +32,7 @@ use crate::{
     state::HostState,
     BackendExternalities,
 };
-use alloc::{
-    format,
-    string::{String, ToString},
-};
+use alloc::{format, string::String};
 use blake2::{digest::typenum::U32, Blake2b, Digest};
 use core::marker::PhantomData;
 use gear_core::{
@@ -1112,9 +1109,7 @@ where
             let io = registry.pre_process(ctx)?;
             let data = io.read(ctx, read_data).unwrap_or_default();
 
-            let s = String::from_utf8_lossy(&data).to_string();
-
-            Err(ActorTerminationReason::Trap(TrapExplanation::Panic(s.into())).into())
+            Err(ActorTerminationReason::Trap(TrapExplanation::Panic(data.into())).into())
         })
     }
 

--- a/core-processor/src/processing.rs
+++ b/core-processor/src/processing.rs
@@ -39,7 +39,7 @@ use gear_core::{
     reservation::GasReservationState,
 };
 use gear_core_backend::{
-    error::{BackendAllocSyscallError, BackendSyscallError, RunFallibleError},
+    error::{BackendAllocSyscallError, BackendSyscallError, RunFallibleError, TrapExplanation},
     BackendExternalities,
 };
 use gear_core_errors::{ErrorReplyReason, SignalCode};
@@ -208,7 +208,7 @@ enum ProcessErrorCase {
 }
 
 impl ProcessErrorCase {
-    pub fn to_reason_and_payload(&self) -> (ErrorReplyReason, String) {
+    pub fn to_reason_and_payload_str(&self) -> (ErrorReplyReason, String) {
         match self {
             ProcessErrorCase::NonExecutable => {
                 let reason = ErrorReplyReason::InactiveActor;
@@ -220,6 +220,18 @@ impl ProcessErrorCase {
             ProcessErrorCase::ReinstrumentationFailed => {
                 let err = ErrorReplyReason::ReinstrumentationFailure;
                 (err, err.to_string())
+            }
+        }
+    }
+
+    pub fn to_reason_and_payload(&self) -> (ErrorReplyReason, Vec<u8>) {
+        match self {
+            ProcessErrorCase::ExecutionFailed(
+                reason @ ActorExecutionErrorReplyReason::Trap(TrapExplanation::Panic(buf)),
+            ) => (reason.as_simple().into(), buf.inner().to_vec()),
+            this => {
+                let (reason, payload) = this.to_reason_and_payload_str();
+                (reason, payload.into_bytes())
             }
         }
     }
@@ -285,8 +297,8 @@ fn process_error(
         let (err, err_payload) = case.to_reason_and_payload();
 
         // Panic is impossible, unless error message is too large or [Payload] max size is too small.
-        let err_payload = err_payload.into_bytes().try_into().unwrap_or_else(|_| {
-            let (_, err_payload) = case.to_reason_and_payload();
+        let err_payload = err_payload.try_into().unwrap_or_else(|_| {
+            let (_, err_payload) = case.to_reason_and_payload_str();
             let err_msg =
                 format!("process_error: Error message is too big. Message id - {message_id}, error payload - {err_payload}",
             );
@@ -317,7 +329,7 @@ fn process_error(
 
     let outcome = match case {
         ProcessErrorCase::ExecutionFailed { .. } | ProcessErrorCase::ReinstrumentationFailed => {
-            let (_, err_payload) = case.to_reason_and_payload();
+            let (_, err_payload) = case.to_reason_and_payload_str();
             match dispatch.kind() {
                 DispatchKind::Init => DispatchOutcome::InitFailure {
                     program_id,

--- a/core/src/message/mod.rs
+++ b/core/src/message/mod.rs
@@ -93,6 +93,11 @@ impl Payload {
 pub struct PanicBuffer(Payload);
 
 impl PanicBuffer {
+    /// Returns ref to the internal data.
+    pub fn inner(&self) -> &[u8] {
+        self.0.inner()
+    }
+
     fn as_limited_str(&self) -> Option<LimitedStr> {
         let s = core::str::from_utf8(self.0.inner()).ok()?;
         LimitedStr::try_from(s).ok()
@@ -106,7 +111,7 @@ where
     fn from(value: T) -> Self {
         let value = value.as_ref();
         let upper_bound = value.len().min(MAX_PAYLOAD_SIZE);
-        Payload::try_from(&value.as_ref()[..upper_bound])
+        Payload::try_from(&value[..upper_bound])
             .map(Self)
             .unwrap_or_else(|PayloadSizeError| unreachable!("payload size is always limited"))
     }

--- a/core/src/str.rs
+++ b/core/src/str.rs
@@ -69,6 +69,11 @@ impl<'a> LimitedStr<'a> {
     pub fn as_str(&self) -> &str {
         self.0.as_ref()
     }
+
+    /// Return inner value.
+    pub fn into_inner(self) -> Cow<'a, str> {
+        self.0
+    }
 }
 
 /// The error type returned when a conversion from `&str` to [`LimitedStr`] fails.

--- a/examples/panic-payload/Cargo.toml
+++ b/examples/panic-payload/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "demo-panic-payload"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+gstd = { workspace = true, features = ["debug"] }
+
+[dev-dependencies]
+gear-core.workspace = true
+gtest.workspace = true
+
+[build-dependencies]
+gear-wasm-builder.workspace = true
+
+[features]
+debug = ["gstd/debug"]
+default = ["std"]
+std = []

--- a/examples/panic-payload/build.rs
+++ b/examples/panic-payload/build.rs
@@ -1,0 +1,21 @@
+// This file is part of Gear.
+
+// Copyright (C) 2023-2025 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+fn main() {
+    gear_wasm_builder::build();
+}

--- a/examples/panic-payload/src/lib.rs
+++ b/examples/panic-payload/src/lib.rs
@@ -1,0 +1,66 @@
+// This file is part of Gear.
+
+// Copyright (C) 2023-2025 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#![no_std]
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+mod code {
+    include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+}
+
+#[cfg(feature = "std")]
+pub use code::WASM_BINARY_OPT as WASM_BINARY;
+
+#[cfg(not(feature = "std"))]
+mod wasm;
+
+#[cfg(test)]
+mod tests {
+    use gear_core::ids::prelude::MessageIdExt;
+    use gstd::{ActorId, MessageId};
+    use gtest::{constants::DEFAULT_USER_ALICE, Program, System};
+
+    #[test]
+    fn payload_received() {
+        let system = System::new();
+        system.init_logger();
+
+        let panicking_prog = Program::current(&system);
+        let sending_prog = Program::current(&system);
+
+        // init
+        let panicking_init_id = panicking_prog.send(DEFAULT_USER_ALICE, ActorId::zero());
+        let sending_init_id = sending_prog.send(DEFAULT_USER_ALICE, panicking_prog.id());
+
+        let res = system.run_next_block();
+        assert!(res.succeed.contains(&panicking_init_id));
+        assert!(res.succeed.contains(&sending_init_id));
+
+        // handle
+        let sending_handle_id = sending_prog.send_bytes(DEFAULT_USER_ALICE, []);
+
+        let mut res = system.run_next_block();
+        assert!(res.succeed.contains(&sending_handle_id));
+        assert_eq!(res.failed.len(), 1);
+        let panicked_msg_id = res.failed.pop_first().unwrap();
+        let reply_msg_id = MessageId::generate_reply(panicked_msg_id);
+        assert!(res.succeed.contains(&reply_msg_id));
+    }
+}

--- a/examples/panic-payload/src/wasm.rs
+++ b/examples/panic-payload/src/wasm.rs
@@ -1,0 +1,44 @@
+// This file is part of Gear.
+
+// Copyright (C) 2023-2025 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use gstd::{ext, msg, prelude::*, ActorId};
+
+static mut PANICKING_ID: ActorId = ActorId::zero();
+
+#[unsafe(no_mangle)]
+extern "C" fn init() {
+    let id = msg::load().unwrap();
+    unsafe {
+        PANICKING_ID = id;
+    }
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn handle() {
+    if !unsafe { PANICKING_ID }.is_zero() {
+        msg::send_bytes(unsafe { PANICKING_ID }, b"1234", 0).expect("Failed to send message");
+    } else {
+        ext::panic(b"\xE0\x80\x80");
+    }
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn handle_reply() {
+    let payload = msg::load_bytes().unwrap();
+    assert_eq!(payload, b"\xE0\x80\x80");
+}

--- a/gcore/src/utils.rs
+++ b/gcore/src/utils.rs
@@ -106,6 +106,8 @@ pub mod ext {
 
     /// Panic
     ///
+    /// Can be used to pass some data to error reply payload.
+    ///
     /// Function is completely free in terms of gas usage.
     ///
     /// # Examples
@@ -115,11 +117,29 @@ pub mod ext {
     ///
     /// #[unsafe(no_mangle)]
     /// extern "C" fn handle() {
-    ///     ext::panic("I decided to panic");
+    ///     ext::panic(&[0, 1, 2, 3]);
     /// }
     /// ```
-    pub fn panic(data: &str) -> ! {
+    pub fn panic(data: &[u8]) -> ! {
         unsafe { gsys::gr_panic(data.as_ptr(), data.len() as u32) }
+    }
+
+    /// Panic
+    ///
+    /// Function is completely free in terms of gas usage.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gcore::ext;
+    ///
+    /// #[unsafe(no_mangle)]
+    /// extern "C" fn handle() {
+    ///     ext::panic_str("I decided to panic");
+    /// }
+    /// ```
+    pub fn panic_str(data: &str) -> ! {
+        panic(data.as_bytes())
     }
 
     /// Out of memory panic

--- a/gstd/src/common/errors.rs
+++ b/gstd/src/common/errors.rs
@@ -126,6 +126,11 @@ impl From<ConversionError> for Error {
 pub struct ErrorReplyPayload(pub Vec<u8>);
 
 impl ErrorReplyPayload {
+    /// Returns byte slice.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
     /// Represents self as utf-8 str, if possible.
     pub fn try_as_str(&self) -> Option<&str> {
         str::from_utf8(&self.0).ok()
@@ -136,6 +141,11 @@ impl ErrorReplyPayload {
     #[track_caller]
     pub fn as_str(&self) -> &str {
         str::from_utf8(&self.0).expect("Failed to create `str`")
+    }
+
+    /// Returns inner byte vector.
+    pub fn into_inner(self) -> Vec<u8> {
+        self.0
     }
 }
 

--- a/gstd/src/common/handlers.rs
+++ b/gstd/src/common/handlers.rs
@@ -66,7 +66,7 @@ mod panic_handler {
         #[cfg(feature = "debug")]
         let _ = ext::debug(MESSAGE);
 
-        ext::panic(MESSAGE)
+        ext::panic_str(MESSAGE)
     }
 
     /// Panic handler with extra information.
@@ -92,6 +92,6 @@ mod panic_handler {
         #[cfg(feature = "debug")]
         let _ = ext::debug(&debug_msg);
 
-        ext::panic(&debug_msg)
+        ext::panic_str(&debug_msg)
     }
 }

--- a/gtest/src/manager/block_exec.rs
+++ b/gtest/src/manager/block_exec.rs
@@ -17,7 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use core_processor::SuccessfulDispatchResultKind;
-use gear_core::{code::MAX_WASM_PAGES_AMOUNT, gas::GasCounter, str::LimitedStr};
+use gear_core::{code::MAX_WASM_PAGES_AMOUNT, gas::GasCounter};
 use task::get_maximum_task_gas;
 
 use super::*;
@@ -515,9 +515,8 @@ impl ExtManager {
             Err(expl) => {
                 mock.debug(expl);
 
-                let err_reply_reason = ActorExecutionErrorReplyReason::Trap(
-                    TrapExplanation::Panic(LimitedStr::from_small_str(expl)),
-                );
+                let err_reply_reason =
+                    ActorExecutionErrorReplyReason::Trap(TrapExplanation::Panic(expl.into()));
                 core_processor::process_execution_error(
                     dispatch,
                     program_id,

--- a/pallets/gear-builtin/src/lib.rs
+++ b/pallets/gear-builtin/src/lib.rs
@@ -112,7 +112,7 @@ impl From<BuiltinActorError> for ActorExecutionErrorReplyReason {
                 TrapExplanation::Panic("Message decoding error".to_string().into()),
             ),
             BuiltinActorError::Custom(e) => {
-                ActorExecutionErrorReplyReason::Trap(TrapExplanation::Panic(e))
+                ActorExecutionErrorReplyReason::Trap(TrapExplanation::Panic(e.into()))
             }
             BuiltinActorError::GasAllowanceExceeded => {
                 unreachable!("Never supposed to be converted to error reply reason")


### PR DESCRIPTION
Now `gr_panic` accepts any byte string, not only UTF-8 one