### PR TITLE
feat(`ethexe`): HashOf transparent serialization/deserialization

### DIFF
--- a/ethexe/common/src/hash.rs
+++ b/ethexe/common/src/hash.rs
@@ -50,6 +50,7 @@ pub struct HashOf<T: 'static> {
     hash: H256,
     #[into(ignore)]
     #[codec(skip)]
+    #[cfg_attr(feature = "std", serde(skip))]
     _phantom: PhantomData<T>,
 }
 


### PR DESCRIPTION
Before:
```
{"hash":{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000"}}
```
Now:
```
{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000"}
```

@osipov-mit @breathx 
