### PR TITLE
Use `mimalloc` allocator for pallet-gear tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4619,7 +4619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11243,6 +11243,7 @@ dependencies = [
  "gsys",
  "hex",
  "log",
+ "mimalloc",
  "pallet-authorship",
  "pallet-balances",
  "pallet-gear-bank",
@@ -13217,7 +13218,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.7",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13952,7 +13953,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -17650,7 +17651,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/pallets/gear/Cargo.toml
+++ b/pallets/gear/Cargo.toml
@@ -124,6 +124,7 @@ demo-vec.workspace = true
 test-syscalls = { workspace = true, features = ["debug"] }
 frame-support-test = { workspace = true, features = ["std"] }
 common = { workspace = true, features = ["std"] }
+mimalloc = { workspace = true, default-features = false }
 pallet-gear-gas = { workspace = true, features = ["std"] }
 pallet-gear-messenger = { workspace = true, features = ["std"] }
 pallet-gear-scheduler = { workspace = true, features = ["std"] }

--- a/pallets/gear/src/tests.rs
+++ b/pallets/gear/src/tests.rs
@@ -70,6 +70,7 @@ use gstd::{
     collections::BTreeMap,
     errors::{CoreError, Error as GstdError},
 };
+use mimalloc::MiMalloc;
 use pallet_gear_voucher::PrepaidCall;
 use sp_core::H256;
 use sp_runtime::{
@@ -83,6 +84,9 @@ pub use utils::init_logger;
 use utils::*;
 
 type Gas = <<Test as Config>::GasProvider as common::GasProvider>::GasTree;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 #[test]
 fn err_reply_comes_with_value() {


### PR DESCRIPTION
Resolves #4730 .

- Use `mimalloc` allocator for pallet-gear tests