### PR TITLE
chore(ci): Enable recursive submodule checkout in build and check workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,6 +339,8 @@ jobs:
     steps:
       - name: "ACTIONS: Checkout"
         uses: actions/checkout@v6
+        with: 
+          submodules: recursive
 
       - name: "Install: Setup linker"
         uses: ./.github/actions/setup-linker

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -219,6 +219,8 @@ jobs:
     steps:
       - name: "ACTIONS: Checkout"
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: "Install: Setup linker"
         uses: ./.github/actions/setup-linker


### PR DESCRIPTION


## Summary
Fixes CI fail on wasm and build jobs by recursively cloning submodules

## How to test
Run CI

## Notes


## Checklist

- [x] PR title follows Conventional Commits (`type(scope): description`)
- [x] Single logical change
- [-] Tests added or updated (if logic changed)
- [-] Docs updated (if needed)
