### PR TITLE
chore: Update rust to nightly-2025-05-28

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-05-09"
+channel = "nightly-2025-05-28"
 components = [ "llvm-tools" ]
 targets = [ "wasm32v1-none" ]


### PR DESCRIPTION


To get rid of the missing cargo component

@gear-tech/dev 