### PR TITLE
feat(ethexe/blob-loader): add logging for responses that could not be  decoded into JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5081,7 +5081,6 @@ name = "ethexe-blob-loader"
 version = "1.10.0"
 dependencies = [
  "alloy",
- "bytes",
  "ethexe-common",
  "ethexe-ethereum",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5081,6 +5081,7 @@ name = "ethexe-blob-loader"
 version = "1.10.0"
 dependencies = [
  "alloy",
+ "bytes",
  "ethexe-common",
  "ethexe-ethereum",
  "futures",
@@ -5089,6 +5090,7 @@ dependencies = [
  "gsigner",
  "log",
  "reqwest 0.12.28",
+ "serde_json",
  "thiserror 2.0.17",
  "tokio",
 ]

--- a/ethexe/blob-loader/Cargo.toml
+++ b/ethexe/blob-loader/Cargo.toml
@@ -13,8 +13,10 @@ ethexe-common = { workspace = true, features = ["std"] }
 gprimitives = { workspace = true, features = ["std"] }
 
 alloy = { workspace = true, features = ["rpc", "rpc-types", "rpc-types-beacon"] }
+bytes.workspace = true
 thiserror.workspace = true
 reqwest = { workspace = true, features = ["default-tls", "json"] }
+serde_json.workspace = true
 futures.workspace = true
 log.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "fs"] }

--- a/ethexe/blob-loader/Cargo.toml
+++ b/ethexe/blob-loader/Cargo.toml
@@ -13,7 +13,6 @@ ethexe-common = { workspace = true, features = ["std"] }
 gprimitives = { workspace = true, features = ["std"] }
 
 alloy = { workspace = true, features = ["rpc", "rpc-types", "rpc-types-beacon"] }
-bytes.workspace = true
 thiserror.workspace = true
 reqwest = { workspace = true, features = ["default-tls", "json"] }
 serde_json.workspace = true

--- a/ethexe/blob-loader/src/lib.rs
+++ b/ethexe/blob-loader/src/lib.rs
@@ -23,7 +23,6 @@ use alloy::{
     rpc::types::beacon::{genesis::GenesisResponse, sidecar::GetBlobsResponse},
     transports::{RpcError, TransportErrorKind},
 };
-use bytes::Bytes;
 use ethexe_common::{
     CodeAndIdUnchecked, CodeBlobInfo,
     db::{CodesStorageRO, OnChainStorageRO},
@@ -56,11 +55,8 @@ pub enum BlobLoaderError {
 enum ReadBlobBundleError {
     #[error("failed to read blob bundle from beacon node: {0}")]
     Reqwest(#[from] reqwest::Error),
-    #[error("failed to decode blob bundle response: {error}, bytes: {bytes:?}")]
-    Serde {
-        error: serde_json::Error,
-        bytes: Bytes,
-    },
+    #[error("failed to decode blob bundle response: {0}")]
+    Serde(#[from] serde_json::Error),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -239,8 +235,10 @@ impl ConsensusLayerBlobReader {
             .send()
             .await?;
         let bytes = response.bytes().await?;
-        let blobs_response = serde_json::from_slice::<GetBlobsResponse>(&bytes)
-            .map_err(|error| ReadBlobBundleError::Serde { error, bytes })?;
+        let blobs_response = serde_json::from_slice::<GetBlobsResponse>(&bytes).map_err(|err| {
+            log::trace!("failed to decode blob bundle response: {err}, bytes: {bytes:?}");
+            err
+        })?;
         Ok(blobs_response)
     }
 }

--- a/ethexe/blob-loader/src/lib.rs
+++ b/ethexe/blob-loader/src/lib.rs
@@ -222,7 +222,7 @@ impl ConsensusLayerBlobReader {
         versioned_hashes: &[B256],
     ) -> Result<GetBlobsResponse, ReadBlobBundleError> {
         let ethereum_beacon_rpc = &self.config.ethereum_beacon_rpc;
-        let response = self
+        let bytes = self
             .http_client
             .get(format!(
                 "{ethereum_beacon_rpc}/eth/v1/beacon/blobs/{slot}?versioned_hashes={}",
@@ -233,12 +233,13 @@ impl ConsensusLayerBlobReader {
                     .join(",")
             ))
             .send()
+            .await?
+            .bytes()
             .await?;
-        let bytes = response.bytes().await?;
-        let blobs_response = serde_json::from_slice::<GetBlobsResponse>(&bytes).map_err(|err| {
-            log::trace!("failed to decode blob bundle response: {err}, bytes: {bytes:?}");
-            err
-        })?;
+        let blobs_response =
+            serde_json::from_slice::<GetBlobsResponse>(&bytes).inspect_err(|err| {
+                log::trace!("failed to decode blob bundle response: {err}, bytes: {bytes:?}")
+            })?;
         Ok(blobs_response)
     }
 }

--- a/ethexe/blob-loader/src/lib.rs
+++ b/ethexe/blob-loader/src/lib.rs
@@ -23,6 +23,7 @@ use alloy::{
     rpc::types::beacon::{genesis::GenesisResponse, sidecar::GetBlobsResponse},
     transports::{RpcError, TransportErrorKind},
 };
+use bytes::Bytes;
 use ethexe_common::{
     CodeAndIdUnchecked, CodeBlobInfo,
     db::{CodesStorageRO, OnChainStorageRO},
@@ -52,6 +53,17 @@ pub enum BlobLoaderError {
 }
 
 #[derive(thiserror::Error, Debug)]
+enum ReadBlobBundleError {
+    #[error("failed to read blob bundle from beacon node: {0}")]
+    Reqwest(#[from] reqwest::Error),
+    #[error("failed to decode blob bundle response: {error}, bytes: {bytes:?}")]
+    Serde {
+        error: serde_json::Error,
+        bytes: Bytes,
+    },
+}
+
+#[derive(thiserror::Error, Debug)]
 enum ReaderError {
     #[error("transport error: {0}")]
     Transport(#[from] RpcError<TransportErrorKind>),
@@ -64,7 +76,7 @@ enum ReaderError {
     #[error("failed to get block by hash: {0}")]
     BlockNotFound(H256),
     #[error("failed to read blob bundle: {0}")]
-    ReadBlob(reqwest::Error),
+    ReadBlob(#[from] ReadBlobBundleError),
     #[error("failed to decode blobs")]
     DecodeBlobs,
     #[error("failed to access genesis time: {0}")]
@@ -212,9 +224,10 @@ impl ConsensusLayerBlobReader {
         &self,
         slot: u64,
         versioned_hashes: &[B256],
-    ) -> reqwest::Result<GetBlobsResponse> {
+    ) -> Result<GetBlobsResponse, ReadBlobBundleError> {
         let ethereum_beacon_rpc = &self.config.ethereum_beacon_rpc;
-        self.http_client
+        let response = self
+            .http_client
             .get(format!(
                 "{ethereum_beacon_rpc}/eth/v1/beacon/blobs/{slot}?versioned_hashes={}",
                 versioned_hashes
@@ -224,9 +237,11 @@ impl ConsensusLayerBlobReader {
                     .join(",")
             ))
             .send()
-            .await?
-            .json::<GetBlobsResponse>()
-            .await
+            .await?;
+        let bytes = response.bytes().await?;
+        let blobs_response = serde_json::from_slice::<GetBlobsResponse>(&bytes)
+            .map_err(|error| ReadBlobBundleError::Serde { error, bytes })?;
+        Ok(blobs_response)
     }
 }
 


### PR DESCRIPTION
Resolves #5327
Example:
```
2026-04-10T07:20:26.416983Z TRACE ethexe_blob_loader: trying to get blob, attempt #0
2026-04-10T07:20:26.438152Z TRACE ethexe_blob_loader: failed to decode blob bundle response: expected value at line 1 column 1, bytes: b"hello world"
2026-04-10T07:20:26.438201Z  WARN ethexe_blob_loader: failed to get blob on attempt #0: failed to read blob bundle: failed to decode blob bundle response: expected value at line 1 column 1
```
@gear-tech/dev

