### PR TITLE
fix(ci): retry flaky ethexe-ethereum tests that spawn Anvil

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -47,6 +47,6 @@ threads-required = 4
 
 # ethexe
 [[profile.ci.overrides]]
-filter = 'package(ethexe-service) or package(ethexe-observer)'
+filter = 'package(ethexe-service) or package(ethexe-observer) or package(ethexe-ethereum)'
 retries = 5
 threads-required = 4


### PR DESCRIPTION
Adds `ethexe-ethereum` to the nextest retry override alongside `ethexe-service` / `ethexe-observer`. Same reason: Anvil spawn occasionally times out on busy CI runners.