### PR TITLE
feat(pallet-gear): Skip mailbox insertion on zero destination

### DIFF
--- a/pallets/gear/src/internal.rs
+++ b/pallets/gear/src/internal.rs
@@ -1056,6 +1056,17 @@ where
                 log::error!("{err_msg}");
                 unreachable!("{err_msg}")
             });
+
+            // Validate that destination is not a zero address
+            if message.destination() == ActorId::zero() {
+                log::warn!(
+                    "send_user_message: attempted to insert message into mailbox with zero destination address. \
+                    Message id - {message_id}, source - {from:?}. Skipping mailbox insertion.",
+                    from = message.source(),
+                );
+                return None;
+            }
+
             MailboxOf::<T>::insert(message, hold.expected()).unwrap_or_else(|e| {
                 let err_msg = format!(
                     "send_user_message: failed inserting message into mailbox. \
@@ -1207,6 +1218,17 @@ where
                     log::error!("{err_msg}");
                     unreachable!("{err_msg}")
                 });
+
+            // Validate that destination is not a zero address
+            if message.destination() == ActorId::zero() {
+                log::warn!(
+                    "send_user_message_after_delay: attempted to insert message into mailbox with zero destination address. \
+                        Message id - {message_id}, source - {from:?}. Skipping mailbox insertion.",
+                    from = message.source(),
+                );
+                return None;
+            }
+
             MailboxOf::<T>::insert(message, hold.expected()).unwrap_or_else(|e| {
                 let err_msg = format!(
                     "send_user_message_after_delay: failed inserting message into mailbox. \

--- a/pallets/gear/src/internal.rs
+++ b/pallets/gear/src/internal.rs
@@ -1064,7 +1064,7 @@ where
                     Message id - {message_id}, source - {from:?}. Skipping mailbox insertion.",
                     from = message.source(),
                 );
-                return None;
+                return;
             }
 
             MailboxOf::<T>::insert(message, hold.expected()).unwrap_or_else(|e| {
@@ -1226,7 +1226,7 @@ where
                         Message id - {message_id}, source - {from:?}. Skipping mailbox insertion.",
                     from = message.source(),
                 );
-                return None;
+                return;
             }
 
             MailboxOf::<T>::insert(message, hold.expected()).unwrap_or_else(|e| {


### PR DESCRIPTION
Skip inserting user messages with a zero destination so we no longer lock gas/value or queue mailbox tasks for an invalid actor.
Tests now cover the zero-address path and the reservation cleanup and were updated to match the corrected value accounting.

@gear-tech/dev 