### PR TITLE
chore: Bump down `tempfile` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4613,7 +4613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13257,7 +13257,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.7",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13993,7 +13993,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -17670,7 +17670,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,7 @@ wasmparser = { version = "0.230", default-features = false, features = ["validat
 which = "4.4.2"
 winapi = "0.3.9"
 paste = "1.0"
-tempfile = "3.20"
+tempfile = "3.19"
 ark-std = { version = "0.4.0", default-features = false }
 ark-bls12-381 = { version = "0.4.0", default-features = false }
 ark-serialize = { version = "0.4", default-features = false }


### PR DESCRIPTION
The `3.20` is incompatible with `sails`, as the latter uses `cargo-generate`, which in its latest version has tempfile defined with `~3.19`.
