### PR TITLE
build(nix): update pins

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre855922.c6a788f552b7/nixexprs.tar.xz",
-      "hash": "0p9aa19hw2xlr5d951yr7z6gdbwqmnff2m2pj5bysirnr8fq1apn"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre906997.a672be65651c/nixexprs.tar.xz",
+      "hash": "1vjmw739x11bmllig28i11rs5rbs1b8483426f2940kyxjp8myfw"
     },
     "nixpkgs-old": {
       "type": "Git",


### PR DESCRIPTION
Runned `npins update` and commited the result.

Updates devenv tooling. Also updates `cargo shear` to the latest version.