### PR TITLE
refactor(gear-bank): Derive gear bank account id from the pallet id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11057,6 +11057,7 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]

--- a/gclient/src/api/calls.rs
+++ b/gclient/src/api/calls.rs
@@ -360,8 +360,10 @@ impl GearApi {
                 }
             })?;
 
+        let bank_address = self.bank_address().await?;
+
         let src_bank_account_data = self
-            .account_data_at(crate::bank_address(), src_block_hash)
+            .account_data_at(bank_address.clone(), src_block_hash)
             .await
             .or_else(|e| {
                 if let Error::GearSDK(GsdkError::StorageNotFound) = e {
@@ -443,7 +445,7 @@ impl GearApi {
             .await?;
 
         dest_node_api
-            .force_set_balance(crate::bank_address(), src_bank_account_data.free)
+            .force_set_balance(bank_address, src_bank_account_data.free)
             .await?;
 
         dest_node_api

--- a/gclient/src/api/storage/mod.rs
+++ b/gclient/src/api/storage/mod.rs
@@ -119,7 +119,7 @@ impl GearApi {
     }
 
     /// Get bank account data by `account_id` at specified block.
-    pub(crate) async fn bank_address(&self) -> Result<AccountId32> {
+    pub async fn bank_address(&self) -> Result<AccountId32> {
         Ok(self.0.api().bank_address().await?)
     }
 

--- a/gclient/src/api/storage/mod.rs
+++ b/gclient/src/api/storage/mod.rs
@@ -24,7 +24,10 @@ use crate::Error;
 use account_id::IntoAccountId32;
 use gear_core::{ids::*, message::UserStoredMessage};
 use gsdk::{
-    ext::sp_core::{crypto::Ss58Codec, H256},
+    ext::{
+        sp_core::{crypto::Ss58Codec, H256},
+        sp_runtime::AccountId32,
+    },
     metadata::runtime_types::{
         gear_common::storage::primitives::Interval, gear_core::message::user,
         pallet_balances::types::AccountData, pallet_gear_bank::pallet::BankAccount,
@@ -113,6 +116,11 @@ impl GearApi {
             .api()
             .bank_info_at(account_id.into_account_id(), block_hash)
             .await?)
+    }
+
+    /// Get bank account data by `account_id` at specified block.
+    pub(crate) async fn bank_address(&self) -> Result<AccountId32> {
+        Ok(self.0.api().bank_address().await?)
     }
 
     /// Get the total balance of the account identified by `account_id`.

--- a/gclient/src/utils.rs
+++ b/gclient/src/utils.rs
@@ -18,7 +18,6 @@
 
 use crate::{Error, Result};
 pub use gear_utils::now_micros;
-use gsdk::ext::sp_runtime::AccountId32;
 use std::{fs, path::Path};
 
 /// Return the full path to the optimized Wasm binary file with the `demo_name`
@@ -51,11 +50,4 @@ pub fn code_from_os(path: impl AsRef<Path>) -> Result<Vec<u8>> {
 /// Convert hex string to byte array.
 pub fn hex_to_vec(string: impl AsRef<str>) -> Result<Vec<u8>> {
     hex::decode(string.as_ref().trim_start_matches("0x")).map_err(Into::into)
-}
-
-/// Returns default bank address.
-pub fn bank_address() -> AccountId32 {
-    const BANK_ADDRESS: [u8; 32] = *b"gearbankgearbankgearbankgearbank";
-
-    BANK_ADDRESS.into()
 }

--- a/gsdk/src/metadata/generated.rs
+++ b/gsdk/src/metadata/generated.rs
@@ -11596,6 +11596,7 @@ pub mod storage {
     #[doc = "Storage of pallet `GearBank`."]
     pub enum GearBankStorage {
         Bank,
+        BankAddress,
         UnusedValue,
         OnFinalizeTransfers,
         OnFinalizeValue,
@@ -11605,6 +11606,7 @@ pub mod storage {
         fn storage_name(&self) -> &'static str {
             match self {
                 Self::Bank => "Bank",
+                Self::BankAddress => "BankAddress",
                 Self::UnusedValue => "UnusedValue",
                 Self::OnFinalizeTransfers => "OnFinalizeTransfers",
                 Self::OnFinalizeValue => "OnFinalizeValue",

--- a/gsdk/src/storage.rs
+++ b/gsdk/src/storage.rs
@@ -219,8 +219,9 @@ impl Api {
         let thunk = self
             .get_storage(None)
             .await?
-            .fetch_or_default(&addr)
+            .fetch(&addr)
             .await?
+            .ok_or(Error::StorageNotFound)?
             .into_encoded();
         Ok(AccountId32::decode(&mut thunk.as_ref())?)
     }

--- a/gsdk/src/storage.rs
+++ b/gsdk/src/storage.rs
@@ -212,6 +212,18 @@ impl Api {
 
         self.fetch_storage_at(&addr, block_hash).await
     }
+
+    /// Get Gear bank's sovereign account id.
+    pub async fn bank_address(&self) -> Result<AccountId32> {
+        let addr = Self::storage_root(GearBankStorage::BankAddress);
+        let thunk = self
+            .get_storage(None)
+            .await?
+            .fetch_or_default(&addr)
+            .await?
+            .into_encoded();
+        Ok(AccountId32::decode(&mut thunk.as_ref())?)
+    }
 }
 
 // pallet-gear

--- a/node/testing/src/genesis.rs
+++ b/node/testing/src/genesis.rs
@@ -22,7 +22,7 @@ use crate::keyring::*;
 use sp_keyring::{Ed25519Keyring, Sr25519Keyring};
 use sp_runtime::{Perbill, Perquintill};
 use vara_runtime::{
-    constants::currency::*, AccountId, BabeConfig, BalancesConfig, BankAddress, GrandpaConfig,
+    constants::currency::*, AccountId, BabeConfig, BalancesConfig, GearBank, GrandpaConfig,
     RuntimeGenesisConfig, SessionConfig, StakerStatus, StakingConfig, StakingRewardsConfig,
     SudoConfig, BABE_GENESIS_EPOCH_CONFIG,
 };
@@ -42,7 +42,7 @@ pub fn config_endowed(extra_endowed: Vec<AccountId>) -> RuntimeGenesisConfig {
         (dave(), 111 * ECONOMIC_UNITS),
         (eve(), 101 * ECONOMIC_UNITS),
         (ferdie(), 100 * ECONOMIC_UNITS),
-        (BankAddress::get(), UNITS),
+        (GearBank::bank_address(), UNITS),
     ];
 
     endowed.extend(

--- a/node/testing/src/genesis.rs
+++ b/node/testing/src/genesis.rs
@@ -22,9 +22,9 @@ use crate::keyring::*;
 use sp_keyring::{Ed25519Keyring, Sr25519Keyring};
 use sp_runtime::{Perbill, Perquintill};
 use vara_runtime::{
-    constants::currency::*, AccountId, BabeConfig, BalancesConfig, GearBank, GrandpaConfig,
-    RuntimeGenesisConfig, SessionConfig, StakerStatus, StakingConfig, StakingRewardsConfig,
-    SudoConfig, BABE_GENESIS_EPOCH_CONFIG,
+    constants::currency::*, AccountId, BabeConfig, BalancesConfig, GearBank, GearBankConfig,
+    GrandpaConfig, RuntimeGenesisConfig, SessionConfig, StakerStatus, StakingConfig,
+    StakingRewardsConfig, SudoConfig, BABE_GENESIS_EPOCH_CONFIG,
 };
 
 /// Create genesis runtime configuration for tests.
@@ -118,6 +118,9 @@ pub fn config_endowed(extra_endowed: Vec<AccountId>) -> RuntimeGenesisConfig {
             ideal_stake: Perquintill::from_percent(85), // 85%
             target_inflation: Perquintill::from_rational(578_u64, 10_000_u64), // 5.78%
             filtered_accounts: Default::default(),
+        },
+        gear_bank: GearBankConfig {
+            _config: Default::default(),
         },
     }
 }

--- a/pallets/gear-bank/Cargo.toml
+++ b/pallets/gear-bank/Cargo.toml
@@ -20,7 +20,9 @@ frame-support.workspace = true
 frame-system.workspace = true
 frame-benchmarking = { workspace = true, optional = true }
 pallet-authorship.workspace = true
+pallet-balances.workspace = true
 sp-runtime.workspace = true
+sp-std.workspace = true
 
 [dev-dependencies]
 common = { workspace = true, features = ["std"] }

--- a/pallets/gear-bank/src/lib.rs
+++ b/pallets/gear-bank/src/lib.rs
@@ -33,10 +33,13 @@ use alloc::format;
 
 pub use pallet::*;
 
-use frame_support::traits::{
-    fungible,
-    tokens::{Fortitude, Preservation, Provenance},
-    Currency, StorageVersion,
+use frame_support::{
+    traits::{
+        fungible,
+        tokens::{Fortitude, Preservation, Provenance},
+        Currency, StorageVersion,
+    },
+    PalletId,
 };
 
 #[macro_export]
@@ -62,7 +65,7 @@ macro_rules! impl_config_inner {
     ($runtime:ty$(,)?) => {
         impl pallet_gear_bank::Config for $runtime {
             type Currency = Balances;
-            type BankAddress = BankAddress;
+            type PalletId = BankPalletId;
             type GasMultiplier = GasMultiplier;
             type TreasuryAddress = GearBankConfigTreasuryAddress;
             type TreasuryGasFeeShare = GearBankConfigTreasuryGasFeeShare;
@@ -101,11 +104,11 @@ pub(crate) const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 #[frame_support::pallet]
 pub mod pallet {
     use super::*;
-    use core::ops::Add;
+    use core::{marker::PhantomData, ops::Add};
     use frame_support::{
         ensure,
         pallet_prelude::{StorageMap, StorageValue, ValueQuery},
-        sp_runtime::Saturating,
+        sp_runtime::{traits::AccountIdConversion, Saturating},
         traits::{
             tokens::DepositConsequence, ExistenceRequirement, Get, Hooks, LockableCurrency,
             ReservableCurrency,
@@ -132,9 +135,9 @@ pub mod pallet {
             + LockableCurrency<AccountIdOf<Self>>
             + fungible::Unbalanced<AccountIdOf<Self>, Balance = BalanceOf<Self>>;
 
-        /// Bank account address, that will keep all reserved funds.
+        /// The gear bank's pallet id, used for deriving its sovereign account ID.
         #[pallet::constant]
-        type BankAddress: Get<AccountIdOf<Self>>;
+        type PalletId: Get<PalletId>;
 
         /// Gas price converter.
         #[pallet::constant]
@@ -228,6 +231,18 @@ pub mod pallet {
     #[pallet::storage]
     type Bank<T> = StorageMap<_, Identity, AccountIdOf<T>, BankAccount<BalanceOf<T>>>;
 
+    /// The default account ID of the Gear Bank.
+    struct DefaulBankAddress<T: Config>(PhantomData<T>);
+    impl<T: Config> Get<AccountIdOf<T>> for DefaulBankAddress<T> {
+        fn get() -> AccountIdOf<T> {
+            Pallet::<T>::bank_address()
+        }
+    }
+
+    // Private storage to hold the GearBank's AccountId.
+    #[pallet::storage]
+    type BankAddress<T> = StorageValue<_, AccountIdOf<T>, ValueQuery, DefaulBankAddress<T>>;
+
     // Private storage that keeps amount of value that wasn't sent because owner is inexistent account.
     #[pallet::storage]
     pub type UnusedValue<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
@@ -282,13 +297,21 @@ pub mod pallet {
     }
 
     impl<T: Config> Pallet<T> {
+        /// The account ID of the Gear Bank.
+        ///
+        /// This does some computation. Since GearBank account ID is used often,
+        /// the value should better be cached in the pallet storage.
+        pub fn bank_address() -> T::AccountId {
+            T::PalletId::get().into_account_truncating()
+        }
+
         /// Transfers value from `account_id` to bank address.
         fn deposit(
             account_id: &AccountIdOf<T>,
             value: BalanceOf<T>,
             keep_alive: bool,
         ) -> Result<(), Error<T>> {
-            let bank_address = T::BankAddress::get();
+            let bank_address = BankAddress::<T>::get();
 
             match <CurrencyOf<T> as fungible::Inspect<_>>::can_deposit(
                 &bank_address,
@@ -320,7 +343,7 @@ pub mod pallet {
         /// Ensures that bank account is able to transfer requested value.
         fn ensure_bank_can_transfer(value: BalanceOf<T>) -> Result<(), Error<T>> {
             let available_balance = <CurrencyOf<T> as fungible::Inspect<_>>::reducible_balance(
-                &T::BankAddress::get(),
+                &BankAddress::<T>::get(),
                 Preservation::Expendable,
                 Fortitude::Polite,
             )
@@ -357,7 +380,7 @@ pub mod pallet {
 
             // Check on zero value is inside `pallet_balances` implementation.
             CurrencyOf::<T>::transfer(
-                &T::BankAddress::get(),
+                &BankAddress::<T>::get(),
                 account_id,
                 value,
                 // We always require bank account to be alive.
@@ -679,7 +702,7 @@ pub mod pallet {
 
         fn bank_balance_full_data() -> (BalanceOf<T>, BalanceOf<T>, BalanceOf<T>) {
             (
-                Self::reducible_balance(&T::BankAddress::get()),
+                Self::reducible_balance(&BankAddress::<T>::get()),
                 UnusedValue::<T>::get(),
                 OnFinalizeValue::<T>::get(),
             )

--- a/pallets/gear-bank/src/lib.rs
+++ b/pallets/gear-bank/src/lib.rs
@@ -23,6 +23,8 @@
 
 extern crate alloc;
 
+pub mod migrations;
+
 #[cfg(test)]
 mod mock;
 
@@ -99,7 +101,7 @@ pub(crate) type GasMultiplier<T> = common::GasMultiplier<BalanceOf<T>, u64>;
 pub(crate) type GasMultiplierOf<T> = <T as Config>::GasMultiplier;
 
 /// The current storage version.
-pub(crate) const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+pub(crate) const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/pallets/gear-bank/src/lib.rs
+++ b/pallets/gear-bank/src/lib.rs
@@ -234,7 +234,7 @@ pub mod pallet {
     type Bank<T> = StorageMap<_, Identity, AccountIdOf<T>, BankAccount<BalanceOf<T>>>;
 
     /// The default account ID of the Gear Bank.
-    struct DefaulBankAddress<T: Config>(PhantomData<T>);
+    pub struct DefaulBankAddress<T: Config>(PhantomData<T>);
     impl<T: Config> Get<AccountIdOf<T>> for DefaulBankAddress<T> {
         fn get() -> AccountIdOf<T> {
             Pallet::<T>::bank_address()
@@ -243,7 +243,7 @@ pub mod pallet {
 
     // Private storage to hold the GearBank's AccountId.
     #[pallet::storage]
-    type BankAddress<T> = StorageValue<_, AccountIdOf<T>, ValueQuery, DefaulBankAddress<T>>;
+    pub type BankAddress<T> = StorageValue<_, AccountIdOf<T>, ValueQuery, DefaulBankAddress<T>>;
 
     // Private storage that keeps amount of value that wasn't sent because owner is inexistent account.
     #[pallet::storage]

--- a/pallets/gear-bank/src/migrations.rs
+++ b/pallets/gear-bank/src/migrations.rs
@@ -203,6 +203,9 @@ mod tests {
             .assimilate_storage(&mut storage)
             .unwrap();
 
+        // Note: pallet_gear_bank GenesisConfig is deliberately not applied to simulate
+        // current on-chain situation where the bank address is not present in storage.
+
         sp_io::TestExternalities::new(storage)
     }
 

--- a/pallets/gear-bank/src/migrations.rs
+++ b/pallets/gear-bank/src/migrations.rs
@@ -61,7 +61,7 @@ where
 
             // Transfer all funds from the old gear bank account to the new one
             if Balances::<T>::transfer_all(
-                OriginFor::<T>::signed(T::AccountId::from_origin(OLD_BANK_ADDRESS.into()).cast()),
+                OriginFor::<T>::signed(T::AccountId::from_origin(OLD_BANK_ADDRESS.into())),
                 T::Lookup::unlookup(Pallet::<T>::bank_address()),
                 false,
             )

--- a/pallets/gear-bank/src/migrations.rs
+++ b/pallets/gear-bank/src/migrations.rs
@@ -1,0 +1,234 @@
+// This file is part of Gear.
+//
+// Copyright (C) 2024-2025 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{Config, Pallet};
+use common::Origin;
+use frame_support::{
+    pallet_prelude::Weight,
+    traits::{Currency, Get, GetStorageVersion, OnRuntimeUpgrade, OriginTrait},
+};
+use frame_system::pallet_prelude::OriginFor;
+use pallet_balances::{Pallet as Balances, WeightInfo};
+use sp_runtime::traits::{StaticLookup, Zero};
+
+#[cfg(feature = "try-runtime")]
+use {
+    frame_support::ensure,
+    sp_runtime::{
+        codec::{Decode, Encode},
+        TryRuntimeError,
+    },
+    sp_std::vec::Vec,
+};
+
+const OLD_BANK_ADDRESS: [u8; 32] = *b"gearbankgearbankgearbankgearbank";
+
+pub(crate) type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
+pub(crate) type BalanceOf<T> = <<T as Config>::Currency as Currency<AccountIdOf<T>>>::Balance;
+
+pub struct MigrateToV1<T>(sp_std::marker::PhantomData<T>);
+impl<T: Config> OnRuntimeUpgrade for MigrateToV1<T>
+where
+    T: pallet_balances::Config,
+    T::AccountId: Origin,
+{
+    fn on_runtime_upgrade() -> Weight {
+        let current = Pallet::<T>::in_code_storage_version();
+        let on_chain = Pallet::<T>::on_chain_storage_version();
+
+        if current == 1 && on_chain == 0 {
+            current.put::<Pallet<T>>();
+
+            // Transfer all funds from the old gear bank account to the new one
+            if Balances::<T>::transfer_all(
+                OriginFor::<T>::signed(T::AccountId::from_origin(OLD_BANK_ADDRESS.into()).cast()),
+                T::Lookup::unlookup(Pallet::<T>::bank_address()),
+                false,
+            )
+            .is_ok()
+            {
+                log::info!("Migration to v1 applied successfully.");
+            } else {
+                log::error!("Migration to v1 failed");
+            }
+
+            <T as pallet_balances::Config>::WeightInfo::transfer_all()
+                .saturating_add(T::DbWeight::get().reads_writes(2, 1))
+        } else {
+            log::warn!("v1 migration is not applicable.");
+            T::DbWeight::get().reads(2)
+        }
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+        let current = Pallet::<T>::in_code_storage_version();
+        let onchain = Pallet::<T>::on_chain_storage_version();
+
+        let res = if current == 1 && onchain == 0 {
+            Some((
+                T::Currency::free_balance(&T::AccountId::from_origin(OLD_BANK_ADDRESS.into())),
+                T::Currency::free_balance(&Pallet::<T>::bank_address()),
+            ))
+        } else {
+            None
+        };
+
+        Ok(res.encode())
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn post_upgrade(state: Vec<u8>) -> Result<(), TryRuntimeError> {
+        if let Some(old_balances) =
+            Option::<(BalanceOf<T>, BalanceOf<T>)>::decode(&mut state.as_ref())
+                .map_err(|_| "`pre_upgrade` provided an invalid state")?
+        {
+            let new_balances = (
+                T::Currency::free_balance(&T::AccountId::from_origin(OLD_BANK_ADDRESS.into())),
+                T::Currency::free_balance(&Pallet::<T>::bank_address()),
+            );
+
+            ensure!(
+                new_balances.0 == BalanceOf::<T>::zero(),
+                "Old gear bank address still has funds"
+            );
+            ensure!(
+                new_balances.1 == old_balances.0,
+                "Balance at destination is different from the source"
+            );
+            ensure!(
+                Pallet::<T>::on_chain_storage_version() == 1,
+                "v1 not applied"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(all(feature = "try-runtime", test))]
+mod tests {
+    use super::*;
+    use crate as pallet_gear_bank;
+    use frame_support::{
+        assert_ok, construct_runtime, parameter_types,
+        traits::{ConstU32, FindAuthor, StorageVersion},
+        weights::constants::RocksDbWeight,
+        PalletId,
+    };
+    use primitive_types::H256;
+    use sp_runtime::{
+        traits::{BlakeTwo256, IdentityLookup},
+        AccountId32, BuildStorage,
+    };
+
+    static BLOCK_AUTHOR: AccountId32 = AccountId32::new(*b"blk/author/blk/author/blk/author");
+    const EXISTENTIAL_DEPOSIT: Balance = 100_000;
+
+    type AccountId = AccountId32;
+    type Block = frame_system::mocking::MockBlock<Test>;
+    type Balance = u128;
+    type BlockNumber = u64;
+
+    parameter_types! {
+        pub const BankPalletId: PalletId = PalletId(*b"py/gbank");
+        pub const GasMultiplier: common::GasMultiplier<Balance, u64> = common::GasMultiplier::ValuePerGas(1);
+        pub const BlockHashCount: BlockNumber = 250;
+        pub const ExistentialDeposit: Balance = EXISTENTIAL_DEPOSIT;
+        pub const TreasuryAddress: AccountId = AccountId32::new(*b"treasuryaccount/treasuryaccount/");
+    }
+
+    construct_runtime!(
+        pub enum Test
+        {
+            System: frame_system,
+            Authorship: pallet_authorship,
+            Balances: pallet_balances,
+            GearBank: pallet_gear_bank,
+        }
+    );
+
+    common::impl_pallet_system!(Test, DbWeight = RocksDbWeight, BlockWeights = ());
+    common::impl_pallet_balances!(Test);
+    pallet_gear_bank::impl_config!(Test, TreasuryAddress = TreasuryAddress);
+
+    pub struct FixedBlockAuthor;
+    impl FindAuthor<AccountId> for FixedBlockAuthor {
+        fn find_author<'a, I: 'a>(_: I) -> Option<AccountId> {
+            Some(BLOCK_AUTHOR.clone())
+        }
+    }
+    impl pallet_authorship::Config for Test {
+        type FindAuthor = FixedBlockAuthor;
+        type EventHandler = ();
+    }
+
+    pub fn new_test_ext() -> sp_io::TestExternalities {
+        let mut storage = frame_system::GenesisConfig::<Test>::default()
+            .build_storage()
+            .unwrap();
+
+        let balances = vec![(OLD_BANK_ADDRESS.into(), EXISTENTIAL_DEPOSIT)];
+
+        pallet_balances::GenesisConfig::<Test> { balances }
+            .assimilate_storage(&mut storage)
+            .unwrap();
+
+        sp_io::TestExternalities::new(storage)
+    }
+
+    #[test]
+    fn migration_works() {
+        new_test_ext().execute_with(|| {
+            StorageVersion::new(0).put::<GearBank>();
+            let new_bank_address = GearBank::bank_address();
+            // Pour some more funds into the Gear bank
+            let _ = Balances::deposit_creating(&OLD_BANK_ADDRESS.into(), 1_000_000);
+
+            // Take note of the current total issuance before the upgrade
+            let total_issuance = Balances::total_issuance();
+            // New Gear bank account balance before the upgrade should be 0
+            assert_eq!(Balances::free_balance(&new_bank_address), 0);
+
+            // Run the migration
+            let state = MigrateToV1::<Test>::pre_upgrade().unwrap();
+            let weight = MigrateToV1::<Test>::on_runtime_upgrade();
+            assert_ok!(MigrateToV1::<Test>::post_upgrade(state));
+
+            println!("Weight: {:?}", weight);
+            assert!(!weight.is_zero());
+
+            assert_eq!(StorageVersion::get::<GearBank>(), 1);
+
+            // Total issuance should have remained intact
+            assert_eq!(Balances::total_issuance(), total_issuance);
+
+            // Check that balances add up
+            assert_eq!(
+                Balances::free_balance(AccountId32::from(OLD_BANK_ADDRESS)),
+                0,
+                "Old bank address should be empty"
+            );
+            assert_eq!(
+                Balances::free_balance(&new_bank_address),
+                1_000_000 + EXISTENTIAL_DEPOSIT,
+                "New bank address should have the funds"
+            );
+        })
+    }
+}

--- a/pallets/gear-bank/src/mock.rs
+++ b/pallets/gear-bank/src/mock.rs
@@ -107,6 +107,12 @@ pub fn new_test_ext() -> TestExternalities {
         .assimilate_storage(&mut storage)
         .unwrap();
 
+    pallet_gear_bank::GenesisConfig::<Test> {
+        _config: Default::default(),
+    }
+    .assimilate_storage(&mut storage)
+    .unwrap();
+
     let mut ext = TestExternalities::new(storage);
     ext.execute_with(|| System::set_block_number(1));
     ext

--- a/pallets/gear-bank/src/mock.rs
+++ b/pallets/gear-bank/src/mock.rs
@@ -21,6 +21,7 @@ use frame_support::{
     construct_runtime, parameter_types,
     traits::{ConstU32, FindAuthor},
     weights::constants::RocksDbWeight,
+    PalletId,
 };
 use primitive_types::H256;
 use sp_io::TestExternalities;
@@ -47,8 +48,6 @@ mod consts {
 
     pub const BLOCK_AUTHOR: AccountId = 255;
 
-    pub const BANK_ADDRESS: AccountId = 137;
-
     pub const CHARLIE: AccountId = 3;
     pub const EVE: AccountId = 4;
 
@@ -62,7 +61,7 @@ mod consts {
 pub use consts::*;
 
 parameter_types! {
-    pub const BankAddress: AccountId = BANK_ADDRESS;
+    pub const BankPalletId: PalletId = PalletId(*b"py/gbank");
     pub const GasMultiplier: common::GasMultiplier<Balance, u64> = common::GasMultiplier::ValuePerGas(VALUE_PER_GAS);
     pub const BlockHashCount: BlockNumber = 250;
     pub const ExistentialDeposit: Balance = EXISTENTIAL_DEPOSIT;
@@ -97,7 +96,7 @@ pub fn new_test_ext() -> TestExternalities {
     let balances = vec![
         (ALICE, ALICE_BALANCE),
         (BOB, BOB_BALANCE),
-        (BANK_ADDRESS, EXISTENTIAL_DEPOSIT),
+        (GearBank::bank_address(), EXISTENTIAL_DEPOSIT),
         (BLOCK_AUTHOR, EXISTENTIAL_DEPOSIT),
         (CHARLIE, EXISTENTIAL_DEPOSIT),
         (EVE, EXISTENTIAL_DEPOSIT),

--- a/pallets/gear-bank/src/tests.rs
+++ b/pallets/gear-bank/src/tests.rs
@@ -17,7 +17,11 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{mock::*, GasMultiplier, OnFinalizeValue, UnusedValue, *};
-use frame_support::{assert_noop, assert_ok, traits::Hooks};
+use frame_support::{
+    assert_noop, assert_ok,
+    storage::{generator::StorageValue, unhashed},
+    traits::Hooks,
+};
 use sp_runtime::{traits::Zero, Percent, StateVersion};
 use utils::*;
 
@@ -1574,6 +1578,15 @@ fn spend_gas_on_finalize_single_user() {
         assert_block_author_inc(gas_price(BURN_1 + BURN_2));
 
         GearBank::on_initialize(2);
+    })
+}
+
+#[test]
+fn bank_address_always_in_storage() {
+    new_test_ext().execute_with(|| {
+        let key = BankAddress::<Test>::storage_value_final_key();
+        unhashed::get::<<Test as frame_system::Config>::AccountId>(&key)
+            .expect("Bank address not found in storage");
     })
 }
 

--- a/pallets/gear-bank/src/tests.rs
+++ b/pallets/gear-bank/src/tests.rs
@@ -151,7 +151,7 @@ fn deposit_gas_insufficient_deposit() {
         assert!(gas_price(GAS_AMOUNT) < CurrencyOf::<Test>::minimum_balance());
 
         assert_ok!(Balances::transfer_all(
-            RuntimeOrigin::signed(BANK_ADDRESS),
+            RuntimeOrigin::signed(GearBank::bank_address()),
             Zero::zero(),
             false,
         ));
@@ -294,7 +294,10 @@ fn withdraw_gas_small_amount_user_account_deleted() {
         assert_ok!(GearBank::withdraw_gas(&ALICE, GAS_AMOUNT, mult()));
 
         assert_eq!(UnusedValue::<Test>::get(), GAS_VALUE_AMOUNT);
-        assert_balance(&BANK_ADDRESS, EXISTENTIAL_DEPOSIT + GAS_VALUE_AMOUNT);
+        assert_balance(
+            &GearBank::bank_address(),
+            EXISTENTIAL_DEPOSIT + GAS_VALUE_AMOUNT,
+        );
 
         assert_bank_balance(0, 0);
 
@@ -330,7 +333,7 @@ fn withdraw_gas_insufficient_bank_balance() {
         assert_ok!(GearBank::deposit_gas(&ALICE, GAS_AMOUNT, false));
 
         assert_ok!(Balances::transfer_all(
-            RuntimeOrigin::signed(BANK_ADDRESS),
+            RuntimeOrigin::signed(GearBank::bank_address()),
             Zero::zero(),
             false,
         ));
@@ -552,7 +555,10 @@ fn spend_gas_small_amount_validator_account_deleted() {
         let unused_value_inc = block_author_share * GAS_VALUE_AMOUNT;
 
         assert_eq!(UnusedValue::<Test>::get(), unused_value_inc);
-        assert_balance(&BANK_ADDRESS, EXISTENTIAL_DEPOSIT + unused_value_inc);
+        assert_balance(
+            &GearBank::bank_address(),
+            EXISTENTIAL_DEPOSIT + unused_value_inc,
+        );
 
         assert_bank_balance(0, 0);
 
@@ -590,16 +596,17 @@ fn spend_gas_insufficient_bank_balance() {
         let _block_author = Authorship::author();
 
         const GAS_AMOUNT: u64 = 123_456;
+        let bank_address = GearBank::bank_address();
 
         assert_ok!(GearBank::deposit_gas(&ALICE, GAS_AMOUNT, false));
 
         assert_ok!(Balances::transfer_all(
-            RuntimeOrigin::signed(BANK_ADDRESS),
+            RuntimeOrigin::signed(bank_address),
             Zero::zero(),
             false,
         ));
 
-        assert_balance(&BANK_ADDRESS, 0);
+        assert_balance(&bank_address, 0);
 
         assert_noop!(
             GearBank::spend_gas(&ALICE, GAS_AMOUNT, mult()),
@@ -775,7 +782,7 @@ fn deposit_value_insufficient_deposit() {
         const VALUE: Balance = EXISTENTIAL_DEPOSIT - 1;
 
         assert_ok!(Balances::transfer_all(
-            RuntimeOrigin::signed(BANK_ADDRESS),
+            RuntimeOrigin::signed(GearBank::bank_address()),
             Zero::zero(),
             false,
         ));
@@ -908,7 +915,7 @@ fn withdraw_value_small_amount_user_account_deleted() {
         assert_ok!(GearBank::withdraw_value(&ALICE, VALUE));
 
         assert_eq!(UnusedValue::<Test>::get(), VALUE);
-        assert_balance(&BANK_ADDRESS, EXISTENTIAL_DEPOSIT + VALUE);
+        assert_balance(&GearBank::bank_address(), EXISTENTIAL_DEPOSIT + VALUE);
 
         assert_bank_balance(0, 0);
 
@@ -944,7 +951,7 @@ fn withdraw_value_insufficient_bank_balance() {
         assert_ok!(GearBank::deposit_value(&ALICE, VALUE, false));
 
         assert_ok!(Balances::transfer_all(
-            RuntimeOrigin::signed(BANK_ADDRESS),
+            RuntimeOrigin::signed(GearBank::bank_address()),
             Zero::zero(),
             false,
         ));
@@ -1192,7 +1199,7 @@ fn transfer_value_small_amount_destination_account_deleted() {
         assert_ok!(GearBank::transfer_value(&ALICE, &CHARLIE, VALUE));
 
         assert_eq!(UnusedValue::<Test>::get(), VALUE);
-        assert_balance(&BANK_ADDRESS, EXISTENTIAL_DEPOSIT + VALUE);
+        assert_balance(&GearBank::bank_address(), EXISTENTIAL_DEPOSIT + VALUE);
 
         assert_bank_balance(0, 0);
 
@@ -1218,7 +1225,7 @@ fn transfer_value_small_amount_self_account_deleted() {
         assert_ok!(GearBank::transfer_value(&ALICE, &ALICE, VALUE));
 
         assert_eq!(UnusedValue::<Test>::get(), VALUE);
-        assert_balance(&BANK_ADDRESS, EXISTENTIAL_DEPOSIT + VALUE);
+        assert_balance(&GearBank::bank_address(), EXISTENTIAL_DEPOSIT + VALUE);
 
         assert_bank_balance(0, 0);
 
@@ -1253,16 +1260,17 @@ fn transfer_value_insufficient_bank_balance() {
     // Unreachable case for Gear protocol.
     new_test_ext().execute_with(|| {
         const VALUE: Balance = 123_456_000;
+        let bank_address = GearBank::bank_address();
 
         assert_ok!(GearBank::deposit_value(&ALICE, VALUE, false));
 
         assert_ok!(Balances::transfer_all(
-            RuntimeOrigin::signed(BANK_ADDRESS),
+            RuntimeOrigin::signed(bank_address),
             Zero::zero(),
             false,
         ));
 
-        assert_balance(&BANK_ADDRESS, 0);
+        assert_balance(&bank_address, 0);
 
         assert_noop!(
             GearBank::transfer_value(&ALICE, &CHARLIE, VALUE),
@@ -1608,7 +1616,7 @@ mod utils {
     pub fn assert_bank_balance(gas: u64, value: Balance) {
         let gas_value = gas_price(gas);
         assert_balance(
-            &BANK_ADDRESS,
+            &GearBank::bank_address(),
             CurrencyOf::<Test>::minimum_balance()
                 + UnusedValue::<Test>::get()
                 + OnFinalizeValue::<Test>::get()

--- a/pallets/gear-builtin/src/mock.rs
+++ b/pallets/gear-builtin/src/mock.rs
@@ -29,6 +29,7 @@ use frame_support::{
     traits::{
         ConstBool, ConstU32, ConstU64, FindAuthor, Get, InstanceFilter, OnFinalize, OnInitialize,
     },
+    PalletId,
 };
 use frame_support_test::TestRandomness;
 use frame_system::{self as system, limits::BlockWeights, pallet_prelude::BlockNumberFor};
@@ -215,7 +216,7 @@ parameter_types! {
     pub ResumeMinimalPeriod: BlockNumber = 100;
     pub ResumeSessionDuration: BlockNumber = 1_000;
     pub const PerformanceMultiplier: u32 = 100;
-    pub const BankAddress: AccountId = 15082001;
+    pub const BankPalletId: PalletId = PalletId(*b"py/gbank");
     pub const GasMultiplier: common::GasMultiplier<Balance, u64> = common::GasMultiplier::ValuePerGas(100);
 }
 
@@ -516,7 +517,7 @@ pub(crate) fn gas_tree_empty() -> bool {
 }
 
 pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
-    let bank_address = <Test as pallet_gear_bank::Config>::BankAddress::get();
+    let bank_address = GearBank::bank_address();
 
     ExtBuilder::default()
         .endowment(ENDOWMENT)

--- a/pallets/gear-builtin/src/tests/bad_builtin_ids.rs
+++ b/pallets/gear-builtin/src/tests/bad_builtin_ids.rs
@@ -22,6 +22,7 @@ use crate::{
 use frame_support::{
     construct_runtime, parameter_types,
     traits::{ConstBool, ConstU32, ConstU64, FindAuthor, OnFinalize, OnInitialize},
+    PalletId,
 };
 use frame_support_test::TestRandomness;
 use frame_system::{self as system, pallet_prelude::BlockNumberFor};
@@ -82,7 +83,7 @@ parameter_types! {
     pub ResumeMinimalPeriod: BlockNumber = 100;
     pub ResumeSessionDuration: BlockNumber = 1_000;
     pub const PerformanceMultiplier: u32 = 100;
-    pub const BankAddress: AccountId = 15082001;
+    pub const BankPalletId: PalletId = PalletId(*b"py/gbank");
     pub const GasMultiplier: common::GasMultiplier<Balance, u64> = common::GasMultiplier::ValuePerGas(100);
 }
 
@@ -208,7 +209,7 @@ pub(crate) fn on_finalize(current_blk: BlockNumberFor<Test>) {
 }
 
 pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
-    let bank_address = <Test as pallet_gear_bank::Config>::BankAddress::get();
+    let bank_address = GearBank::bank_address();
 
     ExtBuilder::default()
         .endowment(ENDOWMENT)

--- a/pallets/gear-builtin/src/tests/staking.rs
+++ b/pallets/gear-builtin/src/tests/staking.rs
@@ -663,6 +663,7 @@ mod util {
         pallet_prelude::{DispatchClass, Weight},
         parameter_types,
         traits::{ConstBool, ConstU64, FindAuthor, Get, OnFinalize, OnInitialize},
+        PalletId,
     };
     use frame_support_test::TestRandomness;
     use frame_system::{self as system, limits::BlockWeights, pallet_prelude::BlockNumberFor};
@@ -764,7 +765,7 @@ mod util {
         pub ResumeMinimalPeriod: BlockNumber = 100;
         pub ResumeSessionDuration: BlockNumber = 1_000;
         pub const PerformanceMultiplier: u32 = 100;
-        pub const BankAddress: AccountId = 15082001;
+        pub const BankPalletId: PalletId = PalletId(*b"py/gbank");
         pub const GasMultiplier: common::GasMultiplier<Balance, u64> = common::GasMultiplier::ValuePerGas(100);
     }
 
@@ -981,7 +982,7 @@ mod util {
     }
 
     pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
-        let bank_address = <Test as pallet_gear_bank::Config>::BankAddress::get();
+        let bank_address = GearBank::bank_address();
 
         ExtBuilder::default()
             .initial_authorities(vec![

--- a/pallets/gear-debug/src/mock.rs
+++ b/pallets/gear-debug/src/mock.rs
@@ -24,6 +24,7 @@ use frame_support::{
     parameter_types,
     traits::{ConstU32, FindAuthor, Get, OnFinalize, OnInitialize},
     weights::Weight,
+    PalletId,
 };
 use frame_support_test::TestRandomness;
 use frame_system::{self as system, limits::BlockWeights, pallet_prelude::BlockNumberFor};
@@ -68,7 +69,7 @@ parameter_types! {
     pub RentCostPerBlock: Balance = 11;
     pub ResumeMinimalPeriod: BlockNumber = 100;
     pub ResumeSessionDuration: BlockNumber = 1_000;
-    pub const BankAddress: AccountId = 15082001;
+    pub const BankPalletId: PalletId = PalletId(*b"py/gbank");
     pub const GasMultiplier: common::GasMultiplier<Balance, u64> = common::GasMultiplier::ValuePerGas(100);
     pub ReserveThreshold: BlockNumber = 1;
 }
@@ -113,7 +114,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
             (1, 100_000_000_000_000_u128),
             (2, 2_000_u128),
             (BLOCK_AUTHOR, 1_000_u128),
-            (BankAddress::get(), ExistentialDeposit::get()),
+            (GearBank::bank_address(), ExistentialDeposit::get()),
         ],
     }
     .assimilate_storage(&mut t)

--- a/pallets/gear-eth-bridge/src/mock.rs
+++ b/pallets/gear-eth-bridge/src/mock.rs
@@ -161,7 +161,7 @@ parameter_types! {
     pub ResumeMinimalPeriod: BlockNumber = 100;
     pub ResumeSessionDuration: BlockNumber = 1_000;
     pub const PerformanceMultiplier: u32 = 100;
-    pub const BankAddress: AccountId = 15082001;
+    pub const BankPalletId: PalletId = PalletId(*b"py/gbank");
     pub const GasMultiplier: common::GasMultiplier<Balance, u64> = common::GasMultiplier::ValuePerGas(100);
 }
 
@@ -447,7 +447,7 @@ pub(crate) fn on_finalize_gear_block(bn: BlockNumberFor<Test>) {
 }
 
 pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
-    let bank_address = <Test as pallet_gear_bank::Config>::BankAddress::get();
+    let bank_address = GearBank::bank_address();
 
     ExtBuilder::default()
         .endowment(ENDOWMENT)

--- a/pallets/gear-scheduler/src/mock.rs
+++ b/pallets/gear-scheduler/src/mock.rs
@@ -25,6 +25,7 @@ use frame_support::{
     parameter_types,
     traits::{ConstU32, ConstU64, FindAuthor},
     weights::constants::RocksDbWeight,
+    PalletId,
 };
 use frame_support_test::TestRandomness;
 use frame_system::{self as system, limits::BlockWeights, pallet_prelude::BlockNumberFor};
@@ -92,7 +93,7 @@ parameter_types! {
     pub RentCostPerBlock: Balance = 11;
     pub ResumeMinimalPeriod: BlockNumber = 100;
     pub ResumeSessionDuration: BlockNumber = 1_000;
-    pub const BankAddress: AccountId = 15082001;
+    pub const BankPalletId: PalletId = PalletId(*b"py/gbank");
     pub const GasMultiplier: common::GasMultiplier<Balance, u64> = common::GasMultiplier::ValuePerGas(100);
 }
 
@@ -109,7 +110,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
             (USER_3, 500_000_000_000_000_u128),
             (LOW_BALANCE_USER, 1_000_000_u128),
             (BLOCK_AUTHOR, 500_000_u128),
-            (BankAddress::get(), ExistentialDeposit::get()),
+            (GearBank::bank_address(), ExistentialDeposit::get()),
         ],
     }
     .assimilate_storage(&mut t)

--- a/pallets/gear/src/mock.rs
+++ b/pallets/gear/src/mock.rs
@@ -159,7 +159,7 @@ impl Drop for DynamicScheduleReset {
 }
 
 parameter_types! {
-    pub const BankAddress: AccountId = 15082001;
+    pub const BankPalletId: PalletId = PalletId(*b"py/gbank");
     pub const GasMultiplier: common::GasMultiplier<Balance, u64> = common::GasMultiplier::ValuePerGas(100);
     pub const MinVoucherDuration: BlockNumber = 5;
     pub const MaxVoucherDuration: BlockNumber = 100_000_000;
@@ -195,7 +195,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
             (LOW_BALANCE_USER, 1_000_000_u128),
             (BLOCK_AUTHOR, 500_000_u128),
             (RENT_POOL, ExistentialDeposit::get()),
-            (BankAddress::get(), ExistentialDeposit::get()),
+            (GearBank::bank_address(), ExistentialDeposit::get()),
         ],
     }
     .assimilate_storage(&mut t)

--- a/pallets/payment/src/mock.rs
+++ b/pallets/payment/src/mock.rs
@@ -119,7 +119,7 @@ parameter_types! {
     pub RentCostPerBlock: Balance = 11;
     pub ResumeMinimalPeriod: BlockNumber = 100;
     pub ResumeSessionDuration: BlockNumber = 1_000;
-    pub const BankAddress: AccountId = 15082001;
+    pub const BankPalletId: PalletId = PalletId(*b"py/gbank");
     pub const GasMultiplier: common::GasMultiplier<Balance, u64> = common::GasMultiplier::ValuePerGas(100);
 }
 
@@ -203,7 +203,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
             (BOB, 10_000u128),
             (BLOCK_AUTHOR, 1_000u128),
             (FEE_PAYER, 10_000_000u128),
-            (BankAddress::get(), ExistentialDeposit::get()),
+            (GearBank::bank_address(), ExistentialDeposit::get()),
         ],
     }
     .assimilate_storage(&mut t)

--- a/runtime/common/src/constants.rs
+++ b/runtime/common/src/constants.rs
@@ -36,9 +36,6 @@ pub const RENT_RESUME_WEEK_FACTOR: BlockNumber = 4;
 /// The amount of blocks for processing resume session represented as a factor of hours.
 pub const RESUME_SESSION_DURATION_HOUR_FACTOR: BlockNumber = 1;
 
-/// Address of bank account represented as 32 bytes.
-pub const BANK_ADDRESS: [u8; 32] = *b"gearbankgearbankgearbankgearbank";
-
 /// The free of charge period of rent represented as a factor of months.
 pub const RENT_FREE_PERIOD_MONTH_FACTOR: BlockNumber = 6;
 

--- a/runtime/vara/src/genesis_config_presets.rs
+++ b/runtime/vara/src/genesis_config_presets.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use super::{GearBank, UNITS as TOKEN, *};
+use super::{UNITS as TOKEN, *};
 use pallet_balances::GenesisConfig;
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_staking::{Forcing, StakerStatus};
@@ -118,6 +118,9 @@ pub fn testnet_genesis(
         sudo: SudoConfig {
             // Assign network admin rights.
             key: Some(root_key),
+        },
+        gear_bank: GearBankConfig {
+            _config: Default::default(),
         },
         ..Default::default()
     }

--- a/runtime/vara/src/genesis_config_presets.rs
+++ b/runtime/vara/src/genesis_config_presets.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use super::{UNITS as TOKEN, *};
+use super::{GearBank, UNITS as TOKEN, *};
 use pallet_balances::GenesisConfig;
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_staking::{Forcing, StakerStatus};
@@ -185,7 +185,7 @@ pub fn development_genesis() -> RuntimeGenesisConfig {
             get_account_id_from_seed::<sr25519::Public>("Alice"),
             get_account_id_from_seed::<sr25519::Public>("Bob"),
         ],
-        BANK_ADDRESS.into(),
+        GearBank::bank_address(),
         true,
     )
 }
@@ -208,7 +208,7 @@ pub fn local_testnet_genesis() -> RuntimeGenesisConfig {
             get_account_id_from_seed::<sr25519::Public>("Eve"),
             get_account_id_from_seed::<sr25519::Public>("Ferdie"),
         ],
-        BANK_ADDRESS.into(),
+        GearBank::bank_address(),
         true,
     )
 }

--- a/runtime/vara/src/integration_tests.rs
+++ b/runtime/vara/src/integration_tests.rs
@@ -159,7 +159,7 @@ impl ExtBuilder {
             )
             .collect::<Vec<_>>();
 
-        balances.push((BankAddress::get(), EXISTENTIAL_DEPOSIT));
+        balances.push((GearBank::bank_address(), EXISTENTIAL_DEPOSIT));
 
         pallet_balances::GenesisConfig::<Runtime> { balances }
             .assimilate_storage(&mut storage)

--- a/runtime/vara/src/lib.rs
+++ b/runtime/vara/src/lib.rs
@@ -115,8 +115,8 @@ pub use frame_support::{
 };
 pub use gear_runtime_common::{
     constants::{
-        BANK_ADDRESS, RENT_DISABLED_DELTA_WEEK_FACTOR, RENT_FREE_PERIOD_MONTH_FACTOR,
-        RENT_RESUME_WEEK_FACTOR, RESUME_SESSION_DURATION_HOUR_FACTOR,
+        RENT_DISABLED_DELTA_WEEK_FACTOR, RENT_FREE_PERIOD_MONTH_FACTOR, RENT_RESUME_WEEK_FACTOR,
+        RESUME_SESSION_DURATION_HOUR_FACTOR,
     },
     impl_runtime_apis_plus_common, BlockHashCount, DealWithFees, AVERAGE_ON_INITIALIZE_RATIO,
     GAS_LIMIT_MIN_PERCENTAGE_NUM, NORMAL_DISPATCH_LENGTH_RATIO, NORMAL_DISPATCH_WEIGHT_RATIO,
@@ -1138,7 +1138,7 @@ parameter_types! {
 
 parameter_types! {
     pub Schedule: pallet_gear::Schedule<Runtime> = Default::default();
-    pub BankAddress: AccountId = BANK_ADDRESS.into();
+    pub const BankPalletId: PalletId = PalletId(*b"py/gbank");
     pub const GasMultiplier: common::GasMultiplier<Balance, u64> = common::GasMultiplier::ValuePerGas(VALUE_PER_GAS);
     pub const TreasuryGasFeeShare: Percent = Percent::one();
     pub const TreasuryTxFeeShare: Percent = Percent::one();
@@ -1146,7 +1146,7 @@ parameter_types! {
 
 impl pallet_gear_bank::Config for Runtime {
     type Currency = Balances;
-    type BankAddress = BankAddress;
+    type PalletId = BankPalletId;
     type GasMultiplier = GasMultiplier;
     type TreasuryAddress = TreasuryAccount;
     type TreasuryGasFeeShare = TreasuryGasFeeShare;

--- a/runtime/vara/src/migrations.rs
+++ b/runtime/vara/src/migrations.rs
@@ -19,7 +19,10 @@
 use crate::*;
 
 /// All migrations that will run on the next runtime upgrade.
-pub type Migrations = (BagsListMigrate<Runtime>,);
+pub type Migrations = (
+    BagsListMigrate<Runtime>,
+    pallet_gear_bank::migrations::MigrateToV1<Runtime>,
+);
 
 pub struct BagsListMigrate<T: pallet_bags_list::Config<pallet_bags_list::Instance1>>(
     core::marker::PhantomData<T>,

--- a/utils/runtime-fuzzer/src/runtime/mod.rs
+++ b/utils/runtime-fuzzer/src/runtime/mod.rs
@@ -25,7 +25,7 @@ use runtime_primitives::Balance;
 use sp_io::TestExternalities;
 use sp_runtime::BuildStorage;
 use vara_runtime::{
-    AccountId, Balances, BankAddress, Runtime, RuntimeOrigin, SessionConfig, SessionKeys,
+    AccountId, Balances, GearBank, Runtime, RuntimeOrigin, SessionConfig, SessionKeys,
 };
 
 pub use account::{acc_max_balance_gas, account, BalanceManager, BalanceState};
@@ -51,7 +51,7 @@ pub fn new_test_ext() -> TestExternalities {
             ))),
             account::gas_to_value(account::acc_max_balance_gas()),
         ),
-        (BankAddress::get(), Balances::minimum_balance()),
+        (GearBank::bank_address(), Balances::minimum_balance()),
     ];
 
     BalancesConfig::<Runtime> {


### PR DESCRIPTION
Transfers to gear bank can occur multiple times at each block (with every message sent).
Currently for an external observer these transfers look as transfers to an unknown address (which might look weird if not suspicious).
This change links the gear bank account id to the pallet id the same way it is done for other pallets (treasury, staking rewards pool etc.).
The bank account id is stored in the pallet storage which spares the address recalculation each time it is needed (potentially, many times in a single block); on the contrary, it should be fetched from storage only once per block and be kept in overlay across all extrinsics.

Changes:

- [x] Update the derivation of the gear bank account id (involves modification of the `Config` trait)
- [x] Apply a migration to move all funds from the old account id to the new one.
- [x] Update the `gsdk` and `gclient` API.