### PR TITLE
feat(`ethexe-rpc`): Serialize ReplyCode as hex string of bytes. 

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -65,7 +65,7 @@ pub struct ReplyInfo {
     pub code: ReplyCode,
 }
 
-/// Serializer and deserializer for ReplyCode as bytes (`[u8; 4]` array).
+/// Serializer and deserializer for ReplyCode as 0x-prefixed hex string.
 #[cfg(feature = "std")]
 pub(crate) mod serialize_reply_code {
     use super::ReplyCode;


### PR DESCRIPTION
Promise serialization before PR:
```
{"tx_hash"
{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000"},"reply":{"payload":"0x01020304","value":1000,
"code":{"Success":"Manual"}}}
```

Now:
```
{"tx_hash":{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000"},"reply":{"payload":"0x01020304","value":1000,
"code":"0x00010000"}}
```

Note: in another pull request I will fix the problem with serializing `tx_hash: {"hash": "0x00.."}}`.

@osipov-mit @breathx 