### PR TITLE
fix(ethexe-processor): Enable wasmtime cache

### DIFF
--- a/ethexe/processor/src/host/mod.rs
+++ b/ethexe/processor/src/host/mod.rs
@@ -55,7 +55,9 @@ pub(crate) struct InstanceCreator {
 
 impl InstanceCreator {
     pub fn new(runtime: Vec<u8>) -> Result<Self> {
-        let engine = wasmtime::Engine::default();
+        let mut config = wasmtime::Config::new();
+        config.cache_config_load_default()?;
+        let engine = wasmtime::Engine::new(&config)?;
 
         let module = wasmtime::Module::new(&engine, runtime)?;
         let mut linker = wasmtime::Linker::new(&engine);


### PR DESCRIPTION
Disabled caching was the reason of CPU load spikes during `ethexe-service` tests