### PR TITLE
fix(ci): Update rustls-platform-verifier to v0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14477,9 +14477,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93bda3f493b9abe5b93b3e7e3ecde0df292f2bd28c0296b90586ee0055ff5123"
+checksum = "afbb878bdfdf63a336a5e63561b1835e7a8c91524f51621db870169eac84b490"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",


### PR DESCRIPTION
https://github.com/rustls/rustls-platform-verifier/issues/126