### PR TITLE
chore(vara.eth): Remove scale codec from id generation

### DIFF
--- a/ethexe/common/src/injected.rs
+++ b/ethexe/common/src/injected.rs
@@ -84,8 +84,8 @@ impl ToDigest for InjectedTransaction {
 impl InjectedTransaction {
     /// Returns the hash of [`InjectedTransaction`].
     pub fn to_hash(&self) -> HashOf<InjectedTransaction> {
-        // Safe because we hash corresponding type itself
-        unsafe { HashOf::new(gear_core::utils::hash(&self.encode()).into()) }
+        // Safe because we hash the corresponding type itself
+        unsafe { HashOf::new(H256::from_slice(self.to_digest().as_ref())) }
     }
 
     /// Creates [`MessageId`] from [`InjectedTransaction`].

--- a/ethexe/common/src/primitives.rs
+++ b/ethexe/common/src/primitives.rs
@@ -24,7 +24,7 @@ use alloc::{
     collections::{btree_map::BTreeMap, btree_set::BTreeSet},
     vec::Vec,
 };
-use gear_core::{ids::prelude::CodeIdExt as _, utils};
+use gear_core::ids::prelude::CodeIdExt as _;
 use gprimitives::{ActorId, CodeId, H256, MessageId};
 use parity_scale_codec::{Decode, Encode};
 use sha3::Digest as _;
@@ -90,8 +90,8 @@ pub struct Announce {
 
 impl Announce {
     pub fn to_hash(&self) -> HashOf<Self> {
-        // # Safety because of implementation
-        unsafe { HashOf::new(H256(utils::hash(&self.encode()))) }
+        // Safe because `HashOf` is constructed from Announce digest
+        unsafe { HashOf::new(H256::from_slice(self.to_digest().as_ref())) }
     }
 
     pub fn base(block_hash: H256, parent: HashOf<Self>) -> Self {


### PR DESCRIPTION
Resolves # .

-
-
-

@reviewer-or-team
