### PR TITLE
refactor(ethexe-network): Implement `db-sync` handle

### DIFF
--- a/ethexe/network/src/db_sync/mod.rs
+++ b/ethexe/network/src/db_sync/mod.rs
@@ -241,35 +241,35 @@ pub enum Response {
     ValidCodes(#[debug("{:?}", AlternateCollectionFmt::set(_0, "codes"))] BTreeSet<CodeId>),
 }
 
-type DbSyncOneshot = oneshot::Sender<Result<Response, (RequestFailure, RetriableRequest)>>;
+pub type HandleResult = Result<Response, (RequestFailure, RetriableRequest)>;
 
-enum DbSyncAction {
+enum HandleAction {
     Request(RequestId, Request),
     Retry(RetriableRequest),
 }
 
-impl DbSyncAction {
+impl HandleAction {
     fn request_id(&self) -> RequestId {
         match self {
-            DbSyncAction::Request(request_id, _) => *request_id,
-            DbSyncAction::Retry(request) => request.id(),
+            HandleAction::Request(request_id, _) => *request_id,
+            HandleAction::Retry(request) => request.id(),
         }
     }
 }
 
-pub struct DbSyncHandleFuture {
+pub struct HandleFuture {
     request_id: RequestId,
-    rx: oneshot::Receiver<Result<Response, (RequestFailure, RetriableRequest)>>,
+    rx: oneshot::Receiver<HandleResult>,
 }
 
-impl DbSyncHandleFuture {
+impl HandleFuture {
     pub fn request_id(&self) -> RequestId {
         self.request_id
     }
 }
 
-impl Future for DbSyncHandleFuture {
-    type Output = Result<Response, (RequestFailure, RetriableRequest)>;
+impl Future for HandleFuture {
+    type Output = HandleResult;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.rx
@@ -279,10 +279,10 @@ impl Future for DbSyncHandleFuture {
 }
 
 #[derive(Clone)]
-pub struct DbSyncHandle(mpsc::UnboundedSender<(DbSyncAction, DbSyncOneshot)>);
+pub struct Handle(mpsc::UnboundedSender<(HandleAction, oneshot::Sender<HandleResult>)>);
 
-impl DbSyncHandle {
-    fn send(&self, action: DbSyncAction) -> DbSyncHandleFuture {
+impl Handle {
+    fn send(&self, action: HandleAction) -> HandleFuture {
         let (tx, rx) = oneshot::channel();
         let request_id = action.request_id();
 
@@ -290,40 +290,40 @@ impl DbSyncHandle {
             .send((action, tx))
             .expect("channel should never be closed");
 
-        DbSyncHandleFuture { request_id, rx }
+        HandleFuture { request_id, rx }
     }
 
-    pub fn request(&self, request: Request) -> DbSyncHandleFuture {
-        self.send(DbSyncAction::Request(RequestId::next(), request))
+    pub fn request(&self, request: Request) -> HandleFuture {
+        self.send(HandleAction::Request(RequestId::next(), request))
     }
 
-    pub fn retry(&self, request: RetriableRequest) -> DbSyncHandleFuture {
-        self.send(DbSyncAction::Retry(request))
+    pub fn retry(&self, request: RetriableRequest) -> HandleFuture {
+        self.send(HandleAction::Retry(request))
     }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Encode, Decode)]
-pub struct InnerProgramIdsRequest {
+pub(crate) struct InnerProgramIdsRequest {
     at: H256,
 }
 
 /// Network-only type to be encoded-decoded and sent over the network
 #[derive(Debug, Clone, Eq, PartialEq, Encode, Decode, derive_more::From)]
-pub enum InnerRequest {
+pub(crate) enum InnerRequest {
     Hashes(HashesRequest),
     ProgramIds(InnerProgramIdsRequest),
     ValidCodes,
 }
 
 #[derive(Debug, Default, Eq, PartialEq, Encode, Decode)]
-pub struct InnerHashesResponse(BTreeMap<H256, Vec<u8>>);
+pub(crate) struct InnerHashesResponse(BTreeMap<H256, Vec<u8>>);
 
 #[derive(Debug, Default, Eq, PartialEq, Encode, Decode)]
-pub struct InnerProgramIdsResponse(BTreeSet<ActorId>);
+pub(crate) struct InnerProgramIdsResponse(BTreeSet<ActorId>);
 
 /// Network-only type to be encoded-decoded and sent over the network
 #[derive(Debug, Eq, PartialEq, derive_more::From, Encode, Decode)]
-pub enum InnerResponse {
+pub(crate) enum InnerResponse {
     Hashes(InnerHashesResponse),
     ProgramIds(InnerProgramIdsResponse),
     ValidCodes(BTreeSet<CodeId>),
@@ -331,10 +331,10 @@ pub enum InnerResponse {
 
 type InnerBehaviour = request_response::Behaviour<ParityScaleCodec<InnerRequest, InnerResponse>>;
 
-pub struct Behaviour {
+pub(crate) struct Behaviour {
     inner: InnerBehaviour,
-    handle: DbSyncHandle,
-    rx: mpsc::UnboundedReceiver<(DbSyncAction, DbSyncOneshot)>,
+    handle: Handle,
+    rx: mpsc::UnboundedReceiver<(HandleAction, oneshot::Sender<HandleResult>)>,
     peer_score_handle: peer_score::Handle,
     ongoing_requests: OngoingRequests,
     ongoing_responses: OngoingResponses,
@@ -349,7 +349,7 @@ impl Behaviour {
         db: Database,
     ) -> Self {
         let (handle, rx) = mpsc::unbounded_channel();
-        let handle = DbSyncHandle(handle);
+        let handle = Handle(handle);
 
         Self {
             inner: InnerBehaviour::new(
@@ -368,7 +368,7 @@ impl Behaviour {
         }
     }
 
-    pub fn handle(&self) -> DbSyncHandle {
+    pub fn handle(&self) -> Handle {
         self.handle.clone()
     }
 
@@ -531,10 +531,10 @@ impl NetworkBehaviour for Behaviour {
     ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
         if let Poll::Ready(Some((action, channel))) = self.rx.poll_recv(cx) {
             match action {
-                DbSyncAction::Request(request_id, request) => {
+                HandleAction::Request(request_id, request) => {
                     self.ongoing_requests.request(request_id, request, channel);
                 }
-                DbSyncAction::Retry(request) => {
+                HandleAction::Retry(request) => {
                     self.ongoing_requests.retry(request, channel);
                 }
             }

--- a/ethexe/network/src/db_sync/mod.rs
+++ b/ethexe/network/src/db_sync/mod.rs
@@ -29,6 +29,7 @@ pub(crate) use crate::{
 use async_trait::async_trait;
 use ethexe_common::gear::CodeState;
 use ethexe_db::Database;
+use futures::FutureExt;
 use gprimitives::{ActorId, CodeId, H256};
 use libp2p::{
     StreamProtocol,
@@ -43,9 +44,12 @@ use libp2p::{
 use parity_scale_codec::{Decode, Encode};
 use std::{
     collections::{BTreeMap, BTreeSet},
+    pin::Pin,
+    sync::atomic::{AtomicU64, Ordering},
     task::{Context, Poll},
     time::Duration,
 };
+use tokio::sync::{mpsc, oneshot};
 
 const STREAM_PROTOCOL: StreamProtocol =
     StreamProtocol::new(concat!("/ethexe/db-sync/", env!("CARGO_PKG_VERSION")));
@@ -90,13 +94,11 @@ pub enum Event {
     RequestSucceed {
         /// The ID of request
         request_id: RequestId,
-        /// Response to the request itself
-        response: Response,
     },
     /// Request failed
     RequestFailed {
         /// The failed request
-        request: RetriableRequest,
+        request_id: RequestId,
         /// Reason of request failure
         error: RequestFailure,
     },
@@ -179,6 +181,13 @@ pub trait ExternalDataProvider: Send + Sync {
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
 pub struct RequestId(pub(crate) u64);
 
+impl RequestId {
+    fn next() -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        RequestId(COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
 pub struct ResponseId(pub(crate) u64);
 
@@ -232,6 +241,67 @@ pub enum Response {
     ValidCodes(#[debug("{:?}", AlternateCollectionFmt::set(_0, "codes"))] BTreeSet<CodeId>),
 }
 
+type DbSyncOneshot = oneshot::Sender<Result<Response, (RequestFailure, RetriableRequest)>>;
+
+enum DbSyncAction {
+    Request(RequestId, Request),
+    Retry(RetriableRequest),
+}
+
+impl DbSyncAction {
+    fn request_id(&self) -> RequestId {
+        match self {
+            DbSyncAction::Request(request_id, _) => *request_id,
+            DbSyncAction::Retry(request) => request.id(),
+        }
+    }
+}
+
+pub struct DbSyncHandleFuture {
+    request_id: RequestId,
+    rx: oneshot::Receiver<Result<Response, (RequestFailure, RetriableRequest)>>,
+}
+
+impl DbSyncHandleFuture {
+    pub fn request_id(&self) -> RequestId {
+        self.request_id
+    }
+}
+
+impl Future for DbSyncHandleFuture {
+    type Output = Result<Response, (RequestFailure, RetriableRequest)>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.rx
+            .poll_unpin(cx)
+            .map(|res| res.expect("channel should never be closed"))
+    }
+}
+
+#[derive(Clone)]
+pub struct DbSyncHandle(mpsc::UnboundedSender<(DbSyncAction, DbSyncOneshot)>);
+
+impl DbSyncHandle {
+    fn send(&self, action: DbSyncAction) -> DbSyncHandleFuture {
+        let (tx, rx) = oneshot::channel();
+        let request_id = action.request_id();
+
+        self.0
+            .send((action, tx))
+            .expect("channel should never be closed");
+
+        DbSyncHandleFuture { request_id, rx }
+    }
+
+    pub fn request(&self, request: Request) -> DbSyncHandleFuture {
+        self.send(DbSyncAction::Request(RequestId::next(), request))
+    }
+
+    pub fn retry(&self, request: RetriableRequest) -> DbSyncHandleFuture {
+        self.send(DbSyncAction::Retry(request))
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Encode, Decode)]
 pub struct InnerProgramIdsRequest {
     at: H256,
@@ -263,6 +333,8 @@ type InnerBehaviour = request_response::Behaviour<ParityScaleCodec<InnerRequest,
 
 pub struct Behaviour {
     inner: InnerBehaviour,
+    handle: DbSyncHandle,
+    rx: mpsc::UnboundedReceiver<(DbSyncAction, DbSyncOneshot)>,
     peer_score_handle: peer_score::Handle,
     ongoing_requests: OngoingRequests,
     ongoing_responses: OngoingResponses,
@@ -276,11 +348,16 @@ impl Behaviour {
         external_data_provider: Box<dyn ExternalDataProvider>,
         db: Database,
     ) -> Self {
+        let (handle, rx) = mpsc::unbounded_channel();
+        let handle = DbSyncHandle(handle);
+
         Self {
             inner: InnerBehaviour::new(
                 [(STREAM_PROTOCOL, ProtocolSupport::Full)],
                 request_response::Config::default(),
             ),
+            handle,
+            rx,
             peer_score_handle: peer_score_handle.clone(),
             ongoing_requests: OngoingRequests::new(
                 &config,
@@ -291,12 +368,8 @@ impl Behaviour {
         }
     }
 
-    pub fn request(&mut self, request: Request) -> RequestId {
-        self.ongoing_requests.request(request)
-    }
-
-    pub fn retry(&mut self, request: RetriableRequest) {
-        self.ongoing_requests.retry(request);
+    pub fn handle(&self) -> DbSyncHandle {
+        self.handle.clone()
     }
 
     fn handle_inner_event(
@@ -456,6 +529,17 @@ impl NetworkBehaviour for Behaviour {
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+        if let Poll::Ready(Some((action, channel))) = self.rx.poll_recv(cx) {
+            match action {
+                DbSyncAction::Request(request_id, request) => {
+                    self.ongoing_requests.request(request_id, request, channel);
+                }
+                DbSyncAction::Retry(request) => {
+                    self.ongoing_requests.retry(request, channel);
+                }
+            }
+        }
+
         if let Poll::Ready(request_event) = self.ongoing_requests.poll(cx, &mut self.inner) {
             return Poll::Ready(ToSwarm::GenerateEvent(request_event));
         }
@@ -543,6 +627,7 @@ pub(crate) mod tests {
         init_logger();
 
         let (mut alice, _alice_db, _data_provider) = new_swarm().await;
+        let alice_handle = alice.behaviour().handle();
         let (mut bob, bob_db, _data_provider) = new_swarm().await;
         let bob_peer_id = *bob.local_peer_id();
 
@@ -579,9 +664,8 @@ pub(crate) mod tests {
             }
         });
 
-        let request_id = alice
-            .behaviour_mut()
-            .request(Request::hashes([hello_hash, world_hash]));
+        let request = alice_handle.request(Request::hashes([hello_hash, world_hash]));
+        let request_id = request.request_id();
 
         let event = alice.next_behaviour_event().await;
         assert_eq!(
@@ -594,18 +678,18 @@ pub(crate) mod tests {
         );
 
         let event = alice.next_behaviour_event().await;
+        assert_eq!(event, Event::RequestSucceed { request_id });
+
+        let response = request.await.unwrap();
         assert_eq!(
-            event,
-            Event::RequestSucceed {
-                request_id,
-                response: Response::Hashes(
-                    [
-                        (hello_hash, b"hello".to_vec()),
-                        (world_hash, b"world".to_vec())
-                    ]
-                    .into()
-                )
-            }
+            response,
+            Response::Hashes(
+                [
+                    (hello_hash, b"hello".to_vec()),
+                    (world_hash, b"world".to_vec())
+                ]
+                .into()
+            )
         )
     }
 
@@ -615,6 +699,7 @@ pub(crate) mod tests {
 
         let alice_config = Config::default().with_max_rounds_per_request(1);
         let (mut alice, _alice_db, _data_provider) = new_swarm_with_config(alice_config).await;
+        let alice_handle = alice.behaviour().handle();
 
         let mut bob = Swarm::new_ephemeral_tokio(move |_keypair| {
             InnerBehaviour::new(
@@ -624,7 +709,8 @@ pub(crate) mod tests {
         });
         bob.connect(&mut alice).await;
 
-        let request_id = alice.behaviour_mut().request(Request::hashes([]));
+        let request = alice_handle.request(Request::hashes([]));
+        let request_id = request.request_id();
 
         let event = alice.next_behaviour_event().await;
         assert_eq!(
@@ -653,13 +739,15 @@ pub(crate) mod tests {
         });
 
         let event = alice.next_behaviour_event().await;
-        assert_matches!(
+        assert_eq!(
             event,
             Event::RequestFailed {
-                request,
+                request_id,
                 error: RequestFailure::OutOfRounds,
-            } if request.id() == request_id
+            }
         );
+
+        request.await.unwrap_err();
     }
 
     #[tokio::test(start_paused = true)]
@@ -670,6 +758,7 @@ pub(crate) mod tests {
 
         let alice_config = Config::default().with_request_timeout(Duration::from_secs(3));
         let (mut alice, _alice_db, _data_provider) = new_swarm_with_config(alice_config).await;
+        let alice_handle = alice.behaviour().handle();
 
         // idle connection timeout is lowered because `libp2p` uses `future_timer` inside,
         // so we cannot advance time like in tokio
@@ -684,7 +773,8 @@ pub(crate) mod tests {
         let bob_peer_id = *bob.local_peer_id();
         bob.connect(&mut alice).await;
 
-        let request_id = alice.behaviour_mut().request(Request::hashes([]));
+        let request = alice_handle.request(Request::hashes([]));
+        let request_id = request.request_id();
 
         let event = alice.next_behaviour_event().await;
         assert_eq!(
@@ -716,13 +806,14 @@ pub(crate) mod tests {
         time::advance(Config::default().request_timeout).await;
 
         let event = alice.next_behaviour_event().await;
-        assert!(matches!(
+        assert_eq!(
             event,
             Event::RequestFailed {
-                request,
+                request_id,
                 error: RequestFailure::Timeout,
-            } if request.id() == request_id
-        ));
+            }
+        );
+        request.await.unwrap_err();
 
         time::resume();
         time::sleep(IDLE_CONNECTION_TIMEOUT).await;
@@ -738,6 +829,7 @@ pub(crate) mod tests {
         init_logger();
 
         let (mut alice, _alice_db, _data_provider) = new_swarm().await;
+        let alice_handle = alice.behaviour().handle();
 
         let mut bob = Swarm::new_ephemeral_tokio(move |_keypair| {
             InnerBehaviour::new(
@@ -751,9 +843,8 @@ pub(crate) mod tests {
         let data_1 = ethexe_db::hash(&DATA[1]);
         let data_2 = ethexe_db::hash(&DATA[2]);
 
-        let request_id = alice
-            .behaviour_mut()
-            .request(Request::hashes([data_0, data_1]));
+        let request = alice_handle.request(Request::hashes([data_0, data_1]));
+        let request_id = request.request_id();
 
         let event = alice.next_behaviour_event().await;
         assert_eq!(
@@ -798,14 +889,12 @@ pub(crate) mod tests {
         });
 
         let event = alice.next_behaviour_event().await;
+        assert_eq!(event, Event::RequestSucceed { request_id });
+
+        let response = request.await.unwrap();
         assert_eq!(
-            event,
-            Event::RequestSucceed {
-                request_id,
-                response: Response::Hashes(
-                    [(data_0, DATA[0].to_vec()), (data_1, DATA[1].to_vec())].into()
-                )
-            }
+            response,
+            Response::Hashes([(data_0, DATA[0].to_vec()), (data_1, DATA[1].to_vec())].into())
         );
     }
 
@@ -815,6 +904,7 @@ pub(crate) mod tests {
 
         let alice_config = Config::default().with_max_rounds_per_request(1);
         let (mut alice, _alice_db, _data_provider) = new_swarm_with_config(alice_config).await;
+        let alice_handle = alice.behaviour().handle();
 
         let mut bob = Swarm::new_ephemeral_tokio(move |_keypair| {
             InnerBehaviour::new(
@@ -824,7 +914,8 @@ pub(crate) mod tests {
         });
         bob.connect(&mut alice).await;
 
-        let request_id = alice.behaviour_mut().request(Request::hashes([]));
+        let request = alice_handle.request(Request::hashes([]));
+        let request_id = request.request_id();
 
         let event = alice.next_behaviour_event().await;
         assert_eq!(
@@ -855,13 +946,15 @@ pub(crate) mod tests {
         });
 
         let event = alice.next_behaviour_event().await;
-        assert_matches!(
+        assert_eq!(
             event,
             Event::RequestFailed {
-                request,
+                request_id,
                 error: RequestFailure::OutOfRounds,
-            } if request.id() == request_id
+            }
         );
+
+        request.await.unwrap_err();
     }
 
     #[tokio::test]
@@ -869,6 +962,7 @@ pub(crate) mod tests {
         init_logger();
 
         let (mut alice, _alice_db, _data_provider) = new_swarm().await;
+        let alice_handle = alice.behaviour().handle();
         let (mut bob, bob_db, _data_provider) = new_swarm().await;
         let (mut charlie, charlie_db, _data_provider) = new_swarm().await;
         let (mut dave, dave_db, _data_provider) = new_swarm().await;
@@ -884,9 +978,8 @@ pub(crate) mod tests {
         let world_hash = charlie_db.write_hash(b"world");
         let mark_hash = dave_db.write_hash(b"!");
 
-        let request_id = alice
-            .behaviour_mut()
-            .request(Request::hashes([hello_hash, world_hash, mark_hash]));
+        let request = alice_handle.request(Request::hashes([hello_hash, world_hash, mark_hash]));
+        let request_id = request.request_id();
 
         // first round
         let event = alice.next_behaviour_event().await;
@@ -908,19 +1001,19 @@ pub(crate) mod tests {
         );
 
         let event = alice.next_behaviour_event().await;
+        assert_eq!(event, Event::RequestSucceed { request_id });
+
+        let response = request.await.unwrap();
         assert_eq!(
-            event,
-            Event::RequestSucceed {
-                request_id,
-                response: Response::Hashes(
-                    [
-                        (hello_hash, b"hello".to_vec()),
-                        (world_hash, b"world".to_vec()),
-                        (mark_hash, b"!".to_vec()),
-                    ]
-                    .into()
-                ),
-            }
+            response,
+            Response::Hashes(
+                [
+                    (hello_hash, b"hello".to_vec()),
+                    (world_hash, b"world".to_vec()),
+                    (mark_hash, b"!".to_vec()),
+                ]
+                .into()
+            )
         );
     }
 
@@ -929,6 +1022,7 @@ pub(crate) mod tests {
         init_logger();
 
         let (mut alice, _alice_db, _data_provider) = new_swarm().await;
+        let alice_handle = alice.behaviour().handle();
         let (mut bob, bob_db, _data_provider) = new_swarm().await;
         let bob_peer_id = *bob.local_peer_id();
         let (charlie, charlie_db, _data_provider) = new_swarm().await;
@@ -941,9 +1035,8 @@ pub(crate) mod tests {
         let hello_hash = bob_db.write_hash(b"hello");
         let world_hash = charlie_db.write_hash(b"world");
 
-        let request_id = alice
-            .behaviour_mut()
-            .request(Request::hashes([hello_hash, world_hash]));
+        let request = alice_handle.request(Request::hashes([hello_hash, world_hash]));
+        let request_id = request.request_id();
 
         // first round
         let event = alice.next_behaviour_event().await;
@@ -974,19 +1067,19 @@ pub(crate) mod tests {
         );
 
         let event = alice.next_behaviour_event().await;
+        assert_eq!(event, Event::RequestSucceed { request_id });
+
+        let response = request.await.unwrap();
         assert_eq!(
-            event,
-            Event::RequestSucceed {
-                request_id,
-                response: Response::Hashes(
-                    [
-                        (hello_hash, b"hello".to_vec()),
-                        (world_hash, b"world".to_vec())
-                    ]
-                    .into()
-                )
-            }
-        )
+            response,
+            Response::Hashes(
+                [
+                    (hello_hash, b"hello".to_vec()),
+                    (world_hash, b"world".to_vec())
+                ]
+                .into()
+            )
+        );
     }
 
     #[tokio::test]
@@ -995,6 +1088,7 @@ pub(crate) mod tests {
 
         let alice_config = Config::default().with_request_timeout(Duration::from_secs(2));
         let (mut alice, _alice_db, _data_provider) = new_swarm_with_config(alice_config).await;
+        let alice_handle = alice.behaviour().handle();
 
         // idle connection timeout is lowered because `libp2p` uses `future_timer` inside,
         // so we cannot advance time like in tokio
@@ -1007,7 +1101,8 @@ pub(crate) mod tests {
         bob.connect(&mut alice).await;
         tokio::spawn(bob.loop_on_next());
 
-        let request_id = alice.behaviour_mut().request(Request::hashes([]));
+        let request = alice_handle.request(Request::hashes([]));
+        let request_id = request.request_id();
 
         let event = alice.next_behaviour_event().await;
         assert_eq!(
@@ -1023,7 +1118,13 @@ pub(crate) mod tests {
         assert_eq!(event, Event::PendingStateRequest { request_id });
 
         let event = alice.next_behaviour_event().await;
-        assert_matches!(event, Event::RequestFailed { request, error: RequestFailure::Timeout } if request.id() == request_id);
+        assert_eq!(
+            event,
+            Event::RequestFailed {
+                request_id,
+                error: RequestFailure::Timeout
+            }
+        );
 
         let event = alice.next_swarm_event().await;
         assert_matches!(event, SwarmEvent::ConnectionClosed { peer_id, .. } if peer_id == bob_peer_id);
@@ -1036,6 +1137,7 @@ pub(crate) mod tests {
         let alice_config = Config::default().with_max_simultaneous_responses(2);
         let (mut alice, _alice_db, _data_provider) = new_swarm_with_config(alice_config).await;
         let (mut bob, _bob_db, _data_provider) = new_swarm().await;
+        let bob_handle = bob.behaviour().handle();
         let bob_peer_id = *bob.local_peer_id();
         alice.connect(&mut bob).await;
 
@@ -1045,9 +1147,9 @@ pub(crate) mod tests {
                 .take(24 * 1024)
                 .collect::<BTreeSet<H256>>(),
         );
-        bob.behaviour_mut().request(request.clone());
-        bob.behaviour_mut().request(request.clone());
-        bob.behaviour_mut().request(request);
+        let _fut = bob_handle.request(request.clone());
+        let _fut = bob_handle.request(request.clone());
+        let _fut = bob_handle.request(request);
         tokio::spawn(bob.loop_on_next());
 
         let event = alice.next_behaviour_event().await;
@@ -1075,6 +1177,7 @@ pub(crate) mod tests {
 
         let alice_config = Config::default().with_max_rounds_per_request(1);
         let (mut alice, _alice_db, _data_provider) = new_swarm_with_config(alice_config).await;
+        let alice_handle = alice.behaviour().handle();
         let mut bob = Swarm::new_ephemeral_tokio(move |_keypair| {
             InnerBehaviour::new(
                 [(STREAM_PROTOCOL, ProtocolSupport::Full)],
@@ -1084,9 +1187,8 @@ pub(crate) mod tests {
         bob.connect(&mut alice).await;
 
         let request_key = ethexe_db::hash(b"test");
-        let request_id = alice
-            .behaviour_mut()
-            .request(Request::hashes([request_key]));
+        let request = alice_handle.request(Request::hashes([request_key]));
+        let request_id = request.request_id();
 
         // first round
         let event = alice.next_behaviour_event().await;
@@ -1117,14 +1219,15 @@ pub(crate) mod tests {
         time::advance(Config::default().request_timeout).await;
 
         let event = alice.next_behaviour_event().await;
-        let Event::RequestFailed {
-            request: ongoing_request,
-            error: RequestFailure::Timeout,
-        } = event
-        else {
-            unreachable!("unexpected event: {event:?}");
-        };
-        assert_eq!(request_id, ongoing_request.id());
+        assert_eq!(
+            event,
+            Event::RequestFailed {
+                request_id,
+                error: RequestFailure::Timeout,
+            }
+        );
+        let (error, retriable_request) = request.await.unwrap_err();
+        assert_eq!(error, RequestFailure::Timeout);
 
         time::resume();
 
@@ -1136,7 +1239,8 @@ pub(crate) mod tests {
 
         let key = charlie_db.write_hash(b"test");
         assert_eq!(request_key, key);
-        alice.behaviour_mut().retry(ongoing_request);
+        let request = alice_handle.retry(retriable_request);
+        let request_id = request.request_id();
 
         // retry round
         let event = alice.next_behaviour_event().await;
@@ -1145,12 +1249,12 @@ pub(crate) mod tests {
         );
 
         let event = alice.next_behaviour_event().await;
+        assert_eq!(event, Event::RequestSucceed { request_id });
+
+        let response = request.await.unwrap();
         assert_eq!(
-            event,
-            Event::RequestSucceed {
-                request_id,
-                response: Response::Hashes([(request_key, b"test".to_vec())].into()),
-            }
+            response,
+            Response::Hashes([(request_key, b"test".to_vec())].into())
         );
     }
 
@@ -1159,6 +1263,7 @@ pub(crate) mod tests {
         init_logger();
 
         let (mut alice, _alice_db, alice_data_provider) = new_swarm().await;
+        let alice_handle = alice.behaviour().handle();
         let (mut bob, _bob_db, _data_provider) = new_swarm().await;
         let (mut charlie, charlie_db, _data_provider) = new_swarm().await;
         let bob_peer_id = *bob.local_peer_id();
@@ -1168,9 +1273,8 @@ pub(crate) mod tests {
         alice.connect(&mut bob).await;
         tokio::spawn(bob.loop_on_next());
 
-        let request_id = alice
-            .behaviour_mut()
-            .request(Request::program_ids(H256::zero(), 2));
+        let request = alice_handle.request(Request::program_ids(H256::zero(), 2));
+        let request_id = request.request_id();
 
         let event = alice.next_behaviour_event().await;
         assert_eq!(
@@ -1191,13 +1295,10 @@ pub(crate) mod tests {
         // `Event::NewRequestRound` skipped by `connect()` above
 
         let event = alice.next_behaviour_event().await;
-        assert_eq!(
-            event,
-            Event::RequestSucceed {
-                request_id,
-                response: expected_response,
-            }
-        );
+        assert_eq!(event, Event::RequestSucceed { request_id });
+
+        let response = request.await.unwrap();
+        assert_eq!(response, expected_response);
     }
 
     pub(crate) async fn fill_data_provider(

--- a/ethexe/network/src/db_sync/requests.rs
+++ b/ethexe/network/src/db_sync/requests.rs
@@ -206,6 +206,8 @@ impl OngoingRequests {
             self.requests.retain(|&request_id, (fut, channel)| {
                 let response = self.responses.remove(&request_id);
 
+                // it means `HandleFuture` is dropped,
+                // so we just remove the request and don't make any further work
                 if channel.as_ref().expect("always Some").is_closed() {
                     return false;
                 }
@@ -253,6 +255,7 @@ impl OngoingRequests {
                         }
                     };
                     self.pending_events.push_back(event);
+                    // `send()` can return an error because of the channel being dropped, so we ignore it
                     let _res = channel.take().expect("always Some").send(res);
                     return false;
                 }

--- a/ethexe/network/src/db_sync/requests.rs
+++ b/ethexe/network/src/db_sync/requests.rs
@@ -18,10 +18,10 @@
 
 use crate::{
     db_sync::{
-        Config, Event, ExternalDataProvider, HashesRequest, InnerBehaviour, InnerHashesResponse,
-        InnerProgramIdsRequest, InnerProgramIdsResponse, InnerRequest, InnerResponse,
-        NewRequestRoundReason, PeerId, ProgramIdsRequest, Request, RequestFailure, RequestId,
-        Response, ValidCodesRequest,
+        Config, DbSyncOneshot, Event, ExternalDataProvider, HashesRequest, InnerBehaviour,
+        InnerHashesResponse, InnerProgramIdsRequest, InnerProgramIdsResponse, InnerRequest,
+        InnerResponse, NewRequestRoundReason, PeerId, ProgramIdsRequest, Request, RequestFailure,
+        RequestId, Response, ValidCodesRequest,
     },
     peer_score::Handle,
     utils::ConnectionMap,
@@ -53,12 +53,11 @@ type OngoingRequestFuture = BoxFuture<'static, Result<Response, (RequestFailure,
 
 pub(crate) struct OngoingRequests {
     pending_events: VecDeque<Event>,
-    requests: HashMap<RequestId, OngoingRequestFuture>,
+    requests: HashMap<RequestId, (OngoingRequestFuture, Option<DbSyncOneshot>)>,
     active_requests: HashMap<OutboundRequestId, RequestId>,
     responses: HashMap<RequestId, Result<InnerResponse, ()>>,
     connections: ConnectionMap,
     waker: Option<Waker>,
-    request_id_counter: u64,
     // used in requests themselves
     peer_score_handle: Handle,
     external_data_provider: Box<dyn ExternalDataProvider>,
@@ -80,7 +79,6 @@ impl OngoingRequests {
             responses: Default::default(),
             connections: Default::default(),
             waker: None,
-            request_id_counter: 0,
             peer_score_handle,
             external_data_provider,
             request_timeout: config.request_timeout,
@@ -117,43 +115,47 @@ impl OngoingRequests {
         }
     }
 
-    fn next_request_id(&mut self) -> RequestId {
-        let id = self.request_id_counter;
-        self.request_id_counter += 1;
-        RequestId(id)
-    }
-
-    pub(crate) fn request(&mut self, request: Request) -> RequestId {
-        let request_id = self.next_request_id();
+    pub(crate) fn request(
+        &mut self,
+        request_id: RequestId,
+        request: Request,
+        channel: DbSyncOneshot,
+    ) -> RequestId {
         self.requests.insert(
             request_id,
-            OngoingRequest::new(request)
-                .request(
-                    self.peer_score_handle.clone(),
-                    self.external_data_provider.clone_boxed(),
-                    self.request_timeout,
-                    self.max_rounds_per_request,
-                )
-                .boxed(),
+            (
+                OngoingRequest::new(request)
+                    .request(
+                        self.peer_score_handle.clone(),
+                        self.external_data_provider.clone_boxed(),
+                        self.request_timeout,
+                        self.max_rounds_per_request,
+                    )
+                    .boxed(),
+                Some(channel),
+            ),
         );
         request_id
     }
 
-    pub(crate) fn retry(&mut self, request: RetriableRequest) {
+    pub(crate) fn retry(&mut self, request: RetriableRequest, channel: DbSyncOneshot) {
         let RetriableRequest {
             request_id,
             request,
         } = request;
         self.requests.insert(
             request_id,
-            request
-                .request(
-                    self.peer_score_handle.clone(),
-                    self.external_data_provider.clone_boxed(),
-                    self.request_timeout,
-                    self.max_rounds_per_request,
-                )
-                .boxed(),
+            (
+                request
+                    .request(
+                        self.peer_score_handle.clone(),
+                        self.external_data_provider.clone_boxed(),
+                        self.request_timeout,
+                        self.max_rounds_per_request,
+                    )
+                    .boxed(),
+                Some(channel),
+            ),
         );
     }
 
@@ -202,8 +204,13 @@ impl OngoingRequests {
 
             let peers: HashSet<PeerId> = self.connections.peers().collect();
 
-            self.requests.retain(|&request_id, fut| {
+            self.requests.retain(|&request_id, (fut, channel)| {
                 let response = self.responses.remove(&request_id);
+
+                if channel.as_ref().expect("always Some").is_closed() {
+                    return false;
+                }
+
                 let ctx = OngoingRequestContext {
                     state: OnceCell::new(),
                     peers: peers.clone(),
@@ -234,20 +241,20 @@ impl OngoingRequests {
                     };
                     self.pending_events.push_back(event);
                 } else if let Poll::Ready(res) = poll {
-                    let event = match res {
-                        Ok(response) => Event::RequestSucceed {
-                            request_id,
-                            response,
-                        },
-                        Err((error, request)) => Event::RequestFailed {
-                            request: RetriableRequest {
+                    let (event, res) = match res {
+                        Ok(response) => {
+                            (Event::RequestSucceed { request_id }, Ok(response))
+                        }
+                        Err((error, request)) => {
+                            (Event::RequestFailed { request_id, error }, Err((error, RetriableRequest {
                                 request_id,
                                 request,
                             },
-                            error,
+                            )))
                         }
                     };
                     self.pending_events.push_back(event);
+                    let _res = channel.take().expect("always Some").send(res);
                     return false;
                 }
 

--- a/ethexe/network/src/db_sync/requests.rs
+++ b/ethexe/network/src/db_sync/requests.rs
@@ -18,7 +18,7 @@
 
 use crate::{
     db_sync::{
-        Config, DbSyncOneshot, Event, ExternalDataProvider, HashesRequest, InnerBehaviour,
+        Config, Event, ExternalDataProvider, HandleResult, HashesRequest, InnerBehaviour,
         InnerHashesResponse, InnerProgramIdsRequest, InnerProgramIdsResponse, InnerRequest,
         InnerResponse, NewRequestRoundReason, PeerId, ProgramIdsRequest, Request, RequestFailure,
         RequestId, Response, ValidCodesRequest,
@@ -43,7 +43,7 @@ use std::{
     task::{Context, Poll, Waker},
     time::Duration,
 };
-use tokio::time;
+use tokio::{sync::oneshot, time};
 
 ethexe_service_utils::task_local! {
     static CONTEXT: OngoingRequestContext;
@@ -53,7 +53,7 @@ type OngoingRequestFuture = BoxFuture<'static, Result<Response, (RequestFailure,
 
 pub(crate) struct OngoingRequests {
     pending_events: VecDeque<Event>,
-    requests: HashMap<RequestId, (OngoingRequestFuture, Option<DbSyncOneshot>)>,
+    requests: HashMap<RequestId, (OngoingRequestFuture, Option<oneshot::Sender<HandleResult>>)>,
     active_requests: HashMap<OutboundRequestId, RequestId>,
     responses: HashMap<RequestId, Result<InnerResponse, ()>>,
     connections: ConnectionMap,
@@ -119,7 +119,7 @@ impl OngoingRequests {
         &mut self,
         request_id: RequestId,
         request: Request,
-        channel: DbSyncOneshot,
+        channel: oneshot::Sender<HandleResult>,
     ) -> RequestId {
         self.requests.insert(
             request_id,
@@ -138,7 +138,11 @@ impl OngoingRequests {
         request_id
     }
 
-    pub(crate) fn retry(&mut self, request: RetriableRequest, channel: DbSyncOneshot) {
+    pub(crate) fn retry(
+        &mut self,
+        request: RetriableRequest,
+        channel: oneshot::Sender<HandleResult>,
+    ) {
         let RetriableRequest {
             request_id,
             request,

--- a/ethexe/network/src/lib.rs
+++ b/ethexe/network/src/lib.rs
@@ -433,7 +433,7 @@ impl NetworkService {
         self.swarm.behaviour().peer_score.handle()
     }
 
-    pub fn db_sync_handle(&self) -> db_sync::DbSyncHandle {
+    pub fn db_sync_handle(&self) -> db_sync::Handle {
         self.swarm.behaviour().db_sync.handle()
     }
 

--- a/ethexe/network/src/lib.rs
+++ b/ethexe/network/src/lib.rs
@@ -69,10 +69,6 @@ const MAX_ESTABLISHED_INCOMING_CONNECTIONS: u32 = 100;
 
 #[derive(Eq, PartialEq)]
 pub enum NetworkEvent {
-    DbResponse {
-        request_id: db_sync::RequestId,
-        result: Result<db_sync::Response, (db_sync::RetriableRequest, db_sync::RequestFailure)>,
-    },
     Message {
         data: Vec<u8>,
         source: Option<PeerId>,
@@ -84,11 +80,6 @@ pub enum NetworkEvent {
 impl fmt::Debug for NetworkEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            NetworkEvent::DbResponse { request_id, result } => f
-                .debug_struct("DbResponse")
-                .field("request_id", request_id)
-                .field("result", result)
-                .finish(),
             NetworkEvent::Message { data, source } => f
                 .debug_struct("Message")
                 .field(
@@ -428,21 +419,6 @@ impl NetworkService {
             }
             BehaviourEvent::Gossipsub(_) => {}
             //
-            BehaviourEvent::DbSync(db_sync::Event::RequestSucceed {
-                request_id,
-                response,
-            }) => {
-                return Some(NetworkEvent::DbResponse {
-                    request_id,
-                    result: Ok(response),
-                });
-            }
-            BehaviourEvent::DbSync(db_sync::Event::RequestFailed { request, error }) => {
-                return Some(NetworkEvent::DbResponse {
-                    request_id: request.id(),
-                    result: Err((request, error)),
-                });
-            }
             BehaviourEvent::DbSync(_) => {}
         }
 
@@ -455,6 +431,10 @@ impl NetworkService {
 
     pub fn score_handle(&self) -> peer_score::Handle {
         self.swarm.behaviour().peer_score.handle()
+    }
+
+    pub fn db_sync_handle(&self) -> db_sync::DbSyncHandle {
+        self.swarm.behaviour().db_sync.handle()
     }
 
     pub fn publish_message(&mut self, data: Vec<u8>) {
@@ -477,10 +457,6 @@ impl NetworkService {
         {
             log::error!("gossipsub publishing failed: {e}")
         }
-    }
-
-    pub fn db_sync(&mut self) -> &mut db_sync::Behaviour {
-        &mut self.swarm.behaviour_mut().db_sync
     }
 }
 
@@ -740,6 +716,7 @@ mod tests {
         init_logger();
 
         let mut service1 = new_service();
+        let service1_handle = service1.db_sync_handle();
 
         // second service
         let db = Database::from_one(&MemDb::default());
@@ -750,24 +727,19 @@ mod tests {
         let mut service2 = new_service_with(db, Default::default());
 
         service1.connect(&mut service2).await;
+        tokio::spawn(service1.loop_on_next());
         tokio::spawn(service2.loop_on_next());
 
-        let request_id = service1
-            .db_sync()
-            .request(db_sync::Request::hashes([hello, world]));
-
-        let event = timeout(Duration::from_secs(5), service1.next())
+        let request = service1_handle.request(db_sync::Request::hashes([hello, world]));
+        let response = timeout(Duration::from_secs(5), request)
             .await
             .expect("time has elapsed")
             .unwrap();
         assert_eq!(
-            event,
-            NetworkEvent::DbResponse {
-                request_id,
-                result: Ok(db_sync::Response::Hashes(
-                    [(hello, b"hello".to_vec()), (world, b"world".to_vec())].into()
-                ))
-            }
+            response,
+            db_sync::Response::Hashes(
+                [(hello, b"hello".to_vec()), (world, b"world".to_vec())].into()
+            )
         );
     }
 
@@ -800,28 +772,21 @@ mod tests {
 
         let alice_data_provider = DataProvider::default();
         let mut alice = new_service_with(Database::memory(), alice_data_provider.clone());
+        let alice_handle = alice.db_sync_handle();
         let bob_db = Database::memory();
         let mut bob = new_service_with(bob_db.clone(), DataProvider::default());
 
         alice.connect(&mut bob).await;
+        tokio::spawn(alice.loop_on_next());
         tokio::spawn(bob.loop_on_next());
 
         let expected_response = fill_data_provider(alice_data_provider, bob_db).await;
 
-        let request_id = alice
-            .db_sync()
-            .request(db_sync::Request::program_ids(H256::zero(), 2));
-
-        let event = timeout(Duration::from_secs(5), alice.next())
+        let request = alice_handle.request(db_sync::Request::program_ids(H256::zero(), 2));
+        let response = timeout(Duration::from_secs(5), request)
             .await
             .expect("time has elapsed")
             .unwrap();
-        assert_eq!(
-            event,
-            NetworkEvent::DbResponse {
-                request_id,
-                result: Ok(expected_response)
-            }
-        );
+        assert_eq!(response, expected_response);
     }
 }

--- a/ethexe/service/src/fast_sync.rs
+++ b/ethexe/service/src/fast_sync.rs
@@ -38,7 +38,7 @@ use ethexe_db::{
     visitor::DatabaseVisitor,
 };
 use ethexe_ethereum::mirror::MirrorQuery;
-use ethexe_network::{NetworkEvent, NetworkService, db_sync};
+use ethexe_network::{NetworkService, db_sync};
 use ethexe_observer::ObserverService;
 use ethexe_runtime_common::{
     ScheduleRestorer,
@@ -140,25 +140,18 @@ async fn net_fetch(
     network: &mut NetworkService,
     request: db_sync::Request,
 ) -> Result<db_sync::Response> {
-    let request_id = network.db_sync().request(request);
+    let mut fut = network.db_sync_handle().request(request);
     loop {
-        let event = network
-            .next()
-            .await
-            .expect("network service stream is infinite");
-
-        if let NetworkEvent::DbResponse {
-            request_id: rid,
-            result,
-        } = event
-        {
-            debug_assert_eq!(rid, request_id, "unknown request id");
-            match result {
-                Ok(response) => break Ok(response),
-                Err((request, err)) => {
-                    log::warn!("Request {:?} failed: {err}. Retrying...", request.id());
-                    network.db_sync().retry(request);
-                    continue;
+        tokio::select! {
+            _ = network.select_next_some() => {},
+            res = &mut fut => {
+                match res {
+                    Ok(response) => break Ok(response),
+                    Err((err, request)) => {
+                        log::warn!("Request {:?} failed: {err}. Retrying...", request.id());
+                        fut = network.db_sync_handle().retry(request);
+                        continue;
+                    }
                 }
             }
         }

--- a/ethexe/service/src/lib.rs
+++ b/ethexe/service/src/lib.rs
@@ -461,9 +461,6 @@ impl Service {
                                 }
                             };
                         }
-                        NetworkEvent::DbResponse { .. } => {
-                            unreachable!("`db-sync` is never used for requests in the main loop")
-                        }
                         NetworkEvent::PeerBlocked(_) | NetworkEvent::PeerConnected(_) => {}
                     }
                 }

--- a/ethexe/service/src/tests/utils/events.rs
+++ b/ethexe/service/src/tests/utils/events.rs
@@ -25,7 +25,7 @@ use ethexe_common::{
 use ethexe_compute::{BlockProcessed, ComputeEvent};
 use ethexe_consensus::ConsensusEvent;
 use ethexe_db::Database;
-use ethexe_network::{NetworkEvent, db_sync, export::PeerId};
+use ethexe_network::{NetworkEvent, export::PeerId};
 use ethexe_observer::ObserverEvent;
 use ethexe_prometheus::PrometheusEvent;
 use ethexe_rpc::RpcEvent;
@@ -41,14 +41,6 @@ pub type TestingEventReceiver = Receiver<TestingEvent>;
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[allow(dead_code)]
 pub(crate) enum TestingNetworkEvent {
-    DbResponse {
-        request_id: db_sync::RequestId,
-        result: Result<db_sync::Response, db_sync::RequestFailure>,
-    },
-    DbExternalValidation {
-        request_id: db_sync::RequestId,
-        response: db_sync::Response,
-    },
     Message {
         data: Vec<u8>,
         source: Option<PeerId>,
@@ -60,10 +52,6 @@ pub(crate) enum TestingNetworkEvent {
 impl TestingNetworkEvent {
     fn new(event: &NetworkEvent) -> Self {
         match event {
-            NetworkEvent::DbResponse { request_id, result } => Self::DbResponse {
-                request_id: *request_id,
-                result: result.as_ref().map_err(|(_req, err)| *err).cloned(),
-            },
             NetworkEvent::Message { data, source } => Self::Message {
                 data: data.clone(),
                 source: *source,

--- a/ethexe/service/src/tests/utils/events.rs
+++ b/ethexe/service/src/tests/utils/events.rs
@@ -39,7 +39,6 @@ pub type TestingEventSender = Sender<TestingEvent>;
 pub type TestingEventReceiver = Receiver<TestingEvent>;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[allow(dead_code)]
 pub(crate) enum TestingNetworkEvent {
     Message {
         data: Vec<u8>,


### PR DESCRIPTION
Preparation for `tx-pool` to fetch missing data. It allows to not implement event-based state machine in the service, so it would simpler