### PR TITLE
fix(ci): pass model via claude_args, not as action input

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -71,9 +71,8 @@ jobs:
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
-          model: claude-opus-4-6
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--mcp-config /tmp/mcp-config.json --thinking-budget high --allowedTools "Bash,Read,Glob,Grep,mcp__code-review-graph__detect_changes_tool,mcp__code-review-graph__get_review_context_tool,mcp__code-review-graph__get_impact_radius_tool"'
+          claude_args: '--model claude-opus-4-6 --thinking-budget high --mcp-config /tmp/mcp-config.json --allowedTools "Bash,Read,Glob,Grep,mcp__code-review-graph__detect_changes_tool,mcp__code-review-graph__get_review_context_tool,mcp__code-review-graph__get_impact_radius_tool"'
           prompt: |
             Review PR #${{ github.event.pull_request.number }} in gear (114-crate Rust monorepo, Solidity contracts in ethexe/).
 
@@ -213,9 +212,8 @@ jobs:
       - name: Run Claude Delta Review
         uses: anthropics/claude-code-action@v1
         with:
-          model: claude-opus-4-6
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--mcp-config /tmp/mcp-config.json --thinking-budget high --allowedTools "Bash,Read,Glob,Grep,mcp__code-review-graph__detect_changes_tool,mcp__code-review-graph__get_review_context_tool,mcp__code-review-graph__get_impact_radius_tool"'
+          claude_args: '--model claude-opus-4-6 --thinking-budget high --mcp-config /tmp/mcp-config.json --allowedTools "Bash,Read,Glob,Grep,mcp__code-review-graph__detect_changes_tool,mcp__code-review-graph__get_review_context_tool,mcp__code-review-graph__get_impact_radius_tool"'
           prompt: |
             Delta review of new commits on PR #${{ steps.pr.outputs.number }} in gear (114-crate Rust monorepo).
             Diff: ${{ steps.last-review.outputs.sha }}..${{ steps.pr.outputs.head_sha }}. Do NOT re-review old code.


### PR DESCRIPTION
## Summary
- `anthropics/claude-code-action@v1` doesn't have a `model` input — it was silently ignored, causing the review to fail
- Move `--model claude-opus-4-6` into `claude_args` where it's properly passed to the Claude CLI

[skip-ci]