### PR TITLE
fix(ci): prevent bot cascade trigger and checkout race in code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -115,6 +115,9 @@ jobs:
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       github.event.sender.type == 'User' &&
+      (github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'COLLABORATOR') &&
       contains(github.event.comment.body, '/review-delta')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Filter out bot actors from `/review-delta` trigger — claude[bot]'s own review comment was re-triggering the workflow
- Checkout PR by head SHA instead of branch name to prevent race condition

Found during testing on #5289.

## Test plan
- [x] Verified on fork (ukint-vs/gear#8): delta review works with both fixes
- [x] Confirmed #5289 failure was caused by bot cascade

🤖 Generated with [Claude Code](https://claude.com/claude-code)