### PR TITLE
chore(ethexe): add publishing metadata

### DIFF
--- a/ethexe/blob-loader/Cargo.toml
+++ b/ethexe/blob-loader/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "ethexe-blob-loader"
+description = "Beacon blob loading for the ethexe execution layer"
+documentation = "https://docs.rs/ethexe-blob-loader"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/ethexe/cli/Cargo.toml
+++ b/ethexe/cli/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "ethexe-cli"
+description = "Command-line interface for running and managing ethexe nodes"
+documentation = "https://docs.rs/ethexe-cli"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/ethexe/common/Cargo.toml
+++ b/ethexe/common/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "ethexe-common"
+description = "Shared types and primitives for the ethexe execution layer"
+documentation = "https://docs.rs/ethexe-common"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 alloy-primitives = { workspace = true, features = ["serde"] }

--- a/ethexe/compute/Cargo.toml
+++ b/ethexe/compute/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "ethexe-compute"
+description = "Code preparation and program execution orchestration for ethexe"
+documentation = "https://docs.rs/ethexe-compute"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+rust-version.workspace = true
 
 [dependencies]
 ethexe-processor.workspace = true

--- a/ethexe/consensus/Cargo.toml
+++ b/ethexe/consensus/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "ethexe-consensus"
+description = "Validator consensus services for the ethexe execution layer"
+documentation = "https://docs.rs/ethexe-consensus"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 ethexe-db.workspace = true

--- a/ethexe/db/Cargo.toml
+++ b/ethexe/db/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "ethexe-db"
+description = "Database abstractions and implementations for ethexe"
+documentation = "https://docs.rs/ethexe-db"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 ethexe-common = { workspace = true, features = ["std"] }

--- a/ethexe/ethereum/Cargo.toml
+++ b/ethexe/ethereum/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "ethexe-ethereum"
+description = "Ethereum contract bindings and transaction helpers for ethexe"
+documentation = "https://docs.rs/ethexe-ethereum"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 gsigner = { workspace = true, features = ["std", "secp256k1", "codec", "keyring", "serde"] }

--- a/ethexe/network/Cargo.toml
+++ b/ethexe/network/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "ethexe-network"
+description = "libp2p networking for ethexe validators and nodes"
+documentation = "https://docs.rs/ethexe-network"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+rust-version.workspace = true
 
 [package.metadata.cargo-shear]
 # we need it for applying `metrics` feature

--- a/ethexe/node-loader/Cargo.toml
+++ b/ethexe/node-loader/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "ethexe-node-loader"
+description = "Node binary loader for ethexe integration tests and tooling"
+documentation = "https://docs.rs/ethexe-node-loader"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/ethexe/node-wrapper/Cargo.toml
+++ b/ethexe/node-wrapper/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "ethexe-node-wrapper"
+description = "Node process wrapper utilities for ethexe"
+documentation = "https://docs.rs/ethexe-node-wrapper"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/ethexe/observer/Cargo.toml
+++ b/ethexe/observer/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "ethexe-observer"
+description = "Ethereum chain observer for the ethexe execution layer"
+documentation = "https://docs.rs/ethexe-observer"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 ethexe-common = { workspace = true, features = ["std"] }

--- a/ethexe/processor/Cargo.toml
+++ b/ethexe/processor/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "ethexe-processor"
+description = "Gear program processor for the ethexe runtime"
+documentation = "https://docs.rs/ethexe-processor"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 ethexe-common = { workspace = true, features = ["std"] }

--- a/ethexe/prometheus/Cargo.toml
+++ b/ethexe/prometheus/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 description = "Prometheus metrics for ethexe"
+documentation = "https://docs.rs/ethexe-prometheus"
 name = "ethexe-prometheus"
 version.workspace = true
 authors.workspace = true
@@ -7,6 +8,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/ethexe/rpc/Cargo.toml
+++ b/ethexe/rpc/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "ethexe-rpc"
+description = "JSON-RPC server and client APIs for ethexe"
+documentation = "https://docs.rs/ethexe-rpc"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+rust-version.workspace = true
 
 [dependencies]
 tokio = { workspace = true, features = ["sync"] }

--- a/ethexe/runtime/Cargo.toml
+++ b/ethexe/runtime/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "ethexe-runtime"
+description = "Wasm runtime for executing Gear programs in ethexe"
+documentation = "https://docs.rs/ethexe-runtime"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 ## Gear deps.

--- a/ethexe/runtime/common/Cargo.toml
+++ b/ethexe/runtime/common/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "ethexe-runtime-common"
+description = "Shared runtime types and storage traits for ethexe"
+documentation = "https://docs.rs/ethexe-runtime-common"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-
+rust-version.workspace = true
 
 [dependencies]
 ethexe-common.workspace = true

--- a/ethexe/sdk/Cargo.toml
+++ b/ethexe/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethexe-sdk"
-description = "Rust SDK of the Vara.Eth network"
+description = "Rust SDK for the Vara Ethereum execution layer"
 documentation = "https://docs.rs/ethexe-sdk"
 categories = ["wasm", "api-bindings"]
 keywords = ["gear", "actor-model", "api", "sdk"]

--- a/ethexe/service/Cargo.toml
+++ b/ethexe/service/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "ethexe-service"
+description = "Service orchestration for ethexe nodes"
+documentation = "https://docs.rs/ethexe-service"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 ethexe-compute.workspace = true

--- a/ethexe/service/utils/Cargo.toml
+++ b/ethexe/service/utils/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "ethexe-service-utils"
+description = "Testing and service utilities for ethexe"
+documentation = "https://docs.rs/ethexe-service-utils"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 log.workspace = true


### PR DESCRIPTION
Part of #5420 

## Summary

Adds publishing metadata for ethexe crates

## How to test

Dry run publish on ethexe

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): description`)
- [x] Single logical change

