### PR TITLE
refactor: rework `Read*` accessors in `core-backend`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2138,9 +2138,23 @@ checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "bytemuck"
-version = "1.13.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "byteorder"
@@ -6250,6 +6264,7 @@ version = "1.9.2"
 dependencies = [
  "actor-system-error",
  "blake2 0.10.6",
+ "bytemuck",
  "derive_more 2.0.1",
  "gear-core",
  "gear-core-errors",
@@ -6986,6 +7001,7 @@ version = "1.9.2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
+ "bytemuck",
  "derive_more 2.0.1",
  "gear-ss58",
  "hex",
@@ -7125,6 +7141,9 @@ dependencies = [
 [[package]]
 name = "gsys"
 version = "1.9.2"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "gtest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ arbitrary = "1.3.2"
 async-recursion = "1.1.1"
 async-trait = "0.1.81"
 base64 = "0.21.7"
+bytemuck = "1.23.2" 
 byteorder = { version = "1.5.0", default-features = false }
 blake2 = { version = "0.10.6", default-features = false }
 bs58 = { version = "0.5.1", default-features = false }

--- a/core-backend/Cargo.toml
+++ b/core-backend/Cargo.toml
@@ -23,6 +23,7 @@ gear-sandbox-env.workspace = true
 actor-system-error.workspace = true
 
 blake2.workspace = true
+bytemuck = { workspace = true, features = ["const_zeroed"] }
 # Use max_level_debug feature to remove tracing in syscalls by default.
 log.workspace = true
 derive_more.workspace = true
@@ -31,6 +32,7 @@ parity-scale-codec.workspace = true
 [dev-dependencies]
 parity-scale-codec.workspace = true
 tracing-subscriber.workspace = true
+bytemuck = { workspace = true, features = ["derive"] }
 
 [features]
 default = ["std"]

--- a/core-backend/src/accessors.rs
+++ b/core-backend/src/accessors.rs
@@ -29,10 +29,7 @@ use crate::{
 };
 use alloc::vec::Vec;
 use bytemuck::Pod;
-use gear_core::{
-    buffer::{Payload, PayloadSizeError},
-    limited::LimitedVecError,
-};
+use gear_core::{buffer::Payload, limited::LimitedVecError};
 use gear_sandbox::{AsContextExt, Value};
 use gear_sandbox_env::HostError;
 
@@ -461,11 +458,11 @@ impl WriteInGrRead {
     }
 }
 
-impl<T> WriteAs<T> {
+impl<T: Pod> WriteAs<T> {
     pub fn write<Caller, Ext>(
         self,
         ctx: &mut MemoryCallerContext<Caller>,
-        obj: T,
+        obj: &T,
     ) -> Result<(), MemoryAccessError>
     where
         Caller: AsContextExt<State = HostState<Ext, BackendMemory<ExecutorMemory>>>,

--- a/core-backend/src/funcs.rs
+++ b/core-backend/src/funcs.rs
@@ -35,6 +35,7 @@ use crate::{
 };
 use alloc::{format, string::String};
 use blake2::{Blake2b, Digest, digest::typenum::U32};
+use bytemuck::Pod;
 use core::marker::PhantomData;
 use gear_core::{
     buffer::{Payload, RuntimeBuffer},
@@ -230,7 +231,7 @@ impl<F> FallibleSyscall<(), F> {
 impl<T, E, F, Caller, Ext> Syscall<Caller, ()> for FallibleSyscall<E, F>
 where
     F: FnOnce(&mut MemoryCallerContext<Caller>) -> Result<T, RunFallibleError>,
-    E: From<Result<T, u32>>,
+    E: From<Result<T, u32>> + Pod,
     Caller: AsContextExt<State = HostState<Ext, BackendMemory<ExecutorMemory>>>,
     Ext: BackendExternalities + 'static,
 {
@@ -548,7 +549,7 @@ where
             move |ctx: &mut MemoryCallerContext<Caller>| {
                 let size = ctx.caller_wrap.ext_mut().size()? as u32;
 
-                size_write.write(ctx, size).map_err(Into::into)
+                size_write.write(ctx, &size).map_err(Into::into)
             },
         )
     }
@@ -689,7 +690,7 @@ where
             move |ctx: &mut MemoryCallerContext<Caller>| {
                 let height = ctx.caller_wrap.ext_mut().block_height()?;
 
-                height_write.write(ctx, height).map_err(Into::into)
+                height_write.write(ctx, &height).map_err(Into::into)
             },
         )
     }
@@ -700,7 +701,7 @@ where
             move |ctx: &mut MemoryCallerContext<Caller>| {
                 let timestamp = ctx.caller_wrap.ext_mut().block_timestamp()?;
 
-                timestamp_write.write(ctx, timestamp).map_err(Into::into)
+                timestamp_write.write(ctx, &timestamp).map_err(Into::into)
             },
         )
     }
@@ -721,7 +722,7 @@ where
                 let hash = blake2_ctx.finalize().into();
 
                 bn_random_ptr
-                    .write(ctx, BlockNumberWithHash { bn, hash })
+                    .write(ctx, &BlockNumberWithHash { bn, hash })
                     .map_err(Into::into)
             },
         )
@@ -1101,7 +1102,7 @@ where
             move |ctx: &mut MemoryCallerContext<Caller>| {
                 let gas_available = ctx.caller_wrap.ext_mut().gas_available()?;
 
-                gas.write(ctx, gas_available).map_err(Into::into)
+                gas.write(ctx, &gas_available).map_err(Into::into)
             },
         )
     }
@@ -1112,7 +1113,7 @@ where
             move |ctx: &mut MemoryCallerContext<Caller>| {
                 let message_id = ctx.caller_wrap.ext_mut().message_id()?;
 
-                message_id_write.write(ctx, message_id).map_err(Into::into)
+                message_id_write.write(ctx, &message_id).map_err(Into::into)
             },
         )
     }
@@ -1123,7 +1124,7 @@ where
             move |ctx: &mut MemoryCallerContext<Caller>| {
                 let program_id = ctx.caller_wrap.ext_mut().program_id()?;
 
-                program_id_write.write(ctx, program_id).map_err(Into::into)
+                program_id_write.write(ctx, &program_id).map_err(Into::into)
             },
         )
     }
@@ -1134,7 +1135,7 @@ where
             move |ctx: &mut MemoryCallerContext<Caller>| {
                 let source = ctx.caller_wrap.ext_mut().source()?;
 
-                source_write.write(ctx, source).map_err(Into::into)
+                source_write.write(ctx, &source).map_err(Into::into)
             },
         )
     }
@@ -1145,7 +1146,7 @@ where
             move |ctx: &mut MemoryCallerContext<Caller>| {
                 let value = ctx.caller_wrap.ext_mut().value()?;
 
-                value_write.write(ctx, value).map_err(Into::into)
+                value_write.write(ctx, &value).map_err(Into::into)
             },
         )
     }
@@ -1156,7 +1157,7 @@ where
             move |ctx: &mut MemoryCallerContext<Caller>| {
                 let value_available = ctx.caller_wrap.ext_mut().value_available()?;
 
-                value_write.write(ctx, value_available).map_err(Into::into)
+                value_write.write(ctx, &value_available).map_err(Into::into)
             },
         )
     }

--- a/core-backend/src/funcs.rs
+++ b/core-backend/src/funcs.rs
@@ -21,8 +21,8 @@
 use crate::{
     BackendExternalities,
     accessors::{
-        Read, ReadAs, ReadDecoded, ReadDecodedSpecial, ReadPayloadLimited, SyscallArg,
-        SyscallValue, WriteAs, WriteInGrRead,
+        Read, ReadAs, ReadAsOption, ReadPayloadLimited, SyscallArg, SyscallValue, WriteAs,
+        WriteInGrRead,
     },
     error::{
         ActorTerminationReason, BackendAllocSyscallError, BackendSyscallError, RunFallibleError,
@@ -553,7 +553,7 @@ where
         )
     }
 
-    pub fn exit(inheritor_id: ReadDecoded<ActorId>) -> impl Syscall<Caller> {
+    pub fn exit(inheritor_id: ReadAs<ActorId>) -> impl Syscall<Caller> {
         InfallibleSyscall::new(
             CostToken::Exit,
             move |_ctx: &mut MemoryCallerContext<Caller>| {
@@ -706,7 +706,7 @@ where
     }
 
     pub fn random(
-        subject_ptr: ReadDecoded<Hash>,
+        subject_ptr: ReadAs<Hash>,
         bn_random_ptr: WriteAs<BlockNumberWithHash>,
     ) -> impl Syscall<Caller> {
         InfallibleSyscall::new(
@@ -731,9 +731,9 @@ where
         ctx: &mut MemoryCallerContext<Caller>,
         payload: ReadPayloadLimited,
         gas_limit: Option<u64>,
-        value: ReadDecodedSpecial<u128>,
+        value: ReadAsOption<u128>,
     ) -> Result<MessageId, RunFallibleError> {
-        let value = value.into_inner()?;
+        let value = value.into_inner()?.unwrap_or(0);
         let payload = Self::read_payload(payload)?;
 
         ctx.caller_wrap
@@ -742,10 +742,7 @@ where
             .map_err(Into::into)
     }
 
-    pub fn reply(
-        payload: ReadPayloadLimited,
-        value: ReadDecodedSpecial<u128>,
-    ) -> impl Syscall<Caller> {
+    pub fn reply(payload: ReadPayloadLimited, value: ReadAsOption<u128>) -> impl Syscall<Caller> {
         FallibleSyscall::new::<ErrorWithHash>(
             CostToken::Reply(payload.size().into()),
             move |ctx: &mut MemoryCallerContext<Caller>| {
@@ -757,7 +754,7 @@ where
     pub fn reply_wgas(
         payload: ReadPayloadLimited,
         gas_limit: u64,
-        value: ReadDecodedSpecial<u128>,
+        value: ReadAsOption<u128>,
     ) -> impl Syscall<Caller> {
         FallibleSyscall::new::<ErrorWithHash>(
             CostToken::ReplyWGas(payload.size().into()),
@@ -770,9 +767,9 @@ where
     fn reply_commit_inner(
         ctx: &mut MemoryCallerContext<Caller>,
         gas_limit: Option<u64>,
-        value: ReadDecodedSpecial<u128>,
+        value: ReadAsOption<u128>,
     ) -> Result<MessageId, RunFallibleError> {
-        let value = value.into_inner()?;
+        let value = value.into_inner()?.unwrap_or(0);
 
         ctx.caller_wrap
             .ext_mut()
@@ -784,17 +781,14 @@ where
             .map_err(Into::into)
     }
 
-    pub fn reply_commit(value: ReadDecodedSpecial<u128>) -> impl Syscall<Caller> {
+    pub fn reply_commit(value: ReadAsOption<u128>) -> impl Syscall<Caller> {
         FallibleSyscall::new::<ErrorWithHash>(
             CostToken::ReplyCommit,
             move |ctx: &mut MemoryCallerContext<Caller>| Self::reply_commit_inner(ctx, None, value),
         )
     }
 
-    pub fn reply_commit_wgas(
-        gas_limit: u64,
-        value: ReadDecodedSpecial<u128>,
-    ) -> impl Syscall<Caller> {
+    pub fn reply_commit_wgas(gas_limit: u64, value: ReadAsOption<u128>) -> impl Syscall<Caller> {
         FallibleSyscall::new::<ErrorWithHash>(
             CostToken::ReplyCommitWGas,
             move |ctx: &mut MemoryCallerContext<Caller>| {
@@ -881,9 +875,9 @@ where
         offset: u32,
         len: u32,
         gas_limit: Option<u64>,
-        value: ReadDecodedSpecial<u128>,
+        value: ReadAsOption<u128>,
     ) -> Result<MessageId, RunFallibleError> {
-        let value = value.into_inner()?;
+        let value = value.into_inner()?.unwrap_or(0);
 
         // Charge for `len` is inside `reply_push_input`
         ctx.caller_wrap.ext_mut().reply_push_input(offset, len)?;
@@ -898,11 +892,7 @@ where
             .map_err(Into::into)
     }
 
-    pub fn reply_input(
-        offset: u32,
-        len: u32,
-        value: ReadDecodedSpecial<u128>,
-    ) -> impl Syscall<Caller> {
+    pub fn reply_input(offset: u32, len: u32, value: ReadAsOption<u128>) -> impl Syscall<Caller> {
         FallibleSyscall::new::<ErrorWithHash>(
             CostToken::ReplyInput,
             move |ctx: &mut MemoryCallerContext<Caller>| {
@@ -915,7 +905,7 @@ where
         offset: u32,
         len: u32,
         gas_limit: u64,
-        value: ReadDecodedSpecial<u128>,
+        value: ReadAsOption<u128>,
     ) -> impl Syscall<Caller> {
         FallibleSyscall::new::<ErrorWithHash>(
             CostToken::ReplyInputWGas,
@@ -1065,10 +1055,7 @@ where
         )
     }
 
-    pub fn reply_deposit(
-        message_id: ReadDecoded<MessageId>,
-        gas_value: u64,
-    ) -> impl Syscall<Caller> {
+    pub fn reply_deposit(message_id: ReadAs<MessageId>, gas_value: u64) -> impl Syscall<Caller> {
         FallibleSyscall::new::<ErrorBytes>(
             CostToken::ReplyDeposit,
             move |ctx: &mut MemoryCallerContext<Caller>| {
@@ -1082,7 +1069,7 @@ where
         )
     }
 
-    pub fn unreserve_gas(reservation_id: ReadDecoded<ReservationId>) -> impl Syscall<Caller> {
+    pub fn unreserve_gas(reservation_id: ReadAs<ReservationId>) -> impl Syscall<Caller> {
         FallibleSyscall::new::<ErrorWithGas>(
             CostToken::UnreserveGas,
             move |ctx: &mut MemoryCallerContext<Caller>| {
@@ -1215,7 +1202,7 @@ where
         )
     }
 
-    pub fn wake(message_id: ReadDecoded<MessageId>, delay: u32) -> impl Syscall<Caller> {
+    pub fn wake(message_id: ReadAs<MessageId>, delay: u32) -> impl Syscall<Caller> {
         FallibleSyscall::new::<ErrorBytes>(
             CostToken::Wake,
             move |ctx: &mut MemoryCallerContext<Caller>| {

--- a/core-backend/src/memory.rs
+++ b/core-backend/src/memory.rs
@@ -28,7 +28,8 @@ use crate::{
     state::HostState,
 };
 use alloc::{format, vec::Vec};
-use core::{marker::PhantomData, mem::MaybeUninit, slice};
+use bytemuck::Pod;
+use core::{marker::PhantomData, slice};
 use gear_core::{
     buffer::RuntimeBuffer,
     limited::LimitedVecError,
@@ -38,7 +39,6 @@ use gear_core::{
 use gear_core_errors::MemoryError as FallibleMemoryError;
 use gear_lazy_pages_common::ProcessAccessError;
 use gear_sandbox::{AsContextExt, SandboxMemory};
-use parity_scale_codec::{Decode, DecodeAll, MaxEncodedLen};
 
 pub type ExecutorMemory = gear_sandbox::default_executor::Memory;
 
@@ -98,8 +98,6 @@ pub(crate) enum MemoryAccessError {
     Memory(MemoryError),
     ProcessAccess(ProcessAccessError),
     RuntimeBuffer(LimitedVecError),
-    // TODO: remove #2164
-    Decode,
 }
 
 impl BackendSyscallError for MemoryAccessError {
@@ -122,15 +120,6 @@ impl BackendSyscallError for MemoryAccessError {
             // it will be parsed and handled further (issue #3018).
             MemoryAccessError::ProcessAccess(ProcessAccessError::GasLimitExceeded) => {
                 UndefinedTerminationReason::ProcessAccessErrorResourcesExceed
-            }
-            e @ MemoryAccessError::Decode => {
-                let err_msg = format!(
-                    "MemoryAccessError::into_termination_reason: failed to decode memory. \
-                    Got error - {e:?}"
-                );
-
-                log::error!("{err_msg}");
-                unreachable!("{err_msg}")
             }
         }
     }
@@ -212,20 +201,6 @@ where
         }
     }
 
-    pub(crate) fn register_read_decoded<T: Decode + MaxEncodedLen>(
-        &mut self,
-        ptr: u32,
-    ) -> WasmMemoryReadDecoded<T> {
-        let size = T::max_encoded_len() as u32;
-        if size > 0 {
-            self.reads.push(MemoryInterval { offset: ptr, size });
-        }
-        WasmMemoryReadDecoded {
-            ptr,
-            _phantom: PhantomData,
-        }
-    }
-
     pub(crate) fn register_write(&mut self, ptr: u32, size: u32) -> WasmMemoryWrite {
         if size > 0 {
             self.writes.push(MemoryInterval { offset: ptr, size });
@@ -293,48 +268,19 @@ where
         Ok(buff)
     }
 
-    pub(crate) fn read_as<T: Sized>(
+    pub(crate) fn read_as<T: Pod>(
         &self,
         ctx: &mut CallerWrap<Context>,
         read: WasmMemoryReadAs<T>,
     ) -> Result<T, MemoryAccessError> {
-        let mut buf = MaybeUninit::<T>::uninit();
+        let mut value = bytemuck::zeroed();
 
-        let size = size_of::<T>();
-        if size > 0 {
-            // # Safety:
-            //
-            // Usage of mutable slice is safe for the same reason from `write_as`.
-            // `MaybeUninit` is presented on stack as a contiguous sequence of bytes.
-            //
-            // It's also safe to construct T from any bytes, because we use the fn
-            // only for reading primitive const-size types that are `[repr(C)]`,
-            // so they always represented from a sequence of bytes.
-            //
-            // Bytes in memory are always stored continuously and without paddings, properly
-            // aligned due to `[repr(C, packed)]` attribute of the types we use as T.
-            let mut_slice = unsafe { slice::from_raw_parts_mut(buf.as_mut_ptr() as *mut u8, size) };
-
-            self.memory.read(ctx.caller, read.ptr, mut_slice)?;
+        if std::mem::size_of::<T>() != 0 {
+            self.memory
+                .read(ctx.caller, read.ptr, bytemuck::bytes_of_mut(&mut value))?;
         }
-        Ok(unsafe { buf.assume_init() })
-    }
 
-    pub(crate) fn read_decoded<T: Decode + MaxEncodedLen>(
-        &self,
-        ctx: &mut CallerWrap<Context>,
-        read: WasmMemoryReadDecoded<T>,
-    ) -> Result<T, MemoryAccessError> {
-        let size = T::max_encoded_len();
-        let buff = if size == 0 {
-            Vec::new()
-        } else {
-            let mut buff = RuntimeBuffer::try_repeat(0, size)?.into_vec();
-            self.memory.read(ctx.caller, read.ptr, &mut buff)?;
-            buff
-        };
-        let decoded = T::decode_all(&mut &buff[..]).map_err(|_| MemoryAccessError::Decode)?;
-        Ok(decoded)
+        Ok(value)
     }
 
     pub(crate) fn write(
@@ -394,25 +340,18 @@ where
     }
 }
 
-/// Read static size type access wrapper.
-#[must_use]
-pub(crate) struct WasmMemoryReadAs<T> {
-    pub ptr: u32,
-    _phantom: PhantomData<T>,
-}
-
-/// Read decoded type access wrapper.
-#[must_use]
-pub(crate) struct WasmMemoryReadDecoded<T: Decode + MaxEncodedLen> {
-    pub ptr: u32,
-    _phantom: PhantomData<T>,
-}
-
 /// Read access wrapper.
 #[must_use]
 pub(crate) struct WasmMemoryRead {
     pub ptr: u32,
     pub size: u32,
+}
+
+/// Read static size type access wrapper.
+#[must_use]
+pub(crate) struct WasmMemoryReadAs<T> {
+    pub ptr: u32,
+    _phantom: PhantomData<T>,
 }
 
 /// Write static size type access wrapper.
@@ -436,6 +375,7 @@ mod tests {
         mock::{MockExt, MockMemory},
         state::State,
     };
+    use bytemuck::Zeroable;
     use gear_core::pages::WasmPage;
     use gear_sandbox::{SandboxStore, default_executor::Store};
     use parity_scale_codec::Encode;
@@ -445,7 +385,8 @@ mod tests {
     type MemoryAccessIo<'a> =
         crate::memory::MemoryAccessIo<Store<HostState<MockExt, MockMemory>>, MockMemory>;
 
-    #[derive(Encode, Decode, MaxEncodedLen)]
+    #[derive(Encode, Clone, Copy, Pod, Zeroable)]
+    #[repr(C)]
     struct ZeroSizeStruct;
 
     fn new_store() -> Store<HostState<MockExt, MockMemory>> {
@@ -542,9 +483,9 @@ mod tests {
         let mut caller_wrap = CallerWrap::new(&mut store);
 
         let mut registry = MemoryAccessRegistry::default();
-        let read = registry.register_read_decoded::<ZeroSizeStruct>(0);
+        let read = registry.register_read_as::<ZeroSizeStruct>(0);
         let io: MemoryAccessIo = registry.pre_process(&mut caller_wrap).unwrap();
-        io.read_decoded(&mut caller_wrap, read).unwrap();
+        io.read_as(&mut caller_wrap, read).unwrap();
         assert_eq!(caller_wrap.state_mut().memory.read_attempt_count(), 0);
     }
 
@@ -580,72 +521,16 @@ mod tests {
     }
 
     #[test]
-    fn test_read_decoded_with_valid_encoded_data() {
-        #[derive(Encode, Decode, Debug, PartialEq)]
-        struct MockEncodeData {
-            data: u64,
-        }
-
-        let mut store = new_store();
-        let mut caller_wrap = CallerWrap::new(&mut store);
-        let memory = &mut caller_wrap.state_mut().memory;
-        *memory = MockMemory::new(1);
-        let encoded = MockEncodeData { data: 1234 }.encode();
-        memory.write(&mut (), 0, &encoded).unwrap();
-
-        let mut registry = MemoryAccessRegistry::default();
-        let read = registry.register_read_decoded::<u64>(0);
-        let io: MemoryAccessIo = registry.pre_process(&mut caller_wrap).unwrap();
-        let data: u64 = io.read_decoded(&mut caller_wrap, read).unwrap();
-        assert_eq!(data, 1234u64);
-    }
-
-    #[test]
-    fn test_read_decoded_with_invalid_encoded_data() {
-        #[derive(Debug)]
-        struct InvalidDecode {}
-
-        impl Decode for InvalidDecode {
-            fn decode<T>(_input: &mut T) -> Result<Self, parity_scale_codec::Error> {
-                Err("Invalid decoding".into())
-            }
-        }
-
-        impl Encode for InvalidDecode {
-            fn encode_to<T: parity_scale_codec::Output + ?Sized>(&self, _dest: &mut T) {}
-        }
-
-        impl MaxEncodedLen for InvalidDecode {
-            fn max_encoded_len() -> usize {
-                0
-            }
-        }
-
-        let mut store = new_store();
-        let mut caller_wrap = CallerWrap::new(&mut store);
-        let memory = &mut caller_wrap.state_mut().memory;
-        *memory = MockMemory::new(1);
-        let encoded = alloc::vec![7u8; WasmPage::SIZE as usize];
-        memory.write(&mut (), 0, &encoded).unwrap();
-
-        let mut registry = MemoryAccessRegistry::default();
-        let read = registry.register_read_decoded::<InvalidDecode>(0);
-        let io: MemoryAccessIo = registry.pre_process(&mut caller_wrap).unwrap();
-        io.read_decoded::<InvalidDecode>(&mut caller_wrap, read)
-            .unwrap_err();
-    }
-
-    #[test]
-    fn test_read_decoded_reading_error() {
+    fn test_read_as_reading_error() {
         let mut store = new_store();
         let mut caller_wrap = CallerWrap::new(&mut store);
         caller_wrap.state_mut().memory = MockMemory::new(1);
         let mut registry = MemoryAccessRegistry::default();
-        let _read = registry.register_read_decoded::<u64>(0);
+        let _read = registry.register_read_as::<u64>(0);
         let io: MemoryAccessIo = registry.pre_process(&mut caller_wrap).unwrap();
-        io.read_decoded::<u64>(
+        io.read_as::<u64>(
             &mut caller_wrap,
-            WasmMemoryReadDecoded {
+            WasmMemoryReadAs {
                 ptr: u32::MAX,
                 _phantom: PhantomData,
             },
@@ -668,6 +553,38 @@ mod tests {
         let io: MemoryAccessIo = registry.pre_process(&mut caller_wrap).unwrap();
         let decoded = io.read_as::<u64>(&mut caller_wrap, read).unwrap();
         assert_eq!(decoded, 1234);
+    }
+
+    #[test]
+    fn test_read_as_struct() {
+        #[derive(Encode, Debug, PartialEq, Clone, Copy, Zeroable, Pod)]
+        #[repr(C)]
+        struct MockEncodeData {
+            a: u64,
+            b: u64,
+            c: u32,
+            d: u32,
+        }
+
+        let mut store = new_store();
+        let mut caller_wrap = CallerWrap::new(&mut store);
+        let memory = &mut caller_wrap.state_mut().memory;
+        *memory = MockMemory::new(1);
+        let original_data = MockEncodeData {
+            a: 12,
+            b: 34,
+            c: 56,
+            d: 78,
+        };
+        memory
+            .write(&mut (), 0, bytemuck::bytes_of(&original_data))
+            .unwrap();
+
+        let mut registry = MemoryAccessRegistry::default();
+        let read = registry.register_read_as::<MockEncodeData>(0);
+        let io: MemoryAccessIo = registry.pre_process(&mut caller_wrap).unwrap();
+        let data = io.read_as(&mut caller_wrap, read).unwrap();
+        assert_eq!(data, original_data);
     }
 
     #[test]
@@ -842,10 +759,10 @@ mod tests {
     }
 
     #[test]
-    fn test_register_read_of_zero_size_encoded_value() {
+    fn test_register_read_of_zero_size_value() {
         let mut mem_access_manager = MemoryAccessRegistry::default();
 
-        let _read = mem_access_manager.register_read_decoded::<ZeroSizeStruct>(142);
+        let _read = mem_access_manager.register_read_as::<ZeroSizeStruct>(142);
 
         assert_eq!(mem_access_manager.reads.len(), 0);
     }
@@ -876,7 +793,8 @@ mod tests {
         assert_eq!(registry.reads[0].size, size_of::<u8>() as u32);
     }
 
-    #[derive(Debug, PartialEq, Eq, Encode, Decode, MaxEncodedLen)]
+    #[repr(C, packed)]
+    #[derive(Debug, PartialEq, Eq, Clone, Copy, Zeroable, Pod)]
     struct TestStruct {
         a: u32,
         b: u64,
@@ -886,26 +804,32 @@ mod tests {
     fn test_register_read_decoded_with_valid_interval() {
         let mut registry = MemoryAccessRegistry::default();
 
-        let result = registry.register_read_decoded::<TestStruct>(0);
+        let result = registry.register_read_as::<TestStruct>(0);
 
         assert_eq!(result.ptr, 0);
         assert_eq!(registry.reads.len(), 1);
         assert_eq!(registry.writes.len(), 0);
         assert_eq!(registry.reads[0].offset, 0);
-        assert_eq!(registry.reads[0].size, TestStruct::max_encoded_len() as u32);
+        assert_eq!(
+            registry.reads[0].size,
+            std::mem::size_of::<TestStruct>() as u32
+        );
     }
 
     #[test]
-    fn test_register_read_decoded_with_zero_size() {
+    fn test_register_read_with_non_zero_size() {
         let mut registry = MemoryAccessRegistry::default();
 
-        let result = registry.register_read_decoded::<TestStruct>(0);
+        let result = registry.register_read_as::<TestStruct>(0);
 
         assert_eq!(result.ptr, 0);
         assert_eq!(registry.reads.len(), 1);
         assert_eq!(registry.writes.len(), 0);
         assert_eq!(registry.reads[0].offset, 0);
-        assert_eq!(registry.reads[0].size, TestStruct::max_encoded_len() as u32);
+        assert_eq!(
+            registry.reads[0].size,
+            std::mem::size_of::<TestStruct>() as u32
+        );
     }
 
     #[test]

--- a/gprimitives/Cargo.toml
+++ b/gprimitives/Cargo.toml
@@ -13,6 +13,7 @@ rust-version.workspace = true
 [dependencies]
 alloy-primitives = { workspace = true, optional = true }
 alloy-sol-types = { workspace = true, optional = true }
+bytemuck = { workspace = true, features = ["derive"] }
 derive_more.workspace = true
 primitive-types = { workspace = true, features = ["scale-info", "rustc-hex"] }
 scale-info = { workspace = true, features = ["derive"], optional = true }

--- a/gprimitives/src/lib.rs
+++ b/gprimitives/src/lib.rs
@@ -26,6 +26,7 @@
 
 extern crate alloc;
 
+use bytemuck::{Pod, Zeroable};
 pub use gear_ss58::Ss58Address;
 pub use nonzero_u256::NonZeroU256;
 pub use primitive_types::{H160, H256, U256};
@@ -75,7 +76,7 @@ pub enum ConversionError {
 /// initialization, filling the message with payload (can be gradual), and
 /// message sending.
 #[repr(transparent)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, From, Into)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, From, Into, Zeroable, Pod)]
 #[cfg_attr(feature = "codec", derive(TypeInfo, Encode, Decode, MaxEncodedLen), codec(crate = scale))]
 pub struct MessageHandle(u32);
 
@@ -88,7 +89,23 @@ pub struct MessageHandle(u32);
 /// `ActorId` as one of the arguments.
 ///
 /// NOTE: Implementation of `From<u64>` places bytes from idx=12 for Eth compatibility.
-#[derive(Clone, Copy, Default, Hash, Ord, PartialEq, PartialOrd, Eq, From, Into, AsRef, AsMut)]
+#[repr(transparent)]
+#[derive(
+    Clone,
+    Copy,
+    Default,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Eq,
+    From,
+    Into,
+    AsRef,
+    AsMut,
+    Zeroable,
+    Pod,
+)]
 #[as_ref(forward)]
 #[as_mut(forward)]
 #[cfg_attr(feature = "codec", derive(TypeInfo, Encode, Decode, MaxEncodedLen), codec(crate = scale))]
@@ -293,7 +310,23 @@ impl<'de> Deserialize<'de> for ActorId {
 /// struct. The message identifier can be obtained for the currently processed
 /// message using the `gstd::msg::id()` function. Also, each send and reply
 /// functions return a message identifier.
-#[derive(Clone, Copy, Default, Hash, Ord, PartialEq, PartialOrd, Eq, From, Into, AsRef, AsMut)]
+#[repr(transparent)]
+#[derive(
+    Clone,
+    Copy,
+    Default,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Eq,
+    From,
+    Into,
+    AsRef,
+    AsMut,
+    Zeroable,
+    Pod,
+)]
 #[as_ref(forward)]
 #[as_mut(forward)]
 #[cfg_attr(feature = "codec", derive(TypeInfo, Encode, Decode, MaxEncodedLen), codec(crate = scale))]
@@ -309,7 +342,23 @@ macros::impl_primitive!(new zero into_bytes from_u64 from_h256 into_h256 from_st
 ///
 /// Code identifier is required when creating programs from programs (see
 /// `gstd::prog` module for details).
-#[derive(Clone, Copy, Default, Hash, Ord, PartialEq, PartialOrd, Eq, From, Into, AsRef, AsMut)]
+#[repr(transparent)]
+#[derive(
+    Clone,
+    Copy,
+    Default,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Eq,
+    From,
+    Into,
+    AsRef,
+    AsMut,
+    Zeroable,
+    Pod,
+)]
 #[as_ref(forward)]
 #[as_mut(forward)]
 #[cfg_attr(feature = "codec", derive(TypeInfo, Encode, Decode, MaxEncodedLen), codec(crate = scale))]
@@ -321,7 +370,23 @@ macros::impl_primitive!(new zero into_bytes from_u64 from_h256 into_h256 from_st
 ///
 /// The identifier is used to reserve and unreserve gas amount for program
 /// execution later.
-#[derive(Clone, Copy, Default, Hash, Ord, PartialEq, PartialOrd, Eq, From, Into, AsRef, AsMut)]
+#[repr(transparent)]
+#[derive(
+    Clone,
+    Copy,
+    Default,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Eq,
+    From,
+    Into,
+    AsRef,
+    AsMut,
+    Zeroable,
+    Pod,
+)]
 #[as_ref(forward)]
 #[as_mut(forward)]
 #[cfg_attr(feature = "codec", derive(TypeInfo, Encode, Decode, MaxEncodedLen), codec(crate = scale))]

--- a/gsys/Cargo.toml
+++ b/gsys/Cargo.toml
@@ -12,5 +12,8 @@ homepage.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[dependencies]
+bytemuck = { workspace = true, features = ["derive"] }
+
 [features]
 ethexe = []

--- a/gsys/src/lib.rs
+++ b/gsys/src/lib.rs
@@ -20,6 +20,8 @@
 
 #![no_std]
 
+use bytemuck::{Pod, Zeroable};
+
 /// Represents error code type.
 pub type ErrorCode = u32;
 
@@ -80,7 +82,7 @@ impl BlockNumberWithHash {
 
 /// Represents type defining concatenated hash with value. 48 bytes.
 #[repr(C, packed)]
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Copy, Zeroable, Pod)]
 pub struct HashWithValue {
     pub hash: Hash,
     pub value: Value,
@@ -288,7 +290,7 @@ impl TwoHashes {
 
 /// Represents type defining concatenated two hashes with value. 80 bytes.
 #[repr(C, packed)]
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy, Zeroable, Pod)]
 pub struct TwoHashesWithValue {
     pub hash1: Hash,
     pub hash2: Hash,

--- a/gsys/src/lib.rs
+++ b/gsys/src/lib.rs
@@ -67,8 +67,8 @@ pub type SignalCode = u32;
 pub type Value = u128;
 
 /// Represents type defining concatenated block number with hash. 36 bytes.
-#[repr(C, packed)]
-#[derive(Default, Debug)]
+#[repr(C)]
+#[derive(Default, Debug, Clone, Copy, Zeroable, Pod)]
 pub struct BlockNumberWithHash {
     pub bn: BlockNumber,
     pub hash: Hash,
@@ -81,7 +81,7 @@ impl BlockNumberWithHash {
 }
 
 /// Represents type defining concatenated hash with value. 48 bytes.
-#[repr(C, packed)]
+#[repr(C)]
 #[derive(Default, Debug, Clone, Copy, Zeroable, Pod)]
 pub struct HashWithValue {
     pub hash: Hash,
@@ -95,8 +95,8 @@ impl HashWithValue {
 }
 
 /// Represents type defining concatenated reply code with error code. 8 bytes.
-#[repr(C, packed)]
-#[derive(Default, Debug)]
+#[repr(C)]
+#[derive(Default, Debug, Clone, Copy, Zeroable, Pod)]
 pub struct ErrorWithReplyCode {
     pub error_code: ErrorCode,
     pub reply_code: ReplyCode,
@@ -122,8 +122,8 @@ impl From<Result<ReplyCode, ErrorCode>> for ErrorWithReplyCode {
 }
 
 /// Represents type defining concatenated signal code with length. 8 bytes.
-#[repr(C, packed)]
-#[derive(Default, Debug)]
+#[repr(C)]
+#[derive(Default, Debug, Clone, Copy, Zeroable, Pod)]
 pub struct ErrorWithSignalCode {
     pub error_code: ErrorCode,
     pub signal_code: SignalCode,
@@ -150,7 +150,7 @@ impl From<Result<SignalCode, ErrorCode>> for ErrorWithSignalCode {
 
 /// Represents type defining concatenated error code with gas. 12 bytes.
 #[repr(C, packed)]
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy, Zeroable, Pod)]
 pub struct ErrorWithGas {
     pub error_code: ErrorCode,
     pub gas: Gas,
@@ -176,8 +176,8 @@ impl From<Result<Gas, ErrorCode>> for ErrorWithGas {
 }
 
 /// Represents type defining concatenated length with handle. 8 bytes.
-#[repr(C, packed)]
-#[derive(Default, Debug)]
+#[repr(C)]
+#[derive(Default, Debug, Clone, Copy, Zeroable, Pod)]
 pub struct ErrorWithHandle {
     pub error_code: ErrorCode,
     pub handle: Handle,
@@ -202,8 +202,8 @@ impl From<Result<Handle, ErrorCode>> for ErrorWithHandle {
     }
 }
 
-#[repr(C, packed)]
-#[derive(Default, Debug)]
+#[repr(transparent)]
+#[derive(Default, Debug, Clone, Copy, Zeroable, Pod)]
 pub struct ErrorBytes([u8; size_of::<ErrorCode>()]);
 
 impl From<Result<(), ErrorCode>> for ErrorBytes {
@@ -213,8 +213,8 @@ impl From<Result<(), ErrorCode>> for ErrorBytes {
 }
 
 /// Represents type defining concatenated hash with error code. 36 bytes.
-#[repr(C, packed)]
-#[derive(Default, Debug)]
+#[repr(C)]
+#[derive(Default, Debug, Clone, Copy, Zeroable, Pod)]
 pub struct ErrorWithHash {
     pub error_code: ErrorCode,
     pub hash: Hash,
@@ -240,8 +240,8 @@ impl<T: Into<[u8; 32]>> From<Result<T, ErrorCode>> for ErrorWithHash {
 }
 
 /// Represents type defining concatenated two hashes with error code. 68 bytes.
-#[repr(C, packed)]
-#[derive(Default, Debug)]
+#[repr(C)]
+#[derive(Default, Debug, Clone, Copy, Zeroable, Pod)]
 pub struct ErrorWithTwoHashes {
     pub error_code: ErrorCode,
     pub hash1: Hash,
@@ -275,8 +275,8 @@ where
 }
 
 /// Represents type defining concatenated two hashes. 64 bytes.
-#[repr(C, packed)]
-#[derive(Default, Debug)]
+#[repr(C)]
+#[derive(Default, Debug, Clone, Copy, Zeroable, Pod)]
 pub struct TwoHashes {
     pub hash1: Hash,
     pub hash2: Hash,
@@ -289,7 +289,7 @@ impl TwoHashes {
 }
 
 /// Represents type defining concatenated two hashes with value. 80 bytes.
-#[repr(C, packed)]
+#[repr(C)]
 #[derive(Default, Debug, Clone, Copy, Zeroable, Pod)]
 pub struct TwoHashesWithValue {
     pub hash1: Hash,
@@ -309,7 +309,7 @@ impl TwoHashesWithValue {
 /// settings. This structure matches to the most recent version of execution
 /// settings supported by backend.
 #[repr(C, packed)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Zeroable, Pod)]
 pub struct EnvVars {
     /// Current performance multiplier.
     pub performance_multiplier: Percent,
@@ -325,8 +325,8 @@ pub struct EnvVars {
 /// values greater than 100.
 // This is a "copy-paste" of the similar struct from the `core` crate
 // which can't be used here due to its dependencies from codec and TypeInfo.
-#[repr(C, packed)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Zeroable, Pod)]
 pub struct Percent(u32);
 
 impl Percent {
@@ -344,7 +344,7 @@ impl Percent {
 // which can't be used here due to its dependencies from codec and TypeInfo as well
 // as FFI.
 #[repr(C, packed)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Zeroable, Pod)]
 pub struct GasMultiplier {
     gas_per_value: Gas,
     value_per_gas: Value,


### PR DESCRIPTION
Resolves #2164.

- Replace unsound unsafe `ReadAs` and fallible redundant `ReadDecoded` with safe `ReadAs` based on safe transmute from [bytemuck](https://crates.io/crates/bytemuck) crate.
- Replace `ReadDecodedSpecial` with `ReadAsOption` and unify it with `ReadAs`.
- Replace unsound unsafe implementation of `WriteAs` with bytemuck-based implementation.
- Remove unused `MemoryAccessError::DecodeError`.
- Remove `#[repr(packed)]` for some types in `gsys` which doesn't need to be packed for not having padding bytes. Not having padding bytes are now enforced for them by `bytemuck::Pod` derive.
