### PR TITLE
feat(gtest): Introduce builtins to `gtest`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7140,6 +7140,7 @@ dependencies = [
  "demo-ping",
  "etc",
  "gbuiltin-bls381",
+ "gbuiltin-eth-bridge",
  "gear-common",
  "gear-core",
  "gear-core-errors",
@@ -7148,6 +7149,7 @@ dependencies = [
  "gear-lazy-pages-common",
  "gear-lazy-pages-native-interface",
  "gear-utils",
+ "gprimitives",
  "gsys",
  "log",
  "parity-scale-codec",
@@ -7157,6 +7159,7 @@ dependencies = [
  "sha2 0.10.8",
  "sp-core",
  "sp-crypto-ec-utils",
+ "sp-runtime",
  "thiserror 2.0.12",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7124,6 +7124,12 @@ version = "1.9.0"
 name = "gtest"
 version = "1.9.0"
 dependencies = [
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff 0.4.2",
+ "ark-scale",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "cargo_toml",
  "colored",
  "demo-constructor",
@@ -7133,6 +7139,7 @@ dependencies = [
  "demo-piggy-bank",
  "demo-ping",
  "etc",
+ "gbuiltin-bls381",
  "gear-common",
  "gear-core",
  "gear-core-errors",
@@ -7146,7 +7153,10 @@ dependencies = [
  "parity-scale-codec",
  "path-clean",
  "rand 0.8.5",
+ "scale-info",
+ "sha2 0.10.8",
  "sp-core",
+ "sp-crypto-ec-utils",
  "thiserror 2.0.12",
  "tracing-subscriber",
 ]

--- a/gtest/Cargo.toml
+++ b/gtest/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+gprimitives = { workspace = true, features = ["std"] }
 gear-core.workspace = true
 gear-common = { workspace = true, features = ["std"] }
 gear-core-errors.workspace = true
@@ -21,6 +22,8 @@ gear-lazy-pages-native-interface.workspace = true
 gear-utils.workspace = true
 gsys.workspace = true
 gbuiltin-bls381.workspace = true
+gbuiltin-eth-bridge.workspace = true
+
 
 parity-scale-codec = { workspace = true, features = ["derive"] }
 scale-info = { workspace = true, features = ["derive"] }
@@ -33,6 +36,7 @@ cargo_toml.workspace = true
 etc.workspace = true
 thiserror.workspace = true
 
+# Builtins related dependencies
 ark-scale = { workspace = true, features = ["hazmat"] }
 ark-serialize = { workspace = true, features = ["derive"] }
 ark-bls12-381 = { workspace = true, features = ["curve"] }
@@ -40,6 +44,7 @@ ark-ec.workspace = true
 ark-ff.workspace = true
 sha2.workspace = true
 sp-crypto-ec-utils = { workspace = true, features = ["std", "bls12-381"] }
+sp-runtime = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 ark-std.workspace = true

--- a/gtest/Cargo.toml
+++ b/gtest/Cargo.toml
@@ -20,8 +20,10 @@ gear-lazy-pages-common.workspace = true
 gear-lazy-pages-native-interface.workspace = true
 gear-utils.workspace = true
 gsys.workspace = true
+gbuiltin-bls381.workspace = true
 
 parity-scale-codec = { workspace = true, features = ["derive"] }
+scale-info = { workspace = true, features = ["derive"] }
 colored.workspace = true
 tracing-subscriber.workspace = true
 path-clean.workspace = true
@@ -31,7 +33,16 @@ cargo_toml.workspace = true
 etc.workspace = true
 thiserror.workspace = true
 
+ark-scale = { workspace = true, features = ["hazmat"] }
+ark-serialize = { workspace = true, features = ["derive"] }
+ark-bls12-381 = { workspace = true, features = ["curve"] }
+ark-ec.workspace = true
+ark-ff.workspace = true
+sha2.workspace = true
+sp-crypto-ec-utils = { workspace = true, features = ["std", "bls12-381"] }
+
 [dev-dependencies]
+ark-std.workspace = true
 sp-core.workspace = true
 demo-custom.workspace = true
 demo-piggy-bank.workspace = true

--- a/gtest/src/builtins/bls12_381.rs
+++ b/gtest/src/builtins/bls12_381.rs
@@ -333,7 +333,6 @@ mod tests {
     #[test]
     fn test_multi_miller_loop() {
         let sys = System::new();
-        sys.init_logger();
 
         let alice_id = ActorId::from(DEFAULT_USER_ALICE);
         let proxy_pid = ActorId::new([3; 32]);
@@ -385,7 +384,6 @@ mod tests {
     #[test]
     fn test_final_exponentiation() {
         let sys = System::new();
-        sys.init_logger();
 
         let alice_id = ActorId::from(DEFAULT_USER_ALICE);
         let proxy_pid = ActorId::new([3; 32]);
@@ -442,7 +440,6 @@ mod tests {
     #[test]
     fn test_msm_g1() {
         let sys = System::new();
-        sys.init_logger();
 
         let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
         let proxy_pid = ActorId::new([3; 32]);
@@ -552,7 +549,6 @@ mod tests {
     #[test]
     fn test_msm_g2() {
         let sys = System::new();
-        sys.init_logger();
 
         let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
         let proxy_pid = ActorId::new([3; 32]);
@@ -662,7 +658,6 @@ mod tests {
     #[test]
     fn test_projective_multiplication_g1() {
         let sys = System::new();
-        sys.init_logger();
 
         let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
         let proxy_pid = ActorId::new([3; 32]);
@@ -717,7 +712,6 @@ mod tests {
     #[test]
     fn test_projective_multiplication_g2() {
         let sys = System::new();
-        sys.init_logger();
 
         let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
         let proxy_pid = ActorId::new([3; 32]);
@@ -772,7 +766,6 @@ mod tests {
     #[test]
     fn test_aggregate_g1() {
         let sys = System::new();
-        sys.init_logger();
 
         let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
         let proxy_pid = ActorId::new([3; 32]);
@@ -829,7 +822,6 @@ mod tests {
     #[test]
     fn test_map_to_g2affine() {
         let sys = System::new();
-        sys.init_logger();
 
         let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
         let proxy_pid = ActorId::new([3; 32]);

--- a/gtest/src/builtins/bls12_381.rs
+++ b/gtest/src/builtins/bls12_381.rs
@@ -325,7 +325,7 @@ mod tests {
             Calls::builder(),
         );
 
-        let proxy_program = Program::from_binary_with_id(&sys, proxy_id, WASM_BINARY);
+        let proxy_program = Program::from_binary_with_id(sys, proxy_id, WASM_BINARY);
 
         // Initialize proxy with the scheme
         let init_mid = proxy_program.send(reply_receiver, proxy_scheme);

--- a/gtest/src/builtins/bls12_381.rs
+++ b/gtest/src/builtins/bls12_381.rs
@@ -1,4 +1,27 @@
-pub use gbuiltin_bls381::{Request as Bls12Request, Response as Bls12Response};
+// This file is part of Gear.
+//
+// Copyright (C) 2025 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! BLS12-381 builtin actor implementation.
+//!
+//! The main function of the module is `process_bls12_381_dispatch` which processes
+//! incoming dispatches to the bls12-381 builtin actor.
+
+pub use gbuiltin_bls381::{Request as Bls12_381Request, Response as Bls12_381Response};
 
 use super::BuiltinActorError;
 use ark_bls12_381::{G1Projective as G1, G2Affine, G2Projective as G2};
@@ -9,40 +32,41 @@ use ark_ec::{
 use ark_ff::fields::field_hashers::DefaultFieldHasher;
 use ark_scale::{ArkScale, HOST_CALL};
 use ark_serialize::{CanonicalDeserialize, Compress, Validate};
-use gear_core::{ids::ActorId, str::LimitedStr};
+use gear_core::{ids::ActorId, message::StoredDispatch, str::LimitedStr};
 use parity_scale_codec::{Decode, Encode};
 use sp_crypto_ec_utils::bls12_381;
 
 /// The id of the BLS12-381 builtin actor.
 pub const BLS12_381_ID: ActorId = ActorId::new(*b"modl/bia/bls12-381/v-\x01\0/\0\0\0\0\0\0\0\0");
+
 const IS_COMPRESSED: Compress = ark_scale::is_compressed(HOST_CALL);
 const IS_VALIDATED: Validate = ark_scale::is_validated(HOST_CALL);
 
 type ArkScaleLocal<T> = ark_scale::ArkScale<T, { ark_scale::HOST_CALL }>;
 
-pub fn process_bls12_381_dispatch(mut payload: &[u8]) -> Result<Bls12Response, BuiltinActorError> {
-    log::warn!("BLS12_381 PAYLOAD {payload:?}");
+/// Processes a dispatch message sent to the BLS12-381 builtin actor.
+pub(crate) fn process_bls12_381_dispatch(dispatch: &StoredDispatch) -> Result<Bls12_381Response, BuiltinActorError> {
+    let mut payload = dispatch.payload_bytes();
     let payload_decoded =
-        Bls12Request::decode(&mut payload).map_err(|_| BuiltinActorError::DecodingError)?;
+        Bls12_381Request::decode(&mut payload).map_err(|_| BuiltinActorError::DecodingError)?;
 
     match payload_decoded {
-        Bls12Request::MultiMillerLoop { a, b } => multi_miller_loop(a, b),
-        Bls12Request::FinalExponentiation { f } => final_exponentiation(f),
-        Bls12Request::MultiScalarMultiplicationG1 { bases, scalars } => msm_g1(bases, scalars),
-        Bls12Request::MultiScalarMultiplicationG2 { bases, scalars } => msm_g2(bases, scalars),
-        Bls12Request::ProjectiveMultiplicationG1 { base, scalar } => {
+        Bls12_381Request::MultiMillerLoop { a, b } => multi_miller_loop(a, b),
+        Bls12_381Request::FinalExponentiation { f } => final_exponentiation(f),
+        Bls12_381Request::MultiScalarMultiplicationG1 { bases, scalars } => msm_g1(bases, scalars),
+        Bls12_381Request::MultiScalarMultiplicationG2 { bases, scalars } => msm_g2(bases, scalars),
+        Bls12_381Request::ProjectiveMultiplicationG1 { base, scalar } => {
             projective_multiplication_g1(base, scalar)
         }
-        Bls12Request::ProjectiveMultiplicationG2 { base, scalar } => {
+        Bls12_381Request::ProjectiveMultiplicationG2 { base, scalar } => {
             projective_multiplication_g2(base, scalar)
         }
-        Bls12Request::AggregateG1 { points } => aggregate_g1(points),
-        Bls12Request::MapToG2Affine { message } => map_to_g2affine(message),
+        Bls12_381Request::AggregateG1 { points } => aggregate_g1(points),
+        Bls12_381Request::MapToG2Affine { message } => map_to_g2affine(message),
     }
 }
 
-fn multi_miller_loop(a: Vec<u8>, b: Vec<u8>) -> Result<Bls12Response, BuiltinActorError> {
-    // decode the items count
+fn multi_miller_loop(a: Vec<u8>, b: Vec<u8>) -> Result<Bls12_381Response, BuiltinActorError> {
     let mut slice = a.as_slice();
     let mut reader = ark_scale::rw::InputAsRead(&mut slice);
     let Ok(count) = u64::deserialize_with_mode(&mut reader, IS_COMPRESSED, IS_VALIDATED) else {
@@ -68,46 +92,46 @@ fn multi_miller_loop(a: Vec<u8>, b: Vec<u8>) -> Result<Bls12Response, BuiltinAct
     // context.try_charge_gas(to_spend)?;
 
     match bls12_381::host_calls::bls12_381_multi_miller_loop(a, b) {
-        Ok(result) => Ok(Bls12Response::MultiMillerLoop(result)),
+        Ok(result) => Ok(Bls12_381Response::MultiMillerLoop(result)),
         Err(_) => Err(BuiltinActorError::Custom(LimitedStr::from_small_str(
             "Multi Miller loop: computation error",
         ))),
     }
 }
 
-fn final_exponentiation(f: Vec<u8>) -> Result<Bls12Response, BuiltinActorError> {
+fn final_exponentiation(f: Vec<u8>) -> Result<Bls12_381Response, BuiltinActorError> {
     // todo [sab] charge gas
     // let to_spend = WeightInfo::bls12_381_final_exponentiation().ref_time();
     // context.try_charge_gas(to_spend)?;
 
     match bls12_381::host_calls::bls12_381_final_exponentiation(f) {
-        Ok(result) => Ok(Bls12Response::FinalExponentiation(result)),
+        Ok(result) => Ok(Bls12_381Response::FinalExponentiation(result)),
         Err(_) => Err(BuiltinActorError::Custom(LimitedStr::from_small_str(
             "Final exponentiation: computation error",
         ))),
     }
 }
 
-fn msm_g1(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Bls12Response, BuiltinActorError> {
+fn msm_g1(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Bls12_381Response, BuiltinActorError> {
     msm(
         bases,
         scalars,
         |_count| 0, // WeightInfo::bls12_381_msm_g1(count).ref_time(),
         |bases, scalars| {
             bls12_381::host_calls::bls12_381_msm_g1(bases, scalars)
-                .map(Bls12Response::MultiScalarMultiplicationG1)
+                .map(Bls12_381Response::MultiScalarMultiplicationG1)
         },
     )
 }
 
-fn msm_g2(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Bls12Response, BuiltinActorError> {
+fn msm_g2(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Bls12_381Response, BuiltinActorError> {
     msm(
         bases,
         scalars,
         |_count| 0, // WeightInfo::bls12_381_msm_g2(count).ref_time(),
         |bases, scalars| {
             bls12_381::host_calls::bls12_381_msm_g2(bases, scalars)
-                .map(Bls12Response::MultiScalarMultiplicationG2)
+                .map(Bls12_381Response::MultiScalarMultiplicationG2)
         },
     )
 }
@@ -116,9 +140,8 @@ fn msm(
     bases: Vec<u8>,
     scalars: Vec<u8>,
     _gas_to_spend: impl FnOnce(u32) -> u64,
-    call: impl FnOnce(Vec<u8>, Vec<u8>) -> Result<Bls12Response, ()>,
-) -> Result<Bls12Response, BuiltinActorError> {
-    // decode the count of items
+    call: impl FnOnce(Vec<u8>, Vec<u8>) -> Result<Bls12_381Response, ()>,
+) -> Result<Bls12_381Response, BuiltinActorError> {
     let mut slice = bases.as_slice();
     let mut reader = ark_scale::rw::InputAsRead(&mut slice);
     let Ok(count) = u64::deserialize_with_mode(&mut reader, IS_COMPRESSED, IS_VALIDATED) else {
@@ -158,14 +181,14 @@ fn msm(
 fn projective_multiplication_g1(
     base: Vec<u8>,
     scalar: Vec<u8>,
-) -> Result<Bls12Response, BuiltinActorError> {
+) -> Result<Bls12_381Response, BuiltinActorError> {
     projective_multiplication(
         base,
         scalar,
         |_count| 0, // WeightInfo::bls12_381_mul_projective_g1(count).ref_time(),
         |base, scalar| {
             bls12_381::host_calls::bls12_381_mul_projective_g1(base, scalar)
-                .map(Bls12Response::ProjectiveMultiplicationG1)
+                .map(Bls12_381Response::ProjectiveMultiplicationG1)
         },
     )
 }
@@ -173,14 +196,14 @@ fn projective_multiplication_g1(
 fn projective_multiplication_g2(
     base: Vec<u8>,
     scalar: Vec<u8>,
-) -> Result<Bls12Response, BuiltinActorError> {
+) -> Result<Bls12_381Response, BuiltinActorError> {
     projective_multiplication(
         base,
         scalar,
         |_count| 0, // WeightInfo::bls12_381_mul_projective_g2(count).ref_time(),
         |base, scalar| {
             bls12_381::host_calls::bls12_381_mul_projective_g2(base, scalar)
-                .map(Bls12Response::ProjectiveMultiplicationG2)
+                .map(Bls12_381Response::ProjectiveMultiplicationG2)
         },
     )
 }
@@ -189,9 +212,8 @@ fn projective_multiplication(
     base: Vec<u8>,
     scalar: Vec<u8>,
     _gas_to_spend: impl FnOnce(u32) -> u64,
-    call: impl FnOnce(Vec<u8>, Vec<u8>) -> Result<Bls12Response, ()>,
-) -> Result<Bls12Response, BuiltinActorError> {
-    // decode the count of items
+    call: impl FnOnce(Vec<u8>, Vec<u8>) -> Result<Bls12_381Response, ()>,
+) -> Result<Bls12_381Response, BuiltinActorError> {
     let mut slice = scalar.as_slice();
     let mut reader = ark_scale::rw::InputAsRead(&mut slice);
     let Ok(_count) = u64::deserialize_with_mode(&mut reader, IS_COMPRESSED, IS_VALIDATED) else {
@@ -211,8 +233,7 @@ fn projective_multiplication(
     })
 }
 
-fn aggregate_g1(points: Vec<u8>) -> Result<Bls12Response, BuiltinActorError> {
-    // decode the count of items
+fn aggregate_g1(points: Vec<u8>) -> Result<Bls12_381Response, BuiltinActorError> {
     let mut slice = points.as_slice();
     let mut reader = ark_scale::rw::InputAsRead(&mut slice);
     let Ok(_count) = u64::deserialize_with_mode(&mut reader, IS_COMPRESSED, IS_VALIDATED) else {
@@ -221,56 +242,42 @@ fn aggregate_g1(points: Vec<u8>) -> Result<Bls12Response, BuiltinActorError> {
         return Err(BuiltinActorError::DecodingError);
     };
 
-    // todo [sab] charge gas
-    // let to_spend = WeightInfo::bls12_381_aggregate_g1(count as u32).ref_time();
-    // context.try_charge_gas(to_spend)?;
-
-    aggregate_g1_impl(&points)
-        .map(Bls12Response::AggregateG1)
-        .inspect_err(|e| {
-            log::debug!("Failed to aggregate G1-points: {e:?}");
-        })
-}
-
-fn aggregate_g1_impl(points: &[u8]) -> Result<Vec<u8>, BuiltinActorError> {
     let ArkScale(points) = ArkScaleLocal::<Vec<G1>>::decode(&mut &points[..])
         .map_err(|_| BuiltinActorError::DecodingError)?;
-
-    let point_first = points.first().ok_or(BuiltinActorError::EmptyPointList)?;
-
+    let point_first =
+        points
+            .first()
+            .ok_or(BuiltinActorError::Custom(LimitedStr::from_small_str(
+                "The array of G1-points is empty",
+            )))?;
     let point_aggregated = points
         .iter()
         .skip(1)
         .fold(*point_first, |aggregated, point| aggregated + *point);
+    let res = ArkScaleLocal::<G1>::from(point_aggregated).encode();
 
-    Ok(ArkScaleLocal::<G1>::from(point_aggregated).encode())
+    Ok(Bls12_381Response::AggregateG1(res))
 }
 
-fn map_to_g2affine(message: Vec<u8>) -> Result<Bls12Response, BuiltinActorError> {
-    // todo [sab] charge gas
-    // let to_spend = WeightInfo::bls12_381_map_to_g2affine(len).ref_time();
-    // context.try_charge_gas(to_spend)?;
-
-    map_to_g2affine_impl(&message)
-        .map(Bls12Response::MapToG2Affine)
-        .inspect_err(|e| {
-            log::debug!("Failed to map a message: {e:?}");
-        })
-}
-
-fn map_to_g2affine_impl(message: &[u8]) -> Result<Vec<u8>, BuiltinActorError> {
+fn map_to_g2affine(message: Vec<u8>) -> Result<Bls12_381Response, BuiltinActorError> {
     type WBMap = wb::WBMap<<ark_bls12_381::Config as Bls12Config>::G2Config>;
 
     const DST_G2: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
 
     let mapper = MapToCurveBasedHasher::<G2, DefaultFieldHasher<sha2::Sha256>, WBMap>::new(DST_G2)
-        .map_err(|_| BuiltinActorError::MapperCreationError)?;
+        .map_err(|_| {
+            BuiltinActorError::Custom(LimitedStr::from_small_str(
+                "Failed to create `MapToCurveBasedHasher`",
+            ))
+        })?;
+    let point = mapper.hash(&message).map_err(|_| {
+        BuiltinActorError::Custom(LimitedStr::from_small_str(
+            "Failed to map a message to a G2-point",
+        ))
+    })?;
+    let res = ArkScaleLocal::<G2Affine>::from(point).encode();
 
-    let point = mapper
-        .hash(message)
-        .map_err(|_| BuiltinActorError::MessageMappingError)?;
-
-    Ok(ArkScaleLocal::<G2Affine>::from(point).encode())
+    Ok(Bls12_381Response::MapToG2Affine(res))
 }
 
 #[cfg(test)]
@@ -343,6 +350,9 @@ mod tests {
         let alice_id = ActorId::from(DEFAULT_USER_ALICE);
         let proxy_pid = ActorId::new([3; 32]);
 
+        // -----------------------------------------------------------------------
+        // ------------------------ Prepare payload ------------------------------
+        // -----------------------------------------------------------------------
         let mut rng = test_rng();
         let message: G1Affine = G1::rand(&mut rng).into();
         let a: ArkScaleLocal<Vec<<Bls12_381 as Pairing>::G1Affine>> = vec![message].into();
@@ -352,18 +362,27 @@ mod tests {
         let pub_key: G2Affine = generator.mul(priv_key).into();
         let b: ArkScaleLocal<Vec<<Bls12_381 as Pairing>::G2Affine>> = vec![pub_key].into();
 
-        let multi_miller_req = Bls12Request::MultiMillerLoop {
+        let multi_miller_req = Bls12_381Request::MultiMillerLoop {
             a: a.encode(),
             b: b.encode(),
         };
+
+        // -----------------------------------------------------------------------
+        // ------------------------ Create proxy program -------------------------
+        // -----------------------------------------------------------------------
         let proxy_program =
             create_proxy_program(&sys, proxy_pid, multi_miller_req.encode(), alice_id);
 
-        // Send a message to the proxy to trigger the interaction
+        // -----------------------------------------------------------------------
+        // ------------------------- Trigger builtin -----------------------------
+        // -----------------------------------------------------------------------
         let mid = proxy_program.send_bytes(alice_id, b"");
         let res = sys.run_next_block();
         assert!(res.succeed.contains(&mid));
 
+        // -----------------------------------------------------------------------
+        // ------------------------- Check response ------------------------------
+        // -----------------------------------------------------------------------
         assert!(res.contains(&Log::builder().source(proxy_pid).dest(alice_id)));
 
         let mut logs = res.decoded_log();
@@ -371,7 +390,7 @@ mod tests {
 
         assert!(matches!(
             response.payload(),
-            Bls12Response::MultiMillerLoop(_)
+            Bls12_381Response::MultiMillerLoop(_)
         ));
     }
 
@@ -383,9 +402,11 @@ mod tests {
         let alice_id = ActorId::from(DEFAULT_USER_ALICE);
         let proxy_pid = ActorId::new([3; 32]);
 
+        // -----------------------------------------------------------------------
+        // ------------------------ Prepare payload ------------------------------
+        // -----------------------------------------------------------------------
         let mut rng = ark_std::test_rng();
 
-        // message
         let message: G1Affine = G1::rand(&mut rng).into();
         let priv_key: ScalarFieldG2 = UniformRand::rand(&mut rng);
         let generator: G2 = G2::generator();
@@ -395,21 +416,29 @@ mod tests {
         let expected = <Bls12_381 as Pairing>::final_exponentiation(loop_result);
 
         let f: ArkScale<<Bls12_381 as Pairing>::TargetField> = loop_result.0.into();
-        let final_expon_req = Bls12Request::FinalExponentiation { f: f.encode() }.encode();
+        let final_expon_req = Bls12_381Request::FinalExponentiation { f: f.encode() };
 
-        let proxy_program = create_proxy_program(&sys, proxy_pid, final_expon_req, alice_id);
+        // -----------------------------------------------------------------------
+        // ------------------------ Create proxy program -------------------------
+        // -----------------------------------------------------------------------
+        let proxy_program = create_proxy_program(&sys, proxy_pid, final_expon_req.encode(), alice_id);
 
-        // Send a message to the proxy to trigger the interaction
+        // -----------------------------------------------------------------------
+        // ------------------------- Trigger builtin -----------------------------
+        // -----------------------------------------------------------------------
         let mid = proxy_program.send_bytes(alice_id, b"");
         let res = sys.run_next_block();
         assert!(res.succeed.contains(&mid));
 
+        // -----------------------------------------------------------------------
+        // ------------------------- Check response ------------------------------
+        // -----------------------------------------------------------------------
         assert!(res.contains(&Log::builder().source(proxy_pid).dest(alice_id)));
 
         let mut logs = res.decoded_log();
         let response = logs.pop().expect("no log found");
 
-        if let Bls12Response::FinalExponentiation(result_bytes) = response.payload() {
+        if let Bls12_381Response::FinalExponentiation(result_bytes) = response.payload() {
             let actual = ArkScaleLocal::<<Bls12_381 as Pairing>::TargetField>::decode(
                 &mut result_bytes.as_ref(),
             )
@@ -429,26 +458,32 @@ mod tests {
         let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
         let proxy_pid = ActorId::new([3; 32]);
 
+        // -----------------------------------------------------------------------
+        // ------------------------ Prepare payload ------------------------------
+        // -----------------------------------------------------------------------
         let mut rng = test_rng();
 
         let count = 5usize;
-
         let scalars = (0..count)
             .map(|_| ScalarFieldG1::rand(&mut rng))
             .collect::<Vec<_>>();
 
-        let bases = (0..count).map(|_| G1::rand(&mut rng)).collect::<Vec<_>>();
-        let bases = G1::batch_convert_to_mul_base(&bases);
+        let bases = G1::batch_convert_to_mul_base(
+            &(0..count).map(|_| G1::rand(&mut rng)).collect::<Vec<_>>(),
+        );
 
-        let faulty_ark_scalars: ArkScaleLocal<Vec<<G1 as Group>::ScalarField>> =
+        let faulty_ark_scalars: ArkScaleLocal<Vec<ScalarFieldG1>> =
             scalars[1..].to_vec().into();
         let ark_bases: ArkScaleLocal<Vec<G1Affine>> = bases.clone().into();
 
-        let faulty_msm_g1_req = Bls12Request::MultiScalarMultiplicationG1 {
+        let faulty_msm_g1_req = Bls12_381Request::MultiScalarMultiplicationG1 {
             bases: ark_bases.encode(),
             scalars: faulty_ark_scalars.encode(),
         };
 
+        // -----------------------------------------------------------------------
+        // ----------------------- Create a faulty proxy -------------------------
+        // -----------------------------------------------------------------------
         // Because of the impl of the demo_constructor, we have to waste 1 program as we cannot predefine `handle_reply` without
         // defining `handle` (using `Scheme::predefined`). So we have to define a proxy with `handle` sending the faulty request
         let proxy_program = create_proxy_program(
@@ -458,10 +493,16 @@ mod tests {
             alice_actor_id,
         );
 
+        // -----------------------------------------------------------------------
+        // ------------------------- Trigger builtin -----------------------------
+        // -----------------------------------------------------------------------
         let mid = proxy_program.send_bytes(alice_actor_id, b"");
         let res = sys.run_next_block();
         assert!(res.succeed.contains(&mid));
 
+        // -----------------------------------------------------------------------
+        // ----------------------- Check error response --------------------------
+        // -----------------------------------------------------------------------
         let err_payload =
             LimitedStr::from_small_str("Multi scalar multiplication: uneven item count")
                 .into_inner()
@@ -476,6 +517,9 @@ mod tests {
             )
         );
 
+        // -----------------------------------------------------------------------
+        // ------------------------ Prepare valid payload -----------------------
+        // -----------------------------------------------------------------------
         let expected =
             <SWProjective<ark_bls12_381::g1::Config> as VariableBaseMSM>::msm(&bases, &scalars)
                 .expect("msm expected result generation failed");
@@ -483,21 +527,30 @@ mod tests {
         let ark_scalars: ArkScaleLocal<Vec<ScalarFieldG1>> = scalars.into();
         let ark_bases: ArkScaleLocal<Vec<G1Affine>> = bases.into();
 
-        let msm_g1_req = Bls12Request::MultiScalarMultiplicationG1 {
+        let msm_g1_req = Bls12_381Request::MultiScalarMultiplicationG1 {
             bases: ark_bases.encode(),
             scalars: ark_scalars.encode(),
-        }
-        .encode();
+        };
 
-        let proxy_program = create_proxy_program(&sys, proxy_pid, msm_g1_req, alice_actor_id);
+        // -----------------------------------------------------------------------
+        // ------------------------ Create proxy program -------------------------
+        // -----------------------------------------------------------------------
+        let proxy_program = create_proxy_program(&sys, proxy_pid, msm_g1_req.encode(), alice_actor_id);
+
+        // -----------------------------------------------------------------------
+        // ------------------------- Trigger builtin -----------------------------
+        // -----------------------------------------------------------------------
         let mid = proxy_program.send_bytes(alice_actor_id, b"");
         let res = sys.run_next_block();
         assert!(res.succeed.contains(&mid));
 
+        // -----------------------------------------------------------------------
+        // ------------------------- Check response ------------------------------
+        // -----------------------------------------------------------------------
         let mut logs = res.decoded_log();
         let response = logs.pop().expect("no log found");
 
-        if let Bls12Response::MultiScalarMultiplicationG1(result_bytes) = response.payload() {
+        if let Bls12_381Response::MultiScalarMultiplicationG1(result_bytes) = response.payload() {
             let actual = ArkScaleProjective::<G1>::decode(&mut result_bytes.as_ref())
                 .expect("failed to decode result");
 
@@ -515,10 +568,12 @@ mod tests {
         let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
         let proxy_pid = ActorId::new([3; 32]);
 
+        // -----------------------------------------------------------------------
+        // ------------------------ Prepare payload ------------------------------
+        // -----------------------------------------------------------------------
         let mut rng = test_rng();
 
         let count = 5usize;
-
         let scalars = (0..count)
             .map(|_| ScalarFieldG2::rand(&mut rng))
             .collect::<Vec<_>>();
@@ -530,11 +585,14 @@ mod tests {
         let faulty_ark_scalars: ArkScaleLocal<Vec<ScalarFieldG2>> = scalars[1..].to_vec().into();
         let ark_bases: ArkScaleLocal<Vec<G2Affine>> = bases.clone().into();
 
-        let faulty_msm_g2_req = Bls12Request::MultiScalarMultiplicationG2 {
+        let faulty_msm_g2_req = Bls12_381Request::MultiScalarMultiplicationG2 {
             bases: ark_bases.encode(),
             scalars: faulty_ark_scalars.encode(),
         };
 
+        // -----------------------------------------------------------------------
+        // ----------------------- Create a faulty proxy -------------------------
+        // -----------------------------------------------------------------------
         // Because of the impl of the demo_constructor, we have to waste 1 program as we cannot predefine `handle_reply` without
         // defining `handle` (using `Scheme::predefined`). So we have to define a proxy with `handle` sending the faulty request
         let proxy_program = create_proxy_program(
@@ -544,10 +602,16 @@ mod tests {
             alice_actor_id,
         );
 
+        // -----------------------------------------------------------------------
+        // ------------------------- Trigger builtin -----------------------------
+        // -----------------------------------------------------------------------
         let mid = proxy_program.send_bytes(alice_actor_id, b"");
         let res = sys.run_next_block();
         assert!(res.succeed.contains(&mid));
 
+        // -----------------------------------------------------------------------
+        // ----------------------- Check error response --------------------------
+        // -----------------------------------------------------------------------
         let err_payload =
             LimitedStr::from_small_str("Multi scalar multiplication: uneven item count")
                 .into_inner()
@@ -562,6 +626,9 @@ mod tests {
             )
         );
 
+        // -----------------------------------------------------------------------
+        // ------------------------ Prepare valid payload -----------------------
+        // -----------------------------------------------------------------------
         let expected =
             <SWProjective<ark_bls12_381::g2::Config> as VariableBaseMSM>::msm(&bases, &scalars)
                 .expect("msm expected result generation failed");
@@ -569,21 +636,30 @@ mod tests {
         let ark_scalars: ArkScaleLocal<Vec<ScalarFieldG2>> = scalars.into();
         let ark_bases: ArkScaleLocal<Vec<G2Affine>> = bases.into();
 
-        let msm_g2_req = Bls12Request::MultiScalarMultiplicationG2 {
+        let msm_g2_req = Bls12_381Request::MultiScalarMultiplicationG2 {
             bases: ark_bases.encode(),
             scalars: ark_scalars.encode(),
-        }
-        .encode();
+        };
 
-        let proxy_program = create_proxy_program(&sys, proxy_pid, msm_g2_req, alice_actor_id);
+        // -----------------------------------------------------------------------
+        // ------------------------ Create proxy program -------------------------
+        // -----------------------------------------------------------------------
+        let proxy_program = create_proxy_program(&sys, proxy_pid, msm_g2_req.encode(), alice_actor_id);
+
+        // -----------------------------------------------------------------------
+        // ------------------------- Trigger builtin -----------------------------
+        // -----------------------------------------------------------------------
         let mid = proxy_program.send_bytes(alice_actor_id, b"");
         let res = sys.run_next_block();
         assert!(res.succeed.contains(&mid));
 
+        // -----------------------------------------------------------------------
+        // ------------------------- Check response ------------------------------
+        // -----------------------------------------------------------------------
         let mut logs = res.decoded_log();
         let response = logs.pop().expect("no log found");
 
-        if let Bls12Response::MultiScalarMultiplicationG2(result_bytes) = response.payload() {
+        if let Bls12_381Response::MultiScalarMultiplicationG2(result_bytes) = response.payload() {
             let actual = ArkScaleProjective::<G2>::decode(&mut result_bytes.as_ref())
                 .expect("failed to decode result");
 
@@ -601,6 +677,9 @@ mod tests {
         let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
         let proxy_pid = ActorId::new([3; 32]);
 
+        // -----------------------------------------------------------------------
+        // ------------------------ Prepare payload ------------------------------
+        // -----------------------------------------------------------------------
         let mut rng = test_rng();
 
         let bigint = BigInt::<3>::rand(&mut rng).0.to_vec();
@@ -611,21 +690,30 @@ mod tests {
         let ark_bigint: ArkScaleLocal<Vec<u64>> = bigint.into();
         let ark_base: ArkScaleProjective<G1> = base.into();
 
-        let proj_mul_g1_req = Bls12Request::ProjectiveMultiplicationG1 {
+        let proj_mul_g1_req = Bls12_381Request::ProjectiveMultiplicationG1 {
             base: ark_base.encode(),
             scalar: ark_bigint.encode(),
-        }
-        .encode();
+        };
 
-        let proxy_program = create_proxy_program(&sys, proxy_pid, proj_mul_g1_req, alice_actor_id);
+        // -----------------------------------------------------------------------
+        // ------------------------ Create proxy program -------------------------
+        // -----------------------------------------------------------------------
+        let proxy_program = create_proxy_program(&sys, proxy_pid, proj_mul_g1_req.encode(), alice_actor_id);
+
+        // -----------------------------------------------------------------------
+        // ------------------------- Trigger builtin -----------------------------
+        // -----------------------------------------------------------------------
         let mid = proxy_program.send_bytes(alice_actor_id, b"");
         let res = sys.run_next_block();
         assert!(res.succeed.contains(&mid));
 
+        // -----------------------------------------------------------------------
+        // ------------------------- Check response ------------------------------
+        // -----------------------------------------------------------------------
         let mut logs = res.decoded_log();
         let response = logs.pop().expect("no log found");
 
-        if let Bls12Response::ProjectiveMultiplicationG1(result_bytes) = response.payload() {
+        if let Bls12_381Response::ProjectiveMultiplicationG1(result_bytes) = response.payload() {
             let actual = ArkScaleProjective::<G1>::decode(&mut result_bytes.as_ref())
                 .expect("failed to decode result");
 
@@ -643,6 +731,9 @@ mod tests {
         let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
         let proxy_pid = ActorId::new([3; 32]);
 
+        // -----------------------------------------------------------------------
+        // ------------------------ Prepare payload ------------------------------
+        // -----------------------------------------------------------------------
         let mut rng = test_rng();
 
         let bigint = BigInt::<3>::rand(&mut rng).0.to_vec();
@@ -653,21 +744,30 @@ mod tests {
         let ark_bigint: ArkScaleLocal<Vec<u64>> = bigint.into();
         let ark_base: ArkScaleProjective<G2> = base.into();
 
-        let proj_mul_g2_req = Bls12Request::ProjectiveMultiplicationG2 {
+        let proj_mul_g2_req = Bls12_381Request::ProjectiveMultiplicationG2 {
             base: ark_base.encode(),
             scalar: ark_bigint.encode(),
-        }
-        .encode();
+        };
 
-        let proxy_program = create_proxy_program(&sys, proxy_pid, proj_mul_g2_req, alice_actor_id);
+        // -----------------------------------------------------------------------
+        // ------------------------ Create proxy program -------------------------
+        // -----------------------------------------------------------------------
+        let proxy_program = create_proxy_program(&sys, proxy_pid, proj_mul_g2_req.encode(), alice_actor_id);
+
+        // -----------------------------------------------------------------------
+        // ------------------------- Trigger builtin -----------------------------
+        // -----------------------------------------------------------------------
         let mid = proxy_program.send_bytes(alice_actor_id, b"");
         let res = sys.run_next_block();
         assert!(res.succeed.contains(&mid));
 
+        // -----------------------------------------------------------------------
+        // ------------------------- Check response ------------------------------
+        // -----------------------------------------------------------------------
         let mut logs = res.decoded_log();
         let response = logs.pop().expect("no log found");
 
-        if let Bls12Response::ProjectiveMultiplicationG2(result_bytes) = response.payload() {
+        if let Bls12_381Response::ProjectiveMultiplicationG2(result_bytes) = response.payload() {
             let actual = ArkScaleProjective::<G2>::decode(&mut result_bytes.as_ref())
                 .expect("failed to decode result");
 
@@ -685,6 +785,9 @@ mod tests {
         let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
         let proxy_pid = ActorId::new([3; 32]);
 
+        // -----------------------------------------------------------------------
+        // ------------------------ Prepare payload ------------------------------
+        // -----------------------------------------------------------------------
         let mut rng = test_rng();
 
         const COUNT: usize = 5;
@@ -692,20 +795,29 @@ mod tests {
         let points = (0..COUNT).map(|_| G1::rand(&mut rng)).collect::<Vec<_>>();
         let ark_points: ArkScaleLocal<Vec<G1>> = points.clone().into();
 
-        let aggregate_g1_req = Bls12Request::AggregateG1 {
+        let aggregate_g1_req = Bls12_381Request::AggregateG1 {
             points: ark_points.encode(),
-        }
-        .encode();
+        };
 
-        let proxy_program = create_proxy_program(&sys, proxy_pid, aggregate_g1_req, alice_actor_id);
+        // -----------------------------------------------------------------------
+        // ------------------------ Create proxy program -------------------------
+        // -----------------------------------------------------------------------
+        let proxy_program = create_proxy_program(&sys, proxy_pid, aggregate_g1_req.encode(), alice_actor_id);
+
+        // -----------------------------------------------------------------------
+        // ------------------------- Trigger builtin -----------------------------
+        // -----------------------------------------------------------------------
         let mid = proxy_program.send_bytes(alice_actor_id, b"");
         let res = sys.run_next_block();
         assert!(res.succeed.contains(&mid));
 
+        // -----------------------------------------------------------------------
+        // ------------------------- Check response ------------------------------
+        // -----------------------------------------------------------------------
         let mut logs = res.decoded_log();
         let response = logs.pop().expect("no log found");
 
-        if let Bls12Response::AggregateG1(result_bytes) = response.payload() {
+        if let Bls12_381Response::AggregateG1(result_bytes) = response.payload() {
             let actual = ArkScaleLocal::<G1>::decode(&mut result_bytes.as_ref())
                 .expect("failed to decode result");
 
@@ -729,25 +841,34 @@ mod tests {
         let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
         let proxy_pid = ActorId::new([3; 32]);
 
+        // -----------------------------------------------------------------------
+        // ------------------------ Prepare payload ------------------------------
+        // -----------------------------------------------------------------------
         let message = b"Hello, decentralized world!".to_vec();
 
-        let map_to_g2_req = Bls12Request::MapToG2Affine {
-            message: message.clone(), // Use the message directly as Vec<u8>
-        }
-        .encode();
+        let map_to_g2_req = Bls12_381Request::MapToG2Affine {
+            message: message.clone(),
+        };
 
-        log::warn!("Sending payload: {:?}", map_to_g2_req);
-        log::warn!("Payload length: {}", map_to_g2_req.len());
+        // -----------------------------------------------------------------------
+        // ------------------------ Create proxy program -------------------------
+        // -----------------------------------------------------------------------
+        let proxy_program = create_proxy_program(&sys, proxy_pid, map_to_g2_req.encode(), alice_actor_id);
 
-        let proxy_program = create_proxy_program(&sys, proxy_pid, map_to_g2_req, alice_actor_id);
+        // -----------------------------------------------------------------------
+        // ------------------------- Trigger builtin -----------------------------
+        // -----------------------------------------------------------------------
         let mid = proxy_program.send_bytes(alice_actor_id, b"");
         let res = sys.run_next_block();
         assert!(res.succeed.contains(&mid));
 
+        // -----------------------------------------------------------------------
+        // ------------------------- Check response ------------------------------
+        // -----------------------------------------------------------------------
         let mut logs = res.decoded_log();
         let response = logs.pop().expect("no log found");
 
-        if let Bls12Response::MapToG2Affine(result_bytes) = response.payload() {
+        if let Bls12_381Response::MapToG2Affine(result_bytes) = response.payload() {
             let actual = ArkScaleLocal::<G2Affine>::decode(&mut result_bytes.as_ref())
                 .expect("failed to decode result");
 

--- a/gtest/src/builtins/bls12_381.rs
+++ b/gtest/src/builtins/bls12_381.rs
@@ -1,4 +1,4 @@
-pub use gbuiltin_bls381::{Request, Response};
+pub use gbuiltin_bls381::{Request as Bls12Request, Response as Bls12Response};
 
 use super::BuiltinActorError;
 use ark_bls12_381::{G1Projective as G1, G2Affine, G2Projective as G2};
@@ -9,9 +9,8 @@ use ark_ec::{
 use ark_ff::fields::field_hashers::DefaultFieldHasher;
 use ark_scale::{ArkScale, HOST_CALL};
 use ark_serialize::{CanonicalDeserialize, Compress, Validate};
-use gear_core::{ids::ActorId, message::StoredDispatch, str::LimitedStr};
-use parity_scale_codec::{Compact, Decode, Encode, Input};
-use scale_info::TypeInfo;
+use gear_core::{ids::ActorId, str::LimitedStr};
+use parity_scale_codec::{Decode, Encode};
 use sp_crypto_ec_utils::bls12_381;
 
 /// The id of the BLS12-381 builtin actor.
@@ -19,17 +18,26 @@ pub const BLS12_381_ID: ActorId = ActorId::new(*b"modl/bia/bls12-381/v-\x01\0/\0
 const IS_COMPRESSED: Compress = ark_scale::is_compressed(HOST_CALL);
 const IS_VALIDATED: Validate = ark_scale::is_validated(HOST_CALL);
 
-pub fn process_bls12_381_dispatch(mut payload: &[u8]) -> Result<Response, BuiltinActorError> {
+type ArkScaleLocal<T> = ark_scale::ArkScale<T, { ark_scale::HOST_CALL }>;
+
+pub fn process_bls12_381_dispatch(mut payload: &[u8]) -> Result<Bls12Response, BuiltinActorError> {
+    log::warn!("BLS12_381 PAYLOAD {payload:?}");
     let payload_decoded =
-        Request::decode(&mut payload).map_err(|_| BuiltinActorError::DecodingError)?;
+        Bls12Request::decode(&mut payload).map_err(|_| BuiltinActorError::DecodingError)?;
 
     match payload_decoded {
-        Request::MultiMillerLoop { a, b } => multi_miller_loop(a, b),
-        _ => todo!(),
+        Bls12Request::MultiMillerLoop { a, b } => multi_miller_loop(a, b),
+        Bls12Request::FinalExponentiation { f } => final_exponentiation(f),
+        Bls12Request::MultiScalarMultiplicationG1 { bases, scalars } => msm_g1(bases, scalars),
+        Bls12Request::MultiScalarMultiplicationG2 { bases, scalars } => msm_g2(bases, scalars),
+        Bls12Request::ProjectiveMultiplicationG1 { base, scalar } => projective_multiplication_g1(base, scalar),
+        Bls12Request::ProjectiveMultiplicationG2 { base, scalar } => projective_multiplication_g2(base, scalar),
+        Bls12Request::AggregateG1 { points } => aggregate_g1(points),
+        Bls12Request::MapToG2Affine { message } => map_to_g2affine(message),
     }
 }
 
-fn multi_miller_loop(a: Vec<u8>, b: Vec<u8>) -> Result<Response, BuiltinActorError> {
+fn multi_miller_loop(a: Vec<u8>, b: Vec<u8>) -> Result<Bls12Response, BuiltinActorError> {
     // decode the items count
     let mut slice = a.as_slice();
     let mut reader = ark_scale::rw::InputAsRead(&mut slice);
@@ -56,58 +64,56 @@ fn multi_miller_loop(a: Vec<u8>, b: Vec<u8>) -> Result<Response, BuiltinActorErr
     // context.try_charge_gas(to_spend)?;
 
     match bls12_381::host_calls::bls12_381_multi_miller_loop(a, b) {
-        Ok(result) => Ok(Response::MultiMillerLoop(result)),
+        Ok(result) => Ok(Bls12Response::MultiMillerLoop(result)),
         Err(_) => Err(BuiltinActorError::Custom(LimitedStr::from_small_str(
             "Multi Miller loop: computation error",
         ))),
     }
 }
 
-fn final_exponentiation(mut payload: &[u8]) -> Result<Response, BuiltinActorError> {
-    let f = decode_vec(&mut payload)?;
-
+fn final_exponentiation(f: Vec<u8>) -> Result<Bls12Response, BuiltinActorError> {
     // todo [sab] charge gas
     // let to_spend = WeightInfo::bls12_381_final_exponentiation().ref_time();
     // context.try_charge_gas(to_spend)?;
 
     match bls12_381::host_calls::bls12_381_final_exponentiation(f) {
-        Ok(result) => Ok(Response::FinalExponentiation(result)),
+        Ok(result) => Ok(Bls12Response::FinalExponentiation(result)),
         Err(_) => Err(BuiltinActorError::Custom(LimitedStr::from_small_str(
             "Final exponentiation: computation error",
         ))),
     }
 }
 
-fn msm_g1(payload: &[u8]) -> Result<Response, BuiltinActorError> {
+fn msm_g1(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Bls12Response, BuiltinActorError> {
     msm(
-        payload,
-        |count| 0, // WeightInfo::bls12_381_msm_g1(count).ref_time(),
+        bases,
+        scalars,
+        |_count| 0, // WeightInfo::bls12_381_msm_g1(count).ref_time(),
         |bases, scalars| {
             bls12_381::host_calls::bls12_381_msm_g1(bases, scalars)
-                .map(Response::MultiScalarMultiplicationG1)
+                .map(Bls12Response::MultiScalarMultiplicationG1)
         },
     )
 }
 
-fn msm_g2(payload: &[u8]) -> Result<Response, BuiltinActorError> {
+fn msm_g2(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Bls12Response, BuiltinActorError> {
     msm(
-        payload,
-        |count| 0, // WeightInfo::bls12_381_msm_g2(count).ref_time(),
+        bases,
+        scalars,
+        |_count| 0, // WeightInfo::bls12_381_msm_g2(count).ref_time(),
         |bases, scalars| {
             bls12_381::host_calls::bls12_381_msm_g2(bases, scalars)
-                .map(Response::MultiScalarMultiplicationG2)
+                .map(Bls12Response::MultiScalarMultiplicationG2)
         },
     )
 }
 
 fn msm(
-    mut payload: &[u8],
-    gas_to_spend: impl FnOnce(u32) -> u64,
-    call: impl FnOnce(Vec<u8>, Vec<u8>) -> Result<Response, ()>,
-) -> Result<Response, BuiltinActorError> {
-    let bases = decode_vec(&mut payload)?;
-    let scalars = decode_vec(&mut payload)?;
-
+    bases: Vec<u8>,
+    scalars: Vec<u8>,
+    _gas_to_spend: impl FnOnce(u32) -> u64,
+    call: impl FnOnce(Vec<u8>, Vec<u8>) -> Result<Bls12Response, ()>,
+) -> Result<Bls12Response, BuiltinActorError> {
     // decode the count of items
     let mut slice = bases.as_slice();
     let mut reader = ark_scale::rw::InputAsRead(&mut slice);
@@ -145,40 +151,40 @@ fn msm(
     }
 }
 
-fn projective_multiplication_g1(payload: &[u8]) -> Result<Response, BuiltinActorError> {
+fn projective_multiplication_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Bls12Response, BuiltinActorError> {
     projective_multiplication(
-        payload,
-        |count| 0, // WeightInfo::bls12_381_mul_projective_g1(count).ref_time(),
+        base,
+        scalar,
+        |_count| 0, // WeightInfo::bls12_381_mul_projective_g1(count).ref_time(),
         |base, scalar| {
             bls12_381::host_calls::bls12_381_mul_projective_g1(base, scalar)
-                .map(Response::ProjectiveMultiplicationG1)
+                .map(Bls12Response::ProjectiveMultiplicationG1)
         },
     )
 }
 
-fn projective_multiplication_g2(payload: &[u8]) -> Result<Response, BuiltinActorError> {
+fn projective_multiplication_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Bls12Response, BuiltinActorError> {
     projective_multiplication(
-        payload,
-        |count| 0, // WeightInfo::bls12_381_mul_projective_g2(count).ref_time(),
+        base,
+        scalar,
+        |_count| 0, // WeightInfo::bls12_381_mul_projective_g2(count).ref_time(),
         |base, scalar| {
             bls12_381::host_calls::bls12_381_mul_projective_g2(base, scalar)
-                .map(Response::ProjectiveMultiplicationG2)
+                .map(Bls12Response::ProjectiveMultiplicationG2)
         },
     )
 }
 
 fn projective_multiplication(
-    mut payload: &[u8],
-    gas_to_spend: impl FnOnce(u32) -> u64,
-    call: impl FnOnce(Vec<u8>, Vec<u8>) -> Result<Response, ()>,
-) -> Result<Response, BuiltinActorError> {
-    let base = decode_vec(&mut payload)?;
-    let scalar = decode_vec(&mut payload)?;
-
+    base: Vec<u8>,
+    scalar: Vec<u8>,
+    _gas_to_spend: impl FnOnce(u32) -> u64,
+    call: impl FnOnce(Vec<u8>, Vec<u8>) -> Result<Bls12Response, ()>,
+) -> Result<Bls12Response, BuiltinActorError> {
     // decode the count of items
     let mut slice = scalar.as_slice();
     let mut reader = ark_scale::rw::InputAsRead(&mut slice);
-    let Ok(count) = u64::deserialize_with_mode(&mut reader, IS_COMPRESSED, IS_VALIDATED) else {
+    let Ok(_count) = u64::deserialize_with_mode(&mut reader, IS_COMPRESSED, IS_VALIDATED) else {
         log::debug!("Failed to decode items count in scalar");
 
         return Err(BuiltinActorError::DecodingError);
@@ -195,13 +201,11 @@ fn projective_multiplication(
     })
 }
 
-fn aggregate_g1(mut payload: &[u8]) -> Result<Response, BuiltinActorError> {
-    let points = decode_vec(&mut payload)?;
-
+fn aggregate_g1(points: Vec<u8>) -> Result<Bls12Response, BuiltinActorError> {
     // decode the count of items
     let mut slice = points.as_slice();
     let mut reader = ark_scale::rw::InputAsRead(&mut slice);
-    let Ok(count) = u64::deserialize_with_mode(&mut reader, IS_COMPRESSED, IS_VALIDATED) else {
+    let Ok(_count) = u64::deserialize_with_mode(&mut reader, IS_COMPRESSED, IS_VALIDATED) else {
         log::debug!("Failed to decode items count in points");
 
         return Err(BuiltinActorError::DecodingError);
@@ -212,16 +216,14 @@ fn aggregate_g1(mut payload: &[u8]) -> Result<Response, BuiltinActorError> {
     // context.try_charge_gas(to_spend)?;
 
     aggregate_g1_impl(&points)
-        .map(Response::AggregateG1)
+        .map(Bls12Response::AggregateG1)
         .inspect_err(|e| {
             log::debug!("Failed to aggregate G1-points: {e:?}");
         })
 }
 
 fn aggregate_g1_impl(points: &[u8]) -> Result<Vec<u8>, BuiltinActorError> {
-    type ArkScale<T> = ark_scale::ArkScale<T, { ark_scale::HOST_CALL }>;
-
-    let ArkScale(points) = ArkScale::<Vec<G1>>::decode(&mut &points[..])
+    let ArkScale(points) = ArkScaleLocal::<Vec<G1>>::decode(&mut &points[..])
         .map_err(|_| BuiltinActorError::DecodingError)?;
 
     let point_first = points.first().ok_or(BuiltinActorError::EmptyPointList)?;
@@ -231,36 +233,23 @@ fn aggregate_g1_impl(points: &[u8]) -> Result<Vec<u8>, BuiltinActorError> {
         .skip(1)
         .fold(*point_first, |aggregated, point| aggregated + *point);
 
-    Ok(ArkScale::<G1>::from(point_aggregated).encode())
+    Ok(ArkScaleLocal::<G1>::from(point_aggregated).encode())
 }
 
-fn map_to_g2affine(mut payload: &[u8]) -> Result<Response, BuiltinActorError> {
-    let len = Compact::<u32>::decode(&mut payload)
-        .map(u32::from)
-        .map_err(|_| {
-            log::debug!("Failed to scale-decode vector length");
-            BuiltinActorError::DecodingError
-        })?;
-
-    if len != payload.len() as u32 {
-        log::debug!("Failed to scale-decode vector length");
-
-        return Err(BuiltinActorError::DecodingError);
-    }
+fn map_to_g2affine(message: Vec<u8>) -> Result<Bls12Response, BuiltinActorError> {
 
     // todo [sab] charge gas
     // let to_spend = WeightInfo::bls12_381_map_to_g2affine(len).ref_time();
     // context.try_charge_gas(to_spend)?;
 
-    map_to_g2affine_impl(payload)
-        .map(Response::MapToG2Affine)
+    map_to_g2affine_impl(&message)
+        .map(Bls12Response::MapToG2Affine)
         .inspect_err(|e| {
             log::debug!("Failed to map a message: {e:?}");
         })
 }
 
 fn map_to_g2affine_impl(message: &[u8]) -> Result<Vec<u8>, BuiltinActorError> {
-    type ArkScale<T> = ark_scale::ArkScale<T, { ark_scale::HOST_CALL }>;
     type WBMap = wb::WBMap<<ark_bls12_381::Config as Bls12Config>::G2Config>;
 
     const DST_G2: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
@@ -272,25 +261,462 @@ fn map_to_g2affine_impl(message: &[u8]) -> Result<Vec<u8>, BuiltinActorError> {
         .hash(message)
         .map_err(|_| BuiltinActorError::MessageMappingError)?;
 
-    Ok(ArkScale::<G2Affine>::from(point).encode())
+    Ok(ArkScaleLocal::<G2Affine>::from(point).encode())
 }
 
-fn decode_vec<I: Input>(input: &mut I) -> Result<Vec<u8>, BuiltinActorError> {
-    let len = Compact::<u32>::decode(input).map(u32::from).map_err(|_| {
-        log::debug!("Failed to scale-decode vector length");
-        BuiltinActorError::DecodingError
-    })?;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_bls12_381::{Bls12_381, G1Affine, G2Affine,};
+    use ark_ec::{pairing::Pairing, Group, ScalarMul, VariableBaseMSM, short_weierstrass::{Projective as SWProjective, SWCurveConfig}};
+    use ark_ff::{UniformRand, biginteger::BigInt};
+    use ark_scale::hazmat::ArkScaleProjective;
+    use ark_std::test_rng;
+    use gear_common::Origin;
+    use std::ops::Mul;
+    use crate::{System, Program, DEFAULT_USER_ALICE, Log};
+    use demo_constructor::{WASM_BINARY, Arg, Scheme, Calls, Call};
 
-    // todo [sab] charge gas
-    // let to_spend = WeightInfo::decode_bytes(len).ref_time();
-    // context.try_charge_gas(to_spend)?;
+    type ScalarFieldG1 = <G1 as Group>::ScalarField;
+    type ScalarFieldG2 = <G2 as Group>::ScalarField;
 
-    let mut items = vec![0u8; len as usize];
-    let bytes_slice = items.as_mut_slice();
+    fn create_proxy_program(sys: &System, proxy_id: ActorId, builtin_req: Vec<u8>, reply_receiver: ActorId) -> Program<'_> {
+        let proxy_scheme = Scheme::predefined(
+            // init: do nothing
+            Calls::builder().noop(),
+            // handle: load message payload and send it to mock program
+            Calls::builder().add_call(Call::Send(
+                Arg::new(BLS12_381_ID.into_bytes()),
+                Arg::new(builtin_req),
+                None,
+                Arg::new(0u128),
+                Arg::new(0u32),
+            )),
+            // handle_reply: load reply payload and forward it to original sender
+            Calls::builder()
+                .add_call(Call::LoadBytes)
+                .add_call(Call::StoreVec("reply_payload".to_string()))
+                .add_call(Call::Send(
+                    Arg::new(reply_receiver.into_bytes()),
+                    Arg::get("reply_payload"),
+                    Some(Arg::new(0)),
+                    Arg::new(0u128),
+                    Arg::new(0u32),
+                )),
+            // handle_signal: noop
+            Calls::builder(),
+        );
 
-    input.read(bytes_slice).map(|_| items).map_err(|_| {
-        log::debug!("Failed to scale-decode vector data");
+        let proxy_program = Program::from_binary_with_id(&sys, proxy_id, WASM_BINARY);
 
-        BuiltinActorError::DecodingError
-    })
+        // Initialize proxy with the scheme
+        let init_mid = proxy_program.send(reply_receiver, proxy_scheme);
+        let res = sys.run_next_block();
+        assert!(res.succeed.contains(&init_mid));
+
+        proxy_program
+    }
+
+    #[test]
+    fn test_multi_miller_loop() {
+        let sys = System::new();
+        sys.init_logger();
+
+        let alice_id = ActorId::from(DEFAULT_USER_ALICE);
+        let proxy_pid = ActorId::new([3; 32]);
+
+        let mut rng = test_rng();
+        let message: G1Affine = G1::rand(&mut rng).into();
+        let a: ArkScaleLocal<Vec<<Bls12_381 as Pairing>::G1Affine>> = vec![message].into();
+
+        let priv_key: ScalarFieldG2 = UniformRand::rand(&mut rng);
+        let generator = G2::generator();
+        let pub_key: G2Affine = generator.mul(priv_key).into();
+        let b: ArkScaleLocal<Vec<<Bls12_381 as Pairing>::G2Affine>> = vec![pub_key].into();
+
+        let multi_miller_req = Bls12Request::MultiMillerLoop {
+            a: a.encode(),
+            b: b.encode(),
+        };
+        let proxy_program = create_proxy_program(&sys, proxy_pid, multi_miller_req.encode(), alice_id);
+
+        // Send a message to the proxy to trigger the interaction
+        let mid = proxy_program.send_bytes(alice_id, b"");
+        let res = sys.run_next_block();
+        assert!(res.succeed.contains(&mid));
+
+        assert!(
+            res.contains(
+                &Log::builder()
+                    .source(proxy_pid)
+                    .dest(alice_id)
+            )
+        );
+
+        let mut logs = res.decoded_log();
+        let response = logs.pop().expect("no log found");
+
+        assert!(matches!(
+            response.payload(),
+            Bls12Response::MultiMillerLoop(_)
+        ));
+    }
+
+    #[test]
+    fn test_final_exponentiation() {
+        let sys = System::new();
+        sys.init_logger();
+
+        let alice_id = ActorId::from(DEFAULT_USER_ALICE);
+        let proxy_pid = ActorId::new([3; 32]);
+
+        let mut rng = ark_std::test_rng();
+
+        // message
+        let message: G1Affine = G1::rand(&mut rng).into();
+        let priv_key: ScalarFieldG2 = UniformRand::rand(&mut rng);
+        let generator: G2 = G2::generator();
+        let pub_key: G2Affine = generator.mul(priv_key).into();
+
+        let loop_result = <Bls12_381 as Pairing>::multi_miller_loop(vec![message], vec![pub_key]);
+        let expected = <Bls12_381 as Pairing>::final_exponentiation(loop_result);
+
+        let f: ArkScale<<Bls12_381 as Pairing>::TargetField> = loop_result.0.into();
+        let final_expon_req = Bls12Request::FinalExponentiation { f: f.encode() }.encode();
+
+        let proxy_program = create_proxy_program(&sys, proxy_pid, final_expon_req, alice_id);
+
+        // Send a message to the proxy to trigger the interaction
+        let mid = proxy_program.send_bytes(alice_id, b"");
+        let res = sys.run_next_block();
+        assert!(res.succeed.contains(&mid));
+
+        assert!(
+            res.contains(
+                &Log::builder()
+                    .source(proxy_pid)
+                    .dest(alice_id)
+            )
+        );
+
+        let mut logs = res.decoded_log();
+        let response = logs.pop().expect("no log found");
+
+        if let Bls12Response::FinalExponentiation(result_bytes) = response.payload() {
+            let actual  = ArkScaleLocal::<<Bls12_381 as Pairing>::TargetField>::decode(&mut result_bytes.as_ref()).expect("failed to decode result");
+
+            assert!(matches!(expected, Some(inner) if inner.0 == actual.0));
+        } else {
+            panic!("unexpected response");
+        }
+    }
+
+    #[test]
+    fn test_msm_g1() {
+        let sys = System::new();
+        sys.init_logger();
+
+        let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
+        let proxy_pid = ActorId::new([3; 32]);
+
+        let mut rng = test_rng();
+
+        let count = 5usize;
+
+        let scalars = (0..count)
+            .map(|_| ScalarFieldG1::rand(&mut rng))
+            .collect::<Vec<_>>();
+
+        let bases = (0..count).map(|_| G1::rand(&mut rng)).collect::<Vec<_>>();
+        let bases = G1::batch_convert_to_mul_base(&bases);
+
+        let faulty_ark_scalars: ArkScaleLocal<Vec<<G1 as Group>::ScalarField>> = scalars[1..].to_vec().into();
+        let ark_bases: ArkScaleLocal<Vec<G1Affine>> = bases.clone().into();
+
+        let faulty_msm_g1_req = Bls12Request::MultiScalarMultiplicationG1 { bases: ark_bases.encode(), scalars: faulty_ark_scalars.encode() };
+
+        // Because of the impl of the demo_constructor, we have to waste 1 program as we cannot predefine `handle_reply` without
+        // defining `handle` (using `Scheme::predefined`). So we have to define a proxy with `handle` sending the faulty request
+        let proxy_program = create_proxy_program(&sys, gprimitives::H256::random().cast(), faulty_msm_g1_req.encode(), alice_actor_id);
+
+        let mid = proxy_program.send_bytes(alice_actor_id, b"");
+        let res = sys.run_next_block();
+        assert!(res.succeed.contains(&mid));
+
+        let err_payload = LimitedStr::from_small_str("Multi scalar multiplication: uneven item count")
+            .into_inner()
+            .into_owned()
+            .into_bytes();
+        assert!(
+            res.contains(
+                &Log::builder()
+                    .source(proxy_program.id())
+                    .dest(alice_actor_id)
+                    .payload_bytes(err_payload)
+            )
+        );
+
+        let expected = <SWProjective<ark_bls12_381::g1::Config> as VariableBaseMSM>::msm(&bases, &scalars)
+            .expect("msm expected result generation failed");
+
+        let ark_scalars: ArkScaleLocal<Vec<ScalarFieldG1>> = scalars.into();
+        let ark_bases: ArkScaleLocal<Vec<G1Affine>> = bases.into();
+
+        let msm_g1_req = Bls12Request::MultiScalarMultiplicationG1 { bases: ark_bases.encode(), scalars: ark_scalars.encode() }.encode();
+
+        let proxy_program = create_proxy_program(&sys, proxy_pid, msm_g1_req, alice_actor_id);
+        let mid = proxy_program.send_bytes(alice_actor_id, b"");
+        let res = sys.run_next_block();
+        assert!(res.succeed.contains(&mid));
+
+        let mut logs = res.decoded_log();
+        let response = logs.pop().expect("no log found");
+
+        if let Bls12Response::MultiScalarMultiplicationG1(result_bytes) = response.payload() {
+            let actual  = ArkScaleProjective::<G1>::decode(&mut result_bytes.as_ref()).expect("failed to decode result");
+
+            assert_eq!(actual.0, expected);
+        } else {
+            panic!("unexpected response");
+        }
+    }
+
+    #[test]
+    fn test_msm_g2() {
+        let sys = System::new();
+        sys.init_logger();
+
+        let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
+        let proxy_pid = ActorId::new([3; 32]);
+
+        let mut rng = test_rng();
+
+        let count = 5usize;
+
+        let scalars = (0..count)
+            .map(|_| ScalarFieldG2::rand(&mut rng))
+            .collect::<Vec<_>>();
+
+        let bases = G2::batch_convert_to_mul_base(
+            &(0..count).map(|_| G2::rand(&mut rng)).collect::<Vec<_>>()
+        );
+
+        let faulty_ark_scalars: ArkScaleLocal<Vec<ScalarFieldG2>> = scalars[1..].to_vec().into();
+        let ark_bases: ArkScaleLocal<Vec<G2Affine>> = bases.clone().into();
+
+        let faulty_msm_g2_req = Bls12Request::MultiScalarMultiplicationG2 { bases: ark_bases.encode(), scalars: faulty_ark_scalars.encode() };
+
+        // Because of the impl of the demo_constructor, we have to waste 1 program as we cannot predefine `handle_reply` without
+        // defining `handle` (using `Scheme::predefined`). So we have to define a proxy with `handle` sending the faulty request
+        let proxy_program = create_proxy_program(&sys, gprimitives::H256::random().cast(), faulty_msm_g2_req.encode(), alice_actor_id);
+
+        let mid = proxy_program.send_bytes(alice_actor_id, b"");
+        let res = sys.run_next_block();
+        assert!(res.succeed.contains(&mid));
+
+        let err_payload = LimitedStr::from_small_str("Multi scalar multiplication: uneven item count")
+            .into_inner()
+            .into_owned()
+            .into_bytes();
+        assert!(
+            res.contains(
+                &Log::builder()
+                    .source(proxy_program.id())
+                    .dest(alice_actor_id)
+                    .payload_bytes(err_payload)
+            )
+        );
+
+        let expected = <SWProjective<ark_bls12_381::g2::Config> as VariableBaseMSM>::msm(&bases, &scalars)
+            .expect("msm expected result generation failed");
+
+        let ark_scalars: ArkScaleLocal<Vec<ScalarFieldG2>> = scalars.into();
+        let ark_bases: ArkScaleLocal<Vec<G2Affine>> = bases.into();
+
+        let msm_g2_req = Bls12Request::MultiScalarMultiplicationG2 { bases: ark_bases.encode(), scalars: ark_scalars.encode() }.encode();
+
+        let proxy_program = create_proxy_program(&sys, proxy_pid, msm_g2_req, alice_actor_id);
+        let mid = proxy_program.send_bytes(alice_actor_id, b"");
+        let res = sys.run_next_block();
+        assert!(res.succeed.contains(&mid));
+
+        let mut logs = res.decoded_log();
+        let response = logs.pop().expect("no log found");
+
+        if let Bls12Response::MultiScalarMultiplicationG2(result_bytes) = response.payload() {
+            let actual  = ArkScaleProjective::<G2>::decode(&mut result_bytes.as_ref()).expect("failed to decode result");
+
+            assert_eq!(actual.0, expected);
+        } else {
+            panic!("unexpected response");
+        }
+    }
+
+    #[test]
+    fn test_projective_multiplication_g1() {
+        let sys = System::new();
+        sys.init_logger();
+
+        let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
+        let proxy_pid = ActorId::new([3; 32]);
+
+        let mut rng = test_rng();
+
+        let bigint = BigInt::<3>::rand(&mut rng).0.to_vec();
+        let base = G1::rand(&mut rng);
+
+        let expected = <ark_bls12_381::g1::Config as SWCurveConfig>::mul_projective(&base, &bigint);
+
+        let ark_bigint: ArkScaleLocal<Vec<u64>> = bigint.into();
+        let ark_base: ArkScaleProjective<G1> = base.into();
+        
+        let proj_mul_g1_req = Bls12Request::ProjectiveMultiplicationG1 { 
+            base: ark_base.encode(), 
+            scalar: ark_bigint.encode() 
+        }.encode();
+
+        let proxy_program = create_proxy_program(&sys, proxy_pid, proj_mul_g1_req, alice_actor_id);
+        let mid = proxy_program.send_bytes(alice_actor_id, b"");
+        let res = sys.run_next_block();
+        assert!(res.succeed.contains(&mid));
+
+        let mut logs = res.decoded_log();
+        let response = logs.pop().expect("no log found");
+
+        if let Bls12Response::ProjectiveMultiplicationG1(result_bytes) = response.payload() {
+            let actual = ArkScaleProjective::<G1>::decode(&mut result_bytes.as_ref()).expect("failed to decode result");
+
+            assert_eq!(actual.0, expected);
+        } else {
+            panic!("unexpected response");
+        }
+    }
+
+    #[test]
+    fn test_projective_multiplication_g2() {
+        let sys = System::new();
+        sys.init_logger();
+
+        let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
+        let proxy_pid = ActorId::new([3; 32]);
+
+        let mut rng = test_rng();
+
+        let bigint = BigInt::<3>::rand(&mut rng)
+            .0
+            .to_vec();
+        let base = G2::rand(&mut rng);
+
+        let expected = <ark_bls12_381::g2::Config as SWCurveConfig>::mul_projective(&base, &bigint);
+
+        let ark_bigint: ArkScaleLocal<Vec<u64>> = bigint.into();
+        let ark_base: ArkScaleProjective<G2> = base.into();
+        
+        let proj_mul_g2_req = Bls12Request::ProjectiveMultiplicationG2 { 
+            base: ark_base.encode(), 
+            scalar: ark_bigint.encode() 
+        }.encode();
+
+        let proxy_program = create_proxy_program(&sys, proxy_pid, proj_mul_g2_req, alice_actor_id);
+        let mid = proxy_program.send_bytes(alice_actor_id, b"");
+        let res = sys.run_next_block();
+        assert!(res.succeed.contains(&mid));
+
+        let mut logs = res.decoded_log();
+        let response = logs.pop().expect("no log found");
+
+        if let Bls12Response::ProjectiveMultiplicationG2(result_bytes) = response.payload() {
+            let actual = ArkScaleProjective::<G2>::decode(&mut result_bytes.as_ref()).expect("failed to decode result");
+
+            assert_eq!(actual.0, expected);
+        } else {
+            panic!("unexpected response");
+        }
+    }
+
+    #[test]
+    fn test_aggregate_g1() {
+        let sys = System::new();
+        sys.init_logger();
+
+        let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
+        let proxy_pid = ActorId::new([3; 32]);
+
+        let mut rng = test_rng();
+
+        const COUNT: usize = 5;
+
+        let points = (0..COUNT).map(|_| G1::rand(&mut rng)).collect::<Vec<_>>();
+        let ark_points: ArkScaleLocal<Vec<G1>> = points.clone().into();
+
+        let aggregate_g1_req = Bls12Request::AggregateG1 {
+            points: ark_points.encode(),
+        }.encode();
+
+        let proxy_program = create_proxy_program(&sys, proxy_pid, aggregate_g1_req, alice_actor_id);
+        let mid = proxy_program.send_bytes(alice_actor_id, b"");
+        let res = sys.run_next_block();
+        assert!(res.succeed.contains(&mid));
+
+        let mut logs = res.decoded_log();
+        let response = logs.pop().expect("no log found");
+
+        if let Bls12Response::AggregateG1(result_bytes) = response.payload() {
+            let actual = ArkScaleLocal::<G1>::decode(&mut result_bytes.as_ref()).expect("failed to decode result");
+
+            let point_first = points.first().unwrap();
+            let expected = points
+                .iter()
+                .skip(1)
+                .fold(*point_first, |aggregated, point| aggregated + *point);
+
+            assert_eq!(actual.0, expected);
+        } else {
+            panic!("unexpected response");
+        }
+    }
+
+    #[test]
+    fn test_map_to_g2affine() {
+        let sys = System::new();
+        sys.init_logger();
+
+        let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
+        let proxy_pid = ActorId::new([3; 32]);
+
+        let message = b"Hello, decentralized world!".to_vec();
+
+        let map_to_g2_req = Bls12Request::MapToG2Affine {
+            message: message.clone(), // Use the message directly as Vec<u8>
+        }.encode();
+
+        log::warn!("Sending payload: {:?}", map_to_g2_req);
+        log::warn!("Payload length: {}", map_to_g2_req.len());
+
+        let proxy_program = create_proxy_program(&sys, proxy_pid, map_to_g2_req, alice_actor_id);
+        let mid = proxy_program.send_bytes(alice_actor_id, b"");
+        let res = sys.run_next_block();
+        assert!(res.succeed.contains(&mid));
+
+        let mut logs = res.decoded_log();
+        let response = logs.pop().expect("no log found");
+
+        if let Bls12Response::MapToG2Affine(result_bytes) = response.payload() {
+            let actual = ArkScaleLocal::<G2Affine>::decode(&mut result_bytes.as_ref()).expect("failed to decode result");
+
+            // Verify the result matches what arkworks would produce
+            type WBMap = wb::WBMap<<ark_bls12_381::Config as Bls12Config>::G2Config>;
+            const DST_G2: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
+
+            let mapper = MapToCurveBasedHasher::<G2, DefaultFieldHasher<sha2::Sha256>, WBMap>::new(DST_G2)
+                .expect("mapper creation failed");
+            let expected = mapper.hash(&message).expect("hash to curve failed");
+
+            assert_eq!(actual.0, expected);
+        } else {
+            panic!("unexpected response");
+        }
+    }
+
+    
 }

--- a/gtest/src/builtins/bls12_381.rs
+++ b/gtest/src/builtins/bls12_381.rs
@@ -36,6 +36,8 @@ use gear_core::{ids::ActorId, message::StoredDispatch, str::LimitedStr};
 use parity_scale_codec::{Decode, Encode};
 use sp_crypto_ec_utils::bls12_381;
 
+// TODO #4832: Charge gas for bls12_381 ops
+
 /// The id of the BLS12-381 builtin actor.
 pub const BLS12_381_ID: ActorId = ActorId::new(*b"modl/bia/bls12-381/v-\x01\0/\0\0\0\0\0\0\0\0");
 
@@ -89,10 +91,6 @@ fn multi_miller_loop(a: Vec<u8>, b: Vec<u8>) -> Result<Bls12_381Response, Builti
         Ok(_) => (),
     }
 
-    // todo [sab] charge gas
-    // let to_spend = WeightInfo::bls12_381_multi_miller_loop(count as u32).ref_time();
-    // context.try_charge_gas(to_spend)?;
-
     match bls12_381::host_calls::bls12_381_multi_miller_loop(a, b) {
         Ok(result) => Ok(Bls12_381Response::MultiMillerLoop(result)),
         Err(_) => Err(BuiltinActorError::Custom(LimitedStr::from_small_str(
@@ -102,10 +100,6 @@ fn multi_miller_loop(a: Vec<u8>, b: Vec<u8>) -> Result<Bls12_381Response, Builti
 }
 
 fn final_exponentiation(f: Vec<u8>) -> Result<Bls12_381Response, BuiltinActorError> {
-    // todo [sab] charge gas
-    // let to_spend = WeightInfo::bls12_381_final_exponentiation().ref_time();
-    // context.try_charge_gas(to_spend)?;
-
     match bls12_381::host_calls::bls12_381_final_exponentiation(f) {
         Ok(result) => Ok(Bls12_381Response::FinalExponentiation(result)),
         Err(_) => Err(BuiltinActorError::Custom(LimitedStr::from_small_str(
@@ -118,7 +112,7 @@ fn msm_g1(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Bls12_381Response, Builtin
     msm(
         bases,
         scalars,
-        |_count| 0, // WeightInfo::bls12_381_msm_g1(count).ref_time(),
+        |_count| 0,
         |bases, scalars| {
             bls12_381::host_calls::bls12_381_msm_g1(bases, scalars)
                 .map(Bls12_381Response::MultiScalarMultiplicationG1)
@@ -130,7 +124,7 @@ fn msm_g2(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Bls12_381Response, Builtin
     msm(
         bases,
         scalars,
-        |_count| 0, // WeightInfo::bls12_381_msm_g2(count).ref_time(),
+        |_count| 0,
         |bases, scalars| {
             bls12_381::host_calls::bls12_381_msm_g2(bases, scalars)
                 .map(Bls12_381Response::MultiScalarMultiplicationG2)
@@ -168,10 +162,6 @@ fn msm(
         Ok(_) => (),
     }
 
-    // todo [sab] charge gas
-    // let to_spend = gas_to_spend(count as u32);
-    // context.try_charge_gas(to_spend)?;
-
     match call(bases, scalars) {
         Ok(result) => Ok(result),
         Err(_) => Err(BuiltinActorError::Custom(LimitedStr::from_small_str(
@@ -187,7 +177,7 @@ fn projective_multiplication_g1(
     projective_multiplication(
         base,
         scalar,
-        |_count| 0, // WeightInfo::bls12_381_mul_projective_g1(count).ref_time(),
+        |_count| 0,
         |base, scalar| {
             bls12_381::host_calls::bls12_381_mul_projective_g1(base, scalar)
                 .map(Bls12_381Response::ProjectiveMultiplicationG1)
@@ -202,7 +192,7 @@ fn projective_multiplication_g2(
     projective_multiplication(
         base,
         scalar,
-        |_count| 0, // WeightInfo::bls12_381_mul_projective_g2(count).ref_time(),
+        |_count| 0,
         |base, scalar| {
             bls12_381::host_calls::bls12_381_mul_projective_g2(base, scalar)
                 .map(Bls12_381Response::ProjectiveMultiplicationG2)
@@ -223,10 +213,6 @@ fn projective_multiplication(
 
         return Err(BuiltinActorError::DecodingError);
     };
-
-    // todo [sab] charge gas
-    // let to_spend = gas_to_spend(count as u32);
-    // context.try_charge_gas(to_spend)?;
 
     call(base, scalar).map_err(|_| {
         BuiltinActorError::Custom(LimitedStr::from_small_str(

--- a/gtest/src/builtins/bls12_381.rs
+++ b/gtest/src/builtins/bls12_381.rs
@@ -45,7 +45,9 @@ const IS_VALIDATED: Validate = ark_scale::is_validated(HOST_CALL);
 type ArkScaleLocal<T> = ark_scale::ArkScale<T, { ark_scale::HOST_CALL }>;
 
 /// Processes a dispatch message sent to the BLS12-381 builtin actor.
-pub(crate) fn process_bls12_381_dispatch(dispatch: &StoredDispatch) -> Result<Bls12_381Response, BuiltinActorError> {
+pub(crate) fn process_bls12_381_dispatch(
+    dispatch: &StoredDispatch,
+) -> Result<Bls12_381Response, BuiltinActorError> {
     let mut payload = dispatch.payload_bytes();
     let payload_decoded =
         Bls12_381Request::decode(&mut payload).map_err(|_| BuiltinActorError::DecodingError)?;
@@ -421,7 +423,8 @@ mod tests {
         // -----------------------------------------------------------------------
         // ------------------------ Create proxy program -------------------------
         // -----------------------------------------------------------------------
-        let proxy_program = create_proxy_program(&sys, proxy_pid, final_expon_req.encode(), alice_id);
+        let proxy_program =
+            create_proxy_program(&sys, proxy_pid, final_expon_req.encode(), alice_id);
 
         // -----------------------------------------------------------------------
         // ------------------------- Trigger builtin -----------------------------
@@ -472,8 +475,7 @@ mod tests {
             &(0..count).map(|_| G1::rand(&mut rng)).collect::<Vec<_>>(),
         );
 
-        let faulty_ark_scalars: ArkScaleLocal<Vec<ScalarFieldG1>> =
-            scalars[1..].to_vec().into();
+        let faulty_ark_scalars: ArkScaleLocal<Vec<ScalarFieldG1>> = scalars[1..].to_vec().into();
         let ark_bases: ArkScaleLocal<Vec<G1Affine>> = bases.clone().into();
 
         let faulty_msm_g1_req = Bls12_381Request::MultiScalarMultiplicationG1 {
@@ -535,7 +537,8 @@ mod tests {
         // -----------------------------------------------------------------------
         // ------------------------ Create proxy program -------------------------
         // -----------------------------------------------------------------------
-        let proxy_program = create_proxy_program(&sys, proxy_pid, msm_g1_req.encode(), alice_actor_id);
+        let proxy_program =
+            create_proxy_program(&sys, proxy_pid, msm_g1_req.encode(), alice_actor_id);
 
         // -----------------------------------------------------------------------
         // ------------------------- Trigger builtin -----------------------------
@@ -644,7 +647,8 @@ mod tests {
         // -----------------------------------------------------------------------
         // ------------------------ Create proxy program -------------------------
         // -----------------------------------------------------------------------
-        let proxy_program = create_proxy_program(&sys, proxy_pid, msm_g2_req.encode(), alice_actor_id);
+        let proxy_program =
+            create_proxy_program(&sys, proxy_pid, msm_g2_req.encode(), alice_actor_id);
 
         // -----------------------------------------------------------------------
         // ------------------------- Trigger builtin -----------------------------
@@ -698,7 +702,8 @@ mod tests {
         // -----------------------------------------------------------------------
         // ------------------------ Create proxy program -------------------------
         // -----------------------------------------------------------------------
-        let proxy_program = create_proxy_program(&sys, proxy_pid, proj_mul_g1_req.encode(), alice_actor_id);
+        let proxy_program =
+            create_proxy_program(&sys, proxy_pid, proj_mul_g1_req.encode(), alice_actor_id);
 
         // -----------------------------------------------------------------------
         // ------------------------- Trigger builtin -----------------------------
@@ -752,7 +757,8 @@ mod tests {
         // -----------------------------------------------------------------------
         // ------------------------ Create proxy program -------------------------
         // -----------------------------------------------------------------------
-        let proxy_program = create_proxy_program(&sys, proxy_pid, proj_mul_g2_req.encode(), alice_actor_id);
+        let proxy_program =
+            create_proxy_program(&sys, proxy_pid, proj_mul_g2_req.encode(), alice_actor_id);
 
         // -----------------------------------------------------------------------
         // ------------------------- Trigger builtin -----------------------------
@@ -802,7 +808,8 @@ mod tests {
         // -----------------------------------------------------------------------
         // ------------------------ Create proxy program -------------------------
         // -----------------------------------------------------------------------
-        let proxy_program = create_proxy_program(&sys, proxy_pid, aggregate_g1_req.encode(), alice_actor_id);
+        let proxy_program =
+            create_proxy_program(&sys, proxy_pid, aggregate_g1_req.encode(), alice_actor_id);
 
         // -----------------------------------------------------------------------
         // ------------------------- Trigger builtin -----------------------------
@@ -853,7 +860,8 @@ mod tests {
         // -----------------------------------------------------------------------
         // ------------------------ Create proxy program -------------------------
         // -----------------------------------------------------------------------
-        let proxy_program = create_proxy_program(&sys, proxy_pid, map_to_g2_req.encode(), alice_actor_id);
+        let proxy_program =
+            create_proxy_program(&sys, proxy_pid, map_to_g2_req.encode(), alice_actor_id);
 
         // -----------------------------------------------------------------------
         // ------------------------- Trigger builtin -----------------------------

--- a/gtest/src/builtins/bls12_381.rs
+++ b/gtest/src/builtins/bls12_381.rs
@@ -1,0 +1,296 @@
+pub use gbuiltin_bls381::{Request, Response};
+
+use super::BuiltinActorError;
+use ark_bls12_381::{G1Projective as G1, G2Affine, G2Projective as G2};
+use ark_ec::{
+    bls12::Bls12Config,
+    hashing::{HashToCurve, curve_maps::wb, map_to_curve_hasher::MapToCurveBasedHasher},
+};
+use ark_ff::fields::field_hashers::DefaultFieldHasher;
+use ark_scale::{ArkScale, HOST_CALL};
+use ark_serialize::{CanonicalDeserialize, Compress, Validate};
+use gear_core::{ids::ActorId, message::StoredDispatch, str::LimitedStr};
+use parity_scale_codec::{Compact, Decode, Encode, Input};
+use scale_info::TypeInfo;
+use sp_crypto_ec_utils::bls12_381;
+
+/// The id of the BLS12-381 builtin actor.
+pub const BLS12_381_ID: ActorId = ActorId::new(*b"modl/bia/bls12-381/v-\x01\0/\0\0\0\0\0\0\0\0");
+const IS_COMPRESSED: Compress = ark_scale::is_compressed(HOST_CALL);
+const IS_VALIDATED: Validate = ark_scale::is_validated(HOST_CALL);
+
+pub fn process_bls12_381_dispatch(mut payload: &[u8]) -> Result<Response, BuiltinActorError> {
+    let payload_decoded =
+        Request::decode(&mut payload).map_err(|_| BuiltinActorError::DecodingError)?;
+
+    match payload_decoded {
+        Request::MultiMillerLoop { a, b } => multi_miller_loop(a, b),
+        _ => todo!(),
+    }
+}
+
+fn multi_miller_loop(a: Vec<u8>, b: Vec<u8>) -> Result<Response, BuiltinActorError> {
+    // decode the items count
+    let mut slice = a.as_slice();
+    let mut reader = ark_scale::rw::InputAsRead(&mut slice);
+    let Ok(count) = u64::deserialize_with_mode(&mut reader, IS_COMPRESSED, IS_VALIDATED) else {
+        log::debug!("Failed to decode items count in a");
+
+        return Err(BuiltinActorError::DecodingError);
+    };
+
+    let mut slice = b.as_slice();
+    let mut reader = ark_scale::rw::InputAsRead(&mut slice);
+    match u64::deserialize_with_mode(&mut reader, IS_COMPRESSED, IS_VALIDATED) {
+        Ok(count_b) if count_b != count => {
+            return Err(BuiltinActorError::Custom(LimitedStr::from_small_str(
+                "Multi Miller loop: uneven item count",
+            )));
+        }
+        Err(_) => return Err(BuiltinActorError::DecodingError),
+        Ok(_) => (),
+    }
+
+    // todo [sab] charge gas
+    // let to_spend = WeightInfo::bls12_381_multi_miller_loop(count as u32).ref_time();
+    // context.try_charge_gas(to_spend)?;
+
+    match bls12_381::host_calls::bls12_381_multi_miller_loop(a, b) {
+        Ok(result) => Ok(Response::MultiMillerLoop(result)),
+        Err(_) => Err(BuiltinActorError::Custom(LimitedStr::from_small_str(
+            "Multi Miller loop: computation error",
+        ))),
+    }
+}
+
+fn final_exponentiation(mut payload: &[u8]) -> Result<Response, BuiltinActorError> {
+    let f = decode_vec(&mut payload)?;
+
+    // todo [sab] charge gas
+    // let to_spend = WeightInfo::bls12_381_final_exponentiation().ref_time();
+    // context.try_charge_gas(to_spend)?;
+
+    match bls12_381::host_calls::bls12_381_final_exponentiation(f) {
+        Ok(result) => Ok(Response::FinalExponentiation(result)),
+        Err(_) => Err(BuiltinActorError::Custom(LimitedStr::from_small_str(
+            "Final exponentiation: computation error",
+        ))),
+    }
+}
+
+fn msm_g1(payload: &[u8]) -> Result<Response, BuiltinActorError> {
+    msm(
+        payload,
+        |count| 0, // WeightInfo::bls12_381_msm_g1(count).ref_time(),
+        |bases, scalars| {
+            bls12_381::host_calls::bls12_381_msm_g1(bases, scalars)
+                .map(Response::MultiScalarMultiplicationG1)
+        },
+    )
+}
+
+fn msm_g2(payload: &[u8]) -> Result<Response, BuiltinActorError> {
+    msm(
+        payload,
+        |count| 0, // WeightInfo::bls12_381_msm_g2(count).ref_time(),
+        |bases, scalars| {
+            bls12_381::host_calls::bls12_381_msm_g2(bases, scalars)
+                .map(Response::MultiScalarMultiplicationG2)
+        },
+    )
+}
+
+fn msm(
+    mut payload: &[u8],
+    gas_to_spend: impl FnOnce(u32) -> u64,
+    call: impl FnOnce(Vec<u8>, Vec<u8>) -> Result<Response, ()>,
+) -> Result<Response, BuiltinActorError> {
+    let bases = decode_vec(&mut payload)?;
+    let scalars = decode_vec(&mut payload)?;
+
+    // decode the count of items
+    let mut slice = bases.as_slice();
+    let mut reader = ark_scale::rw::InputAsRead(&mut slice);
+    let Ok(count) = u64::deserialize_with_mode(&mut reader, IS_COMPRESSED, IS_VALIDATED) else {
+        log::debug!("Failed to decode items count in bases");
+
+        return Err(BuiltinActorError::DecodingError);
+    };
+
+    let mut slice = scalars.as_slice();
+    let mut reader = ark_scale::rw::InputAsRead(&mut slice);
+    match u64::deserialize_with_mode(&mut reader, IS_COMPRESSED, IS_VALIDATED) {
+        Ok(count_b) if count_b != count => {
+            return Err(BuiltinActorError::Custom(LimitedStr::from_small_str(
+                "Multi scalar multiplication: uneven item count",
+            )));
+        }
+        Err(_) => {
+            log::debug!("Failed to decode items count in scalars");
+
+            return Err(BuiltinActorError::DecodingError);
+        }
+        Ok(_) => (),
+    }
+
+    // todo [sab] charge gas
+    // let to_spend = gas_to_spend(count as u32);
+    // context.try_charge_gas(to_spend)?;
+
+    match call(bases, scalars) {
+        Ok(result) => Ok(result),
+        Err(_) => Err(BuiltinActorError::Custom(LimitedStr::from_small_str(
+            "Multi scalar multiplication: computation error",
+        ))),
+    }
+}
+
+fn projective_multiplication_g1(payload: &[u8]) -> Result<Response, BuiltinActorError> {
+    projective_multiplication(
+        payload,
+        |count| 0, // WeightInfo::bls12_381_mul_projective_g1(count).ref_time(),
+        |base, scalar| {
+            bls12_381::host_calls::bls12_381_mul_projective_g1(base, scalar)
+                .map(Response::ProjectiveMultiplicationG1)
+        },
+    )
+}
+
+fn projective_multiplication_g2(payload: &[u8]) -> Result<Response, BuiltinActorError> {
+    projective_multiplication(
+        payload,
+        |count| 0, // WeightInfo::bls12_381_mul_projective_g2(count).ref_time(),
+        |base, scalar| {
+            bls12_381::host_calls::bls12_381_mul_projective_g2(base, scalar)
+                .map(Response::ProjectiveMultiplicationG2)
+        },
+    )
+}
+
+fn projective_multiplication(
+    mut payload: &[u8],
+    gas_to_spend: impl FnOnce(u32) -> u64,
+    call: impl FnOnce(Vec<u8>, Vec<u8>) -> Result<Response, ()>,
+) -> Result<Response, BuiltinActorError> {
+    let base = decode_vec(&mut payload)?;
+    let scalar = decode_vec(&mut payload)?;
+
+    // decode the count of items
+    let mut slice = scalar.as_slice();
+    let mut reader = ark_scale::rw::InputAsRead(&mut slice);
+    let Ok(count) = u64::deserialize_with_mode(&mut reader, IS_COMPRESSED, IS_VALIDATED) else {
+        log::debug!("Failed to decode items count in scalar");
+
+        return Err(BuiltinActorError::DecodingError);
+    };
+
+    // todo [sab] charge gas
+    // let to_spend = gas_to_spend(count as u32);
+    // context.try_charge_gas(to_spend)?;
+
+    call(base, scalar).map_err(|_| {
+        BuiltinActorError::Custom(LimitedStr::from_small_str(
+            "Projective multiplication: computation error",
+        ))
+    })
+}
+
+fn aggregate_g1(mut payload: &[u8]) -> Result<Response, BuiltinActorError> {
+    let points = decode_vec(&mut payload)?;
+
+    // decode the count of items
+    let mut slice = points.as_slice();
+    let mut reader = ark_scale::rw::InputAsRead(&mut slice);
+    let Ok(count) = u64::deserialize_with_mode(&mut reader, IS_COMPRESSED, IS_VALIDATED) else {
+        log::debug!("Failed to decode items count in points");
+
+        return Err(BuiltinActorError::DecodingError);
+    };
+
+    // todo [sab] charge gas
+    // let to_spend = WeightInfo::bls12_381_aggregate_g1(count as u32).ref_time();
+    // context.try_charge_gas(to_spend)?;
+
+    aggregate_g1_impl(&points)
+        .map(Response::AggregateG1)
+        .inspect_err(|e| {
+            log::debug!("Failed to aggregate G1-points: {e:?}");
+        })
+}
+
+fn aggregate_g1_impl(points: &[u8]) -> Result<Vec<u8>, BuiltinActorError> {
+    type ArkScale<T> = ark_scale::ArkScale<T, { ark_scale::HOST_CALL }>;
+
+    let ArkScale(points) = ArkScale::<Vec<G1>>::decode(&mut &points[..])
+        .map_err(|_| BuiltinActorError::DecodingError)?;
+
+    let point_first = points.first().ok_or(BuiltinActorError::EmptyPointList)?;
+
+    let point_aggregated = points
+        .iter()
+        .skip(1)
+        .fold(*point_first, |aggregated, point| aggregated + *point);
+
+    Ok(ArkScale::<G1>::from(point_aggregated).encode())
+}
+
+fn map_to_g2affine(mut payload: &[u8]) -> Result<Response, BuiltinActorError> {
+    let len = Compact::<u32>::decode(&mut payload)
+        .map(u32::from)
+        .map_err(|_| {
+            log::debug!("Failed to scale-decode vector length");
+            BuiltinActorError::DecodingError
+        })?;
+
+    if len != payload.len() as u32 {
+        log::debug!("Failed to scale-decode vector length");
+
+        return Err(BuiltinActorError::DecodingError);
+    }
+
+    // todo [sab] charge gas
+    // let to_spend = WeightInfo::bls12_381_map_to_g2affine(len).ref_time();
+    // context.try_charge_gas(to_spend)?;
+
+    map_to_g2affine_impl(payload)
+        .map(Response::MapToG2Affine)
+        .inspect_err(|e| {
+            log::debug!("Failed to map a message: {e:?}");
+        })
+}
+
+fn map_to_g2affine_impl(message: &[u8]) -> Result<Vec<u8>, BuiltinActorError> {
+    type ArkScale<T> = ark_scale::ArkScale<T, { ark_scale::HOST_CALL }>;
+    type WBMap = wb::WBMap<<ark_bls12_381::Config as Bls12Config>::G2Config>;
+
+    const DST_G2: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
+
+    let mapper = MapToCurveBasedHasher::<G2, DefaultFieldHasher<sha2::Sha256>, WBMap>::new(DST_G2)
+        .map_err(|_| BuiltinActorError::MapperCreationError)?;
+
+    let point = mapper
+        .hash(message)
+        .map_err(|_| BuiltinActorError::MessageMappingError)?;
+
+    Ok(ArkScale::<G2Affine>::from(point).encode())
+}
+
+fn decode_vec<I: Input>(input: &mut I) -> Result<Vec<u8>, BuiltinActorError> {
+    let len = Compact::<u32>::decode(input).map(u32::from).map_err(|_| {
+        log::debug!("Failed to scale-decode vector length");
+        BuiltinActorError::DecodingError
+    })?;
+
+    // todo [sab] charge gas
+    // let to_spend = WeightInfo::decode_bytes(len).ref_time();
+    // context.try_charge_gas(to_spend)?;
+
+    let mut items = vec![0u8; len as usize];
+    let bytes_slice = items.as_mut_slice();
+
+    input.read(bytes_slice).map(|_| items).map_err(|_| {
+        log::debug!("Failed to scale-decode vector data");
+
+        BuiltinActorError::DecodingError
+    })
+}

--- a/gtest/src/builtins/bls12_381.rs
+++ b/gtest/src/builtins/bls12_381.rs
@@ -297,7 +297,7 @@ mod tests {
         let proxy_scheme = Scheme::predefined(
             // init: do nothing
             Calls::builder().noop(),
-            // handle: load message payload and send it to mock program
+            // handle: send message to bls12-381 builtin
             Calls::builder().add_call(Call::Send(
                 Arg::new(BLS12_381_ID.into_bytes()),
                 Arg::new(builtin_req),

--- a/gtest/src/builtins/eth_bridge.rs
+++ b/gtest/src/builtins/eth_bridge.rs
@@ -17,7 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Eth-bridge builtin actor implementation.
-//! 
+//!
 //! The main function the module is `process_eth_bridge_dispatch` which processes
 //! incoming dispatches to the eth-bridge builtin actor.
 
@@ -34,7 +34,9 @@ use sp_runtime::traits::{Hash, Keccak256};
 pub const ETH_BRIDGE_ID: ActorId = ActorId::new(*b"modl/bia/eth-bridge/v-\x01\0/\0\0\0\0\0\0\0");
 
 /// Processes a dispatch message sent to the Eth-bridge builtin actor.
-pub(crate) fn process_eth_bridge_dispatch(dispatch: &StoredDispatch) -> Result<EthBridgeResponse, BuiltinActorError> {
+pub(crate) fn process_eth_bridge_dispatch(
+    dispatch: &StoredDispatch,
+) -> Result<EthBridgeResponse, BuiltinActorError> {
     let source = dispatch.source();
     let mut payload = dispatch.payload_bytes();
     let request =

--- a/gtest/src/builtins/eth_bridge.rs
+++ b/gtest/src/builtins/eth_bridge.rs
@@ -33,6 +33,8 @@ use sp_runtime::traits::{Hash, Keccak256};
 /// The id of the ETH bridge builtin actor.
 pub const ETH_BRIDGE_ID: ActorId = ActorId::new(*b"modl/bia/eth-bridge/v-\x01\0/\0\0\0\0\0\0\0");
 
+// TODO #4832: Charge gas for eth-bridge ops
+
 /// Processes a dispatch message sent to the Eth-bridge builtin actor.
 pub(crate) fn process_eth_bridge_dispatch(
     dispatch: &StoredDispatch,
@@ -41,8 +43,6 @@ pub(crate) fn process_eth_bridge_dispatch(
     let mut payload = dispatch.payload_bytes();
     let request =
         EthBridgeRequest::decode(&mut payload).map_err(|_| BuiltinActorError::DecodingError)?;
-
-    // todo [sab] charge gas properly
 
     match request {
         EthBridgeRequest::SendEthMessage {

--- a/gtest/src/builtins/eth_bridge.rs
+++ b/gtest/src/builtins/eth_bridge.rs
@@ -1,8 +1,31 @@
+// This file is part of Gear.
+//
+// Copyright (C) 2025 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Eth-bridge builtin actor implementation.
+//! 
+//! The main function the module is `process_eth_bridge_dispatch` which processes
+//! incoming dispatches to the eth-bridge builtin actor.
+
 pub use gbuiltin_eth_bridge::{Request as EthBridgeRequest, Response as EthBridgeResponse};
 
 use super::BuiltinActorError;
 use crate::state::bridge::BridgeBuiltinStorage;
-use gear_core::ids::ActorId;
+use gear_core::{ids::ActorId, message::StoredDispatch};
 use gprimitives::{H160, H256, U256};
 use parity_scale_codec::Decode;
 use sp_runtime::traits::{Hash, Keccak256};
@@ -10,10 +33,10 @@ use sp_runtime::traits::{Hash, Keccak256};
 /// The id of the ETH bridge builtin actor.
 pub const ETH_BRIDGE_ID: ActorId = ActorId::new(*b"modl/bia/eth-bridge/v-\x01\0/\0\0\0\0\0\0\0");
 
-pub(crate) fn process_eth_bridge_dispatch(
-    source: ActorId,
-    mut payload: &[u8],
-) -> Result<EthBridgeResponse, BuiltinActorError> {
+/// Processes a dispatch message sent to the Eth-bridge builtin actor.
+pub(crate) fn process_eth_bridge_dispatch(dispatch: &StoredDispatch) -> Result<EthBridgeResponse, BuiltinActorError> {
+    let source = dispatch.source();
+    let mut payload = dispatch.payload_bytes();
     let request =
         EthBridgeRequest::decode(&mut payload).map_err(|_| BuiltinActorError::DecodingError)?;
 

--- a/gtest/src/builtins/eth_bridge.rs
+++ b/gtest/src/builtins/eth_bridge.rs
@@ -1,0 +1,56 @@
+use std::io::Read;
+
+pub use gbuiltin_eth_bridge::{Request as EthBridgeRequest, Response as EthBridgeResponse};
+
+use super::BuiltinActorError;
+use crate::state::bridge::BridgeBuiltinStorage;
+use gear_core::ids::ActorId;
+use gprimitives::{H160, H256, U256};
+use parity_scale_codec::Decode;
+use sp_runtime::traits::{Hash, Keccak256};
+
+pub const ETH_BRIDGE_ID: ActorId = ActorId::new(*b"modl/bia/eth-bridge/v-\x01\0/\0\0\0\0\0\0\0");
+
+pub(crate) fn process_eth_bridge_dispatch(
+    source: ActorId,
+    mut payload: &[u8],
+) -> Result<EthBridgeResponse, BuiltinActorError> {
+    let request =
+        EthBridgeRequest::decode(&mut payload).map_err(|_| BuiltinActorError::DecodingError)?;
+
+    // todo [sab] charge gas properly
+
+    match request {
+        EthBridgeRequest::SendEthMessage {
+            destination,
+            payload,
+        } => {
+            let (nonce, hash) = create_bridge_call_output(source, destination, payload);
+
+            Ok(EthBridgeResponse::EthMessageQueued { nonce, hash })
+        }
+    }
+}
+
+pub(crate) fn create_bridge_call_output(
+    source: ActorId,
+    destination: H160,
+    payload: Vec<u8>,
+) -> (U256, H256) {
+    let nonce = BridgeBuiltinStorage::fetch_nonce();
+
+    let mut nonce_bytes = [0; 32];
+    nonce.to_little_endian(&mut nonce_bytes);
+
+    let bytes = [
+        nonce_bytes.as_ref(),
+        source.into_bytes().as_ref(),
+        destination.as_bytes(),
+        payload.as_ref(),
+    ]
+    .concat();
+
+    let hash = Keccak256::hash(&bytes);
+
+    (nonce, hash)
+}

--- a/gtest/src/builtins/eth_bridge.rs
+++ b/gtest/src/builtins/eth_bridge.rs
@@ -31,11 +31,7 @@ pub(crate) fn process_eth_bridge_dispatch(
     }
 }
 
-fn create_bridge_call_output(
-    source: ActorId,
-    destination: H160,
-    payload: Vec<u8>,
-) -> (U256, H256) {
+fn create_bridge_call_output(source: ActorId, destination: H160, payload: Vec<u8>) -> (U256, H256) {
     let nonce = BridgeBuiltinStorage::fetch_nonce();
     let hash = bridge_call_hash(nonce, source, destination, &payload);
 
@@ -62,8 +58,8 @@ fn bridge_call_hash(nonce: U256, source: ActorId, destination: H160, payload: &[
 #[cfg(test)]
 mod tests {
     use super::*;
-    use demo_constructor::{WASM_BINARY, Arg, Scheme, Calls, Call};
-    use crate::{Log, System, Program, DEFAULT_USER_ALICE};
+    use crate::{DEFAULT_USER_ALICE, Log, Program, System};
+    use demo_constructor::{Arg, Call, Calls, Scheme, WASM_BINARY};
     use parity_scale_codec::Encode;
 
     #[test]
@@ -80,7 +76,12 @@ mod tests {
 
         // Calculate expected hash and nonce using the same function as the builtin
         let expected_nonce = U256::zero();
-        let expected_hash = bridge_call_hash(expected_nonce, proxy_program_id, destination, &bridge_payload);
+        let expected_hash = bridge_call_hash(
+            expected_nonce,
+            proxy_program_id,
+            destination,
+            &bridge_payload,
+        );
 
         // Create the bridge request
         let bridge_request = EthBridgeRequest::SendEthMessage {

--- a/gtest/src/builtins/eth_bridge.rs
+++ b/gtest/src/builtins/eth_bridge.rs
@@ -90,7 +90,6 @@ mod tests {
     #[test]
     fn test_eth_bridge_builtin() {
         let sys = System::new();
-        sys.init_logger();
 
         let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
         let proxy_program_id = ActorId::new([3; 32]);

--- a/gtest/src/builtins/mod.rs
+++ b/gtest/src/builtins/mod.rs
@@ -1,12 +1,9 @@
 mod bls12_381;
 mod eth_bridge;
 
-pub use bls12_381::{
-    BLS12_381_ID, Request as Bls12_381Request, Response as Bls12_381Response,
-    process_bls12_381_dispatch,
-};
+pub use bls12_381::{BLS12_381_ID, Bls12Request, Bls12Response, process_bls12_381_dispatch};
 pub use eth_bridge::{ETH_BRIDGE_ID, EthBridgeRequest, EthBridgeResponse};
-pub(crate) use eth_bridge::{create_bridge_call_output, process_eth_bridge_dispatch};
+pub(crate) use eth_bridge::process_eth_bridge_dispatch;
 
 use core_processor::common::{ActorExecutionErrorReplyReason, TrapExplanation};
 use gear_core::str::LimitedStr;

--- a/gtest/src/builtins/mod.rs
+++ b/gtest/src/builtins/mod.rs
@@ -2,8 +2,8 @@ mod bls12_381;
 mod eth_bridge;
 
 pub use bls12_381::{BLS12_381_ID, Bls12Request, Bls12Response, process_bls12_381_dispatch};
-pub use eth_bridge::{ETH_BRIDGE_ID, EthBridgeRequest, EthBridgeResponse};
 pub(crate) use eth_bridge::process_eth_bridge_dispatch;
+pub use eth_bridge::{ETH_BRIDGE_ID, EthBridgeRequest, EthBridgeResponse};
 
 use core_processor::common::{ActorExecutionErrorReplyReason, TrapExplanation};
 use gear_core::str::LimitedStr;

--- a/gtest/src/builtins/mod.rs
+++ b/gtest/src/builtins/mod.rs
@@ -1,9 +1,12 @@
 mod bls12_381;
+mod eth_bridge;
 
 pub use bls12_381::{
     BLS12_381_ID, Request as Bls12_381Request, Response as Bls12_381Response,
     process_bls12_381_dispatch,
 };
+pub use eth_bridge::{ETH_BRIDGE_ID, EthBridgeRequest, EthBridgeResponse};
+pub(crate) use eth_bridge::{create_bridge_call_output, process_eth_bridge_dispatch};
 
 use core_processor::common::{ActorExecutionErrorReplyReason, TrapExplanation};
 use gear_core::str::LimitedStr;

--- a/gtest/src/builtins/mod.rs
+++ b/gtest/src/builtins/mod.rs
@@ -1,14 +1,37 @@
+// This file is part of Gear.
+//
+// Copyright (C) 2025 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Builtin actors implementations for gtest.
+
 mod bls12_381;
 mod eth_bridge;
 
-pub use bls12_381::{BLS12_381_ID, Bls12Request, Bls12Response, process_bls12_381_dispatch};
-pub(crate) use eth_bridge::process_eth_bridge_dispatch;
+pub use bls12_381::{BLS12_381_ID, Bls12_381Request, Bls12_381Response};
 pub use eth_bridge::{ETH_BRIDGE_ID, EthBridgeRequest, EthBridgeResponse};
+
+pub(crate) use bls12_381::process_bls12_381_dispatch;
+pub(crate) use eth_bridge::process_eth_bridge_dispatch;
 
 use core_processor::common::{ActorExecutionErrorReplyReason, TrapExplanation};
 use gear_core::str::LimitedStr;
 use parity_scale_codec::{Decode, Encode};
 
+/// Builtin actor errors.
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq)]
 pub enum BuiltinActorError {
     /// Occurs if the underlying call has the weight greater than the `gas_limit`.
@@ -21,12 +44,6 @@ pub enum BuiltinActorError {
     Custom(LimitedStr<'static>),
     /// Occurs if a builtin actor execution does not fit in the current block.
     GasAllowanceExceeded,
-    /// The array of G1-points is empty.
-    EmptyPointList,
-    /// Failed to create `MapToCurveBasedHasher`.
-    MapperCreationError,
-    /// Failed to map a message to a G2-point.
-    MessageMappingError,
 }
 
 impl From<BuiltinActorError> for ActorExecutionErrorReplyReason {
@@ -46,21 +63,6 @@ impl From<BuiltinActorError> for ActorExecutionErrorReplyReason {
             ),
             BuiltinActorError::Custom(e) => {
                 ActorExecutionErrorReplyReason::Trap(TrapExplanation::Panic(e.into()))
-            }
-            BuiltinActorError::EmptyPointList => {
-                ActorExecutionErrorReplyReason::Trap(TrapExplanation::Panic(
-                    LimitedStr::from_small_str("The array of G1-points is empty").into(),
-                ))
-            }
-            BuiltinActorError::MapperCreationError => {
-                ActorExecutionErrorReplyReason::Trap(TrapExplanation::Panic(
-                    LimitedStr::from_small_str("Failed to create `MapToCurveBasedHasher`").into(),
-                ))
-            }
-            BuiltinActorError::MessageMappingError => {
-                ActorExecutionErrorReplyReason::Trap(TrapExplanation::Panic(
-                    LimitedStr::from_small_str("Failed to map a message to a G2-point").into(),
-                ))
             }
             BuiltinActorError::GasAllowanceExceeded => {
                 unreachable!("Never supposed to be converted to error reply reason")

--- a/gtest/src/builtins/mod.rs
+++ b/gtest/src/builtins/mod.rs
@@ -1,0 +1,70 @@
+mod bls12_381;
+
+pub use bls12_381::{
+    BLS12_381_ID, Request as Bls12_381Request, Response as Bls12_381Response,
+    process_bls12_381_dispatch,
+};
+
+use core_processor::common::{ActorExecutionErrorReplyReason, TrapExplanation};
+use gear_core::str::LimitedStr;
+use parity_scale_codec::{Decode, Encode};
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq)]
+pub enum BuiltinActorError {
+    /// Occurs if the underlying call has the weight greater than the `gas_limit`.
+    InsufficientGas,
+    /// Occurs if the dispatch's value is less than the minimum required value.
+    InsufficientValue,
+    /// Occurs if the dispatch's message can't be decoded into a known type.
+    DecodingError,
+    /// Actor's inner error encoded as a String.
+    Custom(LimitedStr<'static>),
+    /// Occurs if a builtin actor execution does not fit in the current block.
+    GasAllowanceExceeded,
+    /// The array of G1-points is empty.
+    EmptyPointList,
+    /// Failed to create `MapToCurveBasedHasher`.
+    MapperCreationError,
+    /// Failed to map a message to a G2-point.
+    MessageMappingError,
+}
+
+impl From<BuiltinActorError> for ActorExecutionErrorReplyReason {
+    /// Convert [`BuiltinActorError`] to [`core_processor::common::ActorExecutionErrorReplyReason`]
+    fn from(err: BuiltinActorError) -> Self {
+        match err {
+            BuiltinActorError::InsufficientGas => {
+                ActorExecutionErrorReplyReason::Trap(TrapExplanation::GasLimitExceeded)
+            }
+            BuiltinActorError::InsufficientValue => {
+                ActorExecutionErrorReplyReason::Trap(TrapExplanation::Panic(
+                    LimitedStr::from_small_str("Not enough value supplied").into(),
+                ))
+            }
+            BuiltinActorError::DecodingError => ActorExecutionErrorReplyReason::Trap(
+                TrapExplanation::Panic(LimitedStr::from_small_str("Message decoding error").into()),
+            ),
+            BuiltinActorError::Custom(e) => {
+                ActorExecutionErrorReplyReason::Trap(TrapExplanation::Panic(e.into()))
+            }
+            BuiltinActorError::EmptyPointList => {
+                ActorExecutionErrorReplyReason::Trap(TrapExplanation::Panic(
+                    LimitedStr::from_small_str("The array of G1-points is empty").into(),
+                ))
+            }
+            BuiltinActorError::MapperCreationError => {
+                ActorExecutionErrorReplyReason::Trap(TrapExplanation::Panic(
+                    LimitedStr::from_small_str("Failed to create `MapToCurveBasedHasher`").into(),
+                ))
+            }
+            BuiltinActorError::MessageMappingError => {
+                ActorExecutionErrorReplyReason::Trap(TrapExplanation::Panic(
+                    LimitedStr::from_small_str("Failed to map a message to a G2-point").into(),
+                ))
+            }
+            BuiltinActorError::GasAllowanceExceeded => {
+                unreachable!("Never supposed to be converted to error reply reason")
+            }
+        }
+    }
+}

--- a/gtest/src/lib.rs
+++ b/gtest/src/lib.rs
@@ -492,6 +492,7 @@
 #![doc(html_logo_url = "https://docs.gear.rs/logo.svg")]
 #![doc(html_favicon_url = "https://gear-tech.io/favicons/favicon.ico")]
 
+mod builtins;
 mod error;
 mod log;
 mod manager;
@@ -500,6 +501,7 @@ mod state;
 mod system;
 
 pub use crate::log::{BlockRunResult, CoreLog, Log};
+pub use builtins::{BLS12_381_ID, Bls12_381Request, Bls12_381Response};
 pub use error::{Result, TestError};
 pub use parity_scale_codec;
 pub use program::{

--- a/gtest/src/lib.rs
+++ b/gtest/src/lib.rs
@@ -512,13 +512,6 @@ pub use system::System;
 pub use constants::Value;
 pub(crate) use constants::*;
 
-// todo [sab] write docs about wasm program.
-// also think of sending messages from it
-// devs doc - it doesn't change global states, but only in few points
-// tests:
-// - user interaction
-// - cross program interaction
-
 /// Module containing constants of Gear protocol.
 pub mod constants {
     /* Constant types */

--- a/gtest/src/lib.rs
+++ b/gtest/src/lib.rs
@@ -502,7 +502,7 @@ mod system;
 
 pub use crate::log::{BlockRunResult, CoreLog, Log};
 pub use builtins::{
-    BLS12_381_ID, Bls12Request, Bls12Response, ETH_BRIDGE_ID, EthBridgeRequest, EthBridgeResponse,
+    BLS12_381_ID, Bls12_381Request, Bls12_381Response, ETH_BRIDGE_ID, EthBridgeRequest, EthBridgeResponse,
 };
 pub use error::{Result, TestError};
 pub use parity_scale_codec;

--- a/gtest/src/lib.rs
+++ b/gtest/src/lib.rs
@@ -501,7 +501,9 @@ mod state;
 mod system;
 
 pub use crate::log::{BlockRunResult, CoreLog, Log};
-pub use builtins::{BLS12_381_ID, Bls12_381Request, Bls12_381Response};
+pub use builtins::{
+    BLS12_381_ID, Bls12Request, Bls12Response, ETH_BRIDGE_ID, EthBridgeRequest, EthBridgeResponse,
+};
 pub use error::{Result, TestError};
 pub use parity_scale_codec;
 pub use program::{

--- a/gtest/src/lib.rs
+++ b/gtest/src/lib.rs
@@ -506,11 +506,16 @@ pub use program::{
     Program, ProgramBuilder, ProgramIdWrapper, WasmProgram, calculate_program_id,
     gbuild::ensure_gbuild,
 };
-pub use state::mailbox::ActorMailbox;
 pub use system::System;
 
 pub use constants::Value;
 pub(crate) use constants::*;
+
+// todo [sab] write docs about wasm program.
+// devs doc - it doesn't change global states, but only in few points
+// tests:
+// - user interaction
+// - cross program interaction
 
 /// Module containing constants of Gear protocol.
 pub mod constants {

--- a/gtest/src/lib.rs
+++ b/gtest/src/lib.rs
@@ -506,12 +506,14 @@ pub use program::{
     Program, ProgramBuilder, ProgramIdWrapper, WasmProgram, calculate_program_id,
     gbuild::ensure_gbuild,
 };
+pub use state::mailbox::ActorMailbox;
 pub use system::System;
 
 pub use constants::Value;
 pub(crate) use constants::*;
 
 // todo [sab] write docs about wasm program.
+// also think of sending messages from it
 // devs doc - it doesn't change global states, but only in few points
 // tests:
 // - user interaction

--- a/gtest/src/lib.rs
+++ b/gtest/src/lib.rs
@@ -502,7 +502,8 @@ mod system;
 
 pub use crate::log::{BlockRunResult, CoreLog, Log};
 pub use builtins::{
-    BLS12_381_ID, Bls12_381Request, Bls12_381Response, ETH_BRIDGE_ID, EthBridgeRequest, EthBridgeResponse,
+    BLS12_381_ID, Bls12_381Request, Bls12_381Response, ETH_BRIDGE_ID, EthBridgeRequest,
+    EthBridgeResponse,
 };
 pub use error::{Result, TestError};
 pub use parity_scale_codec;

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -19,7 +19,7 @@
 use crate::{
     EXISTENTIAL_DEPOSIT, GAS_ALLOWANCE, GAS_MULTIPLIER, MAX_RESERVATIONS, MAX_USER_GAS_LIMIT,
     ProgramBuilder, RESERVE_FOR, Result, TestError, VALUE_PER_GAS,
-    builtins::BLS12_381_ID,
+    builtins::{BLS12_381_ID, ETH_BRIDGE_ID},
     constants::{BlockNumber, Gas, Value},
     error::usage_panic,
     log::{BlockRunResult, CoreLog},
@@ -115,7 +115,7 @@ pub(crate) struct ExtManager {
 
 impl ExtManager {
     pub(crate) fn new() -> Self {
-        let builtins = BTreeSet::from([BLS12_381_ID]);
+        let builtins = BTreeSet::from([BLS12_381_ID, ETH_BRIDGE_ID]);
         Self {
             blocks_manager: BlocksManager,
             messages_processing_enabled: true,

--- a/gtest/src/manager.rs
+++ b/gtest/src/manager.rs
@@ -19,6 +19,7 @@
 use crate::{
     EXISTENTIAL_DEPOSIT, GAS_ALLOWANCE, GAS_MULTIPLIER, MAX_RESERVATIONS, MAX_USER_GAS_LIMIT,
     ProgramBuilder, RESERVE_FOR, Result, TestError, VALUE_PER_GAS,
+    builtins::BLS12_381_ID,
     constants::{BlockNumber, Gas, Value},
     error::usage_panic,
     log::{BlockRunResult, CoreLog},
@@ -101,6 +102,7 @@ pub(crate) struct ExtManager {
     pub(crate) code_metadata: BTreeMap<CodeId, CodeMetadata>,
     pub(crate) messages_processing_enabled: bool,
     pub(crate) first_incomplete_tasks_block: Option<u32>,
+    pub(crate) builtins: BTreeSet<ActorId>,
 
     // Last block execution info
     pub(crate) succeed: BTreeSet<MessageId>,
@@ -113,9 +115,11 @@ pub(crate) struct ExtManager {
 
 impl ExtManager {
     pub(crate) fn new() -> Self {
+        let builtins = BTreeSet::from([BLS12_381_ID]);
         Self {
             blocks_manager: BlocksManager,
             messages_processing_enabled: true,
+            builtins,
             ..Default::default()
         }
     }
@@ -307,5 +311,9 @@ impl ExtManager {
     /// (auxiliaries and internal ones).
     pub(crate) fn disable_overlay(&self) {
         state::disable_overlay();
+    }
+
+    pub(crate) fn is_builtin(&self, id: ActorId) -> bool {
+        self.builtins.contains(&id)
     }
 }

--- a/gtest/src/manager/block_exec.rs
+++ b/gtest/src/manager/block_exec.rs
@@ -18,7 +18,7 @@
 
 use super::*;
 use crate::{
-    builtins::{self, BLS12_381_ID, Bls12_381Request, BuiltinActorError, ETH_BRIDGE_ID},
+    builtins::{self, BLS12_381_ID, BuiltinActorError, ETH_BRIDGE_ID},
     state::{
         blocks,
         programs::{GTestProgram, MockWasmProgram, PLACEHOLDER_MESSAGE_ID},
@@ -29,7 +29,7 @@ use core_processor::{
 };
 use gear_core::{
     code::{InstrumentedCodeAndMetadata, MAX_WASM_PAGES_AMOUNT},
-    gas::{GasAmount, GasCounter},
+    gas::GasCounter,
     message::{ContextOutcomeDrain, DispatchKind, MessageContext, ReplyPacket, StoredDispatch},
     program::ProgramState,
     str::LimitedStr,

--- a/gtest/src/manager/block_exec.rs
+++ b/gtest/src/manager/block_exec.rs
@@ -17,17 +17,24 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
-use crate::state::{
-    blocks,
-    programs::{GTestProgram, MockWasmProgram, PLACEHOLDER_MESSAGE_ID},
+use crate::{
+    builtins::{self, BLS12_381_ID, Bls12_381Request, BuiltinActorError},
+    state::{
+        blocks,
+        programs::{GTestProgram, MockWasmProgram, PLACEHOLDER_MESSAGE_ID},
+    },
 };
-use core_processor::{ContextCharged, ForProgram, ProcessExecutionContext};
+use core_processor::{
+    ContextCharged, ForProgram, ProcessExecutionContext, SystemReservationContext,
+};
 use gear_core::{
     code::{InstrumentedCodeAndMetadata, MAX_WASM_PAGES_AMOUNT},
-    message::{DispatchKind, ReplyPacket, StoredDispatch},
+    gas::{GasAmount, GasCounter},
+    message::{ContextOutcomeDrain, DispatchKind, MessageContext, ReplyPacket, StoredDispatch},
     program::ProgramState,
     str::LimitedStr,
 };
+use parity_scale_codec::Encode;
 
 impl ExtManager {
     pub(crate) fn validate_and_route_dispatch(&mut self, dispatch: Dispatch) -> MessageId {
@@ -307,6 +314,10 @@ impl ExtManager {
             self.gas_allowance,
         );
 
+        if self.is_builtin(destination_id) {
+            return self.process_builtin(dispatch, gas_limit);
+        }
+
         let context = ContextCharged::new(
             destination_id,
             dispatch.into_incoming(gas_limit),
@@ -396,6 +407,95 @@ impl ExtManager {
                 }
             }
         })
+    }
+
+    fn process_builtin(&mut self, dispatch: StoredDispatch, gas_limit: u64) -> Vec<JournalNote> {
+        let destination = dispatch.destination();
+        if !dispatch.kind().is_handle() {
+            unreachable!(
+                "Only handle dispatch kind is supported for built-in programs. Received: {:?}",
+                dispatch.kind()
+            );
+        }
+
+        if dispatch.context().is_some() {
+            unreachable!("Built-in messages can't be executed more than 1 time");
+        }
+
+        let incoming_dispatch = dispatch.into_incoming(gas_limit);
+
+        // todo [sab] charge gas
+        let gas_counter = GasCounter::new(gas_limit);
+
+        match destination {
+            BLS12_381_ID => {
+                let res = builtins::process_bls12_381_dispatch(incoming_dispatch.payload().inner());
+                match res {
+                    Ok(reply) => {
+                        log::debug!("BLS12-381 builtin called successfully: {reply:?}");
+                        let mut dispatch_result = DispatchResult::success(
+                            &incoming_dispatch,
+                            destination,
+                            gas_counter.to_amount(),
+                        );
+
+                        // Create an artificial `MessageContext` object that will help us to generate
+                        // a reply from the builtin actor.
+                        // Dispatch clone is cheap here since it only contains Arc<Payload>
+                        let mut message_context = MessageContext::new(
+                            incoming_dispatch.clone(),
+                            destination,
+                            Default::default(),
+                        );
+                        let reply_payload = reply.encode().try_into().unwrap_or_else(|_| {
+                            unreachable!("Failed to encode reply payload from builtin actor")
+                        });
+                        // todo [sab] value must be non-zero
+                        let packet = ReplyPacket::new(reply_payload, 0);
+
+                        // Mark reply as sent
+                        if let Ok(_reply_id) = message_context.reply_commit(packet.clone(), None) {
+                            let (outcome, context_store) = message_context.drain();
+
+                            dispatch_result.context_store = context_store;
+                            let ContextOutcomeDrain {
+                                outgoing_dispatches: generated_dispatches,
+                                ..
+                            } = outcome.drain();
+                            dispatch_result.generated_dispatches = generated_dispatches;
+                            dispatch_result.reply_sent = true;
+                        } else {
+                            unreachable!("Failed to send reply from builtin actor");
+                        };
+
+                        // Using the core processor logic create necessary `JournalNote`'s for us.
+                        core_processor::process_success(
+                            SuccessfulDispatchResultKind::Success,
+                            dispatch_result,
+                            incoming_dispatch,
+                        )
+                    }
+                    Err(BuiltinActorError::GasAllowanceExceeded) => {
+                        core_processor::process_allowance_exceed(incoming_dispatch, destination, 0)
+                    }
+                    Err(err) => {
+                        // Builtin actor call failed.
+                        log::debug!("Builtin actor error: {err:?}");
+                        let system_reservation_ctx =
+                            SystemReservationContext::from_dispatch(&incoming_dispatch);
+                        // The core processor will take care of creating necessary `JournalNote`'s.
+                        core_processor::process_execution_error(
+                            incoming_dispatch,
+                            destination,
+                            gas_counter.burned(),
+                            system_reservation_ctx,
+                            err,
+                        )
+                    }
+                }
+            }
+            id => unimplemented!("Unknown builtin program id: {id}"),
+        }
     }
 
     fn process_program(

--- a/gtest/src/manager/block_exec.rs
+++ b/gtest/src/manager/block_exec.rs
@@ -431,7 +431,6 @@ impl ExtManager {
                         unreachable!("Failed to encode BLS12-381 builtin reply")
                     })
                 }),
-                // todo [sab] fee charging
                 ETH_BRIDGE_ID => builtins::process_eth_bridge_dispatch(&dispatch).map(|response| {
                     log::debug!("Eth-bridge response: {response:?}");
 
@@ -443,9 +442,9 @@ impl ExtManager {
             };
 
         let incoming_dispatch = dispatch.into_incoming(gas_limit);
-        // todo [sab] charge gas
         let gas_counter = GasCounter::new(gas_limit);
 
+        // TODO #4832 Charge gas for built-in ops
         match builtin_call_res {
             Ok(reply_payload) => {
                 let mut dispatch_result = DispatchResult::success(
@@ -459,8 +458,8 @@ impl ExtManager {
                 // Dispatch clone is cheap here since it only contains Arc<Payload>
                 let mut message_context =
                     MessageContext::new(incoming_dispatch.clone(), destination, Default::default());
-                // todo [sab] value must be non-zero
-                let packet = ReplyPacket::new(reply_payload, 0);
+                // TODO # , currently value is sent back
+                let packet = ReplyPacket::new(reply_payload, incoming_dispatch.value());
 
                 // Mark reply as sent
                 if let Ok(_reply_id) = message_context.reply_commit(packet.clone(), None) {

--- a/gtest/src/manager/block_exec.rs
+++ b/gtest/src/manager/block_exec.rs
@@ -424,8 +424,7 @@ impl ExtManager {
 
         let builtin_call_res =
             match destination {
-                BLS12_381_ID => builtins::process_bls12_381_dispatch(&dispatch)
-                .map(|response| {
+                BLS12_381_ID => builtins::process_bls12_381_dispatch(&dispatch).map(|response| {
                     log::debug!("BLS12-381 response: {response:?}");
 
                     response.encode().try_into().unwrap_or_else(|_| {
@@ -433,8 +432,7 @@ impl ExtManager {
                     })
                 }),
                 // todo [sab] fee charging
-                ETH_BRIDGE_ID => builtins::process_eth_bridge_dispatch(&dispatch)
-                .map(|response| {
+                ETH_BRIDGE_ID => builtins::process_eth_bridge_dispatch(&dispatch).map(|response| {
                     log::debug!("Eth-bridge response: {response:?}");
 
                     response.encode().try_into().unwrap_or_else(|_| {
@@ -479,7 +477,6 @@ impl ExtManager {
                     unreachable!("Failed to send reply from builtin actor");
                 };
 
-                // Using the core processor logic create necessary `JournalNote`'s for us.
                 core_processor::process_success(
                     SuccessfulDispatchResultKind::Success,
                     dispatch_result,
@@ -494,7 +491,6 @@ impl ExtManager {
                 log::debug!("Builtin actor error: {err:?}");
                 let system_reservation_ctx =
                     SystemReservationContext::from_dispatch(&incoming_dispatch);
-                // The core processor will take care of creating necessary `JournalNote`'s.
                 core_processor::process_execution_error(
                     incoming_dispatch,
                     destination,

--- a/gtest/src/manager/block_exec.rs
+++ b/gtest/src/manager/block_exec.rs
@@ -422,149 +422,87 @@ impl ExtManager {
             unreachable!("Built-in messages can't be executed more than 1 time");
         }
 
-        let incoming_dispatch = dispatch.into_incoming(gas_limit);
+        let builtin_call_res =
+            match destination {
+                BLS12_381_ID => builtins::process_bls12_381_dispatch(&dispatch)
+                .map(|response| {
+                    log::debug!("BLS12-381 response: {response:?}");
 
+                    response.encode().try_into().unwrap_or_else(|_| {
+                        unreachable!("Failed to encode BLS12-381 builtin reply")
+                    })
+                }),
+                // todo [sab] fee charging
+                ETH_BRIDGE_ID => builtins::process_eth_bridge_dispatch(&dispatch)
+                .map(|response| {
+                    log::debug!("Eth-bridge response: {response:?}");
+
+                    response.encode().try_into().unwrap_or_else(|_| {
+                        unreachable!("Failed to encode eth-bridge builtin reply")
+                    })
+                }),
+                id => unimplemented!("Unknown builtin program id: {id}"),
+            };
+
+        let incoming_dispatch = dispatch.into_incoming(gas_limit);
         // todo [sab] charge gas
         let gas_counter = GasCounter::new(gas_limit);
 
-        match destination {
-            BLS12_381_ID => {
-                let res = builtins::process_bls12_381_dispatch(incoming_dispatch.payload().inner());
-                match res {
-                    Ok(reply) => {
-                        log::debug!("BLS12-381 builtin called successfully: {reply:?}");
-                        let mut dispatch_result = DispatchResult::success(
-                            &incoming_dispatch,
-                            destination,
-                            gas_counter.to_amount(),
-                        );
-
-                        // Create an artificial `MessageContext` object that will help us to generate
-                        // a reply from the builtin actor.
-                        // Dispatch clone is cheap here since it only contains Arc<Payload>
-                        let mut message_context = MessageContext::new(
-                            incoming_dispatch.clone(),
-                            destination,
-                            Default::default(),
-                        );
-                        let reply_payload = reply.encode().try_into().unwrap_or_else(|_| {
-                            unreachable!("Failed to encode reply payload from builtin actor")
-                        });
-                        // todo [sab] value must be non-zero
-                        let packet = ReplyPacket::new(reply_payload, 0);
-
-                        // Mark reply as sent
-                        if let Ok(_reply_id) = message_context.reply_commit(packet.clone(), None) {
-                            let (outcome, context_store) = message_context.drain();
-
-                            dispatch_result.context_store = context_store;
-                            let ContextOutcomeDrain {
-                                outgoing_dispatches: generated_dispatches,
-                                ..
-                            } = outcome.drain();
-                            dispatch_result.generated_dispatches = generated_dispatches;
-                            dispatch_result.reply_sent = true;
-                        } else {
-                            unreachable!("Failed to send reply from builtin actor");
-                        };
-
-                        // Using the core processor logic create necessary `JournalNote`'s for us.
-                        core_processor::process_success(
-                            SuccessfulDispatchResultKind::Success,
-                            dispatch_result,
-                            incoming_dispatch,
-                        )
-                    }
-                    Err(BuiltinActorError::GasAllowanceExceeded) => {
-                        core_processor::process_allowance_exceed(incoming_dispatch, destination, 0)
-                    }
-                    Err(err) => {
-                        // Builtin actor call failed.
-                        log::debug!("Builtin actor error: {err:?}");
-                        let system_reservation_ctx =
-                            SystemReservationContext::from_dispatch(&incoming_dispatch);
-                        // The core processor will take care of creating necessary `JournalNote`'s.
-                        core_processor::process_execution_error(
-                            incoming_dispatch,
-                            destination,
-                            gas_counter.burned(),
-                            system_reservation_ctx,
-                            err,
-                        )
-                    }
-                }
-            }
-            // todo [sab] fee charging
-            ETH_BRIDGE_ID => {
-                let res = builtins::process_eth_bridge_dispatch(
-                    incoming_dispatch.source(),
-                    incoming_dispatch.payload().inner(),
+        match builtin_call_res {
+            Ok(reply_payload) => {
+                let mut dispatch_result = DispatchResult::success(
+                    &incoming_dispatch,
+                    destination,
+                    gas_counter.to_amount(),
                 );
-                match res {
-                    Ok(reply) => {
-                        log::debug!("Eth-bridge builtin called successfully: {reply:?}");
-                        let mut dispatch_result = DispatchResult::success(
-                            &incoming_dispatch,
-                            destination,
-                            gas_counter.to_amount(),
-                        );
 
-                        // Create an artificial `MessageContext` object that will help us to generate
-                        // a reply from the builtin actor.
-                        // Dispatch clone is cheap here since it only contains Arc<Payload>
-                        let mut message_context = MessageContext::new(
-                            incoming_dispatch.clone(),
-                            destination,
-                            Default::default(),
-                        );
-                        let reply_payload = reply.encode().try_into().unwrap_or_else(|_| {
-                            unreachable!("Failed to encode reply payload from builtin actor")
-                        });
-                        // todo [sab] value must be non-zero
-                        let packet = ReplyPacket::new(reply_payload, 0);
+                // Create an artificial `MessageContext` object that will help us to generate
+                // a reply from the builtin actor.
+                // Dispatch clone is cheap here since it only contains Arc<Payload>
+                let mut message_context =
+                    MessageContext::new(incoming_dispatch.clone(), destination, Default::default());
+                // todo [sab] value must be non-zero
+                let packet = ReplyPacket::new(reply_payload, 0);
 
-                        // Mark reply as sent
-                        if let Ok(_reply_id) = message_context.reply_commit(packet.clone(), None) {
-                            let (outcome, context_store) = message_context.drain();
+                // Mark reply as sent
+                if let Ok(_reply_id) = message_context.reply_commit(packet.clone(), None) {
+                    let (outcome, context_store) = message_context.drain();
 
-                            dispatch_result.context_store = context_store;
-                            let ContextOutcomeDrain {
-                                outgoing_dispatches: generated_dispatches,
-                                ..
-                            } = outcome.drain();
-                            dispatch_result.generated_dispatches = generated_dispatches;
-                            dispatch_result.reply_sent = true;
-                        } else {
-                            unreachable!("Failed to send reply from builtin actor");
-                        };
+                    dispatch_result.context_store = context_store;
+                    let ContextOutcomeDrain {
+                        outgoing_dispatches: generated_dispatches,
+                        ..
+                    } = outcome.drain();
+                    dispatch_result.generated_dispatches = generated_dispatches;
+                    dispatch_result.reply_sent = true;
+                } else {
+                    unreachable!("Failed to send reply from builtin actor");
+                };
 
-                        // Using the core processor logic create necessary `JournalNote`'s for us.
-                        core_processor::process_success(
-                            SuccessfulDispatchResultKind::Success,
-                            dispatch_result,
-                            incoming_dispatch,
-                        )
-                    }
-                    Err(BuiltinActorError::GasAllowanceExceeded) => {
-                        core_processor::process_allowance_exceed(incoming_dispatch, destination, 0)
-                    }
-                    Err(err) => {
-                        // Builtin actor call failed.
-                        log::debug!("Builtin actor error: {err:?}");
-                        let system_reservation_ctx =
-                            SystemReservationContext::from_dispatch(&incoming_dispatch);
-                        // The core processor will take care of creating necessary `JournalNote`'s.
-                        core_processor::process_execution_error(
-                            incoming_dispatch,
-                            destination,
-                            gas_counter.burned(),
-                            system_reservation_ctx,
-                            err,
-                        )
-                    }
-                }
+                // Using the core processor logic create necessary `JournalNote`'s for us.
+                core_processor::process_success(
+                    SuccessfulDispatchResultKind::Success,
+                    dispatch_result,
+                    incoming_dispatch,
+                )
             }
-            id => unimplemented!("Unknown builtin program id: {id}"),
+            Err(BuiltinActorError::GasAllowanceExceeded) => {
+                core_processor::process_allowance_exceed(incoming_dispatch, destination, 0)
+            }
+            Err(err) => {
+                // Builtin actor call failed.
+                log::debug!("Builtin actor error: {err:?}");
+                let system_reservation_ctx =
+                    SystemReservationContext::from_dispatch(&incoming_dispatch);
+                // The core processor will take care of creating necessary `JournalNote`'s.
+                core_processor::process_execution_error(
+                    incoming_dispatch,
+                    destination,
+                    gas_counter.burned(),
+                    system_reservation_ctx,
+                    err,
+                )
+            }
         }
     }
 

--- a/gtest/src/manager/journal.rs
+++ b/gtest/src/manager/journal.rs
@@ -292,16 +292,18 @@ impl JournalHandler for ExtManager {
                     let expiration_block = self.block_height();
                     self.store_program(
                         candidate_id,
-                        GTestProgram::Default(Program::Active(ActiveProgram {
-                            allocations_tree_len: 0,
-                            code_id: code_id.cast(),
-                            state: ProgramState::Uninitialized {
-                                message_id: init_message_id,
-                            },
-                            expiration_block,
-                            memory_infix: Default::default(),
-                            gas_reservation_map: Default::default(),
-                        })),
+                        GTestProgram::Default {
+                            primary: Program::Active(ActiveProgram {
+                                allocations_tree_len: 0,
+                                code_id: code_id.cast(),
+                                state: ProgramState::Uninitialized {
+                                    message_id: init_message_id,
+                                },
+                                expiration_block,
+                                memory_infix: Default::default(),
+                                gas_reservation_map: Default::default(),
+                            }),
+                        },
                     );
 
                     // Transfer the ED from the program-creator to the new program

--- a/gtest/src/manager/journal.rs
+++ b/gtest/src/manager/journal.rs
@@ -125,8 +125,10 @@ impl JournalHandler for ExtManager {
         delay: u32,
         reservation: Option<ReservationId>,
     ) {
-        let to_user = ProgramsStorageManager::is_user(dispatch.destination())
-            && !self.no_code_program.contains(&dispatch.destination());
+        let destination = dispatch.destination();
+        let to_user = !self.is_builtin(destination)
+            && ProgramsStorageManager::is_user(destination)
+            && !self.no_code_program.contains(&destination);
         if delay > 0 {
             log::debug!(
                 "[{message_id}] new delayed dispatch#{} with delay for {delay} blocks",
@@ -140,8 +142,9 @@ impl JournalHandler for ExtManager {
         log::debug!("[{message_id}] new dispatch#{}", dispatch.id());
 
         let source = dispatch.source();
-        let is_program = ProgramsStorageManager::is_program(dispatch.destination())
-            || self.no_code_program.contains(&dispatch.destination());
+        let is_program = self.is_builtin(destination)
+            || ProgramsStorageManager::is_program(destination)
+            || self.no_code_program.contains(&destination);
 
         if is_program {
             let gas_limit = dispatch.gas_limit();

--- a/gtest/src/manager/journal.rs
+++ b/gtest/src/manager/journal.rs
@@ -142,11 +142,7 @@ impl JournalHandler for ExtManager {
         log::debug!("[{message_id}] new dispatch#{}", dispatch.id());
 
         let source = dispatch.source();
-        let is_program = self.is_builtin(destination)
-            || ProgramsStorageManager::is_program(destination)
-            || self.no_code_program.contains(&destination);
-
-        if is_program {
+        if !to_user {
             let gas_limit = dispatch.gas_limit();
             log::debug!(
                 "Sending message {:?} from {:?} with gas limit {:?}",
@@ -290,7 +286,9 @@ impl JournalHandler for ExtManager {
     ) {
         if self.instrumented_code(code_id).is_some() {
             for (init_message_id, candidate_id) in candidates {
-                if !ProgramsStorageManager::has_program(candidate_id) {
+                if !self.is_builtin(candidate_id)
+                    && !ProgramsStorageManager::has_program(candidate_id)
+                {
                     let expiration_block = self.block_height();
                     self.store_program(
                         candidate_id,

--- a/gtest/src/manager/memory.rs
+++ b/gtest/src/manager/memory.rs
@@ -19,6 +19,8 @@
 use super::*;
 use crate::state::programs::GTestProgram;
 
+// todo [sab] state reading for mock
+
 impl ExtManager {
     /// Call non-void meta function from actor stored in manager.
     /// Warning! This is a static call that doesn't change actors pages data.

--- a/gtest/src/manager/memory.rs
+++ b/gtest/src/manager/memory.rs
@@ -19,8 +19,6 @@
 use super::*;
 use crate::state::programs::GTestProgram;
 
-// todo [sab] state reading for mock
-
 impl ExtManager {
     /// Call non-void meta function from actor stored in manager.
     /// Warning! This is a static call that doesn't change actors pages data.

--- a/gtest/src/manager/memory.rs
+++ b/gtest/src/manager/memory.rs
@@ -33,12 +33,11 @@ impl ExtManager {
 
         if ProgramsStorageManager::is_mock_program(program_id) {
             ProgramsStorageManager::modify_program(program_id, |program| {
-                let Some(GTestProgram::Mock(mock_program)) = program else {
+                let Some(GTestProgram::Mock { handlers, .. }) = program else {
                     unreachable!("checked upper, that it's the case for a mock program");
                 };
 
-                mock_program
-                    .handlers_mut()
+                handlers
                     .state()
                     .map_err(|e| TestError::ReadStateError(e.to_string()))
             })

--- a/gtest/src/manager/reservations.rs
+++ b/gtest/src/manager/reservations.rs
@@ -82,7 +82,10 @@ impl ExtManager {
 
     pub(crate) fn remove_gas_reservation_map(&mut self, program_id: ActorId) {
         ProgramsStorageManager::modify_program(program_id, |program| {
-            if let Some(GTestProgram::Default(Program::Active(active_program))) = program {
+            if let Some(GTestProgram::Default {
+                primary: Program::Active(active_program),
+            }) = program
+            {
                 for (reservation_id, slot) in mem::take(&mut active_program.gas_reservation_map) {
                     let slot = self.remove_gas_reservation_slot(reservation_id, slot);
 

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -20,9 +20,7 @@ use crate::{
     MAX_USER_GAS_LIMIT, Result, Value, default_users_list,
     error::usage_panic,
     manager::{CUSTOM_WASM_PROGRAM_CODE_ID, ExtManager},
-    state::programs::{
-        GTestProgram, MockWasmProgram, PLACEHOLDER_MESSAGE_ID, ProgramsStorageManager,
-    },
+    state::programs::{GTestProgram, PLACEHOLDER_MESSAGE_ID, ProgramsStorageManager},
     system::System,
 };
 use gear_common::Origin;
@@ -251,16 +249,18 @@ impl ProgramBuilder {
         Program::program_with_id(
             system,
             id,
-            GTestProgram::Default(PrimaryProgram::Active(ActiveProgram {
-                allocations_tree_len: 0,
-                code_id: code_id.cast(),
-                state: ProgramState::Uninitialized {
-                    message_id: PLACEHOLDER_MESSAGE_ID,
-                },
-                expiration_block,
-                memory_infix: Default::default(),
-                gas_reservation_map: Default::default(),
-            })),
+            GTestProgram::Default {
+                primary: PrimaryProgram::Active(ActiveProgram {
+                    allocations_tree_len: 0,
+                    code_id: code_id.cast(),
+                    state: ProgramState::Uninitialized {
+                        message_id: PLACEHOLDER_MESSAGE_ID,
+                    },
+                    expiration_block,
+                    memory_infix: Default::default(),
+                    gas_reservation_map: Default::default(),
+                }),
+            },
         )
     }
 
@@ -406,8 +406,14 @@ impl<'a> Program<'a> {
             expiration_block: system.0.borrow().block_height(),
         });
 
-        let mock_program = MockWasmProgram::new(Box::new(mock), primary_program);
-        Self::program_with_id(system, id, GTestProgram::Mock(mock_program))
+        Self::program_with_id(
+            system,
+            id,
+            GTestProgram::Mock {
+                primary: primary_program,
+                handlers: Box::new(mock),
+            },
+        )
     }
 
     /// Send message to the program.

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -407,7 +407,6 @@ impl<'a> Program<'a> {
         });
 
         let mock_program = MockWasmProgram::new(Box::new(mock), primary_program);
-
         Self::program_with_id(system, id, GTestProgram::Mock(mock_program))
     }
 

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -47,6 +47,8 @@ use std::{
     str::FromStr,
 };
 
+// todo [sab] rethink concept to make it more useful
+
 /// Trait for mocking gear programs.
 ///
 /// See [`Program`] and [`Program::mock`] for the usages.

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -683,6 +683,7 @@ mod tests {
         builtins::{BLS12_381_ID, Bls12_381Response},
     };
     use ark_ff::UniformRand;
+    use core_processor::common::Actor;
     use demo_constructor::{Arg, Call, Calls, Scheme, WASM_BINARY};
     use gear_core::ids::ActorId;
     use gear_core_errors::{
@@ -1567,5 +1568,94 @@ mod tests {
             response.payload(),
             Bls12_381Response::MultiMillerLoop(_)
         ));
+    }
+
+    #[test]
+    fn test_eth_bridge_builtin() {
+        use crate::builtins::{ETH_BRIDGE_ID, create_bridge_call_output};
+        use gbuiltin_eth_bridge::{Request as EthBridgeRequest, Response as EthBridgeResponse};
+        use gprimitives::H160;
+
+        let sys = System::new();
+        sys.init_logger();
+
+        let alice_actor_id = ActorId::from(DEFAULT_USER_ALICE);
+        let proxy_program_id = ActorId::new([3; 32]);
+
+        // Create destination address and payload for the bridge message
+        let destination = H160::from_slice(&[1u8; 20]);
+        let bridge_payload = b"test bridge message".to_vec();
+
+        // Calculate expected hash and nonce using the same function as the builtin
+        let (expected_nonce, expected_hash) = {
+            sys.0.borrow().enable_overlay();
+
+            let res =
+                create_bridge_call_output(proxy_program_id, destination, bridge_payload.clone());
+            sys.0.borrow().disable_overlay();
+
+            res
+        };
+
+        // Create the bridge request
+        let bridge_request = EthBridgeRequest::SendEthMessage {
+            destination,
+            payload: bridge_payload,
+        };
+
+        let proxy_scheme = Scheme::predefined(
+            // init: do nothing
+            Calls::builder().noop(),
+            // handle: send message to eth bridge builtin
+            Calls::builder().add_call(Call::Send(
+                Arg::new(ETH_BRIDGE_ID.into_bytes()),
+                Arg::new(bridge_request.encode()),
+                None,
+                Arg::new(0u128),
+                Arg::new(0u32),
+            )),
+            // handle_reply: load reply payload and forward it to original sender
+            Calls::builder()
+                .add_call(Call::LoadBytes)
+                .add_call(Call::StoreVec("reply_payload".to_string()))
+                .add_call(Call::Send(
+                    Arg::new(alice_actor_id.into_bytes()),
+                    Arg::get("reply_payload"),
+                    Some(Arg::new(0)),
+                    Arg::new(0u128),
+                    Arg::new(0u32),
+                )),
+            // handle_signal: noop
+            Calls::builder(),
+        );
+
+        let proxy_program = Program::from_binary_with_id(&sys, proxy_program_id, WASM_BINARY);
+
+        // Initialize proxy with the scheme
+        let init_mid = proxy_program.send(alice_actor_id, proxy_scheme);
+        let res = sys.run_next_block();
+        assert!(res.succeed.contains(&init_mid));
+
+        // Send a message to the proxy to trigger the bridge interaction
+        let mid = proxy_program.send_bytes(alice_actor_id, b"");
+        let res = sys.run_next_block();
+        assert!(res.succeed.contains(&mid));
+
+        // Verify that Alice received a response from the proxy
+        assert!(
+            res.contains(
+                &Log::builder()
+                    .source(proxy_program.id())
+                    .dest(alice_actor_id)
+            )
+        );
+
+        let mut logs = res.decoded_log();
+        let response = logs.pop().expect("no log found");
+
+        let EthBridgeResponse::EthMessageQueued { nonce, hash } = response.payload();
+
+        assert_eq!(nonce, &expected_nonce);
+        assert_eq!(hash, &expected_hash);
     }
 }

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -47,8 +47,6 @@ use std::{
     str::FromStr,
 };
 
-// todo [sab] rethink concept to make it more useful
-
 /// Trait for mocking gear programs.
 ///
 /// See [`Program`] and [`Program::mock`] for the usages.

--- a/gtest/src/program.rs
+++ b/gtest/src/program.rs
@@ -689,7 +689,6 @@ mod tests {
     fn test_handle_signal() {
         use demo_constructor::{Calls, Scheme, WASM_BINARY};
         let sys = System::new();
-        sys.init_logger();
 
         let user_id = DEFAULT_USER_ALICE;
         let message = "Signal handle";
@@ -721,7 +720,6 @@ mod tests {
     #[test]
     fn test_queued_message_to_failed_program() {
         let sys = System::new();
-        sys.init_logger();
 
         let user_id = DEFAULT_USER_ALICE;
 
@@ -749,7 +747,6 @@ mod tests {
     #[should_panic]
     fn test_new_message_to_failed_program() {
         let sys = System::new();
-        sys.init_logger();
 
         let user_id = DEFAULT_USER_ALICE;
 
@@ -766,7 +763,6 @@ mod tests {
     #[test]
     fn simple_balance() {
         let sys = System::new();
-        sys.init_logger();
 
         let user_id = 42;
         let mut user_spent_balance = 0;
@@ -807,7 +803,6 @@ mod tests {
     #[test]
     fn piggy_bank() {
         let sys = System::new();
-        sys.init_logger();
 
         let receiver = 42;
         let sender0 = 43;
@@ -918,7 +913,6 @@ mod tests {
     #[test]
     fn claim_zero_value() {
         let sys = System::new();
-        sys.init_logger();
 
         const RECEIVER_INITIAL_BALANCE: Value = 200 * EXISTENTIAL_DEPOSIT;
 
@@ -980,7 +974,6 @@ mod tests {
     fn save_load_memory_dump() {
         use demo_custom::{InitMessage, WASM_BINARY};
         let sys = System::new();
-        sys.init_logger();
 
         let mut prog = Program::from_binary_with_id(&sys, 420, WASM_BINARY);
 
@@ -1034,7 +1027,6 @@ mod tests {
     fn process_wait_for() {
         use demo_custom::{InitMessage, WASM_BINARY};
         let sys = System::new();
-        sys.init_logger();
 
         let prog = Program::from_binary_with_id(&sys, 420, WASM_BINARY);
 
@@ -1094,7 +1086,6 @@ mod tests {
         use demo_constructor::{WASM_BINARY, demo_exit_handle};
 
         let sys = System::new();
-        sys.init_logger();
 
         let user_id = 42;
         let mut user_balance = 4 * EXISTENTIAL_DEPOSIT;
@@ -1126,7 +1117,6 @@ mod tests {
     #[test]
     fn test_insufficient_gas() {
         let sys = System::new();
-        sys.init_logger();
 
         let prog = Program::from_binary_with_id(&sys, 137, demo_ping::WASM_BINARY);
 
@@ -1154,7 +1144,6 @@ mod tests {
         use demo_constructor::{Calls, WASM_BINARY};
 
         let sys = System::new();
-        sys.init_logger();
 
         let user_id = DEFAULT_USER_ALICE;
         let prog = Program::from_binary_with_id(&sys, 4242, WASM_BINARY);
@@ -1203,7 +1192,6 @@ mod tests {
         use demo_constructor::{Calls, WASM_BINARY};
 
         let sys = System::new();
-        sys.init_logger();
 
         let user_id = DEFAULT_USER_ALICE;
         let prog = Program::from_binary_with_id(&sys, 4242, WASM_BINARY);
@@ -1247,7 +1235,6 @@ mod tests {
         use demo_constructor::{Calls, WASM_BINARY};
 
         let sys = System::new();
-        sys.init_logger();
 
         let user_id = DEFAULT_USER_ALICE;
         let prog_id = 4242;
@@ -1311,7 +1298,6 @@ mod tests {
     #[test]
     fn tests_unused_gas_value_not_transferred() {
         let sys = System::new();
-        sys.init_logger();
 
         let user = 42;
         sys.mint_to(user, 2 * EXISTENTIAL_DEPOSIT);
@@ -1330,7 +1316,6 @@ mod tests {
         use demo_delayed_sender::DELAY;
 
         let sys = System::new();
-        sys.init_logger();
 
         let user = DEFAULT_USER_ALICE;
         let program_id = 69;
@@ -1356,7 +1341,6 @@ mod tests {
         use parity_scale_codec::Encode;
 
         let sys = System::new();
-        sys.init_logger();
 
         let user_id = ActorId::from(DEFAULT_USER_ALICE);
         let mock_program_id = ActorId::new([1; 32]);

--- a/gtest/src/state/bridge.rs
+++ b/gtest/src/state/bridge.rs
@@ -46,6 +46,8 @@ impl BridgeBuiltinStorage {
     }
 
     pub(crate) fn clear() {
-        todo!("todo [sab]");
+        storage().with(|nonce| {
+            *nonce.data_mut() = U256::zero();
+        });
     }
 }

--- a/gtest/src/state/bridge.rs
+++ b/gtest/src/state/bridge.rs
@@ -1,0 +1,51 @@
+// This file is part of Gear.
+//
+// Copyright (C) 2025 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Bridge builtin storage manager.
+
+use std::thread::LocalKey;
+
+use crate::state::WithOverlay;
+use gprimitives::U256;
+
+thread_local! {
+    pub(super) static BRIDGE_MESSAGE_NONCE: WithOverlay<U256> = Default::default();
+}
+
+fn storage() -> &'static LocalKey<WithOverlay<U256>> {
+    &BRIDGE_MESSAGE_NONCE
+}
+
+pub(crate) struct BridgeBuiltinStorage;
+
+impl BridgeBuiltinStorage {
+    /// Get the current message nonce.
+    pub(crate) fn fetch_nonce() -> U256 {
+        storage().with(|nonce| {
+            let mut data = nonce.data_mut();
+            let ret = *data;
+            *data = data.saturating_add(U256::one());
+
+            ret
+        })
+    }
+
+    pub(crate) fn clear() {
+        todo!("todo [sab]");
+    }
+}

--- a/gtest/src/state/mod.rs
+++ b/gtest/src/state/mod.rs
@@ -21,6 +21,7 @@
 pub(crate) mod accounts;
 pub(crate) mod bank;
 pub(crate) mod blocks;
+pub(crate) mod bridge;
 pub(crate) mod gas_tree;
 pub(crate) mod mailbox;
 pub(crate) mod nonce;

--- a/gtest/src/state/mod.rs
+++ b/gtest/src/state/mod.rs
@@ -227,15 +227,21 @@ mod tests {
         // Fill the actors storage.
         ProgramsStorageManager::insert_program(
             predef_acc1,
-            GTestProgram::Default(Program::Active(prog1)),
+            GTestProgram::Default {
+                primary: Program::Active(prog1),
+            },
         );
         ProgramsStorageManager::insert_program(
             predef_acc2,
-            GTestProgram::Default(Program::Active(prog2)),
+            GTestProgram::Default {
+                primary: Program::Active(prog2),
+            },
         );
         ProgramsStorageManager::insert_program(
             predef_acc3,
-            GTestProgram::Default(Program::Active(prog3)),
+            GTestProgram::Default {
+                primary: Program::Active(prog3),
+            },
         );
 
         // Fill the bank storage.
@@ -316,11 +322,17 @@ mod tests {
         assert_eq!(new_acc1_balance_overlaid, EXISTENTIAL_DEPOSIT * 1000);
 
         // Adjust actors storage the same way.
-        let acc2_actor_ty = GTestProgram::Default(Program::Exited(H256::random().cast()));
-        let acc3_actor_ty = GTestProgram::Default(Program::Terminated(H256::random().cast()));
+        let acc2_actor_ty = GTestProgram::Default {
+            primary: Program::Exited(H256::random().cast()),
+        };
+        let acc3_actor_ty = GTestProgram::Default {
+            primary: Program::Terminated(H256::random().cast()),
+        };
         ProgramsStorageManager::insert_program(
             new_acc,
-            GTestProgram::Default(Program::Active(create_active_program())),
+            GTestProgram::Default {
+                primary: Program::Active(create_active_program()),
+            },
         );
         ProgramsStorageManager::modify_program(predef_acc1, |actor| {
             *actor.expect("checked") = acc2_actor_ty;

--- a/gtest/src/system.rs
+++ b/gtest/src/system.rs
@@ -462,8 +462,10 @@ impl System {
             None,
         );
 
-        if !ProgramsStorageManager::is_active_program(destination) {
-            usage_panic!("Actor with {destination} id is not active");
+        if !manager_mut.is_builtin(destination)
+            && !ProgramsStorageManager::is_active_program(destination)
+        {
+            usage_panic!("Actor with {destination} id is not executable");
         }
 
         let dispatch = Dispatch::new(DispatchKind::Handle, message);
@@ -538,7 +540,7 @@ impl Drop for System {
         Accounts::clear();
 
         // Clear bridge-builtins state
-        BridgeBuiltinsStorage::clear();
+        BridgeBuiltinStorage::clear();
     }
 }
 

--- a/gtest/src/system.rs
+++ b/gtest/src/system.rs
@@ -537,8 +537,8 @@ impl Drop for System {
         ProgramsStorageManager::clear();
         Accounts::clear();
 
-        // Clear builtins state
-        BridgeBuiltinStorage::clear();
+        // Clear bridge-builtins state
+        BridgeBuiltinsStorage::clear();
     }
 }
 

--- a/gtest/src/system.rs
+++ b/gtest/src/system.rs
@@ -625,7 +625,6 @@ mod tests {
     #[should_panic(expected = "Got message sent to incomplete user program")]
     fn panic_calculate_reply_no_actor() {
         let sys = System::new();
-        sys.init_logger();
 
         let origin = DEFAULT_USER_ALICE;
         let pid = 42;

--- a/gtest/src/system.rs
+++ b/gtest/src/system.rs
@@ -17,12 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    GAS_ALLOWANCE, Gas, Value,
-    error::usage_panic,
-    log::{BlockRunResult, CoreLog},
-    manager::ExtManager,
-    program::{Program, ProgramIdWrapper},
-    state::{accounts::Accounts, mailbox::ActorMailbox, programs::ProgramsStorageManager},
+    error::usage_panic, log::{BlockRunResult, CoreLog}, manager::ExtManager, program::{Program, ProgramIdWrapper}, state::{accounts::Accounts, bridge::BridgeBuiltinStorage, mailbox::ActorMailbox, programs::ProgramsStorageManager}, Gas, Value, GAS_ALLOWANCE
 };
 use core_processor::common::JournalNote;
 use gear_common::MessageId;
@@ -533,6 +528,9 @@ impl Drop for System {
         // Clear programs and accounts storages
         ProgramsStorageManager::clear();
         Accounts::clear();
+
+        // Clear builtins state
+        BridgeBuiltinStorage::clear();
     }
 }
 

--- a/gtest/src/system.rs
+++ b/gtest/src/system.rs
@@ -17,7 +17,15 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    error::usage_panic, log::{BlockRunResult, CoreLog}, manager::ExtManager, program::{Program, ProgramIdWrapper}, state::{accounts::Accounts, bridge::BridgeBuiltinStorage, mailbox::ActorMailbox, programs::ProgramsStorageManager}, Gas, Value, GAS_ALLOWANCE
+    GAS_ALLOWANCE, Gas, Value,
+    error::usage_panic,
+    log::{BlockRunResult, CoreLog},
+    manager::ExtManager,
+    program::{Program, ProgramIdWrapper},
+    state::{
+        accounts::Accounts, bridge::BridgeBuiltinStorage, mailbox::ActorMailbox,
+        programs::ProgramsStorageManager,
+    },
 };
 use core_processor::common::JournalNote;
 use gear_common::MessageId;


### PR DESCRIPTION
1. Adds `eth-bridge` and `bls12_381` builtins with corresponding tests. The introduced codebase almost identically copies builtins from pallet, but doesn't adapt it fully to the `gtest`, leaving some "obtain payload length" functionality for future gas charge feature.
2. Refactors a little bit `WasmProgram` trait for mock programs

The gas charging for builtins is missing and is intended to be introduced in following PRs
