### PR TITLE
fix(ethexe-network): Do not query our own validator identity

### DIFF
--- a/ethexe/network/src/lib.rs
+++ b/ethexe/network/src/lib.rs
@@ -105,12 +105,6 @@ pub enum TransportType {
     Test,
 }
 
-impl TransportType {
-    fn mdns_enabled(&self) -> bool {
-        matches!(self, Self::Default)
-    }
-}
-
 /// Config from CLI
 #[derive(Debug, Clone)]
 pub struct NetworkConfig {
@@ -250,7 +244,7 @@ impl NetworkService {
             keypair: keypair.clone(),
             external_data_provider,
             db: DbSyncDatabase::clone_boxed(&db),
-            enable_mdns: transport_type.mdns_enabled(),
+            transport_type,
             validator_key,
             general_signer,
             validator_list_snapshot: validator_list_snapshot.clone(),
@@ -638,7 +632,7 @@ struct BehaviourConfig {
     keypair: identity::Keypair,
     external_data_provider: Box<dyn db_sync::ExternalDataProvider>,
     db: Box<dyn DbSyncDatabase>,
-    enable_mdns: bool,
+    transport_type: TransportType,
     validator_key: Option<PublicKey>,
     general_signer: Signer,
     validator_list_snapshot: Arc<ValidatorListSnapshot>,
@@ -682,7 +676,7 @@ impl Behaviour {
             keypair,
             external_data_provider,
             db,
-            enable_mdns,
+            transport_type,
             validator_key,
             general_signer,
             validator_list_snapshot,
@@ -715,7 +709,11 @@ impl Behaviour {
             .with_max_pending_outgoing(Some(MAX_PENDING_OUTGOING_CONNECTIONS));
         let connection_limits = connection_limits::Behaviour::new(connection_limits);
 
-        let slots = slots::Behaviour::new(slots::Config::default());
+        let slots_config = match transport_type {
+            TransportType::Default => slots::Config::default(),
+            TransportType::Test => slots::Config::default().with_backoff_period(Duration::ZERO),
+        };
+        let slots = slots::Behaviour::new(slots_config);
 
         let peer_score = peer_score::Behaviour::new(peer_score::Config::default());
         let peer_score_handle = peer_score.handle();
@@ -727,9 +725,13 @@ impl Behaviour {
         let identify = identify::Behaviour::new(identify_config);
 
         let mdns4 = Toggle::from(
-            enable_mdns
-                .then(|| mdns::Behaviour::new(mdns::Config::default(), peer_id))
-                .transpose()?,
+            match transport_type {
+                TransportType::Default => {
+                    Some(mdns::Behaviour::new(mdns::Config::default(), peer_id))
+                }
+                TransportType::Test => None,
+            }
+            .transpose()?,
         );
 
         let kad = kad::Behaviour::new(peer_id, peer_score_handle.clone(), metrics.clone());

--- a/ethexe/network/src/slots.rs
+++ b/ethexe/network/src/slots.rs
@@ -92,6 +92,11 @@ impl Default for Config {
 }
 
 impl Config {
+    pub(crate) fn with_backoff_period(mut self, backoff_period: Duration) -> Self {
+        self.backoff_period = backoff_period;
+        self
+    }
+
     fn incoming_peers_total(&self) -> u32 {
         self.inbound_max_peers + self.inbound_overflowing_peers
     }

--- a/ethexe/network/src/validator/discovery.rs
+++ b/ethexe/network/src/validator/discovery.rs
@@ -383,6 +383,7 @@ pub enum Event {
 }
 
 struct GetIdentities {
+    validator_address: Option<Address>,
     snapshot: Arc<ValidatorListSnapshot>,
     identities: ValidatorIdentities,
     query_identities: Option<BoxStream<'static, GetRecordResult>>,
@@ -405,6 +406,7 @@ impl GetIdentities {
     fn identity_keys(&self) -> impl Iterator<Item = ValidatorIdentityKey> {
         self.snapshot
             .iter()
+            .filter(|&address| Some(address) != self.validator_address)
             .map(|address| ValidatorIdentityKey { validator: address })
     }
 
@@ -430,6 +432,12 @@ impl GetIdentities {
     }
 
     fn put_identity(&mut self, record: ValidatorIdentityRecord) -> Result<bool, VerifyRecordError> {
+        debug_assert_ne!(
+            self.validator_address,
+            Some(record.value.address()),
+            "we never request our own identity"
+        );
+
         let Some(identity) = self.verify_record(record)? else {
             return Ok(false);
         };
@@ -465,10 +473,14 @@ impl GetIdentities {
                     kad.get_record(identity)
                 })
                 .collect::<Vec<_>>();
-            let stream = stream::iter(streams)
-                .flatten_unordered(Some(MAX_IN_FLIGHT_QUERIES))
-                .boxed();
-            self.query_identities.replace(stream);
+            if streams.is_empty() {
+                self.query_identities = None;
+            } else {
+                let stream = stream::iter(streams)
+                    .flatten_unordered(Some(MAX_IN_FLIGHT_QUERIES))
+                    .boxed();
+                self.query_identities.replace(stream);
+            }
             return Poll::Ready(ToSwarm::GenerateEvent(Event::GetIdentitiesStarted));
         }
 
@@ -620,6 +632,7 @@ impl Behaviour {
         Self {
             kad,
             get_identities: GetIdentities {
+                validator_address: validator_key.as_ref().map(|key| key.to_address()),
                 snapshot,
                 identities: HashMap::new(),
                 query_identities: None,
@@ -868,7 +881,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn behaviour_queries_and_puts() {
+    async fn behaviour_skips_self_query_and_puts() {
         let signer = Signer::memory();
         let validator_key = signer.generate().unwrap();
         let config = Config {
@@ -888,9 +901,41 @@ mod tests {
 
         let event = swarm.next_behaviour_event().await;
         assert_matches!(event, Event::GetIdentitiesStarted);
+        assert!(swarm.behaviour().get_identities.query_identities.is_none());
 
         let event = swarm.next_behaviour_event().await;
         assert_matches!(event, Event::PutIdentityStarted);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn behaviour_does_not_query_local_validator_identity() {
+        let signer = Signer::memory();
+        let validator_key = signer.generate().unwrap();
+
+        let (kad_handle, mut kad_callback) = kad::test_utils::HandleCallback::new_pair();
+        kad_callback.on_get_record(move |_key| {
+            panic!("local validator identity should not be requested");
+        });
+        tokio::spawn(kad_callback.loop_on_receiver());
+
+        let config = Config {
+            kad: kad_handle,
+            keypair: Keypair::generate_secp256k1(),
+            validator_key: Some(validator_key),
+            signer,
+            snapshot: new_snapshot(vec![validator_key.to_address()]),
+            allow_non_global_addresses: false,
+        };
+        let behaviour = Behaviour::new(config);
+
+        let mut swarm = Swarm::new_ephemeral_tokio(move |_keypair| behaviour);
+        swarm.add_external_address(test_addr());
+
+        time::advance(KAD_TIMER_START).await;
+
+        let event = swarm.next_behaviour_event().await;
+        assert_matches!(event, Event::GetIdentitiesStarted);
+        assert!(swarm.behaviour().get_identities.query_identities.is_none());
     }
 
     #[tokio::test(start_paused = true)]
@@ -1066,43 +1111,46 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn duplicate_and_self_identity_handling() {
+    async fn duplicate_identity_handling() {
         let signer = Signer::memory();
         let validator_key = signer.generate().unwrap();
         let network_keypair = Keypair::generate_secp256k1();
 
         let config = Config {
             kad: kad::Handle::new_test(),
-            keypair: network_keypair.clone(),
-            validator_key: Some(validator_key),
+            keypair: Keypair::generate_secp256k1(),
+            validator_key: None,
             signer: signer.clone(),
             snapshot: new_snapshot(vec![validator_key.to_address()]),
             allow_non_global_addresses: false,
         };
         let mut behaviour = Behaviour::new(config);
 
-        // Create our own identity (simulating receiving our own record)
-        let our_identity = ValidatorIdentity {
+        let identity = ValidatorIdentity {
             addresses: ValidatorAddresses::new(network_keypair.public().to_peer_id(), test_addr()),
             creation_time: 10,
         };
-        let our_signed_identity = our_identity
+        let signed_identity = identity
             .clone()
             .sign(&signer, validator_key, &network_keypair)
             .unwrap();
 
-        // NOTE: consider ignoring our own identity
         behaviour
             .get_identities
             .put_identity(ValidatorIdentityRecord {
-                value: our_signed_identity.clone(),
+                value: signed_identity,
             })
             .unwrap();
-        assert!(behaviour.get_identity(validator_key.to_address()).is_some());
+        assert_eq!(
+            behaviour
+                .get_identity(validator_key.to_address())
+                .unwrap()
+                .peer_id(),
+            network_keypair.public().to_peer_id()
+        );
 
-        // Test duplicate records from different network keys (same validator)
         let other_network_keypair = Keypair::generate_secp256k1();
-        let duplicate_identity = our_identity
+        let duplicate_identity = identity
             .sign(&signer, validator_key, &other_network_keypair)
             .unwrap();
 
@@ -1113,9 +1161,56 @@ mod tests {
             })
             .unwrap();
 
-        // Should keep the newer one (or the first one if timestamps are equal)
-        // Currently implementation keeps the first one for equal timestamps
-        assert!(behaviour.get_identity(validator_key.to_address()).is_some());
+        // creation time is the same, so the first identity should be kept
+        assert_eq!(
+            behaviour
+                .get_identity(validator_key.to_address())
+                .unwrap()
+                .peer_id(),
+            network_keypair.public().to_peer_id()
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn get_identities_does_not_report_local_address_as_remote_peer() {
+        let signer = Signer::memory();
+        let validator_key = signer.generate().unwrap();
+        let keypair = Keypair::generate_secp256k1();
+        let peer_id = keypair.public().to_peer_id();
+
+        let config = Config {
+            kad: kad::Handle::new_test(),
+            keypair,
+            validator_key: Some(validator_key),
+            signer,
+            snapshot: new_snapshot(vec![validator_key.to_address()]),
+            allow_non_global_addresses: false,
+        };
+        let behaviour = Behaviour::new(config);
+        let mut swarm = Swarm::new_ephemeral_tokio(|_keypair| behaviour);
+        swarm.add_external_address(test_addr());
+
+        time::advance(KAD_TIMER_START).await;
+
+        let event = swarm.next_behaviour_event().await;
+        assert_matches!(event, Event::GetIdentitiesStarted);
+        assert!(
+            swarm
+                .behaviour()
+                .get_identity(validator_key.to_address())
+                .is_none()
+        );
+
+        let addresses = swarm
+            .behaviour_mut()
+            .handle_pending_outbound_connection(
+                ConnectionId::new_unchecked(0),
+                Some(peer_id),
+                &[],
+                Endpoint::Dialer,
+            )
+            .unwrap();
+        assert!(addresses.is_empty());
     }
 
     #[tokio::test(start_paused = true)]
@@ -1216,15 +1311,15 @@ mod tests {
     async fn get_identities_reports_address() {
         let signer = Signer::memory();
         let validator_key = signer.generate().unwrap();
-        let network_keypair = Keypair::generate_secp256k1();
+        let keypair = Keypair::generate_secp256k1();
 
         let identity = new_signed_identity(&signer, validator_key, 10);
         let identity_addr = identity.addresses().iter().next().cloned().unwrap();
 
         let config = Config {
             kad: kad::Handle::new_test(),
-            keypair: network_keypair.clone(),
-            validator_key: Some(validator_key),
+            keypair,
+            validator_key: None,
             signer: signer.clone(),
             snapshot: new_snapshot(vec![validator_key.to_address()]),
             allow_non_global_addresses: false,

--- a/ethexe/service/src/tests/utils/env.rs
+++ b/ethexe/service/src/tests/utils/env.rs
@@ -398,6 +398,11 @@ impl TestEnv {
                 (format!("/memory/{nonce}"), bootstrap_address.clone())
             })
             .unzip();
+        let network_public_key = network_address.as_ref().map(|_| {
+            self.signer
+                .generate()
+                .expect("failed to generate network key")
+        });
 
         Node {
             name,
@@ -413,6 +418,7 @@ impl TestEnv {
             threshold: self.threshold,
             block_time: self.block_time,
             validator_config,
+            network_public_key,
             network_address,
             network_bootstrap_address,
             service_rpc_config,
@@ -908,6 +914,7 @@ pub struct Node {
     threshold: u64,
     block_time: Duration,
     validator_config: Option<ValidatorConfig>,
+    network_public_key: Option<PublicKey>,
     network_address: Option<String>,
     network_bootstrap_address: Option<String>,
     service_rpc_config: Option<RpcConfig>,
@@ -1126,7 +1133,9 @@ impl Node {
 
         let addr = self.network_address.as_ref()?;
 
-        let network_key = self.signer.generate().unwrap();
+        let network_key = self
+            .network_public_key
+            .expect("network public key must exist when network is configured");
         let multiaddr: Multiaddr = addr.parse().unwrap();
 
         let mut config = NetworkConfig::new_test(network_key, self.eth_cfg.router_address);


### PR DESCRIPTION
Also keep network identity in `TestEnv` across start and stops