### PR TITLE
build(nix): add `openssl` to `buildInputs`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -47,4 +47,8 @@ pkgs.mkShell.override { stdenv = pkgs.llvmPackages.stdenv; } {
     pkgs.cargo-binutils
     oldPkgs.rustfilt
   ];
+
+  buildInputs = [
+    pkgs.openssl
+  ];
 }


### PR DESCRIPTION
It turned out that `openssl` in build inputs is required to build `openssl-sys` which some of our crates depend on.