### PR TITLE
revert: Don't build WASMs inside Substrate runtime

### DIFF
--- a/scripts/src/clippy.sh
+++ b/scripts/src/clippy.sh
@@ -42,7 +42,7 @@ examples_clippy() {
 no_std_clippy() {
   mapfile -t no_std < <(
     cargo metadata --no-deps --format-version=1 |
-    jq -r '.packages.[] | select(any(.dependencies.[]; .name == "gear-wasm-builder") | not) | select(.features | index("std")) | "-p=" + .name'
+    jq -r '.packages.[] | select(.features | index("std")) | "-p=" + .name'
   )
   RUSTFLAGS="--cfg=substrate_runtime" \
   __GEAR_WASM_BUILDER_NO_BUILD=1 \

--- a/utils/wasm-builder/src/lib.rs
+++ b/utils/wasm-builder/src/lib.rs
@@ -93,18 +93,8 @@ impl WasmBuilder {
     /// Returns `Some(_)` with a tuple of paths to wasm & opt wasm file
     /// if the build was successful.
     pub fn build(self) -> Option<(PathBuf, PathBuf)> {
-        // it means we are inside a Substrate runtime build script,
-        // so WASM is already built, and we just return paths
-        if env::var("CARGO_CFG_SUBSTRATE_RUNTIME").is_ok() {
-            return self
-                .provide_paths_for_substrate_runtime()
-                .expect("failed to provide paths");
-        }
-
-        let gear_wasm_builder_no_build = env::var("__GEAR_WASM_BUILDER_NO_BUILD").is_ok();
-        let skip_wasm_build = env::var("SKIP_WASM_BUILD").is_ok();
-        if gear_wasm_builder_no_build || skip_wasm_build || is_intellij_sync() {
-            let _ = self.wasm_project.provide_dummy_wasm_binary_if_not_exist();
+        if env::var("__GEAR_WASM_BUILDER_NO_BUILD").is_ok() || is_intellij_sync() {
+            _ = self.wasm_project.provide_dummy_wasm_binary_if_not_exist();
             return None;
         }
 
@@ -118,11 +108,6 @@ impl WasmBuilder {
             }
             Ok(r) => r,
         }
-    }
-
-    fn provide_paths_for_substrate_runtime(mut self) -> Result<Option<(PathBuf, PathBuf)>> {
-        self.wasm_project.generate()?;
-        self.wasm_project.postprocess()
     }
 
     fn build_project(mut self) -> Result<Option<(PathBuf, PathBuf)>> {

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -20,11 +20,8 @@ use crate::{code_validator::validate_program, crate_info::CrateInfo, smart_fs};
 use anyhow::{anyhow, Context, Ok, Result};
 use chrono::offset::Local as ChronoLocal;
 use gear_wasm_optimizer::{self as optimize, Optimizer};
-use itertools::Itertools;
 use std::{
-    env,
-    ffi::OsStr,
-    fs,
+    env, fs,
     path::{Path, PathBuf},
 };
 use toml::value::Table;
@@ -86,29 +83,14 @@ impl WasmProject {
             .expect("`OUT_DIR` is always set in build scripts")
             .into();
 
-        let substrate_runtime = env::var("CARGO_CFG_SUBSTRATE_RUNTIME").is_ok();
-        // Substrate runtime is usually built inside a workspace target in its own target directory,
-        // that looks like `target/debug/wbuild/SUBSTRATE_RUNTIME/target`,
-        // so we need to skip the first occurrence of `target`
-        let mut first_target_reached = false;
-
         let profile = out_dir
             .components()
             .rev()
-            .take_while(|c| {
-                if c.as_os_str() != "target" {
-                    true
-                } else if substrate_runtime && !first_target_reached {
-                    first_target_reached = true;
-                    true
-                } else {
-                    false
-                }
-            })
-            .collect::<PathBuf>()
-            .components()
+            .take_while(|c| c.as_os_str() != "target")
+            .collect::<Vec<_>>()
+            .into_iter()
             .rev()
-            .take_while(|c| c.as_os_str() != "build" && c.as_os_str() != "wbuild")
+            .take_while(|c| c.as_os_str() != "build")
             .last()
             .expect("Path should have subdirs in the `target` dir")
             .as_os_str()
@@ -117,22 +99,12 @@ impl WasmProject {
 
         let mut target_dir = out_dir
             .ancestors()
-            .find(|path| path.ends_with(&profile) && !path.iter().contains(&OsStr::new("wbuild")))
+            .find(|path| path.ends_with(&profile))
             .and_then(|path| path.parent())
-            .expect("Could not find target directory")
-            .to_owned();
+            .map(|p| p.to_owned())
+            .expect("Could not find target directory");
 
         let mut wasm_target_dir = target_dir.clone();
-
-        // remove component to avoid creating a directory inside
-        // `target/x86_64-unknown-linux-gnu` and so on when cross-compiling.
-        //
-        // also don't change the directory if we are inside a Substrate runtime build script
-        // because the branch is always true in such case
-        if !substrate_runtime && env::var("HOST") != env::var("TARGET") {
-            wasm_target_dir.pop();
-        }
-
         wasm_target_dir.push("wasm32-gear");
         wasm_target_dir.push(&profile);
 
@@ -266,7 +238,7 @@ impl WasmProject {
         Ok(())
     }
 
-    fn generate_bin_path(&self, file_base_name: &str) -> Result<()> {
+    fn generate_bin_path(&self, file_base_name: &String) -> Result<()> {
         let relative_path_to_wasm = pathdiff::diff_paths(&self.wasm_target_dir, &self.original_dir)
             .with_context(|| {
                 format!(
@@ -299,14 +271,8 @@ impl WasmProject {
             .map(|ext| self.wasm_target_dir.join([file_base_name, ext].concat()));
 
         // Copy original file to `self.wasm_target_dir`
-        smart_fs::copy_if_newer(&original_wasm_path, &original_copy_wasm_path).with_context(
-            || {
-                format!(
-                    "unable to copy WASM file from {}",
-                    original_copy_wasm_path.display()
-                )
-            },
-        )?;
+        smart_fs::copy_if_newer(&original_wasm_path, &original_copy_wasm_path)
+            .context("unable to copy WASM file")?;
 
         // Optimize wasm using and `wasm-opt` and our optimizations.
         if smart_fs::check_if_newer(&original_wasm_path, &opt_wasm_path)? {
@@ -368,7 +334,7 @@ pub const WASM_BINARY_OPT: &[u8] = include_bytes!("{}");"#,
 
         self.generate_bin_path(file_base_name)?;
 
-        let mut wasm_files = vec![(original_wasm_path.clone(), file_base_name.to_string())];
+        let mut wasm_files = vec![(original_wasm_path.clone(), file_base_name.clone())];
 
         for pre_processor in &self.pre_processors {
             let pre_processor_name = pre_processor.name().to_lowercase().replace('-', "_");


### PR DESCRIPTION
This reverts commit 776dd5e0e048d01fb347e7077753a9f7670d9d4b.

Don't actually work because demo and runtime build scripts can be finished in any order, so runtime will wait for not existing WASM file
