### PR TITLE
fix(ethexe): fix potential problem in consensus implementation

### DIFF
--- a/ethexe/consensus/src/lib.rs
+++ b/ethexe/consensus/src/lib.rs
@@ -75,7 +75,7 @@ pub trait ConsensusService:
     fn receive_validation_reply(&mut self, reply: BatchCommitmentValidationReply) -> Result<()>;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, derive_more::From)]
+#[derive(Debug, Clone, PartialEq, Eq, derive_more::From, derive_more::IsVariant)]
 pub enum ConsensusEvent {
     /// Outer service have to compute block
     #[from(skip)]

--- a/ethexe/consensus/src/mock.rs
+++ b/ethexe/consensus/src/mock.rs
@@ -88,6 +88,8 @@ impl Mock for BatchCommitmentValidationRequest {
             digest: H256::random().0.into(),
             head: Some(H256::random()),
             codes: vec![CodeCommitment::mock(()).id, CodeCommitment::mock(()).id],
+            validators: false,
+            rewards: false,
         }
     }
 }

--- a/ethexe/consensus/src/utils.rs
+++ b/ethexe/consensus/src/utils.rs
@@ -26,7 +26,9 @@ use ethexe_common::{
     Address, Digest, ProducerBlock, SimpleBlockData, ToDigest,
     db::{BlockMetaStorageRead, CodesStorageRead, OnChainStorageRead},
     ecdsa::{ContractSignature, PublicKey, SignedData},
-    gear::{BatchCommitment, ChainCommitment, CodeCommitment},
+    gear::{
+        BatchCommitment, ChainCommitment, CodeCommitment, RewardsCommitment, ValidatorsCommitment,
+    },
     sha3::{self, digest::Digest as _},
 };
 use ethexe_signer::Signer;
@@ -49,6 +51,11 @@ pub struct BatchCommitmentValidationRequest {
     pub head: Option<H256>,
     /// List of codes which are part of the batch
     pub codes: Vec<CodeId>,
+
+    /// +_+_+
+    pub validators: bool,
+    /// +_+_+
+    pub rewards: bool,
 }
 
 impl BatchCommitmentValidationRequest {
@@ -63,6 +70,8 @@ impl BatchCommitmentValidationRequest {
             digest: batch.to_digest(),
             head: batch.chain_commitment.as_ref().map(|c| c.head),
             codes,
+            rewards: batch.rewards_commitment.is_some(),
+            validators: batch.validators_commitment.is_some(),
         }
     }
 }
@@ -73,6 +82,8 @@ impl ToDigest for BatchCommitmentValidationRequest {
             digest,
             head,
             codes,
+            rewards,
+            validators,
         } = self;
 
         hasher.update(digest);
@@ -83,6 +94,8 @@ impl ToDigest for BatchCommitmentValidationRequest {
                 .flat_map(|h| h.into_bytes())
                 .collect::<Vec<u8>>(),
         );
+        hasher.update([*rewards as u8]);
+        hasher.update([*validators as u8]);
     }
 }
 
@@ -265,6 +278,8 @@ pub fn create_batch_commitment<DB: BlockMetaStorageRead>(
     block: &SimpleBlockData,
     chain_commitment: Option<ChainCommitment>,
     code_commitments: Vec<CodeCommitment>,
+    validators_commitment: Option<ValidatorsCommitment>,
+    rewards_commitment: Option<RewardsCommitment>,
 ) -> Result<Option<BatchCommitment>> {
     if chain_commitment.is_none() && code_commitments.is_empty() {
         return Ok(None);
@@ -286,8 +301,8 @@ pub fn create_batch_commitment<DB: BlockMetaStorageRead>(
         previous_batch: last_committed,
         chain_commitment,
         code_commitments,
-        validators_commitment: None,
-        rewards_commitment: None,
+        validators_commitment,
+        rewards_commitment,
     }))
 }
 

--- a/ethexe/consensus/src/utils.rs
+++ b/ethexe/consensus/src/utils.rs
@@ -51,10 +51,9 @@ pub struct BatchCommitmentValidationRequest {
     pub head: Option<H256>,
     /// List of codes which are part of the batch
     pub codes: Vec<CodeId>,
-
-    /// +_+_+
+    /// Whether validators commitment is part of the batch
     pub validators: bool,
-    /// +_+_+
+    /// Whether rewards commitment is part of the batch
     pub rewards: bool,
 }
 

--- a/ethexe/consensus/src/validator/coordinator.rs
+++ b/ethexe/consensus/src/validator/coordinator.rs
@@ -67,7 +67,7 @@ impl StateHandler for Coordinator {
             self.warning(format!("validation reply rejected: {err}"));
         }
 
-        if self.multisigned_batch.signatures().len() as u64 >= self.ctx.signatures_threshold {
+        if self.multisigned_batch.signatures().len() as u64 >= self.ctx.core.signatures_threshold {
             Submitter::create(self.ctx, self.multisigned_batch)
         } else {
             Ok(self.into())
@@ -82,24 +82,28 @@ impl Coordinator {
         batch: BatchCommitment,
     ) -> Result<ValidatorState> {
         ensure!(
-            validators.len() as u64 >= ctx.signatures_threshold,
+            validators.len() as u64 >= ctx.core.signatures_threshold,
             "Number of validators is less than threshold"
         );
 
         ensure!(
-            ctx.signatures_threshold > 0,
+            ctx.core.signatures_threshold > 0,
             "Threshold should be greater than 0"
         );
 
-        let multisigned_batch =
-            MultisignedBatchCommitment::new(batch, &ctx.signer, ctx.router_address, ctx.pub_key)?;
+        let multisigned_batch = MultisignedBatchCommitment::new(
+            batch,
+            &ctx.core.signer,
+            ctx.core.router_address,
+            ctx.core.pub_key,
+        )?;
 
-        if multisigned_batch.signatures().len() as u64 >= ctx.signatures_threshold {
+        if multisigned_batch.signatures().len() as u64 >= ctx.core.signatures_threshold {
             return Submitter::create(ctx, multisigned_batch);
         }
 
-        let validation_request = ctx.signer.signed_data(
-            ctx.pub_key,
+        let validation_request = ctx.core.signer.signed_data(
+            ctx.core.pub_key,
             BatchCommitmentValidationRequest::new(multisigned_batch.batch()),
         )?;
 
@@ -125,7 +129,7 @@ mod tests {
     #[test]
     fn coordinator_create_success() {
         let (mut ctx, keys) = mock_validator_context();
-        ctx.signatures_threshold = 2;
+        ctx.core.signatures_threshold = 2;
         let validators =
             NonEmpty::from_vec(keys.iter().take(3).map(|k| k.to_address()).collect()).unwrap();
         let batch = BatchCommitment::default();
@@ -141,7 +145,7 @@ mod tests {
     #[test]
     fn coordinator_create_insufficient_validators() {
         let (mut ctx, keys) = mock_validator_context();
-        ctx.signatures_threshold = 3;
+        ctx.core.signatures_threshold = 3;
         let validators =
             NonEmpty::from_vec(keys.iter().take(2).map(|k| k.to_address()).collect()).unwrap();
         let batch = BatchCommitment::default();
@@ -155,7 +159,7 @@ mod tests {
     #[test]
     fn coordinator_create_zero_threshold() {
         let (mut ctx, keys) = mock_validator_context();
-        ctx.signatures_threshold = 0;
+        ctx.core.signatures_threshold = 0;
         let validators =
             NonEmpty::from_vec(keys.iter().take(1).map(|k| k.to_address()).collect()).unwrap();
         let batch = BatchCommitment::default();
@@ -169,7 +173,7 @@ mod tests {
     #[test]
     fn process_validation_reply() {
         let (mut ctx, keys) = mock_validator_context();
-        ctx.signatures_threshold = 3;
+        ctx.core.signatures_threshold = 3;
         let validators =
             NonEmpty::from_vec(keys.iter().take(3).map(|k| k.to_address()).collect()).unwrap();
 
@@ -177,30 +181,30 @@ mod tests {
         let digest = batch.to_digest();
 
         let reply1 = BatchCommitmentValidationReply::mock((
-            ctx.signer.clone(),
+            ctx.core.signer.clone(),
             keys[0],
-            ctx.router_address,
+            ctx.core.router_address,
             digest,
         ));
 
         let reply2_invalid = BatchCommitmentValidationReply::mock((
-            ctx.signer.clone(),
+            ctx.core.signer.clone(),
             keys[4],
-            ctx.router_address,
+            ctx.core.router_address,
             digest,
         ));
 
         let reply3_invalid = BatchCommitmentValidationReply::mock((
-            ctx.signer.clone(),
+            ctx.core.signer.clone(),
             keys[1],
-            ctx.router_address,
+            ctx.core.router_address,
             H256::random().0.into(),
         ));
 
         let reply4 = BatchCommitmentValidationReply::mock((
-            ctx.signer.clone(),
+            ctx.core.signer.clone(),
             keys[2],
-            ctx.router_address,
+            ctx.core.router_address,
             digest,
         ));
 

--- a/ethexe/consensus/src/validator/coordinator.rs
+++ b/ethexe/consensus/src/validator/coordinator.rs
@@ -128,7 +128,7 @@ mod tests {
 
     #[test]
     fn coordinator_create_success() {
-        let (mut ctx, keys) = mock_validator_context();
+        let (mut ctx, keys, _) = mock_validator_context();
         ctx.core.signatures_threshold = 2;
         let validators =
             NonEmpty::from_vec(keys.iter().take(3).map(|k| k.to_address()).collect()).unwrap();
@@ -144,7 +144,7 @@ mod tests {
 
     #[test]
     fn coordinator_create_insufficient_validators() {
-        let (mut ctx, keys) = mock_validator_context();
+        let (mut ctx, keys, _) = mock_validator_context();
         ctx.core.signatures_threshold = 3;
         let validators =
             NonEmpty::from_vec(keys.iter().take(2).map(|k| k.to_address()).collect()).unwrap();
@@ -158,7 +158,7 @@ mod tests {
 
     #[test]
     fn coordinator_create_zero_threshold() {
-        let (mut ctx, keys) = mock_validator_context();
+        let (mut ctx, keys, _) = mock_validator_context();
         ctx.core.signatures_threshold = 0;
         let validators =
             NonEmpty::from_vec(keys.iter().take(1).map(|k| k.to_address()).collect()).unwrap();
@@ -172,7 +172,7 @@ mod tests {
 
     #[test]
     fn process_validation_reply() {
-        let (mut ctx, keys) = mock_validator_context();
+        let (mut ctx, keys, _) = mock_validator_context();
         ctx.core.signatures_threshold = 3;
         let validators =
             NonEmpty::from_vec(keys.iter().take(3).map(|k| k.to_address()).collect()).unwrap();

--- a/ethexe/consensus/src/validator/core.rs
+++ b/ethexe/consensus/src/validator/core.rs
@@ -1,0 +1,337 @@
+// This file is part of Gear.
+//
+// Copyright (C) 2025 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Validator core utils and parameters.
+
+use crate::{
+    BatchCommitmentValidationRequest,
+    utils::{self, MultisignedBatchCommitment},
+};
+use anyhow::{Result, anyhow, ensure};
+use async_trait::async_trait;
+use ethexe_common::{
+    Address, Digest, SimpleBlockData, ToDigest,
+    db::BlockMetaStorageRead,
+    ecdsa::PublicKey,
+    gear::{
+        BatchCommitment, ChainCommitment, CodeCommitment, RewardsCommitment, ValidatorsCommitment,
+    },
+};
+use ethexe_db::Database;
+use ethexe_ethereum::middleware::Middleware;
+use ethexe_signer::Signer;
+use futures::lock::Mutex;
+use gprimitives::H256;
+use std::{collections::HashSet, sync::Arc, time::Duration};
+
+#[derive(derive_more::Debug)]
+pub struct ValidatorCore {
+    pub slot_duration: Duration,
+    pub signatures_threshold: u64,
+    pub router_address: Address,
+    pub pub_key: PublicKey,
+
+    #[debug(skip)]
+    pub signer: Signer,
+    #[debug(skip)]
+    pub db: Database,
+    #[debug(skip)]
+    pub committer: Box<dyn BatchCommitter>,
+    #[debug(skip)]
+    pub middleware: Option<Box<dyn MiddlewareExt>>,
+
+    /// Maximum deepness for chain commitment validation.
+    pub validate_chain_deepness_limit: u32,
+    /// Minimum deepness threshold to create chain commitment even if there are no transitions.
+    pub chain_deepness_threshold: u32,
+}
+
+impl Clone for ValidatorCore {
+    fn clone(&self) -> Self {
+        Self {
+            slot_duration: self.slot_duration,
+            signatures_threshold: self.signatures_threshold,
+            router_address: self.router_address,
+            pub_key: self.pub_key,
+            signer: self.signer.clone(),
+            db: self.db.clone(),
+            committer: self.committer.clone_boxed(),
+            middleware: self.middleware.as_ref().map(|x| x.clone_boxed()),
+            validate_chain_deepness_limit: self.validate_chain_deepness_limit,
+            chain_deepness_threshold: self.chain_deepness_threshold,
+        }
+    }
+}
+
+impl ValidatorCore {
+    pub async fn aggregate_batch_commitment(
+        mut self,
+        block: SimpleBlockData,
+    ) -> Result<Option<BatchCommitment>> {
+        let chain_commitment = self.aggregate_chain_commitment(block.hash)?;
+        let code_commitments = self.aggregate_code_commitments(block.hash)?;
+        let validators_commitment = self.aggregate_validators_commitment(&block).await?;
+        let rewards_commitment = self.aggregate_rewards_commitment(&block).await?;
+
+        if chain_commitment.is_none()
+            && code_commitments.is_empty()
+            && validators_commitment.is_none()
+            && rewards_commitment.is_none()
+        {
+            log::debug!(
+                "No commitments for block {} - skip batch commitment",
+                block.hash
+            );
+            return Ok(None);
+        }
+
+        utils::create_batch_commitment(
+            &self.db,
+            &block,
+            chain_commitment,
+            code_commitments,
+            validators_commitment,
+            rewards_commitment,
+        )
+    }
+
+    pub fn aggregate_chain_commitment(&self, block_hash: H256) -> Result<Option<ChainCommitment>> {
+        let Some((commitment, deepness)) =
+            // Max deepness is ignored here, because we want to create chain commitment (not validate)
+            utils::aggregate_chain_commitment(&self.db, block_hash, false, None)?
+        else {
+            return Ok(None);
+        };
+
+        if commitment.transitions.is_empty() && deepness <= self.chain_deepness_threshold {
+            // No transitions and chain is not deep enough, skip chain commitment
+            Ok(None)
+        } else {
+            Ok(Some(commitment))
+        }
+    }
+
+    pub fn aggregate_code_commitments(&self, block_hash: H256) -> Result<Vec<CodeCommitment>> {
+        let queue = self
+            .db
+            .block_codes_queue(block_hash)
+            .ok_or_else(|| anyhow!("Computed block {block_hash} codes queue is not in storage"))?;
+
+        utils::aggregate_code_commitments(&self.db, queue, false)
+    }
+
+    // TODO #4741
+    pub async fn aggregate_validators_commitment(
+        &mut self,
+        _block: &SimpleBlockData,
+    ) -> Result<Option<ValidatorsCommitment>> {
+        // self.middleware.make_election_at(ElectionRequest {
+        //     at_block_hash: todo!(),
+        //     at_timestamp: todo!(),
+        //     max_validators: todo!(),
+        // });
+        Ok(None)
+    }
+
+    // TODO #4742
+    pub async fn aggregate_rewards_commitment(
+        &mut self,
+        _block: &SimpleBlockData,
+    ) -> Result<Option<RewardsCommitment>> {
+        Ok(None)
+    }
+
+    pub async fn validate_batch_commitment_request(
+        mut self,
+        block: SimpleBlockData,
+        request: BatchCommitmentValidationRequest,
+    ) -> Result<Digest> {
+        let BatchCommitmentValidationRequest {
+            digest,
+            head,
+            codes,
+            validators,
+            rewards,
+        } = request;
+
+        ensure!(
+            !(head.is_none() && codes.is_empty()),
+            "Empty batch (change when other commitments are supported)"
+        );
+
+        ensure!(
+            !utils::has_duplicates(codes.as_slice()),
+            "Duplicate codes in validation request"
+        );
+
+        // Check requested codes wait for commitment
+        let waiting_codes = self
+            .db
+            .block_codes_queue(block.hash)
+            .ok_or_else(|| {
+                anyhow!(
+                    "Cannot get from db block codes queue for block {}",
+                    block.hash
+                )
+            })?
+            .into_iter()
+            .collect::<HashSet<_>>();
+        ensure!(
+            codes.iter().all(|code| waiting_codes.contains(code)),
+            "Not all requested codes are waiting for commitment"
+        );
+
+        let chain_commitment = if let Some(head) = head {
+            // TODO #4791: support head != current block hash, have to check head is predecessor of current block
+            ensure!(
+                head == block.hash,
+                "Head cannot be different from current block hash"
+            );
+
+            utils::aggregate_chain_commitment(
+                &self.db,
+                head,
+                true,
+                Some(self.validate_chain_deepness_limit),
+            )?
+            .map(|(commitment, _)| commitment)
+        } else {
+            None
+        };
+
+        let code_commitments = utils::aggregate_code_commitments(&self.db, codes, true)?;
+
+        let validators_commitment = if validators {
+            Self::aggregate_validators_commitment(&mut self, &block).await?
+        } else {
+            None
+        };
+
+        let rewards_commitment = if rewards {
+            Self::aggregate_rewards_commitment(&mut self, &block).await?
+        } else {
+            None
+        };
+
+        let batch = utils::create_batch_commitment(
+            &self.db,
+            &block,
+            chain_commitment,
+            code_commitments,
+            validators_commitment,
+            rewards_commitment,
+        )?
+        .ok_or_else(|| anyhow!("Batch commitment is empty for current block"))?;
+
+        if batch.to_digest() != digest {
+            Err(anyhow!(
+                "Requested and local batch commitment digests mismatch"
+            ))
+        } else {
+            Ok(digest)
+        }
+    }
+}
+
+/// Trait for committing batch commitments to the blockchain.
+#[async_trait]
+pub trait BatchCommitter: Send {
+    /// Creates a boxed clone of the committer.
+    fn clone_boxed(&self) -> Box<dyn BatchCommitter>;
+
+    /// Commits a batch of signed commitments to the blockchain.
+    ///
+    /// # Arguments
+    /// * `batch` - The batch of commitments to commit
+    ///
+    /// # Returns
+    /// The hash of the transaction that was sent to the blockchain
+    async fn commit_batch(self: Box<Self>, batch: MultisignedBatchCommitment) -> Result<H256>;
+}
+
+#[derive(Debug)]
+pub struct ElectionRequest {
+    #[allow(unused)]
+    at_block_hash: H256,
+    #[allow(unused)]
+    at_timestamp: u64,
+    #[allow(unused)]
+    max_validators: u32,
+}
+
+#[async_trait]
+pub trait MiddlewareExt: Send {
+    /// Creates a boxed clone.
+    fn clone_boxed(&self) -> Box<dyn MiddlewareExt>;
+
+    /// +_+_+
+    #[allow(unused)]
+    async fn make_election_at(self: Box<Self>, request: ElectionRequest) -> Result<Vec<Address>>;
+}
+
+pub struct MiddlewareWrapper {
+    inner: Middleware,
+    db: Database,
+    #[allow(clippy::type_complexity)]
+    cached_election_result: Arc<Mutex<Option<(ElectionRequest, Vec<Address>)>>>,
+}
+
+impl MiddlewareWrapper {
+    pub fn new(inner: Middleware, db: Database) -> Self {
+        Self {
+            inner,
+            db,
+            cached_election_result: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+#[async_trait]
+impl MiddlewareExt for MiddlewareWrapper {
+    fn clone_boxed(&self) -> Box<dyn MiddlewareExt> {
+        Box::new(Self {
+            inner: self.inner.clone(),
+            db: self.db.clone(),
+            cached_election_result: self.cached_election_result.clone(),
+        })
+    }
+
+    async fn make_election_at(self: Box<Self>, request: ElectionRequest) -> Result<Vec<Address>> {
+        let mut cached = self.cached_election_result.lock().await;
+
+        if let Some((_cached_request, _cached_result)) = &*cached {
+            // TODO: implement this. If cached_request has same at_timestamp and max_validators and
+            // new request at_block_hash is a successor of cached one, then we can reuse cached.
+            Ok(vec![])
+        } else {
+            log::debug!("Making new election request to rpc: {request:?}");
+
+            let result = self
+                .inner
+                .query()
+                .make_election_at(request.at_timestamp, request.max_validators as u128)
+                .await?;
+
+            let result: Vec<Address> = result.into_iter().collect();
+
+            *cached = Some((request, result.clone()));
+
+            Ok(result)
+        }
+    }
+}

--- a/ethexe/consensus/src/validator/core.rs
+++ b/ethexe/consensus/src/validator/core.rs
@@ -279,7 +279,7 @@ pub trait MiddlewareExt: Send {
     /// Creates a boxed clone.
     fn clone_boxed(&self) -> Box<dyn MiddlewareExt>;
 
-    /// +_+_+
+    /// Requests the election of validators at a specific block and timestamp.
     #[allow(unused)]
     async fn make_election_at(self: Box<Self>, request: ElectionRequest) -> Result<Vec<Address>>;
 }

--- a/ethexe/consensus/src/validator/initial.rs
+++ b/ethexe/consensus/src/validator/initial.rs
@@ -60,11 +60,12 @@ impl StateHandler for Initial {
             State::WaitingForSyncedBlock(block) if block.hash == block_hash => {
                 let validators = self
                     .ctx
+                    .core
                     .db
                     .validators(block_hash)
                     .ok_or(anyhow!("validators not found for block({block_hash})"))?;
                 let producer = self.producer_for(block.header.timestamp, &validators);
-                let my_address = self.ctx.pub_key.to_address();
+                let my_address = self.ctx.core.pub_key.to_address();
 
                 if my_address == producer {
                     log::info!("👷 Start to work as a producer for block: {}", block.hash);
@@ -115,7 +116,7 @@ impl Initial {
     }
 
     fn producer_for(&self, timestamp: u64, validators: &NonEmpty<Address>) -> Address {
-        let slot = timestamp / self.ctx.slot_duration.as_secs();
+        let slot = timestamp / self.ctx.core.slot_duration.as_secs();
         let index = crate::block_producer_index(validators.len(), slot);
         validators
             .get(index)
@@ -151,7 +152,7 @@ mod tests {
     async fn switch_to_producer() {
         let (ctx, keys) = mock_validator_context();
         let validators = nonempty![
-            ctx.pub_key.to_address(),
+            ctx.core.pub_key.to_address(),
             keys[0].to_address(),
             keys[1].to_address(),
         ];
@@ -159,7 +160,7 @@ mod tests {
         let mut block = SimpleBlockData::mock(H256::random());
         block.header.timestamp = 0;
 
-        ctx.db.set_validators(block.hash, validators.clone());
+        ctx.core.db.set_validators(block.hash, validators.clone());
 
         let initial = Initial::create_with_chain_head(ctx, block.clone()).unwrap();
         let producer = initial.process_synced_block(block.hash).unwrap();
@@ -170,7 +171,7 @@ mod tests {
     fn switch_to_subordinate() {
         let (ctx, keys) = mock_validator_context();
         let validators = nonempty![
-            ctx.pub_key.to_address(),
+            ctx.core.pub_key.to_address(),
             keys[1].to_address(),
             keys[2].to_address(),
         ];
@@ -178,7 +179,7 @@ mod tests {
         let mut block = SimpleBlockData::mock(H256::random());
         block.header.timestamp = 1;
 
-        ctx.db.set_validators(block.hash, validators);
+        ctx.core.db.set_validators(block.hash, validators);
 
         let initial = Initial::create_with_chain_head(ctx, block.clone()).unwrap();
         let producer = initial.process_synced_block(block.hash).unwrap();

--- a/ethexe/consensus/src/validator/initial.rs
+++ b/ethexe/consensus/src/validator/initial.rs
@@ -135,14 +135,14 @@ mod tests {
 
     #[test]
     fn create_initial_success() {
-        let (ctx, _) = mock_validator_context();
+        let (ctx, _, _) = mock_validator_context();
         let initial = Initial::create(ctx).unwrap();
         assert!(initial.is_initial());
     }
 
     #[test]
     fn create_with_chain_head_success() {
-        let (ctx, _) = mock_validator_context();
+        let (ctx, _, _) = mock_validator_context();
         let block = SimpleBlockData::mock(H256::random());
         let initial = Initial::create_with_chain_head(ctx, block).unwrap();
         assert!(initial.is_initial());
@@ -150,7 +150,7 @@ mod tests {
 
     #[tokio::test]
     async fn switch_to_producer() {
-        let (ctx, keys) = mock_validator_context();
+        let (ctx, keys, _) = mock_validator_context();
         let validators = nonempty![
             ctx.core.pub_key.to_address(),
             keys[0].to_address(),
@@ -169,7 +169,7 @@ mod tests {
 
     #[test]
     fn switch_to_subordinate() {
-        let (ctx, keys) = mock_validator_context();
+        let (ctx, keys, _) = mock_validator_context();
         let validators = nonempty![
             ctx.core.pub_key.to_address(),
             keys[1].to_address(),
@@ -188,7 +188,7 @@ mod tests {
 
     #[test]
     fn process_synced_block_rejected() {
-        let (ctx, _) = mock_validator_context();
+        let (ctx, _, _) = mock_validator_context();
         let block = SimpleBlockData::mock(H256::random());
 
         let initial = Initial::create(ctx)
@@ -216,7 +216,7 @@ mod tests {
 
     #[test]
     fn producer_for_calculates_correct_producer() {
-        let (ctx, keys) = mock_validator_context();
+        let (ctx, keys, _) = mock_validator_context();
         let validators = NonEmpty::from_vec(keys.iter().map(|k| k.to_address()).collect()).unwrap();
         let timestamp = 10;
 

--- a/ethexe/consensus/src/validator/mock.rs
+++ b/ethexe/consensus/src/validator/mock.rs
@@ -16,8 +16,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use super::*;
+use super::{core::*, *};
+use crate::utils::MultisignedBatchCommitment;
 use anyhow::anyhow;
+use async_trait::async_trait;
 use std::cell::RefCell;
 
 thread_local! {
@@ -117,6 +119,8 @@ pub fn mock_validator_context() -> (ValidatorContext, Vec<PublicKey>) {
             db: Database::memory(),
             committer: Box::new(DummyCommitter),
             middleware: Some(Box::new(DummyMiddleware) as Box<dyn MiddlewareExt>),
+            validate_chain_deepness_limit: MAX_CHAIN_DEEPNESS,
+            chain_deepness_threshold: CHAIN_DEEPNESS_THRESHOLD,
         },
         pending_events: VecDeque::new(),
         output: VecDeque::new(),

--- a/ethexe/consensus/src/validator/mod.rs
+++ b/ethexe/consensus/src/validator/mod.rs
@@ -141,9 +141,13 @@ impl ValidatorService {
                 signer,
                 db: db.clone(),
                 committer: Box::new(EthereumCommitter { router }),
-                middleware: ethereum.middleware().map(|inner| {
-                    Box::new(MiddlewareWrapper::new(inner, db)) as Box<dyn MiddlewareExt>
-                }),
+                middleware: MiddlewareWrapper::new(
+                    ethereum
+                        .middleware()
+                        .map(|m| Box::new(m) as Box<dyn MiddlewareExt>)
+                        .unwrap_or_else(|| Box::new(())),
+                    db,
+                ),
                 validate_chain_deepness_limit: MAX_CHAIN_DEEPNESS,
                 chain_deepness_threshold: CHAIN_DEEPNESS_THRESHOLD,
             },

--- a/ethexe/consensus/src/validator/participant.rs
+++ b/ethexe/consensus/src/validator/participant.rs
@@ -181,7 +181,7 @@ mod tests {
 
     #[test]
     fn create() {
-        let (ctx, pub_keys) = mock_validator_context();
+        let (ctx, pub_keys, _) = mock_validator_context();
         let producer = pub_keys[0];
         let block = SimpleBlockData::mock(H256::random());
 
@@ -193,7 +193,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_with_pending_events() {
-        let (mut ctx, keys) = mock_validator_context();
+        let (mut ctx, keys, _) = mock_validator_context();
         let producer = keys[0];
         let alice = keys[1];
         let block = SimpleBlockData::mock(H256::random());
@@ -245,7 +245,7 @@ mod tests {
 
     #[tokio::test]
     async fn process_validation_request_success() {
-        let (ctx, pub_keys) = mock_validator_context();
+        let (ctx, pub_keys, _) = mock_validator_context();
         let producer = pub_keys[0];
         let batch = prepared_mock_batch_commitment(&ctx.core.db);
         let block = simple_block_data(&ctx.core.db, batch.block_hash);
@@ -279,7 +279,7 @@ mod tests {
 
     #[tokio::test]
     async fn process_validation_request_failure() {
-        let (ctx, pub_keys) = mock_validator_context();
+        let (ctx, pub_keys, _) = mock_validator_context();
         let producer = pub_keys[0];
         let block = SimpleBlockData::mock(H256::random());
         let signed_request = SignedValidationRequest::mock((ctx.core.signer.clone(), producer, ()));
@@ -299,7 +299,7 @@ mod tests {
 
     #[tokio::test]
     async fn codes_not_waiting_for_commitment_error() {
-        let (ctx, pub_keys) = mock_validator_context();
+        let (ctx, pub_keys, _) = mock_validator_context();
         let producer = pub_keys[0];
         let mut batch = prepared_mock_batch_commitment(&ctx.core.db);
         let block = simple_block_data(&ctx.core.db, batch.block_hash);
@@ -326,7 +326,7 @@ mod tests {
 
     #[tokio::test]
     async fn empty_batch_error() {
-        let (ctx, pub_keys) = mock_validator_context();
+        let (ctx, pub_keys, _) = mock_validator_context();
         let producer = pub_keys[0];
         let block = SimpleBlockData::mock(H256::random()).prepare(&ctx.core.db, H256::random());
 
@@ -356,7 +356,7 @@ mod tests {
 
     #[tokio::test]
     async fn duplicate_codes_warning() {
-        let (ctx, pub_keys) = mock_validator_context();
+        let (ctx, pub_keys, _) = mock_validator_context();
         let producer = pub_keys[0];
         let batch = prepared_mock_batch_commitment(&ctx.core.db);
         let block = simple_block_data(&ctx.core.db, batch.block_hash);
@@ -385,7 +385,7 @@ mod tests {
 
     #[tokio::test]
     async fn digest_mismatch_warning() {
-        let (ctx, pub_keys) = mock_validator_context();
+        let (ctx, pub_keys, _) = mock_validator_context();
         let producer = pub_keys[0];
         let batch = prepared_mock_batch_commitment(&ctx.core.db);
         let block = simple_block_data(&ctx.core.db, batch.block_hash);

--- a/ethexe/consensus/src/validator/submitter.rs
+++ b/ethexe/consensus/src/validator/submitter.rs
@@ -16,8 +16,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use super::{BatchCommitter, StateHandler, ValidatorContext, ValidatorState, initial::Initial};
-use crate::{ConsensusEvent, utils::MultisignedBatchCommitment};
+use super::{StateHandler, ValidatorContext, ValidatorState, initial::Initial};
+use crate::{ConsensusEvent, utils::MultisignedBatchCommitment, validator::core::BatchCommitter};
 use anyhow::Result;
 use async_trait::async_trait;
 use derive_more::{Debug, Display};

--- a/ethexe/consensus/src/validator/submitter.rs
+++ b/ethexe/consensus/src/validator/submitter.rs
@@ -107,7 +107,7 @@ mod tests {
 
     #[tokio::test]
     async fn submitter() {
-        let (ctx, _) = mock_validator_context();
+        let (ctx, _, eth) = mock_validator_context();
         let batch = BatchCommitment::mock(());
         let multisigned_batch = MultisignedBatchCommitment::new(
             batch,
@@ -124,6 +124,7 @@ mod tests {
         assert!(initial.is_initial());
         assert!(matches!(event, ConsensusEvent::CommitmentSubmitted(_)));
 
-        with_batch(|submitted_batch| assert_eq!(submitted_batch, Some(&multisigned_batch)));
+        let batch = eth.committed_batch.lock().await.clone();
+        assert_eq!(batch, Some(multisigned_batch));
     }
 }

--- a/ethexe/consensus/src/validator/subordinate.rs
+++ b/ethexe/consensus/src/validator/subordinate.rs
@@ -185,7 +185,7 @@ mod tests {
 
     #[test]
     fn create_empty() {
-        let (ctx, pub_keys) = mock_validator_context();
+        let (ctx, pub_keys, _) = mock_validator_context();
         let producer = pub_keys[0];
         let block = SimpleBlockData::mock(H256::random());
 
@@ -201,7 +201,7 @@ mod tests {
 
     #[test]
     fn create_with_producer_blocks() {
-        let (mut ctx, keys) = mock_validator_context();
+        let (mut ctx, keys, _) = mock_validator_context();
         let producer = keys[0];
         let block = SimpleBlockData::mock(H256::random());
         let pb1 = SignedProducerBlock::mock((ctx.core.signer.clone(), producer, block.hash));
@@ -227,7 +227,7 @@ mod tests {
 
     #[test]
     fn create_with_validation_requests() {
-        let (mut ctx, keys) = mock_validator_context();
+        let (mut ctx, keys, _) = mock_validator_context();
         let producer = keys[0];
         let block = SimpleBlockData::mock(H256::random());
         let request1 = SignedValidationRequest::mock((ctx.core.signer.clone(), producer, ()));
@@ -251,7 +251,7 @@ mod tests {
 
     #[test]
     fn create_with_many_pending_events() {
-        let (mut ctx, keys) = mock_validator_context();
+        let (mut ctx, keys, _) = mock_validator_context();
         let producer = keys[0];
         let block = SimpleBlockData::mock(H256::random());
         let pb = SignedProducerBlock::mock((ctx.core.signer.clone(), producer, block.hash));
@@ -273,7 +273,7 @@ mod tests {
 
     #[test]
     fn simple() {
-        let (ctx, pub_keys) = mock_validator_context();
+        let (ctx, pub_keys, _) = mock_validator_context();
         let producer = pub_keys[0];
         let block = SimpleBlockData::mock(H256::random());
         let pb = SignedProducerBlock::mock((ctx.core.signer.clone(), producer, block.hash));
@@ -301,7 +301,7 @@ mod tests {
 
     #[test]
     fn simple_not_validator() {
-        let (ctx, pub_keys) = mock_validator_context();
+        let (ctx, pub_keys, _) = mock_validator_context();
         let producer = pub_keys[0];
         let block = SimpleBlockData::mock(H256::random());
         let pb = SignedProducerBlock::mock((ctx.core.signer.clone(), producer, block.hash));
@@ -329,7 +329,7 @@ mod tests {
 
     #[test]
     fn create_with_multiple_producer_blocks() {
-        let (mut ctx, keys) = mock_validator_context();
+        let (mut ctx, keys, _) = mock_validator_context();
         let producer = keys[0];
         let block = SimpleBlockData::mock(H256::random());
         let pb1 = SignedProducerBlock::mock((ctx.core.signer.clone(), producer, block.hash));
@@ -346,7 +346,7 @@ mod tests {
 
     #[test]
     fn process_external_event_with_invalid_producer_block() {
-        let (ctx, pub_keys) = mock_validator_context();
+        let (ctx, pub_keys, _) = mock_validator_context();
         let producer = pub_keys[0];
         let block = SimpleBlockData::mock(H256::random());
         let invalid_pb =
@@ -363,7 +363,7 @@ mod tests {
 
     #[test]
     fn process_computed_block_with_unexpected_hash() {
-        let (ctx, pub_keys) = mock_validator_context();
+        let (ctx, pub_keys, _) = mock_validator_context();
         let producer = pub_keys[0];
         let block = SimpleBlockData::mock(H256::random());
         let unexpected_hash = H256::random();

--- a/ethexe/consensus/src/validator/subordinate.rs
+++ b/ethexe/consensus/src/validator/subordinate.rs
@@ -204,8 +204,8 @@ mod tests {
         let (mut ctx, keys) = mock_validator_context();
         let producer = keys[0];
         let block = SimpleBlockData::mock(H256::random());
-        let pb1 = SignedProducerBlock::mock((ctx.signer.clone(), producer, block.hash));
-        let pb2 = SignedProducerBlock::mock((ctx.signer.clone(), keys[1], block.hash));
+        let pb1 = SignedProducerBlock::mock((ctx.core.signer.clone(), producer, block.hash));
+        let pb2 = SignedProducerBlock::mock((ctx.core.signer.clone(), keys[1], block.hash));
 
         ctx.pending(pb1.clone());
         ctx.pending(pb2.clone());
@@ -230,8 +230,8 @@ mod tests {
         let (mut ctx, keys) = mock_validator_context();
         let producer = keys[0];
         let block = SimpleBlockData::mock(H256::random());
-        let request1 = SignedValidationRequest::mock((ctx.signer.clone(), producer, ()));
-        let request2 = SignedValidationRequest::mock((ctx.signer.clone(), keys[1], ()));
+        let request1 = SignedValidationRequest::mock((ctx.core.signer.clone(), producer, ()));
+        let request2 = SignedValidationRequest::mock((ctx.core.signer.clone(), keys[1], ()));
 
         ctx.pending(request1.clone());
         ctx.pending(request2.clone());
@@ -254,13 +254,13 @@ mod tests {
         let (mut ctx, keys) = mock_validator_context();
         let producer = keys[0];
         let block = SimpleBlockData::mock(H256::random());
-        let pb = SignedProducerBlock::mock((ctx.signer.clone(), producer, block.hash));
+        let pb = SignedProducerBlock::mock((ctx.core.signer.clone(), producer, block.hash));
 
         ctx.pending(pb.clone());
 
         // Fill with fake blocks
         for _ in 0..10 * MAX_PENDING_EVENTS {
-            let pb = SignedProducerBlock::mock((ctx.signer.clone(), keys[0], block.hash));
+            let pb = SignedProducerBlock::mock((ctx.core.signer.clone(), keys[0], block.hash));
             ctx.pending(pb);
         }
 
@@ -276,7 +276,7 @@ mod tests {
         let (ctx, pub_keys) = mock_validator_context();
         let producer = pub_keys[0];
         let block = SimpleBlockData::mock(H256::random());
-        let pb = SignedProducerBlock::mock((ctx.signer.clone(), producer, block.hash));
+        let pb = SignedProducerBlock::mock((ctx.core.signer.clone(), producer, block.hash));
 
         let s = Subordinate::create(ctx, block.clone(), producer.to_address(), true).unwrap();
         assert!(s.is_subordinate());
@@ -304,7 +304,7 @@ mod tests {
         let (ctx, pub_keys) = mock_validator_context();
         let producer = pub_keys[0];
         let block = SimpleBlockData::mock(H256::random());
-        let pb = SignedProducerBlock::mock((ctx.signer.clone(), producer, block.hash));
+        let pb = SignedProducerBlock::mock((ctx.core.signer.clone(), producer, block.hash));
 
         let s = Subordinate::create(ctx, block.clone(), producer.to_address(), false).unwrap();
         assert!(s.is_subordinate());
@@ -332,8 +332,8 @@ mod tests {
         let (mut ctx, keys) = mock_validator_context();
         let producer = keys[0];
         let block = SimpleBlockData::mock(H256::random());
-        let pb1 = SignedProducerBlock::mock((ctx.signer.clone(), producer, block.hash));
-        let pb2 = SignedProducerBlock::mock((ctx.signer.clone(), keys[1], block.hash));
+        let pb1 = SignedProducerBlock::mock((ctx.core.signer.clone(), producer, block.hash));
+        let pb2 = SignedProducerBlock::mock((ctx.core.signer.clone(), keys[1], block.hash));
 
         ctx.pending(pb1.clone());
         ctx.pending(pb2.clone());
@@ -349,7 +349,8 @@ mod tests {
         let (ctx, pub_keys) = mock_validator_context();
         let producer = pub_keys[0];
         let block = SimpleBlockData::mock(H256::random());
-        let invalid_pb = SignedProducerBlock::mock((ctx.signer.clone(), pub_keys[1], block.hash));
+        let invalid_pb =
+            SignedProducerBlock::mock((ctx.core.signer.clone(), pub_keys[1], block.hash));
 
         let mut s = Subordinate::create(ctx, block.clone(), producer.to_address(), true).unwrap();
 

--- a/ethexe/ethereum/src/deploy.rs
+++ b/ethexe/ethereum/src/deploy.rs
@@ -428,7 +428,7 @@ mod tests {
             .await?;
 
         let router = ethereum.router();
-        let middleware = ethereum.middleware();
+        let middleware = ethereum.middleware().unwrap();
 
         assert_eq!(
             middleware.query().router().await?,

--- a/ethexe/ethereum/src/lib.rs
+++ b/ethexe/ethereum/src/lib.rs
@@ -120,13 +120,12 @@ impl Ethereum {
         Router::new(self.router, self.wvara, self.provider())
     }
 
-    pub fn middleware(&self) -> Middleware {
-        debug_assert_ne!(
-            self.middleware,
-            Address::ZERO,
-            "Middleware address is zero. Make sure to deploy the middleware contract and pass `with_middleware` flag to `EthereumDeployer`."
-        );
-        Middleware::new(self.middleware, self.provider())
+    pub fn middleware(&self) -> Option<Middleware> {
+        if self.middleware == Address::ZERO {
+            None
+        } else {
+            Some(Middleware::new(self.middleware, self.provider()))
+        }
     }
 }
 


### PR DESCRIPTION
The problem was in ValidatorState Stream implementation, where we call poll_next_state only once. This can cause problems if some state would wait for a new future finish after poll_next_state calling and if no events generated. Because there were no situation like this in present consensus implementation - we do not observe tests hang on.

Additionally prepare consensus for more async logic inside, in order to use it for rewards and validators in nearest future.

Bug was found by @ecol-master