### PR TITLE
feat(ethexe-rpc): Optimize `calculate_reply_for_handle` by cleaning queues for concerned programs

### DIFF
--- a/ethexe/compute/src/lib.rs
+++ b/ethexe/compute/src/lib.rs
@@ -135,6 +135,7 @@ struct ChainHeadProcessContext {
 }
 
 impl ChainHeadProcessContext {
+    /// Processes the chain of not computed blocks starting from the given `head`.
     async fn process(mut self, head: H256) -> Result<BlockProcessed> {
         let chain = Self::collect_not_computed_blocks_chain(&self.db, head)?;
 
@@ -152,6 +153,7 @@ impl ChainHeadProcessContext {
             header,
         } = block_data;
 
+        // Events must be set for all synced blocks.
         let events = OnChainStorage::block_events(&self.db, block)
             .ok_or_else(|| anyhow!("events not found for synced block {block}"))?;
 
@@ -216,6 +218,13 @@ impl ChainHeadProcessContext {
         Ok(())
     }
 
+    /// Gets `wait for commitment` blocks queue from the `parent` of the `block`.
+    ///
+    /// The returned data doesn't contain waiting for commitment blocks included
+    /// into current (`block`) block.
+    ///
+    /// The `block` can have requests for code validation. These requests are united with those
+    /// from the `parent` block and set to the `block`'s codes queue.
     fn propagate_data_from_parent<'a>(
         db: &Database,
         block: H256,
@@ -283,6 +292,7 @@ impl ChainHeadProcessContext {
                 return Err(anyhow!("Block {block} is not synced, but must be"));
             }
 
+            // Headers must be set for all synced blocks.
             let header = OnChainStorage::block_header(db, block)
                 .ok_or_else(|| anyhow!("header not found for synced block {block}"))?;
 

--- a/ethexe/db/src/database.rs
+++ b/ethexe/db/src/database.rs
@@ -211,6 +211,9 @@ impl Database {
         self.block_small_data(block_hash).map(f)
     }
 
+    /// Mutates `BlockSmallData` for the given block hash.
+    ///
+    /// If data wasn't found, it will be created with default values and then mutated.
     fn mutate_small_data(&self, block_hash: H256, f: impl FnOnce(&mut BlockSmallData)) {
         let mut data = self.block_small_data(block_hash).unwrap_or_default();
         f(&mut data);

--- a/ethexe/ethereum/src/abi/mod.rs
+++ b/ethexe/ethereum/src/abi/mod.rs
@@ -20,6 +20,7 @@ use alloy::sol;
 
 mod events;
 mod gear;
+// mod mod_expanded;
 
 pub use mirror_abi::*;
 

--- a/ethexe/observer/src/lib.rs
+++ b/ethexe/observer/src/lib.rs
@@ -139,7 +139,7 @@ impl Stream for ObserverService {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // If subscription stream finished working, a new subscription is requested to be created.
-        // The subscription createion request is a future itself, and it is polled here. If it's ready,
+        // The subscription creation request is a future itself, and it is polled here. If it's ready,
         // a new stream from it is created and used further to poll the next header.
         if let Some(future) = self.subscription_future.as_mut() {
             match future.poll_unpin(cx) {
@@ -286,9 +286,6 @@ impl ObserverService {
         })
     }
 
-    // TODO #4563: this is a temporary solution.
-    // Choose a better place for this, out of ObserverService.
-
     /// Populates database with genesis block data.
     ///
     /// Basically, requests data for the block, which is considered to be a genesis block
@@ -304,6 +301,8 @@ impl ObserverService {
     ///   and processing outcome (state transitions) are set to default (empty) values.
     ///
     /// If genesis block was computed earlier, this function returns immediately.
+    // TODO #4563: this is a temporary solution.
+    // Choose a better place for this, out of ObserverService.
     async fn pre_process_genesis_for_db(
         db: &Database,
         provider: &RootProvider,

--- a/ethexe/observer/src/lib.rs
+++ b/ethexe/observer/src/lib.rs
@@ -138,6 +138,9 @@ impl Stream for ObserverService {
     type Item = Result<ObserverEvent>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // If subscription stream finished working, a new subscription is requested to be created.
+        // The subscription createion request is a future itself, and it is polled here. If it's ready,
+        // a new stream from it is created and used further to poll the next header.
         if let Some(future) = self.subscription_future.as_mut() {
             match future.poll_unpin(cx) {
                 Poll::Ready(Ok(subscription)) => self.headers_stream = subscription.into_stream(),
@@ -285,7 +288,22 @@ impl ObserverService {
 
     // TODO #4563: this is a temporary solution.
     // Choose a better place for this, out of ObserverService.
-    /// If genesis block is not yet fully setup in the database, we need to do it
+
+    /// Populates database with genesis block data.
+    ///
+    /// Basically, requests data for the block, which is considered to be a genesis block
+    /// inside the `Router` contract on Ethereum. The data is processed the following way:
+    /// - header is stored in the database
+    /// - events are set as empty
+    /// - block is set as synced
+    /// - block is set as computed
+    /// - block is set as latest synced block (it's height)
+    /// - block is set as latest computed block
+    /// - previous non-empty block for the genesis one is set to blake2b256(0)
+    /// - all the runtime storages related to the block (message queue, tasks schedule, codes queue) also programs states,
+    ///   and processing outcome (state transitions) are set to default (empty) values.
+    ///
+    /// If genesis block was computed earlier, this function returns immediately.
     async fn pre_process_genesis_for_db(
         db: &Database,
         provider: &RootProvider,

--- a/ethexe/observer/src/sync.rs
+++ b/ethexe/observer/src/sync.rs
@@ -90,7 +90,7 @@ impl<DB: OnChainStorage + CodesStorage> ChainSync<DB> {
 
         if header.height <= latest_synced_block_height {
             log::warn!(
-                "Get a block with number {} <= latest synced block number: {}, maybe a reorg",
+                "Got a block with number {} <= latest synced block number: {}, maybe a reorg",
                 header.height,
                 latest_synced_block_height
             );

--- a/ethexe/processor/src/handling/mod.rs
+++ b/ethexe/processor/src/handling/mod.rs
@@ -27,6 +27,11 @@ use gprimitives::{ActorId, CodeId, H256};
 pub(crate) mod events;
 pub(crate) mod run;
 
+/// A high-level interface for executing ops,
+/// which mutate states based on the current block request events.
+///
+/// This is based a wrapper which hols data needed to instantiate [`TransitionController`],
+/// which itself performs recording actual state transitions.
 pub struct ProcessingHandler {
     pub block_hash: H256,
     pub db: Database,
@@ -41,6 +46,7 @@ impl ProcessingHandler {
         }
     }
 
+    /// A wrapper for the lower level [`TransitionController::update_state`].
     pub fn update_state<T>(
         &mut self,
         program_id: ActorId,
@@ -51,6 +57,11 @@ impl ProcessingHandler {
 }
 
 impl Processor {
+    /// Creates a new [`ProcessingHandler`] for the given block hash.
+    ///
+    /// The [`InBlockTransitions`] is created using states of the parent of the block with `block_hash` hash.
+    /// That's done because the parent actually has the latest view on program states. Also program states
+    /// for the `block_hash` block are written to database only after the block is processed.
     pub fn handler(&self, block_hash: H256) -> Result<ProcessingHandler> {
         let header = self
             .db

--- a/ethexe/processor/src/host/mod.rs
+++ b/ethexe/processor/src/host/mod.rs
@@ -34,6 +34,13 @@ pub mod runtime;
 mod context;
 mod threads;
 
+/// Returns wasm runtime bytes.
+///
+/// The returned runtime is able to perform some functions
+/// related to executing programs in the context of the gear protocol.
+/// These functions are:
+/// - `instrument_code` - instrument the code of the program.
+/// - `run` - execute messages of the program in the context of the gear protocol.
 pub fn runtime() -> Vec<u8> {
     let mut runtime = runtime::Runtime::new();
     runtime.add_start_section();
@@ -54,6 +61,16 @@ pub(crate) struct InstanceCreator {
 }
 
 impl InstanceCreator {
+    /// Instantiates a wasm runtime instance creator.
+    ///
+    /// A wasm runtime here is a runtime for executing wasm programs
+    /// in the context of the gear protocol programs execution.
+    /// That actually brings some requirements for the wasm module
+    /// instantiation, like linking expected host functions to use
+    /// lazy pages, allocator or have an access to database.
+    ///
+    /// A wasm runtime modules is expected to use some runtime interface,
+    /// which calls linked host functions.
     pub fn new(runtime: Vec<u8>) -> Result<Self> {
         let engine = wasmtime::Engine::default();
 
@@ -117,6 +134,7 @@ impl InstanceWrapper {
         self.store.data_mut()
     }
 
+    /// Call to the exported `instrument_code` function of the wasm module.
     pub fn instrument(
         &mut self,
         original_code: impl AsRef<[u8]>,
@@ -124,6 +142,11 @@ impl InstanceWrapper {
         self.call("instrument_code", original_code)
     }
 
+    /// Call to the exported `run` function of the wasm module.
+    ///
+    /// The `run` function actually executed program's queue in accordance to
+    /// the gear protocol. The returned sequence of `JournalNote`s is later
+    /// processed out of the wasm module.
     pub fn run(
         &mut self,
         db: Database,
@@ -155,6 +178,7 @@ impl InstanceWrapper {
         Ok((journal, origin))
     }
 
+    /// Low-level call to exported from the wasm module `name` function.
     fn call<D: Decode>(&mut self, name: &'static str, input: impl AsRef<[u8]>) -> Result<D> {
         self.with_host_state(|instance_wrapper| {
             let func = instance_wrapper

--- a/ethexe/processor/src/lib.rs
+++ b/ethexe/processor/src/lib.rs
@@ -124,6 +124,7 @@ impl Processor {
         Ok(outcomes)
     }
 
+    /// todo [sab]
     pub fn process_block_events_raw(
         &mut self,
         block_hash: H256,
@@ -161,7 +162,7 @@ impl Processor {
     pub fn process_queue(&mut self, handler: &mut ProcessingHandler) {
         self.creator.set_chain_head(handler.block_hash);
 
-        run::run(&self, &mut handler.transitions);
+        run::run(self, &mut handler.transitions);
     }
 }
 
@@ -237,6 +238,6 @@ impl OverlaidProcessor {
     fn process_queue(&mut self, handler: &mut ProcessingHandler, program_id: ActorId) {
         self.0.creator.set_chain_head(handler.block_hash);
 
-        run::run_overlaid(&self, &mut handler.transitions, program_id);
+        run::run_overlaid(self, &mut handler.transitions, program_id);
     }
 }

--- a/ethexe/processor/src/tests.rs
+++ b/ethexe/processor/src/tests.rs
@@ -804,9 +804,9 @@ fn overlay_execution_noop() {
     processor.db.set_block_schedule(block3, schedule);
 
     // Check queues are still not empty in the block3.
-    let ping_mq = get_program_mq(ping_id, block3, &&processor).expect("ping mq wasn't found");
+    let ping_mq = get_program_mq(ping_id, block3, &processor).expect("ping mq wasn't found");
     assert_eq!(ping_mq.len(), 2);
-    let async_mq = get_program_mq(async_id, block3, &&processor).expect("async mq wasn't found");
+    let async_mq = get_program_mq(async_id, block3, &processor).expect("async mq wasn't found");
     assert_eq!(async_mq.len(), 3);
 
     // Send message using overlay on the block3.

--- a/ethexe/processor/src/tests.rs
+++ b/ethexe/processor/src/tests.rs
@@ -21,7 +21,7 @@ use ethexe_common::events::{BlockRequestEvent, MirrorRequestEvent, RouterRequest
 use ethexe_db::{
     BlockHeader, BlockMetaStorage, CodesStorage, MemDb, OnChainStorage, ScheduledTask,
 };
-use ethexe_runtime_common::state::Expiring;
+use ethexe_runtime_common::state::{Expiring, MessageQueue};
 use gear_core::ids::{prelude::CodeIdExt, ProgramId};
 use gprimitives::{ActorId, MessageId};
 use parity_scale_codec::Encode;
@@ -570,6 +570,282 @@ fn many_waits() {
     for (_pid, message) in handler.transitions.current_messages() {
         assert_eq!(message.payload, b"Hello, world!");
     }
+}
+
+// Tests that when overlay execution is performed, it doesn't change the original state.
+#[test]
+fn overlay_execution_noop() {
+    init_logger();
+
+    // Define message id generator.
+    let mut message_nonce: u64 = 0;
+    let mut get_next_message_id = || {
+        message_nonce += 1;
+        MessageId::from(message_nonce)
+    };
+
+    // Define function to get message queue from state hash.
+    let get_mq_from_state_hash =
+        |state_hash: H256, processor: &Processor| -> Result<MessageQueue> {
+            let state = processor
+                .db
+                .read_state(state_hash)
+                .ok_or(anyhow!("failed to read pid state"))?;
+
+            state.queue_hash.query(&processor.db)
+        };
+
+    // Define function to get message queue from a specific block.
+    let get_program_mq =
+        |pid: ProgramId, block_hash: H256, processor: &Processor| -> Result<MessageQueue> {
+            let states = processor
+                .db
+                .block_program_states(block_hash)
+                .ok_or(anyhow!("failed to get block states"))?;
+            let pid_state = states
+                .get(&pid)
+                .ok_or(anyhow!("failed to get pid state hash"))?;
+
+            get_mq_from_state_hash(*pid_state, processor)
+        };
+
+    let user_id = ActorId::from(10);
+
+    let db = MemDb::default();
+    let mut processor = Processor::new(Database::from_one(&db)).unwrap();
+
+    // Initialize db.
+    let parent = init_genesis_block(&mut processor);
+    let block1 = init_new_block_from_parent(&mut processor, parent);
+
+    let ping_id = ProgramId::from(0x10000000);
+    let async_id = ProgramId::from(0x20000000);
+
+    // Upload ping and async codes.
+    let ping_code_id = processor
+        .handle_new_code(demo_ping::WASM_BINARY)
+        .expect("failed to call runtime api")
+        .expect("code failed verification or instrumentation");
+
+    let upload_code_id = processor
+        .handle_new_code(demo_async::WASM_BINARY)
+        .expect("failed to call runtime api")
+        .expect("code failed verification or instrumentation");
+
+    let events = vec![
+        // Create ping program, top up balance and send init message.
+        BlockRequestEvent::Router(RouterRequestEvent::ProgramCreated {
+            actor_id: ping_id,
+            code_id: ping_code_id,
+        }),
+        BlockRequestEvent::Mirror {
+            actor_id: ping_id,
+            event: MirrorRequestEvent::ExecutableBalanceTopUpRequested {
+                value: 10_000_000_000,
+            },
+        },
+        BlockRequestEvent::Mirror {
+            actor_id: ping_id,
+            event: MirrorRequestEvent::MessageQueueingRequested {
+                id: get_next_message_id(),
+                source: user_id,
+                payload: b"PING".to_vec(),
+                value: 0,
+            },
+        },
+        // Сreate async program, top up balance and send init message.
+        BlockRequestEvent::Router(RouterRequestEvent::ProgramCreated {
+            actor_id: async_id,
+            code_id: upload_code_id,
+        }),
+        BlockRequestEvent::Mirror {
+            actor_id: async_id,
+            event: MirrorRequestEvent::ExecutableBalanceTopUpRequested {
+                value: 10_000_000_000,
+            },
+        },
+        BlockRequestEvent::Mirror {
+            actor_id: async_id,
+            event: MirrorRequestEvent::MessageQueueingRequested {
+                id: get_next_message_id(),
+                source: user_id,
+                payload: ping_id.encode(),
+                value: 0,
+            },
+        },
+    ];
+
+    // Check no block states before processing events.
+    let res = get_program_mq(ping_id, block1, &processor);
+    assert_eq!(
+        res.unwrap_err().to_string(),
+        "failed to get block states".to_string()
+    );
+    assert!(get_program_mq(async_id, block1, &processor).is_err());
+
+    // Process events
+    let _ = processor
+        .process_block_events(block1, events)
+        .expect("failed to process events");
+
+    // Check that program have empty queues
+    let ping_mq = get_program_mq(ping_id, block1, &processor).expect("ping mq wasn't found");
+    let async_mq = get_program_mq(async_id, block1, &processor).expect("async mq wasn't found");
+    assert!(ping_mq.is_empty());
+    assert!(async_mq.is_empty());
+
+    // Create a new block for sending messages to programs.
+    // This block won't be processed, but there will be messages saved into corresponsing queues.
+    // Such a behaviour is needed to test a case when RPC calculate reply for handle is called and
+    // the target program during cross-program communication sends a message to another program,
+    // which has a long list of messages
+    let block2 = init_new_block_from_parent(&mut processor, block1);
+    let mut handler_block2 = processor.handler(block2).unwrap();
+
+    // Manually add messages to programs queues
+    let new_block_ping_mid1 = get_next_message_id();
+    handler_block2
+        .handle_mirror_event(
+            ping_id,
+            MirrorRequestEvent::MessageQueueingRequested {
+                id: new_block_ping_mid1,
+                source: user_id,
+                payload: b"PING".to_vec(),
+                value: 0,
+            },
+        )
+        .expect("failed to send message");
+
+    let new_block_ping_mid2 = get_next_message_id();
+    handler_block2
+        .handle_mirror_event(
+            ping_id,
+            MirrorRequestEvent::MessageQueueingRequested {
+                id: new_block_ping_mid2,
+                source: user_id,
+                payload: b"PING".to_vec(),
+                value: 0,
+            },
+        )
+        .expect("failed to send message");
+
+    let new_block_async_mid1 = get_next_message_id();
+    handler_block2
+        .handle_mirror_event(
+            async_id,
+            MirrorRequestEvent::MessageQueueingRequested {
+                id: new_block_async_mid1,
+                source: user_id,
+                payload: demo_async::Command::Common.encode().encode(),
+                value: 0,
+            },
+        )
+        .expect("failed to send message");
+    let new_block_async_mid2 = get_next_message_id();
+    handler_block2
+        .handle_mirror_event(
+            async_id,
+            MirrorRequestEvent::MessageQueueingRequested {
+                id: new_block_async_mid2,
+                source: user_id,
+                payload: demo_async::Command::Common.encode().encode(),
+                value: 0,
+            },
+        )
+        .expect("failed to send message");
+    let new_block_async_mid3 = get_next_message_id();
+    handler_block2
+        .handle_mirror_event(
+            async_id,
+            MirrorRequestEvent::MessageQueueingRequested {
+                id: new_block_async_mid3,
+                source: user_id,
+                payload: demo_async::Command::Common.encode().encode(),
+                value: 0,
+            },
+        )
+        .expect("failed to send message");
+
+    // Handler ops wrote to the storage states of particular programs,
+    // but block programs states are not updated yet.
+    // That's why state hash isn't obtained from the db.
+    let ping_state_hash = handler_block2
+        .transitions
+        .state_of(&ping_id)
+        .expect("failed to get ping state");
+    let ping_mq = get_mq_from_state_hash(ping_state_hash, &processor)
+        .expect("failed to get ping message queue");
+    assert_eq!(ping_mq.len(), 2);
+
+    let async_state_hash = handler_block2
+        .transitions
+        .state_of(&async_id)
+        .expect("failed to get async state");
+    let async_mq = get_mq_from_state_hash(async_state_hash, &processor)
+        .expect("failed to get async message queue");
+    assert_eq!(async_mq.len(), 3);
+
+    // Finalize (from the ethexe-processor point of view) the block
+    let (_, states, schedule) = handler_block2.transitions.finalize();
+    processor.db.set_block_program_states(block2, states);
+    processor.db.set_block_schedule(block2, schedule);
+
+    // Same checks as above, but with obtaining states from db
+    let ping_mq = get_program_mq(ping_id, block2, &processor).expect("ping mq wasn't found");
+    assert_eq!(ping_mq.len(), 2);
+    let async_mq = get_program_mq(async_id, block2, &processor).expect("async mq wasn't found");
+    assert_eq!(async_mq.len(), 3);
+
+    // Start a new block and finalize it without processing queue.
+    let block3 = init_new_block_from_parent(&mut processor, block2);
+    let handler_block3 = processor.handler(block3).unwrap();
+    let (_, states, schedule) = handler_block3.transitions.finalize();
+    processor.db.set_block_program_states(block3, states);
+    processor.db.set_block_schedule(block3, schedule);
+
+    // Check queues are still not empty in the block3.
+    let ping_mq = get_program_mq(ping_id, block3, &&processor).expect("ping mq wasn't found");
+    assert_eq!(ping_mq.len(), 2);
+    let async_mq = get_program_mq(async_id, block3, &&processor).expect("async mq wasn't found");
+    assert_eq!(async_mq.len(), 3);
+
+    // Send message using overlay on the block3.
+    let mut overlaid_processor = processor.clone().overlaid();
+    let reply_info = overlaid_processor
+        .execute_for_reply(
+            block3,
+            user_id,
+            async_id,
+            demo_async::Command::Common.encode(),
+            0,
+        )
+        .expect("failed to call execute_for_reply");
+    assert_eq!(reply_info.payload, MessageId::zero().encode());
+
+    // Check mq states on overlaid processor for block3
+    let ping_mq =
+        get_program_mq(ping_id, block3, &overlaid_processor.0).expect("ping mq wasn't found");
+    assert_eq!(ping_mq.len(), 0);
+    let async_mq =
+        get_program_mq(async_id, block3, &overlaid_processor.0).expect("async mq wasn't found");
+    assert_eq!(async_mq.len(), 0);
+
+    // Check mq states on the main processor for block3
+    let mut ping_mq = get_program_mq(ping_id, block3, &processor).expect("ping mq wasn't found");
+    assert_eq!(ping_mq.len(), 2);
+    let ping_msg1 = ping_mq.dequeue().expect("mq is empty");
+    assert_eq!(ping_msg1.id, new_block_ping_mid1);
+    let ping_msg2 = ping_mq.dequeue().expect("mq is empty");
+    assert_eq!(ping_msg2.id, new_block_ping_mid2);
+
+    let mut async_mq = get_program_mq(async_id, block3, &processor).expect("async mq wasn't found");
+    assert_eq!(async_mq.len(), 3);
+    let async_msg1 = async_mq.dequeue().expect("mq is empty");
+    assert_eq!(async_msg1.id, new_block_async_mid1);
+    let async_msg2 = async_mq.dequeue().expect("mq is empty");
+    assert_eq!(async_msg2.id, new_block_async_mid2);
+    let async_msg3 = async_mq.dequeue().expect("mq is empty");
+    assert_eq!(async_msg3.id, new_block_async_mid3);
 }
 
 mod utils {

--- a/ethexe/rpc/src/apis/program.rs
+++ b/ethexe/rpc/src/apis/program.rs
@@ -123,7 +123,7 @@ impl ProgramServer for ProgramApi {
         payload: Bytes,
         value: u128,
     ) -> RpcResult<ReplyInfo> {
-        let block_hash = block_header_at_or_latest(&self.db, at)?.0;
+        let (block_hash, _) = block_header_at_or_latest(&self.db, at)?;
 
         // TODO (breathx): spawn in a new thread and catch panics. (?) Generally catch runtime panics (?).
         // TODO (breathx): optimize here instantiation if matches actual runtime.

--- a/ethexe/rpc/src/test_utils.rs
+++ b/ethexe/rpc/src/test_utils.rs
@@ -20,11 +20,9 @@
 
 use anyhow::{bail, Result as AnyhowResult};
 use ethexe_common::tx_pool::OffchainTransaction;
-use gprimitives::{H160, H256};
 use jsonrpsee::types::ErrorObjectOwned;
 use reqwest::{Client, Response, Result};
 use serde::{de::DeserializeOwned, Deserialize};
-use sp_core::Bytes;
 
 /// Client for the ethexe rpc server.
 pub struct RpcClient {
@@ -51,30 +49,6 @@ impl RpcClient {
             "params": {
                 "ethexe_tx": ethexe_tx,
                 "signature": signature,
-            },
-            "id": 1,
-        });
-
-        self.client.post(&self.url).json(&body).send().await
-    }
-
-    pub async fn calculate_reply_for_handle(
-        &self,
-        at: Option<H256>,
-        source: H160,
-        program_id: H160,
-        payload: Bytes,
-        value: u128,
-    ) -> Result<Response> {
-        let body = serde_json::json!({
-            "jsonrpc": "2.0",
-            "method": "program_calculateReplyForHandle",
-            "params": {
-                "at": at,
-                "source": source,
-                "program_id": program_id,
-                "payload": payload,
-                "value": value,
             },
             "id": 1,
         });

--- a/ethexe/runtime/common/src/lib.rs
+++ b/ethexe/runtime/common/src/lib.rs
@@ -63,6 +63,12 @@ pub trait RuntimeInterface<S: Storage> {
     fn storage(&self) -> &S;
 }
 
+/// A main low-level interface to perform state changes
+/// for programs.
+///
+/// Has a main method [`update_state`] which allows to update program state
+/// along with writing the updated state to the storage.
+/// By design updates are stored in-memory inside the [`InBlockTransitions`].
 pub struct TransitionController<'a, S: Storage> {
     pub storage: &'a S,
     pub transitions: &'a mut InBlockTransitions,

--- a/ethexe/runtime/common/src/state.rs
+++ b/ethexe/runtime/common/src/state.rs
@@ -712,6 +712,22 @@ impl MessageQueue {
     }
 }
 
+/// Methods introduced due to solution to #4513.
+/// Remove when becomes unnecessary.
+impl MessageQueue {
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn clear(&mut self) {
+        self.0.clear()
+    }
+
+    pub fn pop_back(&mut self) -> Option<Dispatch> {
+        self.0.pop_back()
+    }
+}
+
 #[derive(Clone, Default, Debug, Encode, Decode, PartialEq, Eq, derive_more::Into)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct Waitlist {

--- a/ethexe/runtime/common/src/transitions.rs
+++ b/ethexe/runtime/common/src/transitions.rs
@@ -28,6 +28,15 @@ use ethexe_common::{
 };
 use gprimitives::{ActorId, H256};
 
+/// In-memory store for the state transitions
+/// that are going to be applied in the current block.
+///
+/// The type is instantiated with states taken from the parent
+/// block, as parent block stores latest states to be possibly
+/// updated in the current block.
+///
+/// The type actually stores latest state transitions, which are going to be
+/// applied in the current block.
 #[derive(Debug, Default)]
 pub struct InBlockTransitions {
     header: BlockHeader,

--- a/ethexe/runtime/common/src/transitions.rs
+++ b/ethexe/runtime/common/src/transitions.rs
@@ -55,7 +55,7 @@ impl InBlockTransitions {
     }
 
     pub fn state_of(&self, actor_id: &ActorId) -> Option<H256> {
-        self.states.get(actor_id).cloned()
+        self.states.get(actor_id).copied()
     }
 
     pub fn states_amount(&self) -> usize {
@@ -67,7 +67,7 @@ impl InBlockTransitions {
     }
 
     pub fn known_programs(&self) -> Vec<ActorId> {
-        self.states.keys().cloned().collect()
+        self.states.keys().copied().collect()
     }
 
     pub fn current_messages(&self) -> Vec<(ActorId, Message)> {

--- a/ethexe/service/src/tests.rs
+++ b/ethexe/service/src/tests.rs
@@ -38,14 +38,14 @@ use ethexe_ethereum::{router::RouterQuery, Ethereum};
 use ethexe_observer::{EthereumConfig, MockBlobReader};
 use ethexe_processor::Processor;
 use ethexe_prometheus::PrometheusConfig;
-use ethexe_rpc::{test_utils::RpcClient, RpcConfig};
+use ethexe_rpc::{test_utils::{RpcClient, SerdeJsonRpcResponse}, RpcConfig};
 use ethexe_runtime_common::state::{Expiring, MailboxMessage, PayloadLookup, Storage};
 use ethexe_signer::Signer;
 use ethexe_tx_pool::{OffchainTransaction, RawOffchainTransaction, SignedOffchainTransaction};
 use ethexe_validator::Validator;
 use gear_core::{
     ids::prelude::*,
-    message::{ReplyCode, SuccessReplyReason},
+    message::{ReplyCode, ReplyInfo, SuccessReplyReason},
 };
 use gear_core_errors::{ErrorReplyReason, SimpleExecutionError};
 use gprimitives::{ActorId, CodeId, MessageId, H160, H256};
@@ -1137,6 +1137,152 @@ async fn tx_pool_gossip() {
         .get_offchain_transaction(tx_hash)
         .expect("tx not found");
     assert_eq!(node1_db_tx, signed_ethexe_tx);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ntest::timeout(60_000)]
+async fn test_calculate_reply_for_handle_ping() {
+    utils::init_logger();
+
+    let mut env = TestEnv::new(Default::default()).await.unwrap();
+    log::info!("📗 Starting node");
+    let sequencer_public_key = env.wallets.next();
+    let mut validator = env.new_node(
+        NodeConfig::default()
+            .sequencer(sequencer_public_key)
+            .validator(env.validators[0], env.validator_session_public_keys[0])
+            .service_rpc(9505),
+    );
+    validator.start_service().await;
+
+    // Upload program
+    log::info!("📗 Uploading program");
+    let res = env
+        .upload_code(demo_ping::WASM_BINARY)
+        .await
+        .unwrap()
+        .wait_for()
+        .await
+        .unwrap();
+    assert_eq!(res.code, demo_ping::WASM_BINARY);
+    assert!(res.valid);
+
+    // Create program
+    log::info!("📗 Creating program");
+    let ping_code_id = res.code_id;
+    let res = env
+        .create_program(ping_code_id, 500_000_000_000_000)
+        .await
+        .unwrap()
+        .wait_for()
+        .await
+        .unwrap();
+
+    // Why is that essential for the test? Does that serve as an init?
+    let res = env
+        .send_message(res.program_id, b"PING", 0)
+        .await
+        .unwrap()
+        .wait_for()
+        .await
+        .unwrap();
+
+    assert_eq!(res.code, ReplyCode::Success(SuccessReplyReason::Manual));
+    assert_eq!(res.payload, b"PONG");
+    assert_eq!(res.value, 0);
+
+    // Wait until the program is initialized
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Calculate reply for handle
+    log::info!("📗 Calculating reply for handle");
+    let sender_id = env.sender_id.try_into().unwrap();
+    let program_id = res.program_id.try_into().unwrap();
+    let rpc_client = validator.rpc_client().expect("rpc server is set");
+    let resp = rpc_client
+        .calculate_reply_for_handle(None, sender_id, program_id, b"PING".to_vec().into(), 0)
+        .await
+        .expect("failed sending request");
+    let reply_info = SerdeJsonRpcResponse::new(resp)
+        .await
+        .expect("failed to deserialize json response from rpc")
+        .try_extract_res::<ReplyInfo>()
+        .expect("failed to deserialize reply info");
+
+    assert_eq!(reply_info.payload, b"PONG".to_vec());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ntest::timeout(60_000)]
+async fn test_calculate_reply_for_handle_async() {
+    utils::init_logger();
+
+    let mut env = TestEnv::new(Default::default()).await.unwrap();
+    log::info!("📗 Starting node");
+    let sequencer_public_key = env.wallets.next();
+    let mut validator = env.new_node(
+        NodeConfig::default()
+            .sequencer(sequencer_public_key)
+            .validator(env.validators[0], env.validator_session_public_keys[0])
+            .service_rpc(9505),
+    );
+    validator.start_service().await;
+
+    let res = env
+        .upload_code(demo_async::WASM_BINARY)
+        .await
+        .unwrap()
+        .wait_for()
+        .await
+        .unwrap();
+
+    assert!(res.valid);
+
+    let code_id = res.code_id;
+
+    let res = env
+        .create_program(code_id, 500_000_000_000_000)
+        .await
+        .unwrap()
+        .wait_for()
+        .await
+        .unwrap();
+
+    let init_res = env
+        .send_message(res.program_id, &env.sender_id.encode(), 0)
+        .await
+        .unwrap()
+        .wait_for()
+        .await
+        .unwrap();
+    assert_eq!(init_res.code, ReplyCode::Success(SuccessReplyReason::Auto));
+
+    // Wait until the program is initialized
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let pid = res.program_id;
+
+    env.approve_wvara(pid).await;
+
+    log::info!("📗 Calculating reply for handle");
+    let rpc_client = validator.rpc_client().expect("rpc server is set");
+    let resp = rpc_client
+        .calculate_reply_for_handle(
+            None,
+            env.sender_id.try_into().unwrap(),
+            pid.try_into().unwrap(),
+            demo_async::Command::Common.encode().into(),
+            0,
+        )
+        .await
+        .expect("failed sending request");
+    let err = SerdeJsonRpcResponse::new(resp)
+        .await
+        .expect("failed to deserialize json response from rpc")
+        .try_extract_err()
+        .expect("failed to deserialize reply info");
+
+    assert!(err.data().unwrap().get().contains("reply wasn't found"));
 }
 
 mod utils {


### PR DESCRIPTION
Resolves #4513

- Introduce `OverlayRunContext` which nullifies queues during the first access to the program
- Tests: overlay execution doesn't change the original state, nullification is performed properly (no double nullification)
- Clarifying docs to some types and functions

The solution could be by cleaning all the queues before even calling the `run` function, but that would make us to iterate over all the programs twice: once before processing queue, once during queue processing. To avoid that and to gather all the changes in one place, a current solution was provided - everything is done inside `run_overlaid` function in one particular module.
This solution won't create much obstacles for the #4488, as changes are clear to understand and adapt.
