### PR TITLE
ci: integrate code-review-graph for AST-based PR reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,252 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+
+jobs:
+  full-review:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.label.name == 'A0-pleasereview'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Fetch base commit
+        run: git fetch origin ${{ github.event.pull_request.base.sha }} --depth=1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install code-review-graph
+        run: pip install code-review-graph==2.1.0
+
+      - name: Restore graph cache
+        id: cache-graph
+        uses: actions/cache@v4
+        with:
+          path: .code-review-graph
+          key: code-review-graph-${{ github.event.pull_request.base.sha }}
+          restore-keys: |
+            code-review-graph-
+
+      - name: Build or update graph
+        run: |
+          if [ "${{ steps.cache-graph.outputs.cache-hit }}" = "true" ]; then
+            code-review-graph update
+          else
+            code-review-graph build
+          fi
+
+      - name: Create MCP config
+        run: |
+          cat > /tmp/mcp-config.json << 'EOF'
+          {
+            "mcpServers": {
+              "code-review-graph": {
+                "command": "code-review-graph",
+                "args": ["serve"]
+              }
+            }
+          }
+          EOF
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--mcp-config /tmp/mcp-config.json --allowedTools "Bash,Read,Glob,Grep,mcp__code-review-graph__detect_changes_tool,mcp__code-review-graph__get_review_context_tool,mcp__code-review-graph__get_impact_radius_tool"'
+          prompt: |
+            Review PR #${{ github.event.pull_request.number }} in gear (114-crate Rust monorepo, Solidity contracts in ethexe/).
+
+            FIRST: Run `git diff ${{ github.event.pull_request.base.sha }} --name-only` to see exactly which files changed.
+            Only review those files. Do NOT review files that are not in the diff.
+
+            Read .gemini/styleguide.md for review priorities and anti-noise rules.
+
+            Graph tools (ALWAYS use include_source=false, max_depth=1 — large repo):
+            1. detect_changes_tool base="${{ github.event.pull_request.base.sha }}"
+            2. get_review_context_tool base="${{ github.event.pull_request.base.sha }}"
+            3. Read source of high-risk functions directly if needed.
+
+            Then READ each changed file + its direct callers. Verify:
+            - Callers still work with changed behavior
+            - No stale assumptions (error codes, return types, invariants)
+            - Tests cover changed paths
+            - No breaking API/wire format/serialization changes
+
+            Post line-specific findings as PR review comments using gh CLI:
+            gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments -f body="comment" -f commit_id="${{ github.event.pull_request.head.sha }}" -f path="file" -F line=N -f side=RIGHT
+            Then post summary: gh pr comment ${{ github.event.pull_request.number }} --body "<!-- claude-review sha:${{ github.event.pull_request.head.sha }} -->\n<body>"
+
+            Summary format (use exactly this structure):
+            ## Summary
+            One sentence: what the PR does.
+
+            ## Findings
+            | Severity | Finding | Suggestion |
+            |----------|---------|------------|
+            | critical/high/medium/low | What's wrong (no file paths or line numbers) | What to do about it |
+
+            If no findings, write "No issues found."
+            Do NOT mention file paths or line numbers in the summary — those belong in inline comments only.
+            Keep it SHORT. Max 5 rows in the table.
+            At the end of the summary, add: "\n---\n> After pushing new commits, comment `/review-delta` to get an incremental review."
+
+  delta-review:
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/review-delta')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+    concurrency:
+      group: claude-review-${{ github.event.issue.number }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Get PR details
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}")
+          echo "head_sha=$(echo "$PR_JSON" | jq -r '.head.sha')" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$(echo "$PR_JSON" | jq -r '.head.ref')" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$(echo "$PR_JSON" | jq -r '.base.sha')" >> "$GITHUB_OUTPUT"
+          echo "number=$(echo "$PR_JSON" | jq -r '.number')" >> "$GITHUB_OUTPUT"
+
+      - name: Get last reviewed SHA
+        id: last-review
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LAST_SHA=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            --jq '[.[] | select(.user.login == "claude[bot]" and (.body | contains("<!-- claude-review sha:")))] | last | .body | capture("<!-- claude-review sha:(?<sha>[a-f0-9]+) -->") | .sha // empty' 2>/dev/null || true)
+          if [ -n "$LAST_SHA" ]; then
+            echo "sha=$LAST_SHA" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=${{ steps.pr.outputs.base_sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.head_ref }}
+          fetch-depth: 1
+
+      - name: Fetch delta base commit
+        run: git fetch origin ${{ steps.last-review.outputs.sha }} --depth=1
+
+      - name: Fetch previous review content
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            --jq '[.[] | select(.user.login == "claude[bot]" and (.body | contains("<!-- claude-review sha:")))] | last | .body // "No previous review found."' \
+            > /tmp/prev-review.md 2>/dev/null || echo "No previous review found." > /tmp/prev-review.md
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install code-review-graph
+        run: pip install code-review-graph==2.1.0
+
+      - name: Restore graph cache
+        id: cache-graph
+        uses: actions/cache@v4
+        with:
+          path: .code-review-graph
+          key: code-review-graph-${{ steps.pr.outputs.base_sha }}
+          restore-keys: |
+            code-review-graph-
+
+      - name: Build or update graph
+        run: |
+          if [ "${{ steps.cache-graph.outputs.cache-hit }}" = "true" ]; then
+            code-review-graph update
+          else
+            code-review-graph build
+          fi
+
+      - name: Create MCP config
+        run: |
+          cat > /tmp/mcp-config.json << 'EOF'
+          {
+            "mcpServers": {
+              "code-review-graph": {
+                "command": "code-review-graph",
+                "args": ["serve"]
+              }
+            }
+          }
+          EOF
+
+      - name: Run Claude Delta Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--mcp-config /tmp/mcp-config.json --allowedTools "Bash,Read,Glob,Grep,mcp__code-review-graph__detect_changes_tool,mcp__code-review-graph__get_review_context_tool,mcp__code-review-graph__get_impact_radius_tool"'
+          prompt: |
+            Delta review of new commits on PR #${{ steps.pr.outputs.number }} in gear (114-crate Rust monorepo).
+            Diff: ${{ steps.last-review.outputs.sha }}..${{ steps.pr.outputs.head_sha }}. Do NOT re-review old code.
+
+            FIRST: Run `git diff ${{ steps.last-review.outputs.sha }} --name-only` to see exactly which files changed.
+            Only review those files. Do NOT review files that are not in the diff.
+
+            Read /tmp/prev-review.md — your previous review. Do not repeat covered findings.
+
+            Graph tools (ALWAYS use include_source=false, max_depth=1 — large repo):
+            1. detect_changes_tool base="${{ steps.last-review.outputs.sha }}"
+            2. get_review_context_tool base="${{ steps.last-review.outputs.sha }}"
+            3. Read source of high-risk functions directly if needed.
+
+            Then READ each changed file + its direct callers. Check:
+            - Do new changes address previous review issues?
+            - Any NEW correctness issues?
+            - Callers still work with changed behavior?
+
+            Post line-specific findings as PR review comments using gh CLI:
+            gh api repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/comments -f body="comment" -f commit_id="${{ steps.pr.outputs.head_sha }}" -f path="file" -F line=N -f side=RIGHT
+            Then post summary: gh pr comment ${{ steps.pr.outputs.number }} --body "<!-- claude-review sha:${{ steps.pr.outputs.head_sha }} -->\n<body>"
+
+            Summary format (use exactly this structure):
+            ## Delta Review
+            One sentence: what changed since last review.
+
+            ## Previous Issues
+            | Status | Finding |
+            |--------|---------|
+            | fixed/open | One-line description from previous review |
+
+            ## New Findings
+            | Severity | Finding | Suggestion |
+            |----------|---------|------------|
+            | critical/high/medium/low | What's wrong (no file paths or line numbers) | What to do about it |
+
+            If no new findings, write "No new issues."
+            Do NOT mention file paths or line numbers in the summary — those belong in inline comments only.
+            Keep it SHORT. Max 5 rows per table.


### PR DESCRIPTION
## Summary
- Replace generic `code-review@claude-code-plugins` with [code-review-graph](https://github.com/tirth8205/code-review-graph) MCP server for AST-based reviews with blast-radius analysis
- Two review modes: **full review** (label-gated) and **delta review** (comment-triggered)
- Graph DB cached per base SHA (first run ~1-3min, subsequent ~2s)
- Pinned `code-review-graph==2.1.0` for supply-chain safety

## How it works

### Full review
1. Add `A0-pleasereview` label to a PR
2. Claude builds AST graph, analyzes changed files + callers, posts inline comments and a structured summary

### Delta review
1. Push new commits to the PR
2. Comment `/review-delta`
3. Claude reviews only the new changes, references previous review findings, tracks fixed/open issues

## Changes
- `pull_request` + `labeled` trigger for full review, `issue_comment` trigger for delta
- Python 3.12 + pinned code-review-graph install
- Graph cache keyed on `pull_request.base.sha` with restore-keys fallback
- MCP server config via `--mcp-config`
- `--allowedTools` includes Bash, Read, Glob, Grep, and MCP graph tools
- Inline comments via `gh api` PR comments endpoint
- Structured summary: severity table, no file paths (detail in inline comments)
- SHA marker `<!-- claude-review sha:... -->` for delta tracking
- Delta extracts last reviewed SHA and previous review content
- Concurrency control (`cancel-in-progress`) per PR
- `/review-delta` hint appended to full review summaries

## Test plan
- [x] Verified full review on fork (ukint-vs/gear#8): inline comments + structured summary
- [x] Verified delta review on fork: tracks previous issues, reviews only new changes
- [x] Verified label gate: no review without `A0-pleasereview`
- [x] Verified `/review-delta` comment trigger: correct job selection
- [x] Verified concurrency: only latest review completes
- [ ] Verify on upstream after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)