### PR TITLE
fix(ci): Use OpenSSL LTS release on Windows

### DIFF
--- a/.github/actions/setup-compilation-env/action.yml
+++ b/.github/actions/setup-compilation-env/action.yml
@@ -99,13 +99,15 @@ runs:
         sudo apt-fast update
         sudo apt-fast install -y protobuf-compiler binaryen innoextract
 
-        wget -qO - https://raw.githubusercontent.com/ScoopInstaller/Main/refs/heads/master/bucket/openssl.json | jq -r '.architecture."64bit".url' | xargs wget -qO openssl_installer.exe
+        wget -qO - https://raw.githubusercontent.com/ScoopInstaller/Main/refs/heads/master/bucket/openssl-lts.json | jq -r '.architecture."64bit".url' | xargs wget -qO openssl_installer.exe
         innoextract -d ${{ runner.temp }}/openssl_extracted -I app/include -I app/lib/VC/x64/MT openssl_installer.exe
         rm openssl_installer.exe
         
         echo "X86_64_PC_WINDOWS_MSVC_OPENSSL_NO_VENDOR=1" >> $GITHUB_ENV
         echo "X86_64_PC_WINDOWS_MSVC_OPENSSL_INCLUDE_DIR=${{ runner.temp }}/openssl_extracted/app/include" >> $GITHUB_ENV
         echo "X86_64_PC_WINDOWS_MSVC_OPENSSL_LIB_DIR=${{ runner.temp }}/openssl_extracted/app/lib/VC/x64/MT" >> $GITHUB_ENV
+        echo "X86_64_PC_WINDOWS_MSVC_OPENSSL_LIBS=libcrypto_static:libssl_static" >> $GITHUB_ENV
+        echo "X86_64_PC_WINDOWS_MSVC_OPENSSL_STATIC=1" >> $GITHUB_ENV
         cargo xwin env | sed -e 's/^export //' -e 's/;$//' -e 's/="\(.*\)"$/=\1/' >> $GITHUB_ENV
       shell: bash
 


### PR DESCRIPTION
slproweb.com currently provides OpenSSL 3.0. The next LTS release is OpenSSL 3.5 (8 April 2026) and will be supported until 2030. I believe slproweb.com will update its version soon. This should be enough to ensure we aren’t bothered by "something broken in CI again".

Also link OpenSSL statically, so Gear node doesn't require OpenSSL dynamic libraries to be installed.