### PR TITLE
chore(ethexe): Use single-threaded tokio runtime for tests

### DIFF
--- a/ethexe/observer/src/tests.rs
+++ b/ethexe/observer/src/tests.rs
@@ -34,7 +34,7 @@ fn wat2wasm(s: &str) -> Vec<u8> {
     wat2wasm_with_validate(s, true)
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn test_deployment() -> Result<()> {
     gear_utils::init_default_logger();
 

--- a/ethexe/processor/src/tests.rs
+++ b/ethexe/processor/src/tests.rs
@@ -176,7 +176,7 @@ mod utils {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn ping_init() {
     init_logger();
 
@@ -313,7 +313,7 @@ fn handle_new_code_invalid() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn ping_pong() {
     init_logger();
 
@@ -387,7 +387,7 @@ async fn ping_pong() {
     assert_eq!(message.payload, b"PONG");
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn async_and_ping() {
     init_logger();
 
@@ -506,7 +506,7 @@ async fn async_and_ping() {
     assert_eq!(message.payload, wait_for_reply_to.into_bytes());
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn many_waits() {
     init_logger();
 
@@ -666,7 +666,7 @@ async fn many_waits() {
 }
 
 // Tests that when overlay execution is performed, it doesn't change the original state.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn overlay_execution() {
     init_logger();
 
@@ -914,7 +914,7 @@ async fn overlay_execution() {
     assert_eq!(reply_info.payload, MessageId::zero().encode());
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn injected_ping_pong() {
     init_logger();
 
@@ -1022,7 +1022,7 @@ async fn injected_ping_pong() {
 }
 
 #[cfg(debug_assertions)] // FIXME: test fails in release mode
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn injected_prioritized_over_canonical() {
     const MSG_NUM: usize = 100;
 
@@ -1137,7 +1137,7 @@ async fn injected_prioritized_over_canonical() {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn executable_balance_charged() {
     init_logger();
 
@@ -1216,7 +1216,7 @@ async fn executable_balance_charged() {
     assert!(exec_balance_after < exec_balance_before);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn executable_balance_injected_panic_not_charged() {
     // Testing special case when injected message causes panic in the program.
     // In this case executable balance should not be charged if gas burned during
@@ -1360,7 +1360,7 @@ async fn executable_balance_injected_panic_not_charged() {
     assert!(exec_balance_after < init_balance);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn insufficient_executable_balance_still_charged() {
     // Just enough balance to charge for instrumentation and instantiation but not enough to process the message.
     const INSUFFICIENT_EXECUTABLE_BALANCE: u128 = 30_000_000_000;
@@ -1424,7 +1424,7 @@ async fn insufficient_executable_balance_still_charged() {
     assert!(exec_balance_after < INSUFFICIENT_EXECUTABLE_BALANCE);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn call_gr_wait_is_forbidden() {
     init_logger();
 
@@ -1452,7 +1452,7 @@ async fn call_gr_wait_is_forbidden() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn call_wake_with_delay_is_unsupported() {
     init_logger();
 
@@ -1502,7 +1502,7 @@ async fn call_wake_with_delay_is_unsupported() {
     assert_eq!(reply_code, ReplyCode::Success(SuccessReplyReason::Auto));
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn call_wait_up_to_with_huge_duration() {
     init_logger();
 

--- a/ethexe/service/src/tests/mod.rs
+++ b/ethexe/service/src/tests/mod.rs
@@ -150,14 +150,16 @@ async fn basics() {
     Service::new(&config).await.unwrap();
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(30_000)]
 async fn invalid_code() {
     init_logger();
 
     let mut env = TestEnv::new(Default::default()).await.unwrap();
 
-    let mut node = env.new_node(NodeConfig::default().validator(env.validators[0]));
+    let mut node = env
+        .new_node(NodeConfig::default().validator(env.validators[0]))
+        .await;
     node.start_service().await;
 
     let wasm_binary = [1; 10]; // Invalid WASM binary
@@ -171,14 +173,16 @@ async fn invalid_code() {
     assert!(!res.valid);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn write_memory_to_last_byte() {
     init_logger();
 
     let mut env = TestEnv::new(Default::default()).await.unwrap();
 
-    let mut node = env.new_node(NodeConfig::default().validator(env.validators[0]));
+    let mut node = env
+        .new_node(NodeConfig::default().validator(env.validators[0]))
+        .await;
     node.start_service().await;
 
     let wat = r#"
@@ -236,14 +240,16 @@ async fn write_memory_to_last_byte() {
     assert_eq!(res.value, 0);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn ping() {
     init_logger();
 
     let mut env = TestEnv::new(Default::default()).await.unwrap();
 
-    let mut node = env.new_node(NodeConfig::default().validator(env.validators[0]));
+    let mut node = env
+        .new_node(NodeConfig::default().validator(env.validators[0]))
+        .await;
     node.start_service().await;
 
     let res = env
@@ -315,14 +321,16 @@ async fn ping() {
     assert_eq!(res.value, 0);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn uninitialized_program() {
     init_logger();
 
     let mut env = TestEnv::new(Default::default()).await.unwrap();
 
-    let mut node = env.new_node(NodeConfig::default().validator(env.validators[0]));
+    let mut node = env
+        .new_node(NodeConfig::default().validator(env.validators[0]))
+        .await;
     node.start_service().await;
 
     let res = env
@@ -471,14 +479,16 @@ async fn uninitialized_program() {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn mailbox() {
     init_logger();
 
     let mut env = TestEnv::new(Default::default()).await.unwrap();
 
-    let mut node = env.new_node(NodeConfig::default().validator(env.validators[0]));
+    let mut node = env
+        .new_node(NodeConfig::default().validator(env.validators[0]))
+        .await;
     node.start_service().await;
 
     let res = env
@@ -711,14 +721,16 @@ async fn mailbox() {
     assert!(schedule.is_empty(), "{schedule:?}");
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn value_reply_program_to_user() {
     init_logger();
 
     let mut env = TestEnv::new(Default::default()).await.unwrap();
 
-    let mut node = env.new_node(NodeConfig::default().validator(env.validators[0]));
+    let mut node = env
+        .new_node(NodeConfig::default().validator(env.validators[0]))
+        .await;
     node.start_service().await;
 
     let res = env
@@ -810,14 +822,16 @@ async fn value_reply_program_to_user() {
     assert!(default_anvil_balance - balance <= measurement_error);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn value_send_program_to_user_and_claimed() {
     init_logger();
 
     let mut env = TestEnv::new(Default::default()).await.unwrap();
 
-    let mut node = env.new_node(NodeConfig::default().validator(env.validators[0]));
+    let mut node = env
+        .new_node(NodeConfig::default().validator(env.validators[0]))
+        .await;
     node.start_service().await;
 
     let res = env
@@ -942,14 +956,16 @@ async fn value_send_program_to_user_and_claimed() {
     assert!(default_anvil_balance - balance <= measurement_error);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn value_send_program_to_user_and_replied() {
     init_logger();
 
     let mut env = TestEnv::new(Default::default()).await.unwrap();
 
-    let mut node = env.new_node(NodeConfig::default().validator(env.validators[0]));
+    let mut node = env
+        .new_node(NodeConfig::default().validator(env.validators[0]))
+        .await;
     node.start_service().await;
 
     let res = env
@@ -1077,14 +1093,16 @@ async fn value_send_program_to_user_and_replied() {
     assert!(default_anvil_balance - balance <= measurement_error);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn incoming_transfers() {
     init_logger();
 
     let mut env = TestEnv::new(Default::default()).await.unwrap();
 
-    let mut node = env.new_node(NodeConfig::default().validator(env.validators[0]));
+    let mut node = env
+        .new_node(NodeConfig::default().validator(env.validators[0]))
+        .await;
     node.start_service().await;
 
     let res = env
@@ -1165,7 +1183,7 @@ async fn incoming_transfers() {
     assert_eq!(local_balance, 2 * VALUE_SENT);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn ping_reorg() {
     init_logger();
@@ -1178,10 +1196,12 @@ async fn ping_reorg() {
     .unwrap();
 
     // Start a separate connect node, to be able to request missed announces.
-    let mut connect_node = env.new_node(NodeConfig::named("connect"));
+    let mut connect_node = env.new_node(NodeConfig::named("connect")).await;
     connect_node.start_service().await;
 
-    let mut node = env.new_node(NodeConfig::named("validator").validator(env.validators[0]));
+    let mut node = env
+        .new_node(NodeConfig::named("validator").validator(env.validators[0]))
+        .await;
     node.start_service().await;
 
     let res = env
@@ -1258,7 +1278,7 @@ async fn ping_reorg() {
 
     // The last step is to test correctness after db cleanup
     node.stop_service().await;
-    node.db = env.new_initialized_db();
+    node.db = env.new_initialized_db().await;
 
     log::info!("📗 Test after db cleanup and service shutting down");
     let send_message = env.send_message(ping_id, b"PING").await.unwrap();
@@ -1278,14 +1298,16 @@ async fn ping_reorg() {
 
 // Stop service - waits 150 blocks - send message - waits 150 blocks - start service.
 // Deep sync must load chain in batch.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn ping_deep_sync() {
     init_logger();
 
     let mut env = TestEnv::new(Default::default()).await.unwrap();
 
-    let mut node = env.new_node(NodeConfig::default().validator(env.validators[0]));
+    let mut node = env
+        .new_node(NodeConfig::default().validator(env.validators[0]))
+        .await;
     node.start_service().await;
 
     let res = env
@@ -1343,7 +1365,7 @@ async fn ping_deep_sync() {
     assert_eq!(res.code, ReplyCode::Success(SuccessReplyReason::Manual));
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn multiple_validators() {
     init_logger();
@@ -1368,7 +1390,9 @@ async fn multiple_validators() {
     let mut validators = vec![];
     for (i, v) in env.validators.clone().into_iter().enumerate() {
         log::info!("📗 Starting validator-{i}");
-        let mut validator = env.new_node(NodeConfig::named(format!("validator-{i}")).validator(v));
+        let mut validator = env
+            .new_node(NodeConfig::named(format!("validator-{i}")).validator(v))
+            .await;
         validator.start_service().await;
         validators.push(validator);
     }
@@ -1506,7 +1530,7 @@ async fn multiple_validators() {
     assert_eq!(res.payload, res.message_id.encode().as_slice());
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn send_injected_tx() {
     init_logger();
@@ -1524,19 +1548,23 @@ async fn send_injected_tx() {
     let validator1_pubkey = env.validators[1].public_key;
 
     log::info!("📗 Starting node 0");
-    let mut node0 = env.new_node(
-        NodeConfig::default()
-            .validator(env.validators[0])
-            .service_rpc(9505),
-    );
+    let mut node0 = env
+        .new_node(
+            NodeConfig::default()
+                .validator(env.validators[0])
+                .service_rpc(9505),
+        )
+        .await;
     node0.start_service().await;
 
     log::info!("📗 Starting node 1");
-    let mut node1 = env.new_node(
-        NodeConfig::default()
-            .service_rpc(9506)
-            .validator(env.validators[1]),
-    );
+    let mut node1 = env
+        .new_node(
+            NodeConfig::default()
+                .service_rpc(9506)
+                .validator(env.validators[1]),
+        )
+        .await;
     node1.start_service().await;
 
     log::info!("Populate node-0 and node-1 with 2 valid blocks");
@@ -1597,7 +1625,7 @@ async fn send_injected_tx() {
     assert_eq!(node1_db_tx, tx_for_node1.tx);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn fast_sync() {
     init_logger();
@@ -1691,7 +1719,9 @@ async fn fast_sync() {
     let mut env = TestEnv::new(config).await.unwrap();
 
     log::info!("📗 Starting Alice");
-    let mut alice = env.new_node(NodeConfig::named("Alice").validator(env.validators[0]));
+    let mut alice = env
+        .new_node(NodeConfig::named("Alice").validator(env.validators[0]))
+        .await;
     alice.start_service().await;
 
     log::info!("📗 Creating `demo-autoreply` programs");
@@ -1732,7 +1762,7 @@ async fn fast_sync() {
     alice.events().find_announce_computed(latest_block).await;
 
     log::info!("Starting Bob (fast-sync)");
-    let mut bob = env.new_node(NodeConfig::named("Bob").fast_sync());
+    let mut bob = env.new_node(NodeConfig::named("Bob").fast_sync()).await;
 
     bob.start_service().await;
 
@@ -1811,7 +1841,7 @@ async fn fast_sync() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn validators_election() {
     init_logger();
@@ -1862,7 +1892,9 @@ async fn validators_election() {
     let mut validators = vec![];
     for (i, v) in env.validators.clone().into_iter().enumerate() {
         log::info!("📗 Starting validator-{i}");
-        let mut validator = env.new_node(NodeConfig::named(format!("validator-{i}")).validator(v));
+        let mut validator = env
+            .new_node(NodeConfig::named(format!("validator-{i}")).validator(v))
+            .await;
         validator.start_service().await;
         validators.push(validator);
     }
@@ -1934,7 +1966,9 @@ async fn validators_election() {
     let mut new_validators = vec![];
     for (i, v) in env.validators.clone().into_iter().enumerate() {
         log::info!("📗 Starting validator-{i}");
-        let mut validator = env.new_node(NodeConfig::named(format!("validator-{i}")).validator(v));
+        let mut validator = env
+            .new_node(NodeConfig::named(format!("validator-{i}")).validator(v))
+            .await;
         validator.start_service().await;
         new_validators.push(validator);
     }
@@ -1957,7 +1991,7 @@ async fn validators_election() {
     assert_eq!(reply.program_id, ping_actor.program_id);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn execution_with_canonical_events_quarantine() {
     init_logger();
@@ -1969,7 +2003,9 @@ async fn execution_with_canonical_events_quarantine() {
     let mut env = TestEnv::new(config).await.unwrap();
 
     log::info!("📗 Starting validator");
-    let mut validator = env.new_node(NodeConfig::default().validator(env.validators[0]));
+    let mut validator = env
+        .new_node(NodeConfig::default().validator(env.validators[0]))
+        .await;
     validator.start_service().await;
 
     let uploaded_code = env
@@ -2076,7 +2112,7 @@ async fn execution_with_canonical_events_quarantine() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn value_send_program_to_program() {
     // 1_000 ETH
@@ -2086,7 +2122,9 @@ async fn value_send_program_to_program() {
 
     let mut env = TestEnv::new(Default::default()).await.unwrap();
 
-    let mut node = env.new_node(NodeConfig::default().validator(env.validators[0]));
+    let mut node = env
+        .new_node(NodeConfig::default().validator(env.validators[0]))
+        .await;
     node.start_service().await;
 
     let res = env
@@ -2222,7 +2260,7 @@ async fn value_send_program_to_program() {
     assert_eq!(router_balance, 0);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn value_send_delayed() {
     // 1_000 ETH
@@ -2232,7 +2270,9 @@ async fn value_send_delayed() {
 
     let mut env = TestEnv::new(Default::default()).await.unwrap();
 
-    let mut node = env.new_node(NodeConfig::default().validator(env.validators[0]));
+    let mut node = env
+        .new_node(NodeConfig::default().validator(env.validators[0]))
+        .await;
     node.start_service().await;
 
     let res = env
@@ -2395,7 +2435,7 @@ async fn value_send_delayed() {
     assert_eq!(router_balance, 0);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn injected_tx_fungible_token() {
     init_logger();
@@ -2409,11 +2449,13 @@ async fn injected_tx_fungible_token() {
     let mut env = TestEnv::new(env_config).await.unwrap();
 
     let pubkey = env.validators[0].public_key;
-    let mut node = env.new_node(
-        NodeConfig::default()
-            .service_rpc(8090)
-            .validator(env.validators[0]),
-    );
+    let mut node = env
+        .new_node(
+            NodeConfig::default()
+                .service_rpc(8090)
+                .validator(env.validators[0]),
+        )
+        .await;
     node.start_service().await;
     let rpc_client = node
         .rpc_ws_client()
@@ -2624,7 +2666,7 @@ async fn injected_tx_fungible_token() {
     tracing::info!("✅ Promise successfully received from RPC subscription");
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn injected_tx_fungible_token_over_network() {
     init_logger();
@@ -2639,7 +2681,9 @@ async fn injected_tx_fungible_token_over_network() {
 
     let user_pubkey = env.signer.generate().unwrap();
 
-    let mut alice_node = env.new_node(NodeConfig::named("Alice").service_rpc(8091));
+    let mut alice_node = env
+        .new_node(NodeConfig::named("Alice").service_rpc(8091))
+        .await;
     alice_node.start_service().await;
     let alice_rpc_client = alice_node
         .rpc_ws_client()
@@ -2647,7 +2691,9 @@ async fn injected_tx_fungible_token_over_network() {
         .expect("RPC client provide by node");
 
     let bob_pubkey = env.validators[0].public_key;
-    let mut bob_node = env.new_node(NodeConfig::named("Bob").validator(env.validators[0]));
+    let mut bob_node = env
+        .new_node(NodeConfig::named("Bob").validator(env.validators[0]))
+        .await;
     bob_node.start_service().await;
 
     // 1. Create Fungible token config
@@ -2773,7 +2819,7 @@ async fn injected_tx_fungible_token_over_network() {
     tracing::info!("✅ Tokens mint successfully");
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(120_000)]
 async fn announces_conflicts() {
     init_logger();
@@ -2789,7 +2835,9 @@ async fn announces_conflicts() {
     let mut validators = vec![];
     for (i, v) in env.validators.clone().into_iter().enumerate() {
         log::info!("📗 Starting validator-{i}");
-        let mut validator = env.new_node(NodeConfig::named(format!("validator-{i}")).validator(v));
+        let mut validator = env
+            .new_node(NodeConfig::named(format!("validator-{i}")).validator(v))
+            .await;
         validator.start_service().await;
         validators.push(validator);
     }
@@ -3031,7 +3079,7 @@ async fn announces_conflicts() {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(120_000)]
 async fn whole_network_restore() {
     init_logger();
@@ -3047,7 +3095,9 @@ async fn whole_network_restore() {
     let mut validators = vec![];
     for (i, v) in env.validators.clone().into_iter().enumerate() {
         log::info!("📗 Starting validator-{i}");
-        let mut validator = env.new_node(NodeConfig::named(format!("validator-{i}")).validator(v));
+        let mut validator = env
+            .new_node(NodeConfig::named(format!("validator-{i}")).validator(v))
+            .await;
         validator.start_service().await;
         validators.push(validator);
     }
@@ -3135,13 +3185,13 @@ async fn whole_network_restore() {
     assert!(seen_messages.insert(init_res.message_id));
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn catch_up_3() {
     catch_up_test_case(3).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn catch_up_5() {
     catch_up_test_case(5).await;
@@ -3208,11 +3258,13 @@ async fn catch_up_test_case(commitment_delay_limit: u32) {
     let mut env = TestEnv::new(config).await.unwrap();
 
     log::info!("📗 Starting Alice");
-    let mut alice = env.new_node(NodeConfig::named("Alice").validator(env.validators[0]));
+    let mut alice = env
+        .new_node(NodeConfig::named("Alice").validator(env.validators[0]))
+        .await;
     alice.start_service().await;
 
     log::info!("📗 Starting Bob");
-    let mut bob = env.new_node(NodeConfig::named("Bob"));
+    let mut bob = env.new_node(NodeConfig::named("Bob")).await;
     bob.start_service().await;
 
     let ping_code_id = env
@@ -3391,14 +3443,16 @@ async fn catch_up_test_case(commitment_delay_limit: u32) {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[ntest::timeout(60_000)]
 async fn reply_callback() {
     init_logger();
 
     let mut env = TestEnv::new(Default::default()).await.unwrap();
 
-    let mut node = env.new_node(NodeConfig::default().validator(env.validators[0]));
+    let mut node = env
+        .new_node(NodeConfig::default().validator(env.validators[0]))
+        .await;
     node.start_service().await;
 
     let res = env

--- a/ethexe/service/src/tests/utils/env.rs
+++ b/ethexe/service/src/tests/utils/env.rs
@@ -231,11 +231,12 @@ impl TestEnv {
         let router_query = router.query();
         let router_address = router.address();
 
-        let db = new_empty_initialized_memory_db(InitConfig {
+        let db = ethexe_db::create_initialized_empty_memory_db(InitConfig {
             ethereum_rpc: ws_rpc_url.clone(),
             router_address,
             slot_duration_secs: block_time.as_secs(),
-        })?;
+        })
+        .await?;
 
         let eth_cfg = EthereumConfig {
             rpc: ws_rpc_url.clone(),
@@ -355,7 +356,7 @@ impl TestEnv {
         })
     }
 
-    pub fn new_node(&mut self, config: NodeConfig) -> Node {
+    pub async fn new_node(&mut self, config: NodeConfig) -> Node {
         let NodeConfig {
             name,
             db,
@@ -366,7 +367,7 @@ impl TestEnv {
 
         let db = match db {
             Some(db) => db,
-            None => self.new_initialized_db(),
+            None => self.new_initialized_db().await,
         };
 
         let (network_address, network_bootstrap_address) = self
@@ -407,12 +408,13 @@ impl TestEnv {
         }
     }
 
-    pub fn new_initialized_db(&self) -> Database {
-        new_empty_initialized_memory_db(InitConfig {
+    pub async fn new_initialized_db(&self) -> Database {
+        ethexe_db::create_initialized_empty_memory_db(InitConfig {
             ethereum_rpc: self.eth_cfg.rpc.clone(),
             router_address: self.eth_cfg.router_address,
             slot_duration_secs: self.eth_cfg.block_time.as_secs(),
         })
+        .await
         .unwrap()
     }
 
@@ -1326,11 +1328,4 @@ impl WaitForReplyTo {
 
         Ok(info)
     }
-}
-
-pub fn new_empty_initialized_memory_db(config: InitConfig) -> anyhow::Result<Database> {
-    let handle = tokio::runtime::Handle::current();
-    tokio::task::block_in_place(|| {
-        handle.block_on(ethexe_db::create_initialized_empty_memory_db(config))
-    })
 }


### PR DESCRIPTION
Test runs on M4 Max:

<details>
	<summary>Mutli-threaded runtime: 100,730s</summary>

	```
	 Nextest run ID 6306e247-2272-4c27-914c-2a961e47a871 with nextest profile: default
	    Starting 333 tests across 19 binaries (2 tests skipped)
	        PASS [   0.007s] ethexe-common primitives::tests::test_era_start_calculation
	        PASS [   0.009s] ethexe-cli utils::tests::test_formatted_value
	        PASS [   0.009s] ethexe-common db::tests::ensure_types_unchanged
	        PASS [   0.010s] ethexe-common primitives::tests::test_era_from_ts_calculation
	        PASS [   0.011s] ethexe-common injected::tests::signed_message_and_injected_transactions
	        PASS [   0.014s] ethexe-blob-loader tests::test_handle_blob
	        PASS [   0.030s] ethexe-compute codes::tests::process_invalid_code
	        PASS [   0.031s] ethexe-compute codes::tests::process_already_validated_code
	        PASS [   0.030s] ethexe-compute codes::tests::process_code
	        PASS [   0.031s] ethexe-compute compute::tests::collect_not_computed_predecessors_work_correctly
	        PASS [   0.032s] ethexe-compute compute::tests::test_compute
	        PASS [   0.033s] ethexe-common primitives::tests::panic_on_era_from_ts_before_genesis
	        PASS [   0.025s] ethexe-compute prepare::tests::test_prepare_one_block
	        PASS [   0.025s] ethexe-compute prepare::tests::test_prepare_with_codes
	        PASS [   0.036s] ethexe-compute service::tests::prepare_block
	        PASS [   0.038s] ethexe-compute service::tests::compute_announce
	        PASS [   0.020s] ethexe-compute service::tests::process_code
	        PASS [   0.045s] ethexe-compute prepare::tests::test_prepare_no_codes
	        PASS [   0.046s] ethexe-compute prepare::tests::test_sub_service_start_with_codes
	        PASS [   0.027s] ethexe-consensus connect::tests::announce_not_computed_after_pending_and_rejected
	        PASS [   0.025s] ethexe-consensus tx_validation::tests::test_check_injected_tx_can_not_initialize_actor
	        PASS [   0.033s] ethexe-consensus tx_validation::tests::test_check_injected_transaction_non_zero_value
	        PASS [   0.034s] ethexe-consensus tx_validation::tests::test_check_tx_duplicate
	        PASS [   0.077s] ethexe-consensus announces::tests::reject_announce_with_too_many_touched_programs
	        PASS [   0.057s] ethexe-consensus tx_validation::tests::test_check_tx_outdated
	        PASS [   0.064s] ethexe-consensus tx_validation::tests::test_check_tx_not_on_current_branch
	        PASS [   0.027s] ethexe-consensus tx_validation::tests::test_reach_start_block_in_branch_check
	        PASS [   0.021s] ethexe-consensus tx_validation::tests::test_rejecting_unknown_reference_block
	        PASS [   0.054s] ethexe-consensus tx_validation::tests::test_check_tx_validity
	        PASS [   0.023s] ethexe-consensus utils::tests::accept_batch_commitment_validation_reply
	        PASS [   0.025s] ethexe-consensus utils::tests::block_producer_index_calculates_correct_index
	        PASS [   0.023s] ethexe-consensus utils::tests::check_origin_closure_behavior
	        PASS [   0.022s] ethexe-consensus utils::tests::producer_for_calculates_correct_producer
	        PASS [   0.023s] ethexe-consensus utils::tests::multisigned_batch_commitment_creation
	        PASS [   0.025s] ethexe-consensus utils::tests::reject_validation_reply_with_incorrect_digest
	        PASS [   0.023s] ethexe-consensus utils::tests::test_has_duplicates
	        PASS [   0.026s] ethexe-consensus validator::batch::tests::accepts_matching_request
	        PASS [   0.028s] ethexe-consensus validator::batch::tests::rejects_code_not_processed_yet
	        PASS [   0.215s] ethexe-compute tests::code_validation_request_does_not_block_preparation
	        PASS [   0.030s] ethexe-consensus validator::batch::tests::rejects_digest_mismatch
	        PASS [   0.033s] ethexe-consensus validator::batch::tests::rejects_duplicate_code_ids
	        PASS [   0.223s] ethexe-compute tests::one_preparation_and_multiple_processing
	        PASS [   0.233s] ethexe-compute tests::block_computation_basic
	        PASS [   0.036s] ethexe-consensus validator::batch::tests::rejects_empty_batch_request
	        PASS [   0.086s] ethexe-consensus validator::batch::tests::rejects_batch_commitment_size_limit_exceeded
	        PASS [   0.029s] ethexe-consensus validator::batch::tests::rejects_when_best_head_chain_is_invalid
	        PASS [   0.034s] ethexe-consensus validator::batch::tests::rejects_not_waiting_code_ids
	        PASS [   0.040s] ethexe-consensus validator::batch::tests::rejects_non_best_chain_head
	        PASS [   0.033s] ethexe-consensus validator::batch::utils::tests::test_aggregate_chain_commitment
	        PASS [   0.265s] ethexe-compute tests::multiple_preparation_and_one_processing
	        PASS [   0.020s] ethexe-consensus validator::batch::utils::tests::test_aggregate_code_commitments
	        PASS [   0.045s] ethexe-consensus validator::batch::tests::test_aggregate_validators_commitment
	        PASS [   0.029s] ethexe-consensus validator::coordinator::tests::coordinator_create_insufficient_validators
	        PASS [   0.036s] ethexe-consensus validator::batch::utils::tests::test_batch_expiry_calculation
	        PASS [   0.036s] ethexe-consensus validator::coordinator::tests::coordinator_create_success
	        PASS [   0.032s] ethexe-consensus validator::coordinator::tests::coordinator_create_zero_threshold
	        PASS [   0.034s] ethexe-consensus validator::coordinator::tests::process_validation_reply
	        PASS [   0.035s] ethexe-consensus validator::initial::tests::announce_propagation_done
	        PASS [   0.024s] ethexe-consensus validator::initial::tests::create_initial_success
	        PASS [   0.035s] ethexe-consensus validator::initial::tests::commitment_with_delay
	        PASS [   0.039s] ethexe-consensus validator::initial::tests::announce_propagation_many_missing_blocks
	        PASS [   0.022s] ethexe-consensus validator::initial::tests::process_announces_response_rejected
	        PASS [   0.036s] ethexe-consensus validator::initial::tests::create_with_chain_head_success
	        PASS [   0.037s] ethexe-consensus validator::initial::tests::missing_announces_request_response
	        PASS [   0.029s] ethexe-consensus validator::initial::tests::process_prepared_block_rejected
	        PASS [   0.028s] ethexe-consensus validator::initial::tests::process_synced_block_rejected
	        PASS [   0.027s] ethexe-consensus validator::initial::tests::switch_to_producer
	        PASS [   0.024s] ethexe-consensus validator::participant::tests::create
	        PASS [   0.028s] ethexe-consensus validator::initial::tests::switch_to_subordinate
	        PASS [   0.035s] ethexe-consensus validator::participant::tests::codes_not_waiting_for_commitment_error
	        PASS [   0.027s] ethexe-consensus validator::participant::tests::digest_mismatch_warning
	        PASS [   0.024s] ethexe-consensus validator::participant::tests::empty_batch_error
	        PASS [   0.024s] ethexe-consensus validator::participant::tests::process_validation_request_failure
	        PASS [   0.029s] ethexe-consensus validator::participant::tests::duplicate_codes_warning
	        PASS [   0.036s] ethexe-consensus validator::participant::tests::create_with_pending_events
	        PASS [   0.027s] ethexe-consensus validator::participant::tests::process_validation_request_success
	        PASS [   0.031s] ethexe-consensus validator::producer::tests::code_commitments_only
	        PASS [   0.024s] ethexe-consensus validator::producer::tests::create
	        PASS [   0.022s] ethexe-consensus validator::subordinate::tests::create_empty
	        PASS [   0.023s] ethexe-consensus validator::subordinate::tests::create_with_multiple_announces
	        PASS [   0.029s] ethexe-consensus validator::producer::tests::simple
	        PASS [   0.033s] ethexe-consensus validator::producer::tests::threshold_one
	        PASS [   0.034s] ethexe-consensus validator::producer::tests::threshold_two
	        PASS [   0.026s] ethexe-consensus validator::subordinate::tests::earlier_received_announces
	        PASS [   0.026s] ethexe-consensus validator::subordinate::tests::create_with_validation_requests
	        PASS [   0.022s] ethexe-consensus validator::subordinate::tests::process_computed_block_with_unexpected_hash
	        PASS [   0.022s] ethexe-consensus validator::subordinate::tests::process_external_event_with_invalid_announce
	        PASS [   0.022s] ethexe-consensus validator::subordinate::tests::reject_announce_from_producer
	        PASS [   0.025s] ethexe-consensus validator::subordinate::tests::simple_not_validator
	        PASS [   0.028s] ethexe-consensus validator::subordinate::tests::simple
	        PASS [   0.023s] ethexe-consensus validator::tx_pool::tests::validate_max_tx_size
	        PASS [   0.036s] ethexe-consensus validator::tx_pool::tests::test_select_for_announce
	        PASS [   0.086s] ethexe-consensus validator::subordinate::tests::create_with_many_pending_events
	        PASS [   0.040s] ethexe-db database::tests::test_allocations
	        PASS [   0.035s] ethexe-db database::tests::test_announce
	        PASS [   0.037s] ethexe-db database::tests::test_announce_outcome
	        PASS [   0.029s] ethexe-db database::tests::test_announce_program_states
	        PASS [   0.037s] ethexe-db database::tests::test_announce_schedule
	        PASS [   0.042s] ethexe-db database::tests::test_block_header
	        PASS [   0.043s] ethexe-db database::tests::test_block_events
	        PASS [   0.037s] ethexe-db database::tests::test_code_blob_info
	        PASS [   0.045s] ethexe-db database::tests::test_block_is_synced
	        PASS [   0.041s] ethexe-db database::tests::test_code_metadata
	        PASS [   0.112s] ethexe-consensus validator::tx_pool::tests::max_touched_programs
	        PASS [   0.036s] ethexe-db database::tests::test_code_valid
	        PASS [   0.030s] ethexe-db database::tests::test_instrumented_code
	        PASS [   0.045s] ethexe-db database::tests::test_injected_transaction
	        PASS [   0.033s] ethexe-db database::tests::test_mailbox
	        PASS [   0.037s] ethexe-db database::tests::test_page_data
	        PASS [   0.036s] ethexe-db database::tests::test_pages_region
	        PASS [   0.035s] ethexe-db database::tests::test_payload
	        PASS [   0.046s] ethexe-db database::tests::test_original_code
	        PASS [   0.043s] ethexe-db database::tests::test_pages
	        PASS [   0.036s] ethexe-db database::tests::test_stash
	        PASS [   0.042s] ethexe-db database::tests::test_program_code_id
	        PASS [   0.040s] ethexe-db database::tests::test_queue
	        PASS [   0.031s] ethexe-db iterator::tests::walk_announce_outcome
	        PASS [   0.033s] ethexe-db database::tests::test_waitlist
	        PASS [   0.039s] ethexe-db database::tests::test_state
	        PASS [   0.038s] ethexe-db iterator::tests::walk_announce_program_states
	        PASS [   0.037s] ethexe-db iterator::tests::walk_announce_schedule
	        PASS [   0.634s] ethexe-compute compute::tests::test_compute_with_promises
	        PASS [   0.040s] ethexe-db iterator::tests::walk_block_schedule_tasks
	        PASS [   0.031s] ethexe-db iterator::tests::walk_code_id_missing_data
	        PASS [   0.029s] ethexe-db iterator::tests::walk_payload_lookup_direct
	        PASS [   0.036s] ethexe-db iterator::tests::walk_block_with_missing_data
	        PASS [   0.035s] ethexe-db iterator::tests::walk_chain_basic
	        PASS [   0.031s] ethexe-db iterator::tests::walk_program_id_missing_code
	        PASS [   0.038s] ethexe-db iterator::tests::walk_state_transition
	        PASS [   0.037s] ethexe-db iterator::tests::walk_state_transition_zero_state_hash
	        PASS [   0.030s] ethexe-db mem::tests::cas_read_write
	        PASS [   0.038s] ethexe-db mem::tests::is_cloneable
	        PASS [   0.036s] ethexe-db mem::tests::kv_iter_prefix
	        PASS [   0.033s] ethexe-db mem::tests::kv_read_write
	        PASS [   0.036s] ethexe-db migrations::v1::tests::ensure_migration_types
	        PASS [   0.039s] ethexe-db rocks::tests::cas_read_write
	        PASS [   0.038s] ethexe-db rocks::tests::is_cloneable
	        PASS [   0.037s] ethexe-db rocks::tests::kv_iter_prefix
	        PASS [   0.045s] ethexe-db rocks::tests::kv_read_write
	        PASS [   0.043s] ethexe-db verifier::tests::test_block_meta_not_prepared_error
	        PASS [   0.036s] ethexe-db verifier::tests::test_block_meta_not_synced_error
	        PASS [   0.041s] ethexe-db verifier::tests::test_block_schedule_has_expired_tasks_error
	        PASS [   0.038s] ethexe-db verifier::tests::test_code_is_not_valid_error
	        PASS [   0.032s] ethexe-db verifier::tests::test_database_visitor_error_propagation
	        PASS [   0.031s] ethexe-db verifier::tests::test_invalid_code_len_in_metadata_error
	        PASS [   0.035s] ethexe-db verifier::tests::test_invalid_block_parent_height_error
	        PASS [   0.037s] ethexe-db verifier::tests::test_invalid_parent_timestamp_error
	        PASS [   0.034s] ethexe-db verifier::tests::test_multiple_errors_collected
	        PASS [   0.035s] ethexe-db verifier::tests::test_no_parent_block_header_error
	        PASS [   0.036s] ethexe-db verifier::tests::test_successful_verification_with_valid_data
	        PASS [   0.007s] ethexe-ethereum abi::utils::casts_are_correct
	        PASS [   0.030s] ethexe-db verifier::tests::test_visit_message_queue_invalid_cached_size
	        PASS [   0.034s] ethexe-db verifier::tests::test_visit_message_queue_success
	        PASS [   0.334s] ethexe-db iterator::tests::walk_payload_lookup_stored
	        PASS [   0.015s] ethexe-ethereum tests::sender_signs_prehashed_message
	        PASS [   0.036s] ethexe-network custom_connection_limits::tests::inbound_connection_denied
	        PASS [   0.107s] ethexe-db verifier::tests::test_visit_message_queue_without_hash_panics
	        PASS [   0.023s] ethexe-network db_sync::requests::tests::try_into_checked_accepts_valid_chain_len
	        PASS [   0.048s] ethexe-network custom_connection_limits::tests::outbound_connection_denied
	        PASS [   0.029s] ethexe-network db_sync::requests::tests::try_into_checked_accepts_valid_tail_range
	        PASS [   0.022s] ethexe-network db_sync::requests::tests::try_into_checked_rejects_empty_response
	        PASS [   0.028s] ethexe-network db_sync::requests::tests::try_into_checked_rejects_head_mismatch
	        PASS [   0.468s] ethexe-db mem::tests::kv_multi_thread
	        PASS [   0.037s] ethexe-network db_sync::requests::tests::try_into_checked_rejects_len_mismatch
	        PASS [   1.157s] ethexe-compute compute::tests::test_compute_with_early_break
	        PASS [   0.024s] ethexe-network db_sync::requests::tests::try_into_checked_rejects_tail_mismatch
	        PASS [   0.460s] ethexe-db rocks::tests::kv_multi_thread
	        PASS [   0.043s] ethexe-network db_sync::requests::tests::try_into_checked_rejects_non_linked_chain
	        PASS [   0.020s] ethexe-network db_sync::requests::tests::validate_data_hash_mismatch
	        PASS [   0.023s] ethexe-network db_sync::requests::tests::validate_data_hash_incomplete
	        PASS [   0.023s] ethexe-network db_sync::requests::tests::validate_data_stripped
	        PASS [   0.024s] ethexe-network db_sync::responses::tests::fails_chain_len_exceeding_max
	        PASS [   0.027s] ethexe-network db_sync::responses::tests::fails_announce_missing
	        PASS [   0.023s] ethexe-network db_sync::responses::tests::fails_reaching_start_non_genesis
	        PASS [   0.040s] ethexe-network db_sync::responses::tests::fails_reaching_max_chain_length
	        PASS [   0.028s] ethexe-network db_sync::responses::tests::fails_when_reaching_genesis
	        PASS [   0.026s] ethexe-network db_sync::responses::tests::returns_announces_until_chain_len
	        PASS [   0.027s] ethexe-network db_sync::responses::tests::returns_announces_until_tail
	        PASS [   0.023s] ethexe-network db_sync::tests::excessive_data_stripped
	        PASS [   0.022s] ethexe-network db_sync::tests::out_of_rounds
	        PASS [   0.028s] ethexe-network db_sync::tests::external_data_provider
	        PASS [   0.022s] ethexe-network db_sync::tests::request_cancelled
	        PASS [   0.024s] ethexe-network db_sync::tests::request_completed_after_new_peer
	        PASS [   0.025s] ethexe-network db_sync::tests::request_completed_by_3_rounds
	        PASS [   0.022s] ethexe-network db_sync::tests::request_response_type_mismatch
	        PASS [   0.020s] ethexe-network db_sync::tests::retry
	        PASS [   0.021s] ethexe-network db_sync::tests::simultaneous_responses_limit
	        PASS [   0.022s] ethexe-network db_sync::tests::smoke
	        PASS [   0.022s] ethexe-network db_sync::tests::timeout
	        PASS [   0.028s] ethexe-network injected::tests::accept
	        PASS [   0.023s] ethexe-network injected::tests::outbound_failure_rejected
	        PASS [   0.028s] ethexe-network injected::tests::rejected
	        PASS [   0.385s] ethexe-ethereum router::tests::storage_view
	        PASS [   0.387s] ethexe-ethereum router::tests::inexistent_code_is_unknown
	        PASS [   0.021s] ethexe-network injected::tests::validator_not_found
	        PASS [   0.023s] ethexe-network injected::tests::transaction_already_sent
	        PASS [   0.039s] ethexe-network injected::tests::too_many_pending_requests
	        PASS [   0.022s] ethexe-network kad::tests::finished_without_additional_record_removes_cached_entry
	        PASS [   0.025s] ethexe-network kad::tests::get_record_cancelled
	        PASS [   0.029s] ethexe-network kad::tests::get_closest_peers_works
	        PASS [   0.025s] ethexe-network kad::tests::get_record_not_found_propagates_error
	        PASS [   0.025s] ethexe-network kad::tests::get_record_success_is_reported_and_cached
	        PASS [   0.027s] ethexe-network kad::tests::inbound_put_record_emits_event_with_validator
	        PASS [   0.028s] ethexe-network kad::tests::put_record_cancelled
	        PASS [   0.030s] ethexe-network kad::tests::query_finishes_once_quorum_reached
	        PASS [   0.025s] ethexe-network kad::tests::record_encode_decode
	        PASS [   0.032s] ethexe-network kad::tests::query_stays_active_when_quorum_not_met
	        PASS [   0.026s] ethexe-network kad::tests::record_errors_on_mismatched_validator
	        PASS [   0.023s] ethexe-network kad::tests::unknown_record_type
	        PASS [   0.023s] ethexe-network kad::tests::validator_does_not_store_when_check_fails
	        PASS [   0.023s] ethexe-network kad::tests::validator_stores_record_after_successful_check
	        PASS [   0.020s] ethexe-network peer_score::tests::decay_math
	        PASS [   0.020s] ethexe-network peer_score::tests::peer_forgot
	        PASS [   0.019s] ethexe-network slots::tests::add_inbound_connection_keeps_initial_outbound_direction
	        PASS [   0.022s] ethexe-network slots::tests::add_inbound_connection_rejects_peer_in_backoff_period
	        PASS [   0.019s] ethexe-network slots::tests::add_inbound_connection_rejects_when_all_inbound_slots_are_used
	        PASS [   0.019s] ethexe-network slots::tests::add_inbound_connection_uses_overflowing_slots_after_normal_limit
	        PASS [   0.019s] ethexe-network slots::tests::add_outbound_connection_allows_multiple_connections_for_known_peer_at_limit
	        PASS [   0.020s] ethexe-network slots::tests::add_outbound_connection_keeps_initial_inbound_direction
	        PASS [   0.019s] ethexe-network slots::tests::add_outbound_connection_rejects_peer_in_backoff_period
	        PASS [   0.017s] ethexe-network slots::tests::add_pending_outbound_connection_ignores_backoff_peers_for_limit
	        PASS [   0.017s] ethexe-network slots::tests::add_pending_outbound_connection_rejects_known_peer_in_backoff_period
	        PASS [   0.021s] ethexe-network slots::tests::add_pending_outbound_connection_does_not_track_known_peer
	        PASS [   0.020s] ethexe-network slots::tests::dial_peers_ignores_backoff_peers_when_counting_outbound_minimum
	        PASS [   0.025s] ethexe-network slots::tests::dial_peers_dials_all_needed_known_peers
	        PASS [   0.019s] ethexe-network slots::tests::dial_peers_is_noop_when_minimum_is_already_satisfied
	        PASS [   0.020s] ethexe-network slots::tests::dial_peers_skips_connected_and_pending_peers
	        PASS [   0.021s] ethexe-network slots::tests::dial_peers_wakes
	        PASS [   0.018s] ethexe-network slots::tests::evict_inbound_overflowing_peers_does_not_evict_fresh_overflowing_peer
	        PASS [   0.018s] ethexe-network slots::tests::evict_inbound_overflowing_peers_closes_only_evictable_peers
	        PASS [   0.018s] ethexe-network slots::tests::evict_inbound_overflowing_peers_waits_until_timeout_is_exceeded
	        PASS [   0.020s] ethexe-network slots::tests::evict_inbound_overflowing_peers_wakes
	        PASS [   0.019s] ethexe-network slots::tests::report_peer_action_is_noop_for_non_overflowing_peers
	        PASS [   0.024s] ethexe-network slots::tests::on_swarm_event_dial_failure_removes_pending_outbound_peer
	        PASS [   0.022s] ethexe-network slots::tests::report_peer_action_updates_latest_action_for_overflowing_inbound_peer
	        PASS [   0.043s] ethexe-network slots::tests::inbound_peers_limit
	        PASS [   0.020s] ethexe-network slots::tests::update_on_periods_removes_just_disconnected_only_after_backoff_period
	        PASS [   0.041s] ethexe-network slots::tests::outbound_peers_limit
	        PASS [   0.024s] ethexe-network tests::peer_blocked_by_score
	        PASS [   0.031s] ethexe-network tests::external_data_provider
	        PASS [   0.028s] ethexe-network tests::request_db_data
	        PASS [   0.025s] ethexe-network tests::test_memory_transport
	        PASS [   0.022s] ethexe-network utils::tests::connection_map_key_cleared
	        PASS [   0.019s] ethexe-network utils::tests::connection_map_limit_works
	        PASS [   0.020s] ethexe-network utils::tests::interval_smoke
	        PASS [   0.020s] ethexe-network utils::tests::interval_tick_at_max
	        PASS [   0.020s] ethexe-network validator::discovery::tests::behaviour_queries_and_puts
	        PASS [   0.020s] ethexe-network validator::discovery::tests::behaviour_stores_identity_for_known_validator
	        PASS [   0.022s] ethexe-network validator::discovery::tests::different_peer_ids_in_identity
	        PASS [   0.022s] ethexe-network validator::discovery::tests::duplicate_and_self_identity_handling
	        PASS [   0.020s] ethexe-network validator::discovery::tests::get_identities_reports_address
	        PASS [   0.022s] ethexe-network validator::discovery::tests::encode_decode_identity
	        PASS [   0.022s] ethexe-network validator::discovery::tests::on_new_snapshot_drops_obsolete_identities
	        PASS [   0.020s] ethexe-network validator::discovery::tests::put_identity_global_addresses
	        PASS [   0.021s] ethexe-network validator::discovery::tests::put_identity_ticks_at_max
	        PASS [   0.023s] ethexe-network validator::discovery::tests::put_identity_prefers_newer_records
	        PASS [   0.018s] ethexe-network validator::discovery::tests::validator_addresses_from_vec_of_vec
	        PASS [   0.024s] ethexe-network validator::discovery::tests::verify_record_rejects_unknown_validator
	        PASS [   0.018s] ethexe-network validator::list::tests::validator_list_advances
	        PASS [   0.018s] ethexe-network validator::topic::tests::current_era_address_is_not_validator
	        PASS [   0.020s] ethexe-network validator::topic::tests::new_era
	        PASS [   0.019s] ethexe-network validator::topic::tests::next_era_address_is_not_validator
	        PASS [   0.022s] ethexe-network validator::topic::tests::new_era_address_is_not_validator
	        PASS [   0.020s] ethexe-network validator::topic::tests::next_validators_arrive_later
	        PASS [   0.017s] ethexe-network validator::topic::tests::old_era
	        PASS [   0.019s] ethexe-network validator::topic::tests::success
	        PASS [   0.019s] ethexe-network validator::topic::tests::too_new_era
	        PASS [   0.018s] ethexe-network validator::topic::tests::too_old_era
	        PASS [   0.020s] ethexe-network validator::topic::tests::verify_promise_ok
	        PASS [   0.019s] ethexe-network validator::topic::tests::verify_promise_unknown_validator
	        PASS [   0.088s] ethexe-processor handling::thread_pool::tests::test_thread_pool
	        PASS [   1.022s] ethexe-network peer_score::tests::smoke
	        PASS [   2.086s] ethexe-db rocks::tests::cas_multi_thread
	        PASS [   2.177s] ethexe-db mem::tests::cas_multi_thread
	        PASS [   4.880s] ethexe-ethereum deploy::tests::test_deployment_with_middleware
	        PASS [   5.023s] ethexe-network db_sync::tests::unsupported_protocol_handled
	        PASS [   6.038s] ethexe-network tests::validator_discovery
	        PASS [   9.259s] ethexe-processor handling::run::tests::nullification
	        PASS [   9.873s] ethexe-processor handling::run::tests::chunk_partitioning
	        PASS [   1.155s] ethexe-processor tests::handle_new_code_valid
	        PASS [   1.138s] ethexe-processor tests::injected_ping_pong
	        PASS [   1.142s] ethexe-processor tests::insufficient_executable_balance_still_charged
	        PASS [   2.063s] ethexe-processor tests::injected_prioritized_over_canonical
	        PASS [   0.980s] ethexe-processor tests::many_waits
	        PASS [  13.500s] ethexe-processor tests::async_and_ping
	        PASS [   0.931s] ethexe-processor tests::overlay_execution
	        PASS [   0.256s] ethexe-prometheus tests::fused_stream_works
	        PASS [   0.706s] ethexe-processor tests::ping_init
	        PASS [   0.736s] ethexe-processor tests::ping_pong
	        PASS [  13.687s] ethexe-processor tests::call_gr_wait_is_forbidden
	        PASS [   0.013s] ethexe-runtime-common journal::tests::charge_exec_balance
	        PASS [   0.015s] ethexe-runtime-common journal::tests::notes_update_state_hash
	        PASS [   0.011s] ethexe-runtime-common schedule::tests::restorer_stash
	        PASS [   0.012s] ethexe-runtime-common schedule::tests::restorer_waitlist
	        PASS [  13.770s] ethexe-processor tests::call_wait_up_to_with_huge_duration
	        PASS [  13.722s] ethexe-processor tests::call_wake_with_delay_is_unsupported
	        PASS [   0.337s] ethexe-runtime-common schedule::tests::restorer_mailbox
	        PASS [   1.133s] ethexe-rpc tests::test_cleanup_promise_subscribers
	        PASS [  11.123s] ethexe-processor tests::executable_balance_charged
	        PASS [   9.348s] ethexe-processor tests::handle_new_code_invalid
	        PASS [  10.917s] ethexe-processor tests::executable_balance_injected_panic_not_charged
	        PASS [  19.026s] ethexe-consensus announces::tests::proptest_propagation_with_committed_announce
	        PASS [  20.958s] ethexe-observer tests::test_deployment
	        PASS [  18.160s] ethexe-rpc tests::test_concurrent_multiple_clients
	        PASS [  35.549s] ethexe-consensus announces::tests::proptest_propagation_committed_delayed
	        PASS [  37.047s] ethexe-consensus announces::tests::proptest_propagation_missing
	        PASS [  19.696s] ethexe-service tests::invalid_code
	        PASS [  22.216s] ethexe-service tests::incoming_transfers
	        PASS [  22.313s] ethexe-service tests::injected_tx_fungible_token
	        PASS [  39.645s] ethexe-consensus announces::tests::proptest_propagation
	        PASS [  17.667s] ethexe-service tests::mailbox
	        PASS [   1.074s] ethexe-service tests::send_injected_tx
	        PASS [  23.295s] ethexe-service tests::injected_tx_fungible_token_over_network
	        PASS [  24.131s] ethexe-service tests::catch_up_5
	        PASS [  24.163s] ethexe-service tests::catch_up_3
	        PASS [   5.249s] ethexe-service tests::ping
	        PASS [  25.311s] ethexe-service tests::execution_with_canonical_events_quarantine
	        PASS [   4.957s] ethexe-service tests::ping_deep_sync
	        PASS [   4.590s] ethexe-service tests::reply_callback
	        PASS [   5.059s] ethexe-service tests::uninitialized_program
	        PASS [   5.872s] ethexe-service tests::ping_reorg
	        PASS [   4.420s] ethexe-service tests::value_reply_program_to_user
	        PASS [   4.590s] ethexe-service tests::value_send_program_to_user_and_claimed
	        PASS [  28.695s] ethexe-service tests::fast_sync
	        PASS [   4.622s] ethexe-service tests::value_send_program_to_user_and_replied
	        PASS [   4.715s] ethexe-service tests::value_send_program_to_program
	        PASS [   4.795s] ethexe-service tests::value_send_delayed
	        PASS [   4.056s] ethexe-service tests::write_memory_to_last_byte
	        PASS [  12.253s] ethexe-service tests::multiple_validators
	        PASS [   5.955s] ethexe-service tests::validators_election
	        PASS [   3.014s] ethexe-service-utils tests::maybe_polling
	        PASS [  33.369s] ethexe-service tests::announces_conflicts
	        PASS [  58.765s] ethexe-service tests::whole_network_restore
	────────────
	     Summary [ 100.730s] 333 tests run: 333 passed, 2 skipped
	```
</details>

<details>
	<summary>Singled-threaded runtime: 72,048s</summary>

	```
	 Nextest run ID 76007574-f4f3-44ad-9062-7c583d5ddb55 with nextest profile: default
	    Starting 333 tests across 19 binaries (2 tests skipped)
	        PASS [   0.008s] ethexe-common primitives::tests::test_era_start_calculation
	        PASS [   0.009s] ethexe-common db::tests::ensure_types_unchanged
	        PASS [   0.009s] ethexe-common primitives::tests::test_era_from_ts_calculation
	        PASS [   0.009s] ethexe-common injected::tests::signed_message_and_injected_transactions
	        PASS [   0.009s] ethexe-blob-loader tests::test_handle_blob
	        PASS [   0.010s] ethexe-cli utils::tests::test_formatted_value
	        PASS [   0.023s] ethexe-compute compute::tests::collect_not_computed_predecessors_work_correctly
	        PASS [   0.023s] ethexe-compute codes::tests::process_already_validated_code
	        PASS [   0.023s] ethexe-compute codes::tests::process_invalid_code
	        PASS [   0.023s] ethexe-compute compute::tests::test_compute
	        PASS [   0.024s] ethexe-compute codes::tests::process_code
	        PASS [   0.026s] ethexe-common primitives::tests::panic_on_era_from_ts_before_genesis
	        PASS [   0.022s] ethexe-compute prepare::tests::test_prepare_no_codes
	        PASS [   0.021s] ethexe-compute service::tests::compute_announce
	        PASS [   0.022s] ethexe-compute prepare::tests::test_sub_service_start_with_codes
	        PASS [   0.021s] ethexe-compute service::tests::prepare_block
	        PASS [   0.025s] ethexe-compute prepare::tests::test_prepare_one_block
	        PASS [   0.025s] ethexe-compute prepare::tests::test_prepare_with_codes
	        PASS [   0.025s] ethexe-compute service::tests::process_code
	        PASS [   0.022s] ethexe-consensus tx_validation::tests::test_check_injected_transaction_non_zero_value
	        PASS [   0.022s] ethexe-consensus connect::tests::announce_not_computed_after_pending_and_rejected
	        PASS [   0.018s] ethexe-consensus tx_validation::tests::test_check_injected_tx_can_not_initialize_actor
	        PASS [   0.030s] ethexe-consensus tx_validation::tests::test_check_tx_duplicate
	        PASS [   0.074s] ethexe-consensus announces::tests::reject_announce_with_too_many_touched_programs
	        PASS [   0.044s] ethexe-consensus tx_validation::tests::test_check_tx_outdated
	        PASS [   0.065s] ethexe-consensus tx_validation::tests::test_check_tx_not_on_current_branch
	        PASS [   0.024s] ethexe-consensus tx_validation::tests::test_rejecting_unknown_reference_block
	        PASS [   0.027s] ethexe-consensus tx_validation::tests::test_reach_start_block_in_branch_check
	        PASS [   0.060s] ethexe-consensus tx_validation::tests::test_check_tx_validity
	        PASS [   0.036s] ethexe-consensus utils::tests::accept_batch_commitment_validation_reply
	        PASS [   0.022s] ethexe-consensus utils::tests::block_producer_index_calculates_correct_index
	        PASS [   0.026s] ethexe-consensus utils::tests::check_origin_closure_behavior
	        PASS [   0.022s] ethexe-consensus utils::tests::multisigned_batch_commitment_creation
	        PASS [   0.022s] ethexe-consensus utils::tests::producer_for_calculates_correct_producer
	        PASS [   0.018s] ethexe-consensus utils::tests::test_has_duplicates
	        PASS [   0.029s] ethexe-consensus utils::tests::reject_validation_reply_with_incorrect_digest
	        PASS [   0.025s] ethexe-consensus validator::batch::tests::accepts_matching_request
	        PASS [   0.192s] ethexe-compute tests::block_computation_basic
	        PASS [   0.193s] ethexe-compute tests::multiple_preparation_and_one_processing
	        PASS [   0.028s] ethexe-consensus validator::batch::tests::rejects_code_not_processed_yet
	        PASS [   0.027s] ethexe-consensus validator::batch::tests::rejects_digest_mismatch
	        PASS [   0.030s] ethexe-consensus validator::batch::tests::rejects_duplicate_code_ids
	        PASS [   0.023s] ethexe-consensus validator::batch::tests::rejects_non_best_chain_head
	        PASS [   0.218s] ethexe-compute tests::one_preparation_and_multiple_processing
	        PASS [   0.221s] ethexe-compute tests::code_validation_request_does_not_block_preparation
	        PASS [   0.033s] ethexe-consensus validator::batch::tests::rejects_not_waiting_code_ids
	        PASS [   0.034s] ethexe-consensus validator::batch::tests::rejects_empty_batch_request
	        PASS [   0.033s] ethexe-consensus validator::batch::tests::rejects_when_best_head_chain_is_invalid
	        PASS [   0.019s] ethexe-consensus validator::batch::utils::tests::test_aggregate_code_commitments
	        PASS [   0.024s] ethexe-consensus validator::batch::utils::tests::test_aggregate_chain_commitment
	        PASS [   0.084s] ethexe-consensus validator::batch::tests::rejects_batch_commitment_size_limit_exceeded
	        PASS [   0.024s] ethexe-consensus validator::batch::utils::tests::test_batch_expiry_calculation
	        PASS [   0.045s] ethexe-consensus validator::batch::tests::test_aggregate_validators_commitment
	        PASS [   0.021s] ethexe-consensus validator::coordinator::tests::coordinator_create_insufficient_validators
	        PASS [   0.024s] ethexe-consensus validator::coordinator::tests::coordinator_create_zero_threshold
	        PASS [   0.025s] ethexe-consensus validator::initial::tests::announce_propagation_done
	        PASS [   0.030s] ethexe-consensus validator::coordinator::tests::coordinator_create_success
	        PASS [   0.020s] ethexe-consensus validator::initial::tests::create_initial_success
	        PASS [   0.033s] ethexe-consensus validator::coordinator::tests::process_validation_reply
	        PASS [   0.026s] ethexe-consensus validator::initial::tests::commitment_with_delay
	        PASS [   0.031s] ethexe-consensus validator::initial::tests::announce_propagation_many_missing_blocks
	        PASS [   0.025s] ethexe-consensus validator::initial::tests::missing_announces_request_response
	        PASS [   0.032s] ethexe-consensus validator::initial::tests::create_with_chain_head_success
	        PASS [   0.022s] ethexe-consensus validator::initial::tests::process_synced_block_rejected
	        PASS [   0.028s] ethexe-consensus validator::initial::tests::process_announces_response_rejected
	        PASS [   0.025s] ethexe-consensus validator::initial::tests::process_prepared_block_rejected
	        PASS [   0.024s] ethexe-consensus validator::initial::tests::switch_to_subordinate
	        PASS [   0.029s] ethexe-consensus validator::participant::tests::codes_not_waiting_for_commitment_error
	        PASS [   0.032s] ethexe-consensus validator::initial::tests::switch_to_producer
	        PASS [   0.023s] ethexe-consensus validator::participant::tests::create
	        PASS [   0.024s] ethexe-consensus validator::participant::tests::create_with_pending_events
	        PASS [   0.028s] ethexe-consensus validator::participant::tests::digest_mismatch_warning
	        PASS [   0.029s] ethexe-consensus validator::participant::tests::duplicate_codes_warning
	        PASS [   0.029s] ethexe-consensus validator::participant::tests::empty_batch_error
	        PASS [   0.025s] ethexe-consensus validator::participant::tests::process_validation_request_failure
	        PASS [   0.024s] ethexe-consensus validator::producer::tests::create
	        PASS [   0.029s] ethexe-consensus validator::participant::tests::process_validation_request_success
	        PASS [   0.029s] ethexe-consensus validator::producer::tests::code_commitments_only
	        PASS [   0.032s] ethexe-consensus validator::producer::tests::simple
	        PASS [   0.026s] ethexe-consensus validator::subordinate::tests::create_empty
	        PASS [   0.028s] ethexe-consensus validator::producer::tests::threshold_two
	        PASS [   0.030s] ethexe-consensus validator::producer::tests::threshold_one
	        PASS [   0.024s] ethexe-consensus validator::subordinate::tests::create_with_multiple_announces
	        PASS [   0.026s] ethexe-consensus validator::subordinate::tests::create_with_validation_requests
	        PASS [   0.026s] ethexe-consensus validator::subordinate::tests::earlier_received_announces
	        PASS [   0.032s] ethexe-consensus validator::subordinate::tests::process_computed_block_with_unexpected_hash
	        PASS [   0.023s] ethexe-consensus validator::subordinate::tests::simple
	        PASS [   0.030s] ethexe-consensus validator::subordinate::tests::process_external_event_with_invalid_announce
	        PASS [   0.029s] ethexe-consensus validator::subordinate::tests::reject_announce_from_producer
	        PASS [   0.029s] ethexe-consensus validator::subordinate::tests::simple_not_validator
	        PASS [   0.076s] ethexe-consensus validator::subordinate::tests::create_with_many_pending_events
	        PASS [   0.025s] ethexe-consensus validator::tx_pool::tests::validate_max_tx_size
	        PASS [   0.036s] ethexe-consensus validator::tx_pool::tests::test_select_for_announce
	        PASS [   0.032s] ethexe-db database::tests::test_announce_outcome
	        PASS [   0.033s] ethexe-db database::tests::test_announce
	        PASS [   0.038s] ethexe-db database::tests::test_allocations
	        PASS [   0.031s] ethexe-db database::tests::test_announce_program_states
	        PASS [   0.032s] ethexe-db database::tests::test_announce_schedule
	        PASS [   0.038s] ethexe-db database::tests::test_block_events
	        PASS [   0.031s] ethexe-db database::tests::test_code_metadata
	        PASS [   0.036s] ethexe-db database::tests::test_block_is_synced
	        PASS [   0.040s] ethexe-db database::tests::test_block_header
	        PASS [   0.037s] ethexe-db database::tests::test_code_blob_info
	        PASS [   0.036s] ethexe-db database::tests::test_code_valid
	        PASS [   0.105s] ethexe-consensus validator::tx_pool::tests::max_touched_programs
	        PASS [   0.035s] ethexe-db database::tests::test_injected_transaction
	        PASS [   0.032s] ethexe-db database::tests::test_instrumented_code
	        PASS [   0.032s] ethexe-db database::tests::test_original_code
	        PASS [   0.032s] ethexe-db database::tests::test_pages
	        PASS [   0.036s] ethexe-db database::tests::test_mailbox
	        PASS [   0.038s] ethexe-db database::tests::test_page_data
	        PASS [   0.031s] ethexe-db database::tests::test_pages_region
	        PASS [   0.035s] ethexe-db database::tests::test_payload
	        PASS [   0.038s] ethexe-db database::tests::test_program_code_id
	        PASS [   0.032s] ethexe-db database::tests::test_queue
	        PASS [   0.542s] ethexe-compute compute::tests::test_compute_with_promises
	        PASS [   0.032s] ethexe-db database::tests::test_stash
	        PASS [   0.030s] ethexe-db database::tests::test_waitlist
	        PASS [   0.032s] ethexe-db database::tests::test_state
	        PASS [   0.033s] ethexe-db iterator::tests::walk_announce_outcome
	        PASS [   0.039s] ethexe-db iterator::tests::walk_announce_program_states
	        PASS [   0.032s] ethexe-db iterator::tests::walk_announce_schedule
	        PASS [   0.030s] ethexe-db iterator::tests::walk_block_schedule_tasks
	        PASS [   0.031s] ethexe-db iterator::tests::walk_block_with_missing_data
	        PASS [   0.030s] ethexe-db iterator::tests::walk_chain_basic
	        PASS [   0.039s] ethexe-db iterator::tests::walk_code_id_missing_data
	        PASS [   0.040s] ethexe-db iterator::tests::walk_payload_lookup_direct
	        PASS [   0.034s] ethexe-db iterator::tests::walk_program_id_missing_code
	        PASS [   0.029s] ethexe-db iterator::tests::walk_state_transition_zero_state_hash
	        PASS [   0.032s] ethexe-db mem::tests::cas_read_write
	        PASS [   0.035s] ethexe-db mem::tests::is_cloneable
	        PASS [   0.044s] ethexe-db iterator::tests::walk_state_transition
	        PASS [   0.034s] ethexe-db mem::tests::kv_iter_prefix
	        PASS [   0.032s] ethexe-db mem::tests::kv_read_write
	        PASS [   0.034s] ethexe-db migrations::v1::tests::ensure_migration_types
	        PASS [   0.036s] ethexe-db rocks::tests::is_cloneable
	        PASS [   0.043s] ethexe-db rocks::tests::cas_read_write
	        PASS [   0.043s] ethexe-db rocks::tests::kv_iter_prefix
	        PASS [   0.041s] ethexe-db rocks::tests::kv_read_write
	        PASS [   0.036s] ethexe-db verifier::tests::test_block_meta_not_prepared_error
	        PASS [   0.036s] ethexe-db verifier::tests::test_block_meta_not_synced_error
	        PASS [   0.037s] ethexe-db verifier::tests::test_block_schedule_has_expired_tasks_error
	        PASS [   0.034s] ethexe-db verifier::tests::test_code_is_not_valid_error
	        PASS [   0.029s] ethexe-db verifier::tests::test_invalid_block_parent_height_error
	        PASS [   0.038s] ethexe-db verifier::tests::test_database_visitor_error_propagation
	        PASS [   0.040s] ethexe-db verifier::tests::test_invalid_code_len_in_metadata_error
	        PASS [   0.036s] ethexe-db verifier::tests::test_invalid_parent_timestamp_error
	        PASS [   0.032s] ethexe-db verifier::tests::test_multiple_errors_collected
	        PASS [   0.030s] ethexe-db verifier::tests::test_no_parent_block_header_error
	        PASS [   0.030s] ethexe-db verifier::tests::test_visit_message_queue_success
	        PASS [   0.035s] ethexe-db verifier::tests::test_successful_verification_with_valid_data
	        PASS [   0.039s] ethexe-db verifier::tests::test_visit_message_queue_invalid_cached_size
	        PASS [   0.010s] ethexe-ethereum abi::utils::casts_are_correct
	        PASS [   0.058s] ethexe-db verifier::tests::test_visit_message_queue_without_hash_panics
	        PASS [   0.019s] ethexe-ethereum tests::sender_signs_prehashed_message
	        PASS [   0.058s] ethexe-network custom_connection_limits::tests::inbound_connection_denied
	        PASS [   0.406s] ethexe-db iterator::tests::walk_payload_lookup_stored
	        PASS [   0.057s] ethexe-network custom_connection_limits::tests::outbound_connection_denied
	        PASS [   0.019s] ethexe-network db_sync::requests::tests::try_into_checked_accepts_valid_tail_range
	        PASS [   0.028s] ethexe-network db_sync::requests::tests::try_into_checked_accepts_valid_chain_len
	        PASS [   0.028s] ethexe-network db_sync::requests::tests::try_into_checked_rejects_empty_response
	        PASS [   0.019s] ethexe-network db_sync::requests::tests::try_into_checked_rejects_head_mismatch
	        PASS [   0.020s] ethexe-network db_sync::requests::tests::try_into_checked_rejects_non_linked_chain
	        PASS [   0.022s] ethexe-network db_sync::requests::tests::try_into_checked_rejects_len_mismatch
	        PASS [   0.451s] ethexe-db mem::tests::kv_multi_thread
	        PASS [   0.022s] ethexe-network db_sync::requests::tests::try_into_checked_rejects_tail_mismatch
	        PASS [   0.022s] ethexe-network db_sync::requests::tests::validate_data_hash_incomplete
	        PASS [   0.024s] ethexe-network db_sync::requests::tests::validate_data_hash_mismatch
	        PASS [   0.022s] ethexe-network db_sync::requests::tests::validate_data_stripped
	        PASS [   0.023s] ethexe-network db_sync::responses::tests::fails_announce_missing
	        PASS [   0.464s] ethexe-db rocks::tests::kv_multi_thread
	        PASS [   0.021s] ethexe-network db_sync::responses::tests::fails_chain_len_exceeding_max
	        PASS [   0.019s] ethexe-network db_sync::responses::tests::fails_reaching_start_non_genesis
	        PASS [   0.020s] ethexe-network db_sync::responses::tests::fails_when_reaching_genesis
	        PASS [   0.022s] ethexe-network db_sync::responses::tests::returns_announces_until_chain_len
	        PASS [   0.036s] ethexe-network db_sync::responses::tests::fails_reaching_max_chain_length
	        PASS [   0.025s] ethexe-network db_sync::responses::tests::returns_announces_until_tail
	        PASS [   0.024s] ethexe-network db_sync::tests::excessive_data_stripped
	        PASS [   0.024s] ethexe-network db_sync::tests::external_data_provider
	        PASS [   0.022s] ethexe-network db_sync::tests::out_of_rounds
	        PASS [   0.025s] ethexe-network db_sync::tests::request_cancelled
	        PASS [   0.026s] ethexe-network db_sync::tests::request_completed_after_new_peer
	        PASS [   0.023s] ethexe-network db_sync::tests::request_completed_by_3_rounds
	        PASS [   1.162s] ethexe-compute compute::tests::test_compute_with_early_break
	        PASS [   0.366s] ethexe-ethereum router::tests::storage_view
	        PASS [   0.023s] ethexe-network db_sync::tests::request_response_type_mismatch
	        PASS [   0.029s] ethexe-network db_sync::tests::retry
	        PASS [   0.022s] ethexe-network db_sync::tests::smoke
	        PASS [   0.022s] ethexe-network db_sync::tests::timeout
	        PASS [   0.396s] ethexe-ethereum router::tests::inexistent_code_is_unknown
	        PASS [   0.036s] ethexe-network db_sync::tests::simultaneous_responses_limit
	        PASS [   0.027s] ethexe-network injected::tests::accept
	        PASS [   0.027s] ethexe-network injected::tests::outbound_failure_rejected
	        PASS [   0.022s] ethexe-network injected::tests::validator_not_found
	        PASS [   0.025s] ethexe-network injected::tests::transaction_already_sent
	        PASS [   0.031s] ethexe-network injected::tests::rejected
	        PASS [   0.039s] ethexe-network injected::tests::too_many_pending_requests
	        PASS [   0.028s] ethexe-network kad::tests::finished_without_additional_record_removes_cached_entry
	        PASS [   0.024s] ethexe-network kad::tests::get_record_cancelled
	        PASS [   0.024s] ethexe-network kad::tests::get_record_not_found_propagates_error
	        PASS [   0.027s] ethexe-network kad::tests::get_record_success_is_reported_and_cached
	        PASS [   0.031s] ethexe-network kad::tests::get_closest_peers_works
	        PASS [   0.025s] ethexe-network kad::tests::inbound_put_record_emits_event_with_validator
	        PASS [   0.027s] ethexe-network kad::tests::put_record_cancelled
	        PASS [   0.023s] ethexe-network kad::tests::record_errors_on_mismatched_validator
	        PASS [   0.031s] ethexe-network kad::tests::query_stays_active_when_quorum_not_met
	        PASS [   0.032s] ethexe-network kad::tests::query_finishes_once_quorum_reached
	        PASS [   0.027s] ethexe-network kad::tests::record_encode_decode
	        PASS [   0.022s] ethexe-network kad::tests::unknown_record_type
	        PASS [   0.025s] ethexe-network kad::tests::validator_does_not_store_when_check_fails
	        PASS [   0.023s] ethexe-network kad::tests::validator_stores_record_after_successful_check
	        PASS [   0.021s] ethexe-network peer_score::tests::peer_forgot
	        PASS [   0.021s] ethexe-network peer_score::tests::decay_math
	        PASS [   0.020s] ethexe-network slots::tests::add_inbound_connection_keeps_initial_outbound_direction
	        PASS [   0.020s] ethexe-network slots::tests::add_inbound_connection_rejects_peer_in_backoff_period
	        PASS [   0.018s] ethexe-network slots::tests::add_inbound_connection_rejects_when_all_inbound_slots_are_used
	        PASS [   0.018s] ethexe-network slots::tests::add_outbound_connection_allows_multiple_connections_for_known_peer_at_limit
	        PASS [   0.018s] ethexe-network slots::tests::add_inbound_connection_uses_overflowing_slots_after_normal_limit
	        PASS [   0.018s] ethexe-network slots::tests::add_outbound_connection_keeps_initial_inbound_direction
	        PASS [   0.022s] ethexe-network slots::tests::add_outbound_connection_rejects_peer_in_backoff_period
	        PASS [   0.018s] ethexe-network slots::tests::add_pending_outbound_connection_does_not_track_known_peer
	        PASS [   0.018s] ethexe-network slots::tests::add_pending_outbound_connection_ignores_backoff_peers_for_limit
	        PASS [   0.018s] ethexe-network slots::tests::add_pending_outbound_connection_rejects_known_peer_in_backoff_period
	        PASS [   0.020s] ethexe-network slots::tests::dial_peers_dials_all_needed_known_peers
	        PASS [   0.024s] ethexe-network slots::tests::dial_peers_ignores_backoff_peers_when_counting_outbound_minimum
	        PASS [   0.019s] ethexe-network slots::tests::dial_peers_is_noop_when_minimum_is_already_satisfied
	        PASS [   0.017s] ethexe-network slots::tests::evict_inbound_overflowing_peers_closes_only_evictable_peers
	        PASS [   0.022s] ethexe-network slots::tests::dial_peers_skips_connected_and_pending_peers
	        PASS [   0.026s] ethexe-network slots::tests::dial_peers_wakes
	        PASS [   0.020s] ethexe-network slots::tests::evict_inbound_overflowing_peers_does_not_evict_fresh_overflowing_peer
	        PASS [   0.018s] ethexe-network slots::tests::evict_inbound_overflowing_peers_waits_until_timeout_is_exceeded
	        PASS [   0.018s] ethexe-network slots::tests::evict_inbound_overflowing_peers_wakes
	        PASS [   0.023s] ethexe-network slots::tests::on_swarm_event_dial_failure_removes_pending_outbound_peer
	        PASS [   0.018s] ethexe-network slots::tests::report_peer_action_updates_latest_action_for_overflowing_inbound_peer
	        PASS [   0.019s] ethexe-network slots::tests::report_peer_action_is_noop_for_non_overflowing_peers
	        PASS [   0.047s] ethexe-network slots::tests::inbound_peers_limit
	        PASS [   0.021s] ethexe-network slots::tests::update_on_periods_removes_just_disconnected_only_after_backoff_period
	        PASS [   0.036s] ethexe-network slots::tests::outbound_peers_limit
	        PASS [   0.027s] ethexe-network tests::peer_blocked_by_score
	        PASS [   0.030s] ethexe-network tests::external_data_provider
	        PASS [   0.024s] ethexe-network tests::test_memory_transport
	        PASS [   0.027s] ethexe-network tests::request_db_data
	        PASS [   0.018s] ethexe-network utils::tests::connection_map_key_cleared
	        PASS [   0.019s] ethexe-network utils::tests::connection_map_limit_works
	        PASS [   0.019s] ethexe-network utils::tests::interval_smoke
	        PASS [   0.018s] ethexe-network utils::tests::interval_tick_at_max
	        PASS [   0.020s] ethexe-network validator::discovery::tests::behaviour_queries_and_puts
	        PASS [   0.020s] ethexe-network validator::discovery::tests::behaviour_stores_identity_for_known_validator
	        PASS [   0.022s] ethexe-network validator::discovery::tests::different_peer_ids_in_identity
	        PASS [   0.022s] ethexe-network validator::discovery::tests::duplicate_and_self_identity_handling
	        PASS [   0.020s] ethexe-network validator::discovery::tests::encode_decode_identity
	        PASS [   0.020s] ethexe-network validator::discovery::tests::get_identities_reports_address
	        PASS [   0.023s] ethexe-network validator::discovery::tests::on_new_snapshot_drops_obsolete_identities
	        PASS [   0.022s] ethexe-network validator::discovery::tests::put_identity_global_addresses
	        PASS [   0.019s] ethexe-network validator::discovery::tests::put_identity_ticks_at_max
	        PASS [   0.023s] ethexe-network validator::discovery::tests::put_identity_prefers_newer_records
	        PASS [   0.017s] ethexe-network validator::discovery::tests::validator_addresses_from_vec_of_vec
	        PASS [   0.019s] ethexe-network validator::discovery::tests::verify_record_rejects_unknown_validator
	        PASS [   0.016s] ethexe-network validator::list::tests::validator_list_advances
	        PASS [   0.018s] ethexe-network validator::topic::tests::current_era_address_is_not_validator
	        PASS [   0.020s] ethexe-network validator::topic::tests::new_era
	        PASS [   0.020s] ethexe-network validator::topic::tests::new_era_address_is_not_validator
	        PASS [   0.018s] ethexe-network validator::topic::tests::next_era_address_is_not_validator
	        PASS [   0.020s] ethexe-network validator::topic::tests::next_validators_arrive_later
	        PASS [   0.018s] ethexe-network validator::topic::tests::old_era
	        PASS [   0.018s] ethexe-network validator::topic::tests::too_new_era
	        PASS [   0.019s] ethexe-network validator::topic::tests::success
	        PASS [   0.018s] ethexe-network validator::topic::tests::too_old_era
	        PASS [   0.018s] ethexe-network validator::topic::tests::verify_promise_ok
	        PASS [   0.019s] ethexe-network validator::topic::tests::verify_promise_unknown_validator
	        PASS [   0.065s] ethexe-processor handling::thread_pool::tests::test_thread_pool
	        PASS [   0.172s] ethexe-processor handling::run::tests::chunk_partitioning
	        PASS [   0.163s] ethexe-processor handling::run::tests::nullification
	        PASS [   0.187s] ethexe-processor tests::call_gr_wait_is_forbidden
	        PASS [   0.340s] ethexe-processor tests::async_and_ping
	        PASS [   1.399s] ethexe-db rocks::tests::cas_multi_thread
	        PASS [   1.461s] ethexe-db mem::tests::cas_multi_thread
	        PASS [   0.332s] ethexe-processor tests::call_wait_up_to_with_huge_duration
	        PASS [   0.205s] ethexe-processor tests::executable_balance_charged
	        PASS [   0.180s] ethexe-processor tests::handle_new_code_invalid
	        PASS [   0.218s] ethexe-processor tests::executable_balance_injected_panic_not_charged
	        PASS [   0.174s] ethexe-processor tests::handle_new_code_valid
	        PASS [   0.322s] ethexe-processor tests::call_wake_with_delay_is_unsupported
	        PASS [   1.023s] ethexe-network peer_score::tests::smoke
	        PASS [   0.236s] ethexe-processor tests::injected_ping_pong
	        PASS [   0.214s] ethexe-processor tests::insufficient_executable_balance_still_charged
	        PASS [   0.197s] ethexe-processor tests::ping_init
	        PASS [   0.378s] ethexe-processor tests::many_waits
	        PASS [   0.395s] ethexe-processor tests::overlay_execution
	        PASS [   0.009s] ethexe-runtime-common journal::tests::charge_exec_balance
	        PASS [   0.010s] ethexe-runtime-common journal::tests::notes_update_state_hash
	        PASS [   0.221s] ethexe-prometheus tests::fused_stream_works
	        PASS [   0.017s] ethexe-runtime-common schedule::tests::restorer_stash
	        PASS [   0.010s] ethexe-runtime-common schedule::tests::restorer_waitlist
	        PASS [   0.278s] ethexe-processor tests::ping_pong
	        PASS [   0.233s] ethexe-runtime-common schedule::tests::restorer_mailbox
	        PASS [   0.684s] ethexe-processor tests::injected_prioritized_over_canonical
	        PASS [   0.978s] ethexe-rpc tests::test_cleanup_promise_subscribers
	        PASS [   4.778s] ethexe-consensus announces::tests::proptest_propagation_with_committed_announce
	        PASS [   3.529s] ethexe-observer tests::test_deployment
	        PASS [   5.321s] ethexe-ethereum deploy::tests::test_deployment_with_middleware
	        PASS [   5.030s] ethexe-network db_sync::tests::unsupported_protocol_handled
	        PASS [   6.030s] ethexe-network tests::validator_discovery
	        PASS [   7.915s] ethexe-consensus announces::tests::proptest_propagation_committed_delayed
	        PASS [   8.633s] ethexe-consensus announces::tests::proptest_propagation_missing
	        PASS [   6.101s] ethexe-service tests::catch_up_3
	        PASS [   5.919s] ethexe-service tests::catch_up_5
	        PASS [   4.546s] ethexe-service tests::incoming_transfers
	        PASS [   4.712s] ethexe-service tests::injected_tx_fungible_token
	        PASS [   3.902s] ethexe-service tests::invalid_code
	        PASS [   7.288s] ethexe-service tests::execution_with_canonical_events_quarantine
	        PASS [  10.704s] ethexe-consensus announces::tests::proptest_propagation
	        PASS [   1.091s] ethexe-service tests::send_injected_tx
	        PASS [   4.721s] ethexe-service tests::mailbox
	        PASS [   6.869s] ethexe-service tests::injected_tx_fungible_token_over_network
	        PASS [   4.413s] ethexe-service tests::ping
	        PASS [   4.556s] ethexe-service tests::ping_deep_sync
	        PASS [   4.544s] ethexe-service tests::reply_callback
	        PASS [  10.920s] ethexe-service tests::fast_sync
	        PASS [   5.724s] ethexe-service tests::ping_reorg
	        PASS [   4.440s] ethexe-service tests::value_reply_program_to_user
	        PASS [   5.139s] ethexe-service tests::uninitialized_program
	        PASS [   4.761s] ethexe-service tests::value_send_delayed
	        PASS [   6.411s] ethexe-service tests::validators_election
	        PASS [   4.654s] ethexe-service tests::value_send_program_to_program
	        PASS [   3.014s] ethexe-service-utils tests::maybe_polling
	        PASS [   4.557s] ethexe-service tests::value_send_program_to_user_and_claimed
	        PASS [   4.522s] ethexe-service tests::value_send_program_to_user_and_replied
	        PASS [   3.938s] ethexe-service tests::write_memory_to_last_byte
	        PASS [  11.547s] ethexe-service tests::multiple_validators
	        PASS [  17.102s] ethexe-service tests::announces_conflicts
	        PASS [  17.718s] ethexe-rpc tests::test_concurrent_multiple_clients
	        PASS [  58.695s] ethexe-service tests::whole_network_restore
	────────────
	     Summary [  72.048s] 333 tests run: 333 passed, 2 skipped
	```
</details>