### PR TITLE
fix(ci): pin Claude review action to v1.0.96 and revert model to Opus 4-6

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -69,10 +69,15 @@ jobs:
           EOF
 
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
+        # Pinned to v1.0.96 + Opus 4-6: last verified green combo (run on
+        # 2026-04-15). v1.0.97+ has a Bun/tsconfig-mismatch crash upstream
+        # (anthropics/claude-code-action#1205, #1234) that exits the Claude
+        # process with code 1 before any API call. v1.0.99+ added Opus 4.7
+        # support but bundled the same regression. Re-bump when #1205 is fixed.
+        uses: anthropics/claude-code-action@v1.0.96
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model claude-opus-4-7 --thinking-budget high --mcp-config /tmp/mcp-config.json --allowedTools "Bash,Read,Glob,Grep,mcp__code-review-graph__detect_changes_tool,mcp__code-review-graph__get_review_context_tool,mcp__code-review-graph__get_impact_radius_tool"'
+          claude_args: '--model claude-opus-4-6 --thinking-budget high --mcp-config /tmp/mcp-config.json --allowedTools "Bash,Read,Glob,Grep,mcp__code-review-graph__detect_changes_tool,mcp__code-review-graph__get_review_context_tool,mcp__code-review-graph__get_impact_radius_tool"'
           prompt: |
             Review PR #${{ github.event.pull_request.number }} in gear (114-crate Rust monorepo, Solidity contracts in ethexe/).
 
@@ -210,10 +215,11 @@ jobs:
           EOF
 
       - name: Run Claude Delta Review
-        uses: anthropics/claude-code-action@v1
+        # See full-review job above for rationale on pinning.
+        uses: anthropics/claude-code-action@v1.0.96
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model claude-opus-4-7 --thinking-budget high --mcp-config /tmp/mcp-config.json --allowedTools "Bash,Read,Glob,Grep,mcp__code-review-graph__detect_changes_tool,mcp__code-review-graph__get_review_context_tool,mcp__code-review-graph__get_impact_radius_tool"'
+          claude_args: '--model claude-opus-4-6 --thinking-budget high --mcp-config /tmp/mcp-config.json --allowedTools "Bash,Read,Glob,Grep,mcp__code-review-graph__detect_changes_tool,mcp__code-review-graph__get_review_context_tool,mcp__code-review-graph__get_impact_radius_tool"'
           prompt: |
             Delta review of new commits on PR #${{ steps.pr.outputs.number }} in gear (114-crate Rust monorepo).
             Diff: ${{ steps.last-review.outputs.sha }}..${{ steps.pr.outputs.head_sha }}. Do NOT re-review old code.


### PR DESCRIPTION
## Summary

- Pins \`anthropics/claude-code-action\` from the floating \`@v1\` tag to \`@v1.0.96\`
- Reverts \`--model\` from \`claude-opus-4-7\` back to \`claude-opus-4-6\` in both the full-review and delta-review jobs

## Why

The latest v1 releases crash on startup with a Bun runtime error before any API call:

\`\`\`
Internal error: directory mismatch for directory ".../tsconfig.json", fd 4
error: Claude Code process exited with code 1
\`\`\`

Reproduced on PR #5365 ([run 24771200029](https://github.com/gear-tech/gear/actions/runs/24771200029/job/72478038510)).

The earlier \`"Could not resolve authentication"\` text in the stack trace is a red herring — it's just minified SDK source that Bun dumps while dying; the process never reaches an API call.

### Upstream issues

- anthropics/claude-code-action#1205 (p1, open) — exact symptom, confirmed reproducible across multiple v1.0.x pins
- anthropics/claude-code-action#1234 (open) — same Bun crash on GitHub-hosted runners
- anthropics/claude-code-action#1225 (closed → regressed) — Opus 4.7 support added in v1.0.99, which is the same release that shipped the Bun crash

### Why this specific combo

\`v1.0.96\` + \`claude-opus-4-6\` is the last combination verified green in this repo's own CI history (run 24443755194, 2026-04-15). Reverting both together is necessary because Opus 4.7 support doesn't exist pre-v1.0.99.

Commit \`14bc43514\` (bump to Opus 4.7) is effectively reverted by this change.

## Test plan

- [ ] Label this PR with \`A0-pleasereview\` after merge to a canary PR and confirm the \`Claude Code Review\` job completes and posts a review
- [ ] Re-bump to the latest action + Opus 4.7 once upstream #1205 is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)