### PR TITLE
fix(ci): Disable success and failure output in nextest config

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -20,6 +20,8 @@ fail-fast = false
 archive.include = [
   { path = "wasm32-gear", relative-to = "target", on-missing = "warn" },
 ]
+success-output = "never"
+failure-output = "never"
 
 [profile.ci.junit]
 path = "junit.xml"


### PR DESCRIPTION
Because we have enabled Rust logs and it looks like spam in GitHub Actions logs. Actual logs can be seen in GitHub Actions artifacts