### PR TITLE
fix(gbuiltin-proxy): Fix proxy builtin actor id

### DIFF
--- a/examples/proxy-broker/src/wasm.rs
+++ b/examples/proxy-broker/src/wasm.rs
@@ -25,7 +25,7 @@ use gstd::{actor_id, debug, errors::Error, msg, ActorId};
 //
 // Calculated as hash((b"built/in", 3u64).encode())
 const BUILTIN_ADDRESS: ActorId =
-    actor_id!("0xf2816ced0b15749595392d3a18b5a2363d6fefe5b3b6153739f218151b7acdbf");
+    actor_id!("0x8263cd9fc648e101f1cd8585dc0b193445c3750a63bf64a39cdf58de14826299");
 
 #[gstd::async_main]
 async fn main() {

--- a/examples/proxy-broker/src/wasm.rs
+++ b/examples/proxy-broker/src/wasm.rs
@@ -25,7 +25,7 @@ use gstd::{actor_id, debug, errors::Error, msg, ActorId};
 //
 // Calculated as hash((b"built/in", 3u64).encode())
 const BUILTIN_ADDRESS: ActorId =
-    actor_id!("0x8263cd9fc648e101f1cd8585dc0b193445c3750a63bf64a39cdf58de14826299");
+    actor_id!("0xf2816ced0b15749595392d3a18b5a2363d6fefe5b3b6153739f218151b7acdbf");
 
 #[gstd::async_main]
 async fn main() {

--- a/pallets/gear-builtin/src/mock.rs
+++ b/pallets/gear-builtin/src/mock.rs
@@ -332,7 +332,7 @@ impl pallet_gear_builtin::Config for Test {
         ActorWithId<ERROR_ACTOR_ID, ErrorBuiltinActor>,
         ActorWithId<HONEST_ACTOR_ID, HonestBuiltinActor>,
         ActorWithId<1, bls12_381::Actor<Self>>,
-        ActorWithId<3, proxy::Actor<Self>>,
+        ActorWithId<4, proxy::Actor<Self>>,
     );
     type BlockLimiter = GearGas;
     type WeightInfo = ();

--- a/pallets/gear-builtin/src/mock.rs
+++ b/pallets/gear-builtin/src/mock.rs
@@ -332,7 +332,7 @@ impl pallet_gear_builtin::Config for Test {
         ActorWithId<ERROR_ACTOR_ID, ErrorBuiltinActor>,
         ActorWithId<HONEST_ACTOR_ID, HonestBuiltinActor>,
         ActorWithId<1, bls12_381::Actor<Self>>,
-        ActorWithId<4, proxy::Actor<Self>>,
+        ActorWithId<3, proxy::Actor<Self>>,
     );
     type BlockLimiter = GearGas;
     type WeightInfo = ();


### PR DESCRIPTION
Proxy id was generated using `ID: u64 = 3`, instead of `4`.
