### PR TITLE
feat(ethexe-middleware): add identifier registration for operators

### DIFF
--- a/ethexe/contracts/src/IMiddleware.sol
+++ b/ethexe/contracts/src/IMiddleware.sol
@@ -114,7 +114,7 @@ interface IMiddleware {
         Gear.SymbioticRegistries registries;
         EnumerableMap.AddressToUintMap operators;
         EnumerableMap.AddressToUintMap vaults;
-        mapping(address => Gear.AggregatedPublicKey) operatorPublicKeys;
+        mapping(address => address) operatorIdentifiers;
     }
 
     struct VaultSlashData {
@@ -151,7 +151,7 @@ interface IMiddleware {
     function roleSlashRequester() external view returns (address);
     function roleSlashExecutor() external view returns (address);
     function operatorRegistry() external view returns (address);
-    function operatorPublicKeys(address operator) external view returns (uint256, uint256);
+    function operatorIdentifiers(address operator) external view returns (address);
 
     // # Calls.
     function changeSlashRequester(address newRole) external;
@@ -185,7 +185,7 @@ interface IMiddleware {
 
     /// @notice Registers a public key for an operator
     /// @param publicKey The aggregated public key to register
-    function registerPublicKey(Gear.AggregatedPublicKey calldata publicKey) external;
+    function registerIdentifier(address publicKey) external;
 
     /* Vaults managing */
 

--- a/ethexe/contracts/src/IMiddleware.sol
+++ b/ethexe/contracts/src/IMiddleware.sol
@@ -114,6 +114,7 @@ interface IMiddleware {
         Gear.SymbioticRegistries registries;
         EnumerableMap.AddressToUintMap operators;
         EnumerableMap.AddressToUintMap vaults;
+        mapping(address => Gear.AggregatedPublicKey) operatorPublicKeys;
     }
 
     struct VaultSlashData {
@@ -150,6 +151,7 @@ interface IMiddleware {
     function roleSlashRequester() external view returns (address);
     function roleSlashExecutor() external view returns (address);
     function operatorRegistry() external view returns (address);
+    function operatorPublicKeys(address operator) external view returns (uint256, uint256);
 
     // # Calls.
     function changeSlashRequester(address newRole) external;
@@ -180,6 +182,10 @@ interface IMiddleware {
 
     /// @notice This function can be called only be operator themselves.
     function unregisterOperator(address operator) external;
+
+    /// @notice Registers a public key for an operator
+    /// @param publicKey The aggregated public key to register
+    function registerPublicKey(Gear.AggregatedPublicKey calldata publicKey) external;
 
     /* Vaults managing */
 

--- a/ethexe/contracts/src/Middleware.sol
+++ b/ethexe/contracts/src/Middleware.sol
@@ -202,9 +202,8 @@ contract Middleware is IMiddleware, OwnableUpgradeable, ReentrancyGuardTransient
         return _storage().registries.operatorRegistry;
     }
 
-    function operatorPublicKeys(address operator) external view returns (uint256, uint256) {
-        Gear.AggregatedPublicKey memory key = _storage().operatorPublicKeys[operator];
-        return (key.x, key.y);
+    function operatorIdentifiers(address operator) external view returns (address) {
+        return _storage().operatorIdentifiers[operator];
     }
 
     // # Calls.
@@ -239,11 +238,11 @@ contract Middleware is IMiddleware, OwnableUpgradeable, ReentrancyGuardTransient
         $.operators.append(msg.sender, 0);
     }
 
-    function registerPublicKey(Gear.AggregatedPublicKey calldata publicKey) external {
+    function registerIdentifier(address identifier) external {
         Storage storage $ = _storage();
         require($.operators.contains(msg.sender), "Operator not registered");
-        require(FROST.isValidPublicKey(publicKey.x, publicKey.y), "Invalid public key");
-        $.operatorPublicKeys[msg.sender] = publicKey;
+        require(identifier != address(0), "Invalid identifier");
+        $.operatorIdentifiers[msg.sender] = identifier;
     }
 
     function disableOperator() external {


### PR DESCRIPTION
 To be used later in DKG session to match and identify operators node.

 - identifier is an address
 - identifier must be unique
 - only registered operator can submit it's identifier

@reviewer-or-team
