### PR TITLE
feat(gsdk): re-export subxt from gsdk

### DIFF
--- a/gsdk/src/lib.rs
+++ b/gsdk/src/lib.rs
@@ -30,7 +30,7 @@ pub use crate::{
     subscription::{Blocks, Events},
 };
 pub use gear_core::rpc::GasInfo;
-pub use subxt::dynamic::Value;
+pub use subxt::{self, dynamic::Value};
 
 use crate::metadata::runtime_types::{
     gear_common::gas_provider::node::{GasNode, GasNodeId},


### PR DESCRIPTION
By re-exporting subxt directly from gsdk allows to avoid version mismatches in projects that have to use gsdk and subxt as dependencies. 