### PR TITLE
feat(ethexe/tpke): threshold encryption primitives for private transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5634,6 +5634,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethexe-tpke"
+version = "1.10.0"
+dependencies = [
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "blake2 0.10.6",
+ "chacha20poly1305",
+ "gear-workspace-hack",
+ "hex",
+ "hex-literal",
+ "hkdf",
+ "parity-scale-codec",
+ "proptest",
+ "rand 0.8.5",
+ "scale-info",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.17",
+ "zeroize",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ blake2 = { version = "0.10.6", default-features = false }
 bs58 = { version = "0.5.1", default-features = false }
 cargo_toml = "0.21.0"
 cargo_metadata = "0.20.0"
+chacha20poly1305 = { version = "0.10.1", default-features = false }
 clap = "4.5.8"
 colored = "2.1.0"
 const-str = "0.5"
@@ -162,6 +163,7 @@ future-timing = "0.1.0" # measure the futures execution
 hashbrown = "0.14.5"
 hex = { version = "0.4.3", default-features = false }
 hex-literal = "0.4.1"
+hkdf = { version = "0.12.4", default-features = false }
 impl-trait-for-tuples = "0.2.2"
 impl-serde = "0.4.0"
 indoc = "2.0.7"
@@ -227,6 +229,7 @@ ark-ec = { version = "0.4.2", default-features = false }
 ark-ff = { version = "0.4.2", default-features = false }
 ark-scale = { version = "0.0.12", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
+zeroize = { version = "1.8", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }
 arrayvec = { version = "0.7.4", default-features = false }
 indexmap = { version = "2.2.6", default-features = false }
@@ -348,6 +351,7 @@ ethexe-compute = { path = "ethexe/compute", default-features = false }
 ethexe-blob-loader = { path = "ethexe/blob-loader", default-features = false }
 ethexe-db-init = { path = "ethexe/db/init", default-features = false }
 ethexe-node-wrapper = {path = "ethexe/node-wrapper", default-features = false}
+ethexe-tpke = { path = "ethexe/tpke", default-features = false }
 
 # Common executor between `sandbox-host` and `lazy-pages-fuzzer`
 wasmi = { version = "0.38" }

--- a/ethexe/tpke/Cargo.toml
+++ b/ethexe/tpke/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+description = "Threshold public-key encryption (Boneh-Franklin IBE) on BLS12-381 for ethexe private transactions"
+name = "ethexe-tpke"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+ark-bls12-381 = { workspace = true, features = ["curve"] }
+ark-ec = { workspace = true }
+ark-ff = { workspace = true }
+ark-serialize = { workspace = true }
+ark-std = { workspace = true }
+blake2 = { workspace = true }
+chacha20poly1305 = { workspace = true, features = ["alloc"] }
+hkdf = { workspace = true }
+parity-scale-codec = { workspace = true, features = ["derive"] }
+rand = { workspace = true, features = ["std", "std_rng"] }
+scale-info = { workspace = true, features = ["derive"] }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+zeroize = { workspace = true, features = ["derive"] }
+gear-workspace-hack.workspace = true
+
+[dev-dependencies]
+hex = { workspace = true, features = ["alloc"] }
+hex-literal = { workspace = true }
+proptest = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+    "ark-bls12-381/std",
+    "ark-ec/std",
+    "ark-ff/std",
+    "ark-serialize/std",
+    "ark-std/std",
+    "blake2/std",
+    "chacha20poly1305/std",
+    "hkdf/std",
+    "parity-scale-codec/std",
+    "rand/std",
+    "scale-info/std",
+    "sha2/std",
+    "thiserror/std",
+    "zeroize/std",
+]

--- a/ethexe/tpke/src/lib.rs
+++ b/ethexe/tpke/src/lib.rs
@@ -89,6 +89,8 @@ pub enum TpkeError {
     DuplicateShareIndex(u32),
     #[error("share index {0} is zero (validator ids start at 1)")]
     ZeroShareIndex(u32),
+    #[error("share #{index} bound to a different envelope id than the target")]
+    ShareEnvelopeMismatch { index: u32 },
     #[error("point serialization failed")]
     Serialization,
     #[error("hash-to-curve failed")]
@@ -148,9 +150,16 @@ pub struct EncryptedEnvelope {
 }
 
 /// Decryption share `Dᵢ = Sᵢ · Q_id ∈ G1`. Validator index is 1-based.
+///
+/// The `id` field binds the share to the envelope it was produced for. `verify`
+/// and `combine` reject shares whose id doesn't match the target envelope —
+/// this prevents accidental cross-envelope mixing from silently producing
+/// garbage plaintext (which would otherwise only surface as a cryptic AEAD
+/// failure downstream).
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct DecryptionShare {
     pub index: u32,
+    pub id: [u8; 32],
     pub point: G1Affine,
 }
 
@@ -237,7 +246,7 @@ impl MasterSecretKey {
         coeffs.zeroize();
 
         Ok(DealerOutput {
-            master_secret: master,
+            master_secret: Some(master),
             master_pub,
             shares,
             share_pubs,
@@ -246,12 +255,41 @@ impl MasterSecretKey {
 }
 
 /// Output of the dealer ceremony.
+///
+/// The `master_secret` is held in an `Option` and is accessible only via
+/// [`take_master_secret`]. This makes the destruction step explicit: take it
+/// once to persist or hand off, then let it drop (zeroized on drop). Cloning
+/// `DealerOutput` clones the shares + pubs but does NOT clone the master
+/// secret — subsequent clones see `None`. A leftover `master_secret` inside
+/// `DealerOutput` is zeroized when the struct is dropped.
+///
+/// [`take_master_secret`]: DealerOutput::take_master_secret
 #[derive(Debug)]
 pub struct DealerOutput {
-    pub master_secret: MasterSecretKey,
+    master_secret: Option<MasterSecretKey>,
     pub master_pub: MasterPublicKey,
     pub shares: Vec<SecretKeyShare>,
     pub share_pubs: Vec<SharePublicKey>,
+}
+
+impl DealerOutput {
+    /// Take ownership of the master secret. Returns `None` if it has already
+    /// been taken or never existed. Subsequent calls return `None`.
+    pub fn take_master_secret(&mut self) -> Option<MasterSecretKey> {
+        self.master_secret.take()
+    }
+}
+
+impl Clone for DealerOutput {
+    fn clone(&self) -> Self {
+        // Deliberately drop the master secret on clone — see struct docs.
+        Self {
+            master_secret: None,
+            master_pub: self.master_pub.clone(),
+            shares: self.shares.clone(),
+            share_pubs: self.share_pubs.clone(),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -394,6 +432,7 @@ impl SecretKeyShare {
         let point = (q_id * self.scalar).into_affine();
         Ok(DecryptionShare {
             index: self.index,
+            id: envelope.id,
             point,
         })
     }
@@ -401,12 +440,15 @@ impl SecretKeyShare {
 
 impl SharePublicKey {
     /// Verify a decryption share: e(Dᵢ, g₂) ?= e(Q_id, PSᵢ).
+    ///
+    /// Returns `Ok(false)` when the share's validator index or envelope id
+    /// doesn't match what we're verifying against.
     pub fn verify(
         &self,
         envelope: &EncryptedEnvelope,
         share: &DecryptionShare,
     ) -> Result<bool, TpkeError> {
-        if share.index != self.index {
+        if share.index != self.index || share.id != envelope.id {
             return Ok(false);
         }
         let q_id = hash_to_g1(&envelope.id)?;
@@ -447,8 +489,14 @@ fn lagrange_coefficient(i: u32, indices: &[u32]) -> Option<Fr> {
 
 /// Combine `t` decryption shares into the plaintext.
 ///
-/// All shares must verify against their share-public-key (call `verify()`
-/// upstream). This function does no verification — it assumes honest shares.
+/// This function does NOT verify shares cryptographically — callers must run
+/// `SharePublicKey::verify` on each share they trust as honest. It DOES enforce:
+///   - share count ≥ threshold
+///   - every share's `id` matches `envelope.id`
+///   - no zero or duplicate validator indices
+///
+/// **Only the first `threshold` shares from `shares` are consumed.** Excess
+/// shares are ignored. To use a specific subset, slice the input yourself.
 pub fn combine(
     envelope: &EncryptedEnvelope,
     shares: &[DecryptionShare],
@@ -465,11 +513,14 @@ pub fn combine(
     // Use the first `threshold` shares.
     let used = &shares[..threshold as usize];
 
-    // Reject zero or duplicate indices.
+    // Reject zero/duplicate indices and envelope mismatches.
     let mut seen: Vec<u32> = Vec::with_capacity(used.len());
     for s in used {
         if s.index == 0 {
             return Err(TpkeError::ZeroShareIndex(0));
+        }
+        if s.id != envelope.id {
+            return Err(TpkeError::ShareEnvelopeMismatch { index: s.index });
         }
         if seen.contains(&s.index) {
             return Err(TpkeError::DuplicateShareIndex(s.index));
@@ -510,14 +561,19 @@ pub fn combine(
 // ---------------------------------------------------------------------------
 
 impl DecryptionShare {
-    pub fn to_bytes(&self) -> Result<(u32, [u8; G1_COMPRESSED_LEN]), TpkeError> {
-        Ok((self.index, serialize_g1(&self.point)?))
+    /// Serialize as `(index, id, compressed_point_bytes)`.
+    pub fn to_bytes(&self) -> Result<(u32, [u8; 32], [u8; G1_COMPRESSED_LEN]), TpkeError> {
+        Ok((self.index, self.id, serialize_g1(&self.point)?))
     }
 
-    pub fn from_bytes(index: u32, bytes: &[u8; G1_COMPRESSED_LEN]) -> Result<Self, TpkeError> {
+    pub fn from_bytes(
+        index: u32,
+        id: [u8; 32],
+        bytes: &[u8; G1_COMPRESSED_LEN],
+    ) -> Result<Self, TpkeError> {
         let point = G1Affine::deserialize_compressed(&bytes[..])
             .map_err(|_| TpkeError::MalformedCiphertext)?;
-        Ok(Self { index, point })
+        Ok(Self { index, id, point })
     }
 }
 
@@ -740,6 +796,96 @@ mod tests {
             let subset: Vec<_> = subset_indices.iter().map(|&i| all[i].clone()).collect();
             let pt = combine(&env, &subset, 1, 0, 3).unwrap();
             assert_eq!(pt, b"abc", "subset {subset_indices:?} failed");
+        }
+    }
+
+    #[test]
+    fn take_master_secret_is_one_shot() {
+        let mut d = deal(2, 3);
+        assert!(d.take_master_secret().is_some());
+        assert!(d.take_master_secret().is_none());
+        // Subsequent state is otherwise intact.
+        assert_eq!(d.shares.len(), 3);
+    }
+
+    #[test]
+    fn clone_dealer_output_drops_master_secret() {
+        let d = deal(2, 3);
+        let mut cloned = d.clone();
+        // Clone never carries the secret.
+        assert!(cloned.take_master_secret().is_none());
+        // Pubs/shares still cloned.
+        assert_eq!(cloned.shares.len(), 3);
+        assert_eq!(cloned.share_pubs.len(), 3);
+    }
+
+    #[test]
+    fn share_from_other_envelope_rejected_in_combine() {
+        let d = deal(2, 3);
+        let mut rng = fixed_rng();
+        let id_a = derive_id(1, 0, b"alpha", &[0xAAu8; 32]);
+        let id_b = derive_id(1, 0, b"beta", &[0xBBu8; 32]);
+        let env_a = encrypt(&d.master_pub, &id_a, 1, 0, b"alpha", &mut rng).unwrap();
+        let env_b = encrypt(&d.master_pub, &id_b, 1, 0, b"beta", &mut rng).unwrap();
+        // Take share #1 from envelope A and share #2 from envelope B.
+        let s_a = d.shares[0].decrypt_share(&env_a).unwrap();
+        let s_b = d.shares[1].decrypt_share(&env_b).unwrap();
+        // Try to combine for envelope A — share #2 has the wrong id.
+        let err = combine(&env_a, &[s_a, s_b], 1, 0, 2).unwrap_err();
+        assert!(matches!(err, TpkeError::ShareEnvelopeMismatch { index: 2 }));
+    }
+
+    #[test]
+    fn verify_rejects_wrong_envelope_id() {
+        let d = deal(2, 3);
+        let mut rng = fixed_rng();
+        let id_a = derive_id(1, 0, b"alpha", &[0xAAu8; 32]);
+        let id_b = derive_id(1, 0, b"beta", &[0xBBu8; 32]);
+        let env_a = encrypt(&d.master_pub, &id_a, 1, 0, b"alpha", &mut rng).unwrap();
+        let env_b = encrypt(&d.master_pub, &id_b, 1, 0, b"beta", &mut rng).unwrap();
+        // Share is for env_a but we verify against env_b — must return false.
+        let share = d.shares[0].decrypt_share(&env_a).unwrap();
+        assert!(!d.share_pubs[0].verify(&env_b, &share).unwrap());
+    }
+
+    // ----- to_bytes / from_bytes roundtrip property tests -----
+
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 16, .. ProptestConfig::default() })]
+
+        #[test]
+        fn proptest_decryption_share_roundtrip(plaintext in proptest::collection::vec(any::<u8>(), 0..200)) {
+            let d = deal(2, 3);
+            let mut rng = fixed_rng();
+            let id = derive_id(1, 0, &plaintext, &[7u8; 32]);
+            let env = encrypt(&d.master_pub, &id, 1, 0, &plaintext, &mut rng).unwrap();
+            let share = d.shares[0].decrypt_share(&env).unwrap();
+            let (idx, id_bytes, point_bytes) = share.to_bytes().unwrap();
+            let restored = DecryptionShare::from_bytes(idx, id_bytes, &point_bytes).unwrap();
+            prop_assert_eq!(share, restored);
+        }
+
+        #[test]
+        fn proptest_master_public_key_roundtrip(seed in any::<u64>()) {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let mut d = MasterSecretKey::deal(2, 3, &mut rng).unwrap();
+            let _ = d.take_master_secret();
+            let bytes = d.master_pub.to_bytes().unwrap();
+            let restored = MasterPublicKey::from_bytes(&bytes).unwrap();
+            prop_assert_eq!(d.master_pub, restored);
+        }
+
+        #[test]
+        fn proptest_share_public_key_roundtrip(seed in any::<u64>()) {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let d = MasterSecretKey::deal(3, 5, &mut rng).unwrap();
+            for ps in &d.share_pubs {
+                let (idx, bytes) = ps.to_bytes().unwrap();
+                let restored = SharePublicKey::from_bytes(idx, &bytes).unwrap();
+                prop_assert_eq!(ps, &restored);
+            }
         }
     }
 }

--- a/ethexe/tpke/src/lib.rs
+++ b/ethexe/tpke/src/lib.rs
@@ -1,0 +1,745 @@
+// This file is part of Gear.
+//
+// Copyright (C) 2026 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+//! Threshold public-key encryption for ethexe private transactions.
+//!
+//! Construction: Boneh-Franklin identity-based TPKE on BLS12-381, with the
+//! master secret split into n Shamir shares (threshold t). Encryption is
+//! identity-bound: every ciphertext carries an `id` and a decryption share
+//! produced for `id` only decrypts that one ciphertext.
+//!
+//! See `~/.claude/plans/prancy-nibbling-pony.md` for the locked design.
+//!
+//! Pairing orientation (Type-3 on BLS12-381):
+//!   - `Q_id ∈ G1` via hash-to-curve (DST below)
+//!   - master pubkey, share pubkeys, ephemeral U  ∈ G2
+//!   - decryption shares                          ∈ G1
+//!   - e: G1 × G2 → GT
+//!
+//! IND-CCA via ChaCha20-Poly1305 (KEM/DEM with HKDF-SHA256 key/nonce derivation).
+//! The DEM AAD binds (id, U_bytes, chain_id, key_epoch_id) into the MAC.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use ark_bls12_381::{Bls12_381, Fr, G1Affine, G1Projective, G2Affine};
+use ark_ec::{
+    AffineRepr, CurveGroup,
+    hashing::{HashToCurve, curve_maps::wb::WBMap, map_to_curve_hasher::MapToCurveBasedHasher},
+    pairing::{Pairing, PairingOutput},
+};
+use ark_ff::{Field, UniformRand, Zero, field_hashers::DefaultFieldHasher};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::rand::{CryptoRng, RngCore};
+use blake2::{Blake2b, Digest, digest::consts::U32};
+use chacha20poly1305::{
+    ChaCha20Poly1305, Key, Nonce,
+    aead::{Aead, KeyInit, Payload},
+};
+use hkdf::Hkdf;
+use parity_scale_codec::{Decode, Encode};
+use scale_info::TypeInfo;
+use sha2::Sha256;
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// Hash-to-curve domain separation tag, version-locked. Changing this string
+/// invalidates every in-flight ciphertext — do not modify post-launch.
+pub const DST_G1: &[u8] = b"ETHEXE-TPKE-V1-BLS12381G1_XMD:SHA-256_SSWU_RO_";
+
+/// HKDF info prefix for the KEM-derived DEM key/nonce.
+pub const HKDF_DEM_INFO: &[u8] = b"ethexe-tpke-dem-v1";
+
+/// Blake2b domain tag for `id` derivation.
+pub const ID_DOMAIN: &[u8] = b"ethexe-tpke-v1";
+
+/// 32-byte ChaCha20-Poly1305 key length.
+const DEM_KEY_LEN: usize = 32;
+/// 12-byte ChaCha20-Poly1305 nonce length.
+const DEM_NONCE_LEN: usize = 12;
+/// Compressed G2 point byte length on BLS12-381.
+pub const G2_COMPRESSED_LEN: usize = 96;
+/// Compressed G1 point byte length on BLS12-381.
+pub const G1_COMPRESSED_LEN: usize = 48;
+
+type Blake2b256 = Blake2b<U32>;
+type G1Hasher = MapToCurveBasedHasher<
+    G1Projective,
+    DefaultFieldHasher<Sha256, 128>,
+    WBMap<ark_bls12_381::g1::Config>,
+>;
+
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
+pub enum TpkeError {
+    #[error("malformed ciphertext envelope")]
+    MalformedCiphertext,
+    #[error("AEAD authentication failed")]
+    AeadAuth,
+    #[error("decryption share did not verify against share public key")]
+    ShareVerification,
+    #[error("not enough shares to combine: got {got}, need {need}")]
+    InsufficientShares { got: usize, need: usize },
+    #[error("duplicate share index {0}")]
+    DuplicateShareIndex(u32),
+    #[error("share index {0} is zero (validator ids start at 1)")]
+    ZeroShareIndex(u32),
+    #[error("point serialization failed")]
+    Serialization,
+    #[error("hash-to-curve failed")]
+    HashToCurve,
+    #[error("invalid threshold: t={t}, n={n} (require 1 <= t <= n)")]
+    InvalidThreshold { t: u32, n: u32 },
+}
+
+/// Master secret key produced by the dealer. Must be destroyed after splitting.
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
+pub struct MasterSecretKey(pub Fr);
+
+impl core::fmt::Debug for MasterSecretKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Never leak the scalar via Debug.
+        f.write_str("MasterSecretKey(<redacted>)")
+    }
+}
+
+/// Per-validator secret share `Sᵢ = f(i)`. Index is 1-based.
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
+pub struct SecretKeyShare {
+    pub index: u32,
+    pub scalar: Fr,
+}
+
+impl core::fmt::Debug for SecretKeyShare {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SecretKeyShare")
+            .field("index", &self.index)
+            .field("scalar", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Master public key `AggPub = S · g₂ ∈ G2`. Published openly.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct MasterPublicKey(pub G2Affine);
+
+/// Per-validator share public key `PSᵢ = Sᵢ · g₂ ∈ G2`. Used by anyone to
+/// verify a decryption share without knowing the secret.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SharePublicKey {
+    pub index: u32,
+    pub point: G2Affine,
+}
+
+/// Encrypted ciphertext envelope. Wire format is the SCALE encoding of this.
+#[derive(Clone, PartialEq, Eq, Debug, Encode, Decode, TypeInfo)]
+pub struct EncryptedEnvelope {
+    /// `U = u · g₂ ∈ G2`, compressed 96-byte serialization.
+    pub u: [u8; G2_COMPRESSED_LEN],
+    /// 32-byte identity binding (see `derive_id`).
+    pub id: [u8; 32],
+    /// ChaCha20-Poly1305 ciphertext incl. 16-byte Poly1305 tag.
+    pub body: Vec<u8>,
+}
+
+/// Decryption share `Dᵢ = Sᵢ · Q_id ∈ G1`. Validator index is 1-based.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct DecryptionShare {
+    pub index: u32,
+    pub point: G1Affine,
+}
+
+// ---------------------------------------------------------------------------
+// Identity binding
+// ---------------------------------------------------------------------------
+
+/// Derive the 32-byte identity that binds a ciphertext to its plaintext,
+/// chain, and key epoch.
+///
+/// `user_nonce` MUST be high-entropy randomness chosen at encryption time.
+/// Without it, an attacker who can guess plaintext (e.g. known token-trade
+/// templates) can verify the guess by recomputing `id` and matching the
+/// ciphertext's id — a known-plaintext attack on the identity.
+pub fn derive_id(
+    chain_id: u64,
+    key_epoch_id: u32,
+    canonical_plaintext: &[u8],
+    user_nonce: &[u8; 32],
+) -> [u8; 32] {
+    let mut h = Blake2b256::new();
+    h.update(ID_DOMAIN);
+    h.update(chain_id.to_le_bytes());
+    h.update(key_epoch_id.to_le_bytes());
+    h.update(canonical_plaintext);
+    h.update(user_nonce);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&h.finalize());
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Dealer (Shamir secret sharing)
+// ---------------------------------------------------------------------------
+
+impl MasterSecretKey {
+    /// Run the dealer ceremony locally: sample a fresh master secret, split
+    /// it into `n` Shamir shares with threshold `t`, and return shares + pubs.
+    ///
+    /// `t` is the number of shares required to decrypt. `n` is the total
+    /// validator count. Indices in the returned shares are 1..=n.
+    ///
+    /// The returned `MasterSecretKey` SHOULD be zeroized by the caller as soon
+    /// as the shares are persisted off-machine (`drop` does this on Drop).
+    pub fn deal<R: RngCore + CryptoRng>(
+        t: u32,
+        n: u32,
+        rng: &mut R,
+    ) -> Result<DealerOutput, TpkeError> {
+        if t == 0 || n == 0 || t > n {
+            return Err(TpkeError::InvalidThreshold { t, n });
+        }
+        // Sample polynomial coefficients: f(x) = a_0 + a_1·x + ... + a_{t-1}·x^{t-1}
+        // where a_0 = S (master secret).
+        let mut coeffs: Vec<Fr> = (0..t).map(|_| Fr::rand(rng)).collect();
+        let master = MasterSecretKey(coeffs[0]);
+
+        // Compute share Sᵢ = f(i) for i in 1..=n using Horner's rule.
+        let mut shares = Vec::with_capacity(n as usize);
+        let mut share_pubs = Vec::with_capacity(n as usize);
+        let g2 = G2Affine::generator();
+        for i in 1..=n {
+            let x = Fr::from(i as u64);
+            // Horner: acc = a_{t-1}; for k in (t-2..=0): acc = acc·x + a_k.
+            let mut acc = coeffs[t as usize - 1];
+            for k in (0..t as usize - 1).rev() {
+                acc = acc * x + coeffs[k];
+            }
+            let sk = SecretKeyShare {
+                index: i,
+                scalar: acc,
+            };
+            let pk = SharePublicKey {
+                index: i,
+                point: (g2 * acc).into_affine(),
+            };
+            shares.push(sk);
+            share_pubs.push(pk);
+        }
+
+        let master_pub = MasterPublicKey((g2 * master.0).into_affine());
+
+        // Wipe intermediate polynomial coefficients.
+        coeffs.zeroize();
+
+        Ok(DealerOutput {
+            master_secret: master,
+            master_pub,
+            shares,
+            share_pubs,
+        })
+    }
+}
+
+/// Output of the dealer ceremony.
+#[derive(Debug)]
+pub struct DealerOutput {
+    pub master_secret: MasterSecretKey,
+    pub master_pub: MasterPublicKey,
+    pub shares: Vec<SecretKeyShare>,
+    pub share_pubs: Vec<SharePublicKey>,
+}
+
+// ---------------------------------------------------------------------------
+// Hash to G1
+// ---------------------------------------------------------------------------
+
+fn hash_to_g1(id: &[u8; 32]) -> Result<G1Affine, TpkeError> {
+    let hasher = G1Hasher::new(DST_G1).map_err(|_| TpkeError::HashToCurve)?;
+    let q = hasher.hash(id).map_err(|_| TpkeError::HashToCurve)?;
+    Ok(q)
+}
+
+// ---------------------------------------------------------------------------
+// Encrypt
+// ---------------------------------------------------------------------------
+
+/// Additional Authenticated Data layout (input to ChaCha20-Poly1305 MAC).
+///
+/// Format: id ‖ U_bytes ‖ chain_id_le ‖ key_epoch_id_le
+fn build_aad(envelope_id: &[u8; 32], u_bytes: &[u8], chain_id: u64, key_epoch_id: u32) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(32 + G2_COMPRESSED_LEN + 8 + 4);
+    aad.extend_from_slice(envelope_id);
+    aad.extend_from_slice(u_bytes);
+    aad.extend_from_slice(&chain_id.to_le_bytes());
+    aad.extend_from_slice(&key_epoch_id.to_le_bytes());
+    aad
+}
+
+fn serialize_g2(p: &G2Affine) -> Result<[u8; G2_COMPRESSED_LEN], TpkeError> {
+    let mut buf = [0u8; G2_COMPRESSED_LEN];
+    p.serialize_compressed(&mut buf[..])
+        .map_err(|_| TpkeError::Serialization)?;
+    Ok(buf)
+}
+
+fn deserialize_g2(bytes: &[u8; G2_COMPRESSED_LEN]) -> Result<G2Affine, TpkeError> {
+    G2Affine::deserialize_compressed(&bytes[..]).map_err(|_| TpkeError::MalformedCiphertext)
+}
+
+fn serialize_g1(p: &G1Affine) -> Result<[u8; G1_COMPRESSED_LEN], TpkeError> {
+    let mut buf = [0u8; G1_COMPRESSED_LEN];
+    p.serialize_compressed(&mut buf[..])
+        .map_err(|_| TpkeError::Serialization)?;
+    Ok(buf)
+}
+
+/// Encode the pairing-target element `z ∈ GT` deterministically for HKDF input.
+fn serialize_gt(z: &PairingOutput<Bls12_381>) -> Result<Vec<u8>, TpkeError> {
+    let mut buf = Vec::with_capacity(576);
+    z.serialize_compressed(&mut buf)
+        .map_err(|_| TpkeError::Serialization)?;
+    Ok(buf)
+}
+
+/// Derive the 44 raw bytes (32-byte AEAD key + 12-byte AEAD nonce) from the
+/// shared secret `z`, identity, and ephemeral `U`.
+fn derive_dem_key_nonce(
+    z: &PairingOutput<Bls12_381>,
+    envelope_id: &[u8; 32],
+    u_bytes: &[u8],
+) -> Result<([u8; DEM_KEY_LEN], [u8; DEM_NONCE_LEN]), TpkeError> {
+    let z_bytes = serialize_gt(z)?;
+    let mut info = Vec::with_capacity(HKDF_DEM_INFO.len() + 32 + u_bytes.len());
+    info.extend_from_slice(HKDF_DEM_INFO);
+    info.extend_from_slice(envelope_id);
+    info.extend_from_slice(u_bytes);
+
+    let hk = Hkdf::<Sha256>::new(None, &z_bytes);
+    let mut okm = [0u8; DEM_KEY_LEN + DEM_NONCE_LEN];
+    hk.expand(&info, &mut okm)
+        .map_err(|_| TpkeError::Serialization)?;
+
+    let mut key = [0u8; DEM_KEY_LEN];
+    let mut nonce = [0u8; DEM_NONCE_LEN];
+    key.copy_from_slice(&okm[..DEM_KEY_LEN]);
+    nonce.copy_from_slice(&okm[DEM_KEY_LEN..]);
+    Ok((key, nonce))
+}
+
+/// Encrypt `plaintext` for identity `id` under master public key `pk`.
+///
+/// `chain_id` and `key_epoch_id` are bound into the AEAD's AAD so a ciphertext
+/// can only be decrypted within its intended chain+epoch context.
+pub fn encrypt<R: RngCore + CryptoRng>(
+    pk: &MasterPublicKey,
+    id: &[u8; 32],
+    chain_id: u64,
+    key_epoch_id: u32,
+    plaintext: &[u8],
+    rng: &mut R,
+) -> Result<EncryptedEnvelope, TpkeError> {
+    let q_id = hash_to_g1(id)?;
+    // Reject the (negligibly likely) malformed id that hashes to the identity.
+    if q_id.is_zero() {
+        return Err(TpkeError::HashToCurve);
+    }
+
+    let u_scalar = Fr::rand(rng);
+    let u_point = (G2Affine::generator() * u_scalar).into_affine();
+    let u_bytes = serialize_g2(&u_point)?;
+
+    // z = e(Q_id, AggPub)^u = e(Q_id, g₂)^(S·u)
+    let z_base = Bls12_381::pairing(q_id, pk.0);
+    let z = z_base * u_scalar;
+
+    let (key_bytes, nonce_bytes) = derive_dem_key_nonce(&z, id, &u_bytes)?;
+    let cipher = ChaCha20Poly1305::new(Key::from_slice(&key_bytes));
+    let aad = build_aad(id, &u_bytes, chain_id, key_epoch_id);
+    let body = cipher
+        .encrypt(
+            Nonce::from_slice(&nonce_bytes),
+            Payload {
+                msg: plaintext,
+                aad: &aad,
+            },
+        )
+        .map_err(|_| TpkeError::AeadAuth)?;
+
+    Ok(EncryptedEnvelope {
+        u: u_bytes,
+        id: *id,
+        body,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Decryption share emit + verify
+// ---------------------------------------------------------------------------
+
+impl SecretKeyShare {
+    /// Validator-side: produce `Dᵢ = Sᵢ · Q_id` for the ciphertext's id.
+    pub fn decrypt_share(
+        &self,
+        envelope: &EncryptedEnvelope,
+    ) -> Result<DecryptionShare, TpkeError> {
+        if self.index == 0 {
+            return Err(TpkeError::ZeroShareIndex(0));
+        }
+        let q_id = hash_to_g1(&envelope.id)?;
+        let point = (q_id * self.scalar).into_affine();
+        Ok(DecryptionShare {
+            index: self.index,
+            point,
+        })
+    }
+}
+
+impl SharePublicKey {
+    /// Verify a decryption share: e(Dᵢ, g₂) ?= e(Q_id, PSᵢ).
+    pub fn verify(
+        &self,
+        envelope: &EncryptedEnvelope,
+        share: &DecryptionShare,
+    ) -> Result<bool, TpkeError> {
+        if share.index != self.index {
+            return Ok(false);
+        }
+        let q_id = hash_to_g1(&envelope.id)?;
+        let g2 = G2Affine::generator();
+        let lhs = Bls12_381::pairing(share.point, g2);
+        let rhs = Bls12_381::pairing(q_id, self.point);
+        Ok(lhs == rhs)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Combine + decrypt
+// ---------------------------------------------------------------------------
+
+/// Compute Lagrange coefficient `λᵢ = ∏_{j != i} (j / (j - i))` evaluated at 0.
+///
+/// Indices are 1-based validator ids. Returns `None` if any (j - i) is zero
+/// (caller must dedupe before calling).
+fn lagrange_coefficient(i: u32, indices: &[u32]) -> Option<Fr> {
+    let xi = Fr::from(i as u64);
+    let mut num = Fr::from(1u64);
+    let mut den = Fr::from(1u64);
+    for &j in indices {
+        if j == i {
+            continue;
+        }
+        let xj = Fr::from(j as u64);
+        num *= xj; // numerator term: x_j (since we evaluate at x = 0: 0 - x_j = -x_j; signs cancel)
+        let diff = xj - xi;
+        if diff.is_zero() {
+            return None;
+        }
+        den *= diff;
+    }
+    let den_inv = den.inverse()?;
+    Some(num * den_inv)
+}
+
+/// Combine `t` decryption shares into the plaintext.
+///
+/// All shares must verify against their share-public-key (call `verify()`
+/// upstream). This function does no verification — it assumes honest shares.
+pub fn combine(
+    envelope: &EncryptedEnvelope,
+    shares: &[DecryptionShare],
+    chain_id: u64,
+    key_epoch_id: u32,
+    threshold: u32,
+) -> Result<Vec<u8>, TpkeError> {
+    if (shares.len() as u32) < threshold {
+        return Err(TpkeError::InsufficientShares {
+            got: shares.len(),
+            need: threshold as usize,
+        });
+    }
+    // Use the first `threshold` shares.
+    let used = &shares[..threshold as usize];
+
+    // Reject zero or duplicate indices.
+    let mut seen: Vec<u32> = Vec::with_capacity(used.len());
+    for s in used {
+        if s.index == 0 {
+            return Err(TpkeError::ZeroShareIndex(0));
+        }
+        if seen.contains(&s.index) {
+            return Err(TpkeError::DuplicateShareIndex(s.index));
+        }
+        seen.push(s.index);
+    }
+
+    // D = Σ λᵢ · Dᵢ (Lagrange in the exponent)
+    let mut acc = G1Projective::zero();
+    for s in used {
+        let lambda =
+            lagrange_coefficient(s.index, &seen).ok_or(TpkeError::DuplicateShareIndex(s.index))?;
+        acc += s.point * lambda;
+    }
+    let d = acc.into_affine();
+
+    // z' = e(D, U)
+    let u_point = deserialize_g2(&envelope.u)?;
+    let z = Bls12_381::pairing(d, u_point);
+
+    // Derive DEM key+nonce identically to encrypt, decrypt body.
+    let (key_bytes, nonce_bytes) = derive_dem_key_nonce(&z, &envelope.id, &envelope.u)?;
+    let cipher = ChaCha20Poly1305::new(Key::from_slice(&key_bytes));
+    let aad = build_aad(&envelope.id, &envelope.u, chain_id, key_epoch_id);
+    cipher
+        .decrypt(
+            Nonce::from_slice(&nonce_bytes),
+            Payload {
+                msg: &envelope.body,
+                aad: &aad,
+            },
+        )
+        .map_err(|_| TpkeError::AeadAuth)
+}
+
+// ---------------------------------------------------------------------------
+// Serialization helpers for testing / wire interop
+// ---------------------------------------------------------------------------
+
+impl DecryptionShare {
+    pub fn to_bytes(&self) -> Result<(u32, [u8; G1_COMPRESSED_LEN]), TpkeError> {
+        Ok((self.index, serialize_g1(&self.point)?))
+    }
+
+    pub fn from_bytes(index: u32, bytes: &[u8; G1_COMPRESSED_LEN]) -> Result<Self, TpkeError> {
+        let point = G1Affine::deserialize_compressed(&bytes[..])
+            .map_err(|_| TpkeError::MalformedCiphertext)?;
+        Ok(Self { index, point })
+    }
+}
+
+impl MasterPublicKey {
+    pub fn to_bytes(&self) -> Result<[u8; G2_COMPRESSED_LEN], TpkeError> {
+        serialize_g2(&self.0)
+    }
+
+    pub fn from_bytes(bytes: &[u8; G2_COMPRESSED_LEN]) -> Result<Self, TpkeError> {
+        Ok(Self(deserialize_g2(bytes)?))
+    }
+}
+
+impl SharePublicKey {
+    pub fn to_bytes(&self) -> Result<(u32, [u8; G2_COMPRESSED_LEN]), TpkeError> {
+        Ok((self.index, serialize_g2(&self.point)?))
+    }
+
+    pub fn from_bytes(index: u32, bytes: &[u8; G2_COMPRESSED_LEN]) -> Result<Self, TpkeError> {
+        Ok(Self {
+            index,
+            point: deserialize_g2(bytes)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_std::rand::{SeedableRng, rngs::StdRng};
+
+    fn fixed_rng() -> StdRng {
+        StdRng::seed_from_u64(0xDEADBEEF_CAFEBABE)
+    }
+
+    fn deal(t: u32, n: u32) -> DealerOutput {
+        let mut rng = fixed_rng();
+        MasterSecretKey::deal(t, n, &mut rng).unwrap()
+    }
+
+    #[test]
+    fn roundtrip_4_of_7() {
+        let d = deal(4, 7);
+        let mut rng = fixed_rng();
+        let id = derive_id(42, 1, b"hello world", &[7u8; 32]);
+        let env = encrypt(&d.master_pub, &id, 42, 1, b"hello world", &mut rng).unwrap();
+        let shares: Vec<DecryptionShare> = d
+            .shares
+            .iter()
+            .take(4)
+            .map(|s| s.decrypt_share(&env).unwrap())
+            .collect();
+        // Verify each share.
+        for (s, ps) in shares.iter().zip(d.share_pubs.iter()) {
+            assert!(ps.verify(&env, s).unwrap());
+        }
+        let pt = combine(&env, &shares, 42, 1, 4).unwrap();
+        assert_eq!(pt, b"hello world");
+    }
+
+    #[test]
+    fn insufficient_shares_returns_err() {
+        let d = deal(3, 5);
+        let mut rng = fixed_rng();
+        let id = derive_id(1, 0, b"x", &[0u8; 32]);
+        let env = encrypt(&d.master_pub, &id, 1, 0, b"x", &mut rng).unwrap();
+        let shares: Vec<_> = d
+            .shares
+            .iter()
+            .take(2)
+            .map(|s| s.decrypt_share(&env).unwrap())
+            .collect();
+        let err = combine(&env, &shares, 1, 0, 3).unwrap_err();
+        assert!(matches!(
+            err,
+            TpkeError::InsufficientShares { got: 2, need: 3 }
+        ));
+    }
+
+    #[test]
+    fn mutated_ciphertext_fails_aead() {
+        let d = deal(2, 3);
+        let mut rng = fixed_rng();
+        let id = derive_id(1, 0, b"abc", &[1u8; 32]);
+        let mut env = encrypt(&d.master_pub, &id, 1, 0, b"abc", &mut rng).unwrap();
+        // Flip one bit of the ciphertext body.
+        env.body[0] ^= 1;
+        let shares: Vec<_> = d
+            .shares
+            .iter()
+            .take(2)
+            .map(|s| s.decrypt_share(&env).unwrap())
+            .collect();
+        let err = combine(&env, &shares, 1, 0, 2).unwrap_err();
+        assert!(matches!(err, TpkeError::AeadAuth));
+    }
+
+    #[test]
+    fn wrong_aad_chain_id_fails_aead() {
+        let d = deal(2, 3);
+        let mut rng = fixed_rng();
+        let id = derive_id(1, 0, b"abc", &[1u8; 32]);
+        let env = encrypt(&d.master_pub, &id, 1, 0, b"abc", &mut rng).unwrap();
+        let shares: Vec<_> = d
+            .shares
+            .iter()
+            .take(2)
+            .map(|s| s.decrypt_share(&env).unwrap())
+            .collect();
+        // Decrypt with wrong chain_id.
+        let err = combine(&env, &shares, 999, 0, 2).unwrap_err();
+        assert!(matches!(err, TpkeError::AeadAuth));
+    }
+
+    #[test]
+    fn share_for_wrong_validator_fails_verify() {
+        let d = deal(2, 3);
+        let mut rng = fixed_rng();
+        let id = derive_id(1, 0, b"abc", &[1u8; 32]);
+        let env = encrypt(&d.master_pub, &id, 1, 0, b"abc", &mut rng).unwrap();
+        // Validator 1 produces a share but we check it against validator 2's pubkey.
+        let share1 = d.shares[0].decrypt_share(&env).unwrap();
+        // Swap index to 2 to bypass the index-mismatch shortcut and trigger the pairing check.
+        let mut fake = share1.clone();
+        fake.index = 2;
+        assert!(!d.share_pubs[1].verify(&env, &fake).unwrap());
+    }
+
+    #[test]
+    fn mutated_id_breaks_share_verification() {
+        let d = deal(2, 3);
+        let mut rng = fixed_rng();
+        let id = derive_id(1, 0, b"abc", &[1u8; 32]);
+        let env = encrypt(&d.master_pub, &id, 1, 0, b"abc", &mut rng).unwrap();
+        let share = d.shares[0].decrypt_share(&env).unwrap();
+        let mut tampered = env.clone();
+        tampered.id[0] ^= 0xFF;
+        // Share was for original id, not the tampered one: pairing check fails.
+        assert!(!d.share_pubs[0].verify(&tampered, &share).unwrap());
+    }
+
+    #[test]
+    fn empty_plaintext_roundtrip() {
+        let d = deal(2, 3);
+        let mut rng = fixed_rng();
+        let id = derive_id(1, 0, b"", &[2u8; 32]);
+        let env = encrypt(&d.master_pub, &id, 1, 0, b"", &mut rng).unwrap();
+        let shares: Vec<_> = d
+            .shares
+            .iter()
+            .take(2)
+            .map(|s| s.decrypt_share(&env).unwrap())
+            .collect();
+        let pt = combine(&env, &shares, 1, 0, 2).unwrap();
+        assert_eq!(pt, b"");
+    }
+
+    #[test]
+    fn duplicate_share_index_rejected() {
+        let d = deal(2, 3);
+        let mut rng = fixed_rng();
+        let id = derive_id(1, 0, b"x", &[3u8; 32]);
+        let env = encrypt(&d.master_pub, &id, 1, 0, b"x", &mut rng).unwrap();
+        let share = d.shares[0].decrypt_share(&env).unwrap();
+        // Same share twice.
+        let err = combine(&env, &[share.clone(), share.clone()], 1, 0, 2).unwrap_err();
+        assert!(matches!(err, TpkeError::DuplicateShareIndex(1)));
+    }
+
+    #[test]
+    fn invalid_threshold_at_deal_time() {
+        let mut rng = fixed_rng();
+        assert!(matches!(
+            MasterSecretKey::deal(0, 3, &mut rng).unwrap_err(),
+            TpkeError::InvalidThreshold { t: 0, n: 3 }
+        ));
+        assert!(matches!(
+            MasterSecretKey::deal(5, 3, &mut rng).unwrap_err(),
+            TpkeError::InvalidThreshold { t: 5, n: 3 }
+        ));
+    }
+
+    #[test]
+    fn id_derivation_is_deterministic_and_nonce_sensitive() {
+        let a = derive_id(1, 0, b"hello", &[0u8; 32]);
+        let b = derive_id(1, 0, b"hello", &[0u8; 32]);
+        let c = derive_id(1, 0, b"hello", &[1u8; 32]);
+        let d = derive_id(2, 0, b"hello", &[0u8; 32]);
+        let e = derive_id(1, 1, b"hello", &[0u8; 32]);
+        assert_eq!(a, b);
+        assert_ne!(a, c, "different nonce must give different id");
+        assert_ne!(a, d, "different chain_id must give different id");
+        assert_ne!(a, e, "different key_epoch_id must give different id");
+    }
+
+    #[test]
+    fn envelope_scale_roundtrip() {
+        let d = deal(2, 3);
+        let mut rng = fixed_rng();
+        let id = derive_id(1, 0, b"abc", &[4u8; 32]);
+        let env = encrypt(&d.master_pub, &id, 1, 0, b"abc", &mut rng).unwrap();
+        let encoded = env.encode();
+        let decoded = EncryptedEnvelope::decode(&mut &encoded[..]).unwrap();
+        assert_eq!(env, decoded);
+    }
+
+    #[test]
+    fn arbitrary_subset_of_t_shares_works() {
+        // 3-of-5: any 3 distinct shares must combine to the same plaintext.
+        let d = deal(3, 5);
+        let mut rng = fixed_rng();
+        let id = derive_id(1, 0, b"abc", &[5u8; 32]);
+        let env = encrypt(&d.master_pub, &id, 1, 0, b"abc", &mut rng).unwrap();
+        let all: Vec<_> = d
+            .shares
+            .iter()
+            .map(|s| s.decrypt_share(&env).unwrap())
+            .collect();
+        for subset_indices in [[0, 1, 2], [0, 1, 4], [1, 3, 4], [2, 3, 4]] {
+            let subset: Vec<_> = subset_indices.iter().map(|&i| all[i].clone()).collect();
+            let pt = combine(&env, &subset, 1, 0, 3).unwrap();
+            assert_eq!(pt, b"abc", "subset {subset_indices:?} failed");
+        }
+    }
+}

--- a/ethexe/tpke/src/lib.rs
+++ b/ethexe/tpke/src/lib.rs
@@ -102,8 +102,21 @@ pub enum TpkeError {
 }
 
 /// Master secret key produced by the dealer. Must be destroyed after splitting.
+///
+/// The scalar field is private — callers can construct via [`Self::new`] and
+/// read it via [`Self::scalar`], but cannot accidentally print or copy it
+/// through direct field access. `Debug` is implemented to elide the scalar.
 #[derive(Clone, Zeroize, ZeroizeOnDrop)]
-pub struct MasterSecretKey(pub Fr);
+pub struct MasterSecretKey(Fr);
+
+impl MasterSecretKey {
+    pub fn new(scalar: Fr) -> Self {
+        Self(scalar)
+    }
+    pub fn scalar(&self) -> Fr {
+        self.0
+    }
+}
 
 impl core::fmt::Debug for MasterSecretKey {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -113,10 +126,22 @@ impl core::fmt::Debug for MasterSecretKey {
 }
 
 /// Per-validator secret share `Sᵢ = f(i)`. Index is 1-based.
+///
+/// `scalar` is private; use [`Self::new`] to construct and [`Self::scalar`]
+/// to read. The `index` is non-sensitive and stays public.
 #[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct SecretKeyShare {
     pub index: u32,
-    pub scalar: Fr,
+    scalar: Fr,
+}
+
+impl SecretKeyShare {
+    pub fn new(index: u32, scalar: Fr) -> Self {
+        Self { index, scalar }
+    }
+    pub fn scalar(&self) -> Fr {
+        self.scalar
+    }
 }
 
 impl core::fmt::Debug for SecretKeyShare {
@@ -158,11 +183,83 @@ pub struct EncryptedEnvelope {
 /// this prevents accidental cross-envelope mixing from silently producing
 /// garbage plaintext (which would otherwise only surface as a cryptic AEAD
 /// failure downstream).
+///
+/// SCALE wire format: `index: u32` ‖ `id: [u8; 32]` ‖ `compressed_point: [u8; 48]`.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct DecryptionShare {
     pub index: u32,
     pub id: [u8; 32],
     pub point: G1Affine,
+}
+
+// SCALE codec for wire types. Manual impls are needed because arkworks' point
+// types don't implement `Encode`/`Decode`/`TypeInfo`. The wire format uses
+// BLS12-381 compressed encodings (48 B for G1, 96 B for G2). Encode panics
+// only on serialization failure of an in-memory valid point, which cannot
+// happen for points produced by this crate; Decode validates and returns a
+// codec error on bad bytes.
+
+impl Encode for DecryptionShare {
+    fn encode_to<T: parity_scale_codec::Output + ?Sized>(&self, dest: &mut T) {
+        self.index.encode_to(dest);
+        self.id.encode_to(dest);
+        let bytes =
+            serialize_g1(&self.point).expect("DecryptionShare always holds a valid G1 point");
+        bytes.encode_to(dest);
+    }
+}
+
+impl Decode for DecryptionShare {
+    fn decode<I: parity_scale_codec::Input>(
+        input: &mut I,
+    ) -> Result<Self, parity_scale_codec::Error> {
+        let index = u32::decode(input)?;
+        let id = <[u8; 32]>::decode(input)?;
+        let bytes = <[u8; G1_COMPRESSED_LEN]>::decode(input)?;
+        let point = deserialize_compressed::<G1Affine, G1_COMPRESSED_LEN>(&bytes)
+            .map_err(|_| parity_scale_codec::Error::from("invalid G1 point in DecryptionShare"))?;
+        Ok(Self { index, id, point })
+    }
+}
+
+impl Encode for MasterPublicKey {
+    fn encode_to<T: parity_scale_codec::Output + ?Sized>(&self, dest: &mut T) {
+        let bytes = serialize_g2(&self.0).expect("MasterPublicKey always holds a valid G2 point");
+        bytes.encode_to(dest);
+    }
+}
+
+impl Decode for MasterPublicKey {
+    fn decode<I: parity_scale_codec::Input>(
+        input: &mut I,
+    ) -> Result<Self, parity_scale_codec::Error> {
+        let bytes = <[u8; G2_COMPRESSED_LEN]>::decode(input)?;
+        // Use from_bytes so identity-point rejection is centralized.
+        Self::from_bytes(&bytes).map_err(|_| {
+            parity_scale_codec::Error::from("invalid or identity G2 point in MasterPublicKey")
+        })
+    }
+}
+
+impl Encode for SharePublicKey {
+    fn encode_to<T: parity_scale_codec::Output + ?Sized>(&self, dest: &mut T) {
+        self.index.encode_to(dest);
+        let bytes =
+            serialize_g2(&self.point).expect("SharePublicKey always holds a valid G2 point");
+        bytes.encode_to(dest);
+    }
+}
+
+impl Decode for SharePublicKey {
+    fn decode<I: parity_scale_codec::Input>(
+        input: &mut I,
+    ) -> Result<Self, parity_scale_codec::Error> {
+        let index = u32::decode(input)?;
+        let bytes = <[u8; G2_COMPRESSED_LEN]>::decode(input)?;
+        Self::from_bytes(index, &bytes).map_err(|_| {
+            parity_scale_codec::Error::from("invalid or identity G2 point in SharePublicKey")
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -217,7 +314,7 @@ impl MasterSecretKey {
         // Sample polynomial coefficients: f(x) = a_0 + a_1·x + ... + a_{t-1}·x^{t-1}
         // where a_0 = S (master secret).
         let mut coeffs: Vec<Fr> = (0..t).map(|_| Fr::rand(rng)).collect();
-        let master = MasterSecretKey(coeffs[0]);
+        let master = MasterSecretKey::new(coeffs[0]);
 
         // Compute share Sᵢ = f(i) for i in 1..=n using Horner's rule.
         let mut shares = Vec::with_capacity(n as usize);
@@ -230,10 +327,7 @@ impl MasterSecretKey {
             for k in (0..t as usize - 1).rev() {
                 acc = acc * x + coeffs[k];
             }
-            let sk = SecretKeyShare {
-                index: i,
-                scalar: acc,
-            };
+            let sk = SecretKeyShare::new(i, acc);
             let pk = SharePublicKey {
                 index: i,
                 point: (g2 * acc).into_affine(),
@@ -242,7 +336,7 @@ impl MasterSecretKey {
             share_pubs.push(pk);
         }
 
-        let master_pub = MasterPublicKey((g2 * master.0).into_affine());
+        let master_pub = MasterPublicKey((g2 * master.scalar()).into_affine());
 
         // Wipe intermediate polynomial coefficients.
         coeffs.zeroize();
@@ -829,6 +923,47 @@ mod tests {
         let encoded = env.encode();
         let decoded = EncryptedEnvelope::decode(&mut &encoded[..]).unwrap();
         assert_eq!(env, decoded);
+    }
+
+    #[test]
+    fn decryption_share_scale_roundtrip() {
+        let d = deal(2, 3);
+        let mut rng = fixed_rng();
+        let id = derive_id(1, 0, b"abc", &[5u8; 32]);
+        let env = encrypt(&d.master_pub, &id, 1, 0, b"abc", &mut rng).unwrap();
+        let share = d.shares[0].decrypt_share(&env).unwrap();
+        let encoded = share.encode();
+        // 4 (index) + 32 (id) + 48 (G1 compressed) = 84 bytes.
+        assert_eq!(encoded.len(), 4 + 32 + 48);
+        let decoded = DecryptionShare::decode(&mut &encoded[..]).unwrap();
+        assert_eq!(share, decoded);
+    }
+
+    #[test]
+    fn master_pub_scale_roundtrip() {
+        let d = deal(2, 3);
+        let encoded = d.master_pub.encode();
+        assert_eq!(encoded.len(), G2_COMPRESSED_LEN);
+        let decoded = MasterPublicKey::decode(&mut &encoded[..]).unwrap();
+        assert_eq!(d.master_pub, decoded);
+    }
+
+    #[test]
+    fn share_pub_scale_roundtrip() {
+        let d = deal(2, 3);
+        let encoded = d.share_pubs[0].encode();
+        assert_eq!(encoded.len(), 4 + G2_COMPRESSED_LEN);
+        let decoded = SharePublicKey::decode(&mut &encoded[..]).unwrap();
+        assert_eq!(d.share_pubs[0], decoded);
+    }
+
+    #[test]
+    fn scale_decode_rejects_identity_master_pub() {
+        // Serialize the G2 identity and try to SCALE-decode as a MasterPublicKey.
+        let mut buf = [0u8; G2_COMPRESSED_LEN];
+        G2Affine::zero().serialize_compressed(&mut buf[..]).unwrap();
+        let encoded = buf.encode();
+        assert!(MasterPublicKey::decode(&mut &encoded[..]).is_err());
     }
 
     #[test]

--- a/ethexe/tpke/src/lib.rs
+++ b/ethexe/tpke/src/lib.rs
@@ -296,10 +296,26 @@ impl Clone for DealerOutput {
 // Hash to G1
 // ---------------------------------------------------------------------------
 
+// The hasher is constructed once per process and reused. DST_G1 is constant,
+// so `G1Hasher::new` only fails for malformed DSTs — which we control at
+// compile time — making the `.expect()` unreachable in practice.
+#[cfg(feature = "std")]
+fn g1_hasher() -> &'static G1Hasher {
+    use std::sync::OnceLock;
+    static HASHER: OnceLock<G1Hasher> = OnceLock::new();
+    HASHER.get_or_init(|| G1Hasher::new(DST_G1).expect("DST_G1 is a valid hash-to-curve DST"))
+}
+
 fn hash_to_g1(id: &[u8; 32]) -> Result<G1Affine, TpkeError> {
-    let hasher = G1Hasher::new(DST_G1).map_err(|_| TpkeError::HashToCurve)?;
-    let q = hasher.hash(id).map_err(|_| TpkeError::HashToCurve)?;
-    Ok(q)
+    #[cfg(feature = "std")]
+    {
+        g1_hasher().hash(id).map_err(|_| TpkeError::HashToCurve)
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        let hasher = G1Hasher::new(DST_G1).map_err(|_| TpkeError::HashToCurve)?;
+        hasher.hash(id).map_err(|_| TpkeError::HashToCurve)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -318,22 +334,33 @@ fn build_aad(envelope_id: &[u8; 32], u_bytes: &[u8], chain_id: u64, key_epoch_id
     aad
 }
 
-fn serialize_g2(p: &G2Affine) -> Result<[u8; G2_COMPRESSED_LEN], TpkeError> {
-    let mut buf = [0u8; G2_COMPRESSED_LEN];
+/// Serialize an arkworks point/element to its fixed-size compressed bytes.
+fn serialize_compressed<P: CanonicalSerialize, const N: usize>(
+    p: &P,
+) -> Result<[u8; N], TpkeError> {
+    let mut buf = [0u8; N];
     p.serialize_compressed(&mut buf[..])
         .map_err(|_| TpkeError::Serialization)?;
     Ok(buf)
+}
+
+/// Deserialize a fixed-size compressed-bytes blob into an arkworks point.
+fn deserialize_compressed<P: CanonicalDeserialize, const N: usize>(
+    bytes: &[u8; N],
+) -> Result<P, TpkeError> {
+    P::deserialize_compressed(&bytes[..]).map_err(|_| TpkeError::MalformedCiphertext)
+}
+
+fn serialize_g2(p: &G2Affine) -> Result<[u8; G2_COMPRESSED_LEN], TpkeError> {
+    serialize_compressed::<_, G2_COMPRESSED_LEN>(p)
 }
 
 fn deserialize_g2(bytes: &[u8; G2_COMPRESSED_LEN]) -> Result<G2Affine, TpkeError> {
-    G2Affine::deserialize_compressed(&bytes[..]).map_err(|_| TpkeError::MalformedCiphertext)
+    deserialize_compressed::<G2Affine, G2_COMPRESSED_LEN>(bytes)
 }
 
 fn serialize_g1(p: &G1Affine) -> Result<[u8; G1_COMPRESSED_LEN], TpkeError> {
-    let mut buf = [0u8; G1_COMPRESSED_LEN];
-    p.serialize_compressed(&mut buf[..])
-        .map_err(|_| TpkeError::Serialization)?;
-    Ok(buf)
+    serialize_compressed::<_, G1_COMPRESSED_LEN>(p)
 }
 
 /// Encode the pairing-target element `z ∈ GT` deterministically for HKDF input.
@@ -571,8 +598,7 @@ impl DecryptionShare {
         id: [u8; 32],
         bytes: &[u8; G1_COMPRESSED_LEN],
     ) -> Result<Self, TpkeError> {
-        let point = G1Affine::deserialize_compressed(&bytes[..])
-            .map_err(|_| TpkeError::MalformedCiphertext)?;
+        let point = deserialize_compressed::<G1Affine, G1_COMPRESSED_LEN>(bytes)?;
         Ok(Self { index, id, point })
     }
 }

--- a/ethexe/tpke/src/lib.rs
+++ b/ethexe/tpke/src/lib.rs
@@ -97,6 +97,8 @@ pub enum TpkeError {
     HashToCurve,
     #[error("invalid threshold: t={t}, n={n} (require 1 <= t <= n)")]
     InvalidThreshold { t: u32, n: u32 },
+    #[error("public key is the identity point — refusing to use it")]
+    IdentityPublicKey,
 }
 
 /// Master secret key produced by the dealer. Must be destroyed after splitting.
@@ -408,6 +410,12 @@ pub fn encrypt<R: RngCore + CryptoRng>(
     plaintext: &[u8],
     rng: &mut R,
 ) -> Result<EncryptedEnvelope, TpkeError> {
+    // Identity public key would make z = e(Q_id, 0) = 1_GT, derivable by anyone
+    // who sees the ciphertext — confidentiality fully bypassed. Reject.
+    if pk.0.is_zero() {
+        return Err(TpkeError::IdentityPublicKey);
+    }
+
     let q_id = hash_to_g1(id)?;
     // Reject the (negligibly likely) malformed id that hashes to the identity.
     if q_id.is_zero() {
@@ -531,6 +539,12 @@ pub fn combine(
     key_epoch_id: u32,
     threshold: u32,
 ) -> Result<Vec<u8>, TpkeError> {
+    // Match deal()'s invariant: threshold 0 would short-circuit to the G1
+    // identity for D and let anyone "decrypt" ciphertexts produced under an
+    // identity master pubkey. Reject up front.
+    if threshold == 0 {
+        return Err(TpkeError::InvalidThreshold { t: 0, n: 0 });
+    }
     if (shares.len() as u32) < threshold {
         return Err(TpkeError::InsufficientShares {
             got: shares.len(),
@@ -608,8 +622,15 @@ impl MasterPublicKey {
         serialize_g2(&self.0)
     }
 
+    /// Deserialize the master pubkey, rejecting the G2 identity point. An
+    /// identity-element master pubkey would make `e(Q_id, pk) = 1_GT`, letting
+    /// anyone with the ciphertext derive the DEM key without shares.
     pub fn from_bytes(bytes: &[u8; G2_COMPRESSED_LEN]) -> Result<Self, TpkeError> {
-        Ok(Self(deserialize_g2(bytes)?))
+        let point = deserialize_g2(bytes)?;
+        if point.is_zero() {
+            return Err(TpkeError::IdentityPublicKey);
+        }
+        Ok(Self(point))
     }
 }
 
@@ -618,11 +639,15 @@ impl SharePublicKey {
         Ok((self.index, serialize_g2(&self.point)?))
     }
 
+    /// Deserialize a share pubkey, rejecting the G2 identity point. An identity
+    /// share-pubkey would make share verification accept any honest share for
+    /// that index regardless of the underlying secret-share scalar.
     pub fn from_bytes(index: u32, bytes: &[u8; G2_COMPRESSED_LEN]) -> Result<Self, TpkeError> {
-        Ok(Self {
-            index,
-            point: deserialize_g2(bytes)?,
-        })
+        let point = deserialize_g2(bytes)?;
+        if point.is_zero() {
+            return Err(TpkeError::IdentityPublicKey);
+        }
+        Ok(Self { index, point })
     }
 }
 
@@ -843,6 +868,51 @@ mod tests {
         // Pubs/shares still cloned.
         assert_eq!(cloned.shares.len(), 3);
         assert_eq!(cloned.share_pubs.len(), 3);
+    }
+
+    // Regression tests for codex review findings (PR gear-tech/gear#5427).
+    //
+    // [P1] An identity G2 master pubkey makes `e(Q_id, pk) = 1_GT`, letting
+    // anyone derive the DEM key from the public envelope alone. Encryption
+    // and pubkey deserialization must reject it.
+    //
+    // [P2] `combine(.., threshold=0)` would slice to an empty share set and
+    // interpolate to the G1 identity, producing a usable D under an attacker-
+    // controlled identity master pubkey. Reject it to mirror deal()'s rule.
+
+    #[test]
+    fn identity_master_pubkey_rejected_at_encrypt() {
+        let identity_pk = MasterPublicKey(G2Affine::zero());
+        let mut rng = fixed_rng();
+        let id = derive_id(1, 0, b"x", &[0u8; 32]);
+        let err = encrypt(&identity_pk, &id, 1, 0, b"x", &mut rng).unwrap_err();
+        assert!(matches!(err, TpkeError::IdentityPublicKey));
+    }
+
+    #[test]
+    fn identity_master_pubkey_rejected_at_from_bytes() {
+        let mut buf = [0u8; G2_COMPRESSED_LEN];
+        G2Affine::zero().serialize_compressed(&mut buf[..]).unwrap();
+        let err = MasterPublicKey::from_bytes(&buf).unwrap_err();
+        assert!(matches!(err, TpkeError::IdentityPublicKey));
+    }
+
+    #[test]
+    fn identity_share_pubkey_rejected_at_from_bytes() {
+        let mut buf = [0u8; G2_COMPRESSED_LEN];
+        G2Affine::zero().serialize_compressed(&mut buf[..]).unwrap();
+        let err = SharePublicKey::from_bytes(1, &buf).unwrap_err();
+        assert!(matches!(err, TpkeError::IdentityPublicKey));
+    }
+
+    #[test]
+    fn zero_threshold_rejected_in_combine() {
+        let d = deal(2, 3);
+        let mut rng = fixed_rng();
+        let id = derive_id(1, 0, b"x", &[0u8; 32]);
+        let env = encrypt(&d.master_pub, &id, 1, 0, b"x", &mut rng).unwrap();
+        let err = combine(&env, &[], 1, 0, 0).unwrap_err();
+        assert!(matches!(err, TpkeError::InvalidThreshold { t: 0, n: 0 }));
     }
 
     #[test]

--- a/ethexe/tpke/tests/kat.rs
+++ b/ethexe/tpke/tests/kat.rs
@@ -133,19 +133,18 @@ fn cross_check_one(v: &Vector) {
         for k in (0..coeffs.len() - 1).rev() {
             acc = acc * x + coeffs[k];
         }
-        rust_shares.push(SecretKeyShare {
-            index: i,
-            scalar: acc,
-        });
+        rust_shares.push(SecretKeyShare::new(i, acc));
     }
     // Sanity: secret_shares_hex matches our reconstruction.
     for (rust_s, py_s) in rust_shares.iter().zip(v.secret_shares_hex.iter()) {
         assert_eq!(rust_s.index, py_s.index);
         let py_scalar = fr_from_be_hex(&py_s.scalar_hex);
         assert_eq!(
-            rust_s.scalar, py_scalar,
+            rust_s.scalar(),
+            py_scalar,
             "{}: secret share #{} mismatch",
-            v.label, rust_s.index
+            v.label,
+            rust_s.index
         );
     }
 
@@ -163,7 +162,7 @@ fn cross_check_one(v: &Vector) {
     // (4) Share pubs: Sᵢ · g₂.
     for (rust_s, py_pub) in rust_shares.iter().zip(v.share_pubs_compressed_hex.iter()) {
         assert_eq!(rust_s.index, py_pub.index);
-        let pt = (g2 * rust_s.scalar).into_affine();
+        let pt = (g2 * rust_s.scalar()).into_affine();
         assert_eq!(
             g2_compressed_hex(&pt),
             py_pub.bytes_hex,
@@ -203,7 +202,7 @@ fn cross_check_one(v: &Vector) {
         .iter()
         .map(|s| SharePublicKey {
             index: s.index,
-            point: (g2 * s.scalar).into_affine(),
+            point: (g2 * s.scalar()).into_affine(),
         })
         .collect();
 

--- a/ethexe/tpke/tests/kat.rs
+++ b/ethexe/tpke/tests/kat.rs
@@ -1,0 +1,241 @@
+//! Known-answer tests against the independent Python (py_ecc) reference.
+//!
+//! What this test cross-checks bit-for-bit:
+//!   1. derive_id(): both impls produce identical 32-byte ids for the same inputs.
+//!   2. hash_to_G1(): both impls produce the same compressed G1 point from id.
+//!   3. Master pub key: S·g₂ matches between impls.
+//!   4. Share pub keys: Sᵢ·g₂ matches.
+//!   5. Decryption shares: Dᵢ = Sᵢ · Q_id matches.
+//!   6. Pairing soundness: e(D, U) and e(Q_id, AggPub)^u produce a working
+//!      Rust-side encrypt-then-decrypt roundtrip.
+//!
+//! What we do NOT cross-check: the AEAD ciphertext body itself, because the
+//! HKDF input depends on GT (Fq12) serialization, and the coefficient ordering
+//! in the towering Fq6/Fq12 construction is not guaranteed to match between
+//! py_ecc and arkworks. The roundtrip in step 6 still ensures end-to-end
+//! correctness on the Rust side.
+
+use ark_bls12_381::{Fr, G1Affine, G2Affine};
+use ark_ec::{AffineRepr, CurveGroup};
+use ark_ff::PrimeField;
+use ark_serialize::CanonicalSerialize;
+use ark_std::rand::{SeedableRng, rngs::StdRng};
+use ethexe_tpke::*;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Vectors {
+    #[allow(dead_code)]
+    version: String,
+    dst: String,
+    vectors: Vec<Vector>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Vector {
+    label: String,
+    chain_id: u64,
+    key_epoch_id: u32,
+    threshold: u32,
+    n: u32,
+    plaintext_hex: String,
+    user_nonce_hex: String,
+    #[allow(dead_code)]
+    u_scalar_hex: String,
+    #[allow(dead_code)]
+    master_secret_hex: String,
+    poly_coeffs_hex: Vec<String>,
+    id_hex: String,
+    master_pub_compressed_hex: String,
+    share_pubs_compressed_hex: Vec<IndexedHex>,
+    secret_shares_hex: Vec<IndexedScalarHex>,
+    #[allow(dead_code)]
+    envelope_u_hex: String,
+    #[allow(dead_code)]
+    envelope_body_hex: String,
+    expected_decryption_shares_hex: Vec<IndexedHex>,
+}
+
+#[derive(Debug, Deserialize)]
+struct IndexedHex {
+    index: u32,
+    bytes_hex: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct IndexedScalarHex {
+    index: u32,
+    scalar_hex: String,
+}
+
+const VECTORS_JSON: &str = include_str!("kat/vectors.json");
+
+fn fr_from_be_hex(h: &str) -> Fr {
+    let bytes = hex::decode(h).expect("hex");
+    assert_eq!(bytes.len(), 32, "expected 32-byte big-endian scalar");
+    Fr::from_be_bytes_mod_order(&bytes)
+}
+
+fn g1_compressed_hex(p: &G1Affine) -> String {
+    let mut buf = [0u8; 48];
+    p.serialize_compressed(&mut buf[..]).unwrap();
+    hex::encode(buf)
+}
+
+fn g2_compressed_hex(p: &G2Affine) -> String {
+    let mut buf = [0u8; 96];
+    p.serialize_compressed(&mut buf[..]).unwrap();
+    hex::encode(buf)
+}
+
+#[test]
+fn dst_matches_reference() {
+    let v: Vectors = serde_json::from_str(VECTORS_JSON).expect("parse vectors.json");
+    assert_eq!(v.dst.as_bytes(), DST_G1, "DST string mismatch");
+}
+
+#[test]
+fn cross_check_every_vector() {
+    let v: Vectors = serde_json::from_str(VECTORS_JSON).expect("parse vectors.json");
+    for vec in &v.vectors {
+        cross_check_one(vec);
+    }
+}
+
+fn cross_check_one(v: &Vector) {
+    eprintln!("KAT: {}", v.label);
+
+    let plaintext = hex::decode(&v.plaintext_hex).unwrap();
+    let user_nonce_vec = hex::decode(&v.user_nonce_hex).unwrap();
+    let user_nonce: [u8; 32] = user_nonce_vec.as_slice().try_into().unwrap();
+
+    // (1) derive_id: must match Python output.
+    let id = derive_id(v.chain_id, v.key_epoch_id, &plaintext, &user_nonce);
+    assert_eq!(hex::encode(id), v.id_hex, "{}: derive_id mismatch", v.label);
+
+    // (2) hash_to_G1: we re-derive Q_id and check by comparing the decryption
+    // share for share index 1: D_1 = S_1 · Q_id. If Q_id matches and S_1
+    // matches, D_1 matches.
+
+    // Reconstruct shares from Python polynomial coefficients to ensure both
+    // sides agree on the secret-share scalars.
+    let coeffs: Vec<Fr> = v
+        .poly_coeffs_hex
+        .iter()
+        .map(|h| fr_from_be_hex(h))
+        .collect();
+    assert_eq!(coeffs.len() as u32, v.threshold);
+
+    let mut rust_shares: Vec<SecretKeyShare> = Vec::with_capacity(v.n as usize);
+    for i in 1..=v.n {
+        let x = Fr::from(i as u64);
+        let mut acc = coeffs[coeffs.len() - 1];
+        for k in (0..coeffs.len() - 1).rev() {
+            acc = acc * x + coeffs[k];
+        }
+        rust_shares.push(SecretKeyShare {
+            index: i,
+            scalar: acc,
+        });
+    }
+    // Sanity: secret_shares_hex matches our reconstruction.
+    for (rust_s, py_s) in rust_shares.iter().zip(v.secret_shares_hex.iter()) {
+        assert_eq!(rust_s.index, py_s.index);
+        let py_scalar = fr_from_be_hex(&py_s.scalar_hex);
+        assert_eq!(
+            rust_s.scalar, py_scalar,
+            "{}: secret share #{} mismatch",
+            v.label, rust_s.index
+        );
+    }
+
+    // (3) Master pub: S · g₂.
+    let master_secret = coeffs[0];
+    let g2 = G2Affine::generator();
+    let master_pub = MasterPublicKey((g2 * master_secret).into_affine());
+    assert_eq!(
+        g2_compressed_hex(&master_pub.0),
+        v.master_pub_compressed_hex,
+        "{}: master pub mismatch",
+        v.label
+    );
+
+    // (4) Share pubs: Sᵢ · g₂.
+    for (rust_s, py_pub) in rust_shares.iter().zip(v.share_pubs_compressed_hex.iter()) {
+        assert_eq!(rust_s.index, py_pub.index);
+        let pt = (g2 * rust_s.scalar).into_affine();
+        assert_eq!(
+            g2_compressed_hex(&pt),
+            py_pub.bytes_hex,
+            "{}: share pub #{} mismatch",
+            v.label,
+            rust_s.index
+        );
+    }
+
+    // (5) Decryption shares: Dᵢ = Sᵢ · Q_id, computed via decrypt_share().
+    // This implicitly verifies hash_to_G1 because Dᵢ depends on Q_id.
+    let envelope = ethexe_tpke::EncryptedEnvelope {
+        u: [0u8; 96], // unused for share derivation (decrypt_share only reads id)
+        id,
+        body: Vec::new(),
+    };
+    for (rust_s, py_share) in rust_shares
+        .iter()
+        .zip(v.expected_decryption_shares_hex.iter())
+    {
+        assert_eq!(rust_s.index, py_share.index);
+        let share = rust_s.decrypt_share(&envelope).unwrap();
+        assert_eq!(
+            g1_compressed_hex(&share.point),
+            py_share.bytes_hex,
+            "{}: decryption share #{} mismatch \
+             (hash_to_G1 or scalar mult diverged from py_ecc reference)",
+            v.label,
+            rust_s.index
+        );
+    }
+
+    // (6) Pairing soundness: full Rust roundtrip with the SAME params.
+    // If e(Q_id, AggPub)^u == e(D, U), this passes. If pairing direction is
+    // swapped or G1/G2 misassigned, decryption fails.
+    let share_pubs: Vec<SharePublicKey> = rust_shares
+        .iter()
+        .map(|s| SharePublicKey {
+            index: s.index,
+            point: (g2 * s.scalar).into_affine(),
+        })
+        .collect();
+
+    // Use a deterministic RNG so this test is reproducible.
+    let mut rng = StdRng::seed_from_u64(0xCAFE_0BEEF_u64.wrapping_mul(v.threshold as u64));
+    let env = encrypt(
+        &master_pub,
+        &id,
+        v.chain_id,
+        v.key_epoch_id,
+        &plaintext,
+        &mut rng,
+    )
+    .unwrap();
+
+    // Verify every share.
+    let mut shares: Vec<DecryptionShare> = Vec::with_capacity(v.threshold as usize);
+    for (i, s) in rust_shares.iter().take(v.threshold as usize).enumerate() {
+        let d = s.decrypt_share(&env).unwrap();
+        assert!(
+            share_pubs[i].verify(&env, &d).unwrap(),
+            "{}: share #{} verification failed",
+            v.label,
+            s.index
+        );
+        shares.push(d);
+    }
+
+    let recovered = combine(&env, &shares, v.chain_id, v.key_epoch_id, v.threshold).unwrap();
+    assert_eq!(
+        recovered, plaintext,
+        "{}: roundtrip decrypt mismatch",
+        v.label
+    );
+}

--- a/ethexe/tpke/tests/kat/generate.py
+++ b/ethexe/tpke/tests/kat/generate.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""
+Independent Python reference implementation of ethexe-tpke for cross-impl KAT.
+
+Generates test vectors that the Rust crate must reproduce bit-for-bit:
+  - hash_to_G1(id) → Q_id
+  - master pub AggPub = S · g₂, share pubs PSᵢ = Sᵢ · g₂
+  - ephemeral U = u · g₂
+  - z = e(Q_id, AggPub)^u (in GT)
+  - HKDF-SHA256(z, info=...) → (key, nonce)
+  - ChaCha20-Poly1305(key, plaintext, aad) → body
+  - decryption shares Dᵢ = Sᵢ · Q_id
+
+A passing Rust test against these vectors means the Rust impl matches the
+construction in the design doc independently of arkworks' specific
+hash-to-curve / pairing internals.
+
+Run:
+    /tmp/tpke_kat_venv/bin/python3 ethexe/tpke/tests/kat/generate.py \
+        > ethexe/tpke/tests/kat/vectors.json
+"""
+
+import hashlib
+import json
+import sys
+from dataclasses import dataclass
+
+from py_ecc.bls.hash_to_curve import hash_to_G1
+from py_ecc.optimized_bls12_381 import (
+    G1,
+    G2,
+    multiply,
+    pairing,
+    normalize,
+    add,
+    Z1,
+    Z2,
+    FQ,
+    FQ2,
+    curve_order,
+)
+import hmac
+
+# -------- Cryptography deps (separate from py_ecc) -----------------------
+# ChaCha20-Poly1305: use cryptography package (already common).
+try:
+    from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
+except ImportError:
+    print("ERROR: pip install cryptography", file=sys.stderr)
+    sys.exit(1)
+
+# -------- Constants (must match Rust) ------------------------------------
+DST_G1 = b"ETHEXE-TPKE-V1-BLS12381G1_XMD:SHA-256_SSWU_RO_"
+HKDF_DEM_INFO = b"ethexe-tpke-dem-v1"
+ID_DOMAIN = b"ethexe-tpke-v1"
+DEM_KEY_LEN = 32
+DEM_NONCE_LEN = 12
+
+
+def derive_id(chain_id: int, key_epoch_id: int, plaintext: bytes, user_nonce: bytes) -> bytes:
+    """Blake2b-256 of the canonical id-binding input. Mirrors Rust derive_id()."""
+    import hashlib
+    h = hashlib.blake2b(digest_size=32)
+    h.update(ID_DOMAIN)
+    h.update(chain_id.to_bytes(8, "little"))
+    h.update(key_epoch_id.to_bytes(4, "little"))
+    h.update(plaintext)
+    h.update(user_nonce)
+    return h.digest()
+
+
+def hkdf_extract_expand(salt: bytes, ikm: bytes, info: bytes, length: int) -> bytes:
+    """HKDF-SHA256(salt, ikm, info, length). Salt None ≡ zero-bytes."""
+    if not salt:
+        salt = b"\x00" * 32
+    prk = hmac.new(salt, ikm, hashlib.sha256).digest()
+    t = b""
+    out = b""
+    counter = 1
+    while len(out) < length:
+        t = hmac.new(prk, t + info + bytes([counter]), hashlib.sha256).digest()
+        out += t
+        counter += 1
+    return out[:length]
+
+
+# -------- BLS12-381 helpers (compressed encoding per zcash spec) ---------
+# IETF BLS12-381 compressed point encoding:
+#   G1 point: 48 bytes. Top 3 bits encode flags (compression=1, infinity, sign_y).
+#   G2 point: 96 bytes. Same flag layout in MSB of first byte.
+# y-sign: take the larger lexicographic representation of y or -y.
+# We match arkworks' CanonicalSerialize::serialize_compressed for BLS12-381,
+# which follows the zcash/zkcrypto encoding (compatible with ETH2 / EIP-2537).
+
+from py_ecc.fields import field_properties as _fp
+P = _fp["bls12_381"]["field_modulus"]
+
+
+def _fq_to_bytes(x: int) -> bytes:
+    return x.to_bytes(48, "big")
+
+
+def serialize_g1_compressed(P_aff) -> bytes:
+    """Compress a normalized G1 affine point per zcash/eth2 BLS spec."""
+    if P_aff is None or P_aff == Z1:
+        # Point at infinity: all-zero except compression+infinity bits.
+        out = bytearray(48)
+        out[0] = 0b11000000
+        return bytes(out)
+    x, y = normalize(P_aff)
+    x_int = x.n
+    y_int = y.n
+    # y-sign: 1 if y > (p - y); arkworks/zkcrypto uses "y is lex-greater" convention.
+    y_neg = P - y_int
+    sign = 1 if y_int > y_neg else 0
+    out = bytearray(_fq_to_bytes(x_int))
+    out[0] |= 0b10000000  # compression flag
+    if sign:
+        out[0] |= 0b00100000
+    return bytes(out)
+
+
+def serialize_g2_compressed(P_aff) -> bytes:
+    """Compress a normalized G2 affine point. G2 coords are Fq2 (c0 + c1·i)."""
+    if P_aff is None or P_aff == Z2:
+        out = bytearray(96)
+        out[0] = 0b11000000
+        return bytes(out)
+    x, y = normalize(P_aff)
+    # FQ2 stores coefficients in y.coeffs = (c0, c1) per py_ecc.
+    x_c0, x_c1 = x.coeffs[0], x.coeffs[1]
+    y_c0, y_c1 = y.coeffs[0], y.coeffs[1]
+    # y-sign: compare (y_c1, y_c0) lex-greater vs (-y_c1, -y_c0).
+    neg_y_c1 = (P - y_c1) % P
+    neg_y_c0 = (P - y_c0) % P
+    if y_c1 > neg_y_c1:
+        sign = 1
+    elif y_c1 < neg_y_c1:
+        sign = 0
+    else:
+        sign = 1 if y_c0 > neg_y_c0 else 0
+    # G2 compressed: x_c1 || x_c0 (big endian Fq each)
+    out = bytearray(_fq_to_bytes(x_c1) + _fq_to_bytes(x_c0))
+    out[0] |= 0b10000000
+    if sign:
+        out[0] |= 0b00100000
+    return bytes(out)
+
+
+def serialize_gt_compressed(z) -> bytes:
+    """Serialize a GT (Fq12) element. arkworks uses 576 bytes uncompressed,
+    288 bytes for compressed (one coeff dropped via reconstruction).
+    For KAT we serialize all 12 Fq coefficients in big-endian, 48 bytes each = 576 bytes.
+    This matches arkworks' CanonicalSerialize::serialize_compressed for PairingOutput<Bls12_381>
+    only if compression yields the same bytes; if not, the Rust KAT test should compare
+    the HKDF *output* rather than the GT serialization.
+
+    SIMPLEST CROSS-CHECK PATH: emit ciphertext body + shares, let Rust decrypt them.
+    The internal GT serialization need not match — only the derived AEAD key+nonce
+    need to be identical, and HKDF input format must agree.
+
+    For the KAT we choose: serialize GT via py_ecc's 12-Fq big-endian flattening
+    (576 B) AND require Rust to match the same canonical encoding. ark-bls12-381's
+    CanonicalSerialize for Fq12 emits 12 Fq elements little-endian, NOT big-endian.
+
+    Therefore: we DO NOT cross-check GT bytes. Instead we cross-check the final
+    AEAD ciphertext: encrypt in Python, decrypt in Rust. If both impls compute the
+    same z and the same HKDF(z) → same key → same body, the Rust decrypt of the
+    Python body must succeed.
+    """
+    # Arkworks Fq12 compressed serialization: 12 Fq elements little-endian.
+    # py_ecc FQ12 has .coeffs as a tuple of 12 ints.
+    coeffs = z.coeffs
+    out = bytearray()
+    for c in coeffs:
+        out += int(c).to_bytes(48, "little")
+    return bytes(out)
+
+
+# -------- Test vector generation -----------------------------------------
+@dataclass
+class TestVector:
+    label: str
+    chain_id: int
+    key_epoch_id: int
+    threshold: int
+    n: int
+    master_secret_hex: str       # Sᵢ derived from polynomial evaluation
+    poly_coeffs_hex: list        # f(x) coefficients, low-degree first
+    plaintext_hex: str
+    user_nonce_hex: str
+    u_scalar_hex: str
+    id_hex: str
+    master_pub_compressed_hex: str   # 96 bytes
+    share_pubs_compressed_hex: list  # [(index, 96B hex)]
+    secret_shares_hex: list          # [(index, 32B scalar hex)] — for Rust to feed in
+    envelope_u_hex: str              # 96 bytes
+    envelope_body_hex: str           # ChaCha20Poly1305 ciphertext (incl. tag)
+    expected_decryption_shares_hex: list  # [(index, 48B hex)]
+
+
+def eval_poly(coeffs: list, x: int, mod: int) -> int:
+    """Horner-evaluate f(x) = a_0 + a_1·x + ... + a_{t-1}·x^{t-1} mod `mod`."""
+    acc = coeffs[-1]
+    for c in reversed(coeffs[:-1]):
+        acc = (acc * x + c) % mod
+    return acc
+
+
+def generate_vector(label: str, chain_id: int, key_epoch_id: int, threshold: int, n: int,
+                    plaintext: bytes, user_nonce: bytes,
+                    poly_seed: int, u_scalar_seed: int) -> dict:
+    """Generate one fully-resolved test vector deterministically."""
+    # Deterministic polynomial coefficients in Fr.
+    rng = hashlib.shake_128(poly_seed.to_bytes(8, "little")).digest(64 * threshold)
+    coeffs = []
+    for i in range(threshold):
+        c = int.from_bytes(rng[i*64:(i+1)*64], "little") % curve_order
+        coeffs.append(c)
+
+    master_secret = coeffs[0]
+    # Compute Sᵢ = f(i) for i in 1..=n.
+    secret_shares = [(i, eval_poly(coeffs, i, curve_order)) for i in range(1, n + 1)]
+
+    # Master pub & share pubs in G2.
+    master_pub = multiply(G2, master_secret)
+    share_pubs = [(idx, multiply(G2, s)) for (idx, s) in secret_shares]
+
+    # u scalar deterministic.
+    u_rng = hashlib.shake_128(u_scalar_seed.to_bytes(8, "little")).digest(64)
+    u_scalar = int.from_bytes(u_rng, "little") % curve_order
+
+    # id.
+    id_bytes = derive_id(chain_id, key_epoch_id, plaintext, user_nonce)
+
+    # Q_id = hash_to_G1(id, DST).
+    q_id = hash_to_G1(id_bytes, DST_G1, hash_function=hashlib.sha256)
+
+    # U = u · g₂.
+    u_point = multiply(G2, u_scalar)
+    u_bytes = serialize_g2_compressed(u_point)
+
+    # z = e(Q_id, AggPub)^u
+    z_base = pairing(master_pub, q_id)  # py_ecc: pairing(G2_pt, G1_pt)
+    # Pairing returns an element of GT (FQ12). Exponentiation by u_scalar:
+    z = z_base ** u_scalar
+
+    # AEAD key + nonce derivation (HKDF-SHA256(z_bytes, info)).
+    z_bytes = serialize_gt_compressed(z)
+    info = HKDF_DEM_INFO + id_bytes + u_bytes
+    okm = hkdf_extract_expand(b"", z_bytes, info, DEM_KEY_LEN + DEM_NONCE_LEN)
+    key = okm[:DEM_KEY_LEN]
+    nonce = okm[DEM_KEY_LEN:]
+
+    # AAD = id ‖ U_bytes ‖ chain_id_le ‖ key_epoch_id_le
+    aad = id_bytes + u_bytes + chain_id.to_bytes(8, "little") + key_epoch_id.to_bytes(4, "little")
+
+    aead = ChaCha20Poly1305(key)
+    body = aead.encrypt(nonce, plaintext, aad)
+
+    # Decryption shares Dᵢ = Sᵢ · Q_id.
+    decryption_shares = [(idx, multiply(q_id, s)) for (idx, s) in secret_shares]
+
+    return {
+        "label": label,
+        "chain_id": chain_id,
+        "key_epoch_id": key_epoch_id,
+        "threshold": threshold,
+        "n": n,
+        "plaintext_hex": plaintext.hex(),
+        "user_nonce_hex": user_nonce.hex(),
+        "u_scalar_hex": u_scalar.to_bytes(32, "big").hex(),
+        "master_secret_hex": master_secret.to_bytes(32, "big").hex(),
+        "poly_coeffs_hex": [c.to_bytes(32, "big").hex() for c in coeffs],
+        "id_hex": id_bytes.hex(),
+        "master_pub_compressed_hex": serialize_g2_compressed(master_pub).hex(),
+        "share_pubs_compressed_hex": [
+            {"index": idx, "bytes_hex": serialize_g2_compressed(pt).hex()}
+            for (idx, pt) in share_pubs
+        ],
+        "secret_shares_hex": [
+            {"index": idx, "scalar_hex": s.to_bytes(32, "big").hex()}
+            for (idx, s) in secret_shares
+        ],
+        "envelope_u_hex": u_bytes.hex(),
+        "envelope_body_hex": body.hex(),
+        "expected_decryption_shares_hex": [
+            {"index": idx, "bytes_hex": serialize_g1_compressed(pt).hex()}
+            for (idx, pt) in decryption_shares
+        ],
+    }
+
+
+def main():
+    vectors = []
+    # Several scenarios that exercise different code paths.
+    vectors.append(generate_vector("basic-3-of-5", 1, 0, 3, 5,
+                                   b"hello world",
+                                   bytes.fromhex("11" * 32),
+                                   poly_seed=0xC0FFEE,
+                                   u_scalar_seed=0xBEEF))
+    vectors.append(generate_vector("empty-plaintext-2-of-3", 7, 2, 2, 3,
+                                   b"",
+                                   bytes.fromhex("22" * 32),
+                                   poly_seed=0xDEAD,
+                                   u_scalar_seed=0xBABE))
+    vectors.append(generate_vector("large-4-of-7", 100, 42, 4, 7,
+                                   b"A" * 256,
+                                   bytes.fromhex("33" * 32),
+                                   poly_seed=0xCAFE,
+                                   u_scalar_seed=0xF00D))
+    out = {"version": "v1", "dst": DST_G1.decode(), "vectors": vectors}
+    print(json.dumps(out, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/ethexe/tpke/tests/kat/vectors.json
+++ b/ethexe/tpke/tests/kat/vectors.json
@@ -1,0 +1,264 @@
+{
+  "version": "v1",
+  "dst": "ETHEXE-TPKE-V1-BLS12381G1_XMD:SHA-256_SSWU_RO_",
+  "vectors": [
+    {
+      "label": "basic-3-of-5",
+      "chain_id": 1,
+      "key_epoch_id": 0,
+      "threshold": 3,
+      "n": 5,
+      "plaintext_hex": "68656c6c6f20776f726c64",
+      "user_nonce_hex": "1111111111111111111111111111111111111111111111111111111111111111",
+      "u_scalar_hex": "20f3dd578f42de1b1386c10bb5e87f6a1d12a8769e8a022112991eb466293876",
+      "master_secret_hex": "3a06617766d72d0ffd61a2d854a8a38b2f3b466ad37d0b5f6bd2c44209d421d4",
+      "poly_coeffs_hex": [
+        "3a06617766d72d0ffd61a2d854a8a38b2f3b466ad37d0b5f6bd2c44209d421d4",
+        "0f4e8f9c0e7ee7850e017adaa9142791e75696ebbc14e193c66825b79e4a7e86",
+        "100765114893732c2587679b6d2f12eb7be0f36286c91f8adf313a1b512596ee"
+      ],
+      "id_hex": "7e10e06570675cb300fe5a776fde82fd4c9f0a21e3c21fd7dda03443eda33bfc",
+      "master_pub_compressed_hex": "925fb075243975e2152d0713ca1b8f2b0ef21e123a56481b8e2935dd2abb3324145a7f1ac670b17d8ca7cd802a127cf4022c1493c41da82a859b90101ac081acd8d472069a0429251ce32adc72a2a13bc69688630ef6b212a8bda40b9daefff8",
+      "share_pubs_compressed_hex": [
+        {
+          "index": 1,
+          "bytes_hex": "909ac58fcc71c207147968e51bc199d6ebdc3b8ff695d88279904c34606bfa9d314af4d01a4b08a501aa012b5077a18a02b9fd456f715e2f1a8e0ac709f59cb8321c5439efd05e8375a1bccb41b458625dd59be186e83ba42fd1af7c819fb520"
+        },
+        {
+          "index": 2,
+          "bytes_hex": "82c38949f22a9a0f30ab4fbf9923b1638926add1d17a02827151ff1e393ad28397fe63c7aeaa4a2433d02fa0f785cd36093347fd7dba46cefac5104d7c7111c417cd26cf335efed063ab7d39d1e69d5970334d0dd6d466f4b41d6a51edfd5887"
+        },
+        {
+          "index": 3,
+          "bytes_hex": "b0f3f4212bd707b32e3b6ee4ebacc25263de4fed2d9d9a43193b9037ab942114b1b0b1f0a3b751ae1e7ff96b72a4533e02285c0d8f1986c06df093cedc454f78e81358c7d0ec5ca31ec6712e148d376cbda37040ea5ca428d4eb55e63f099810"
+        },
+        {
+          "index": 4,
+          "bytes_hex": "b4c8bb4429c3c05a7ef758e229b5f0984b0ffdb457d1f96625c1233d85abf2ac0bcc98e64febb990d52d6f51289ed27106b2047045cdc0ab6e8c13432121f11a6fbd6145b345b1569f9d0f53ce019c94b8bcbfb20020e2e9b8d088960cad24b8"
+        },
+        {
+          "index": 5,
+          "bytes_hex": "b13bf7d2a25dd2bba669a1ae6f433664cc003a503ff5e13b55a8b21a5b1a2b2a414841d3743f53c851c893a418c08ae00830204fd960ce6e8b9835725d299df68c05668874d20721fb40e4993e9c83e8e39f134da9c1972f59bda5351f1a64e5"
+        }
+      ],
+      "secret_shares_hex": [
+        {
+          "index": 1,
+          "scalar_hex": "595c5624bde987c130ea854e6aebde089272d0b9165b0c7e116c2414f9443748"
+        },
+        {
+          "index": 2,
+          "scalar_hex": "24d36da17c854b827c485ef351eb665799ae9dc966ccf0b37567f81f8aff7a97"
+        },
+        {
+          "index": 3,
+          "scalar_hex": "10594f40cc47f59c12b507cf1349147d98ac519ec4d113fe97c64060bf05ebc2"
+        },
+        {
+          "index": 4,
+          "scalar_hex": "1bedfb02ad31860df4307fe1af04e87a8f6bec393067765f7886fcd895578ac9"
+        },
+        {
+          "index": 5,
+          "scalar_hex": "479170e71f41fcd820bac72b251ee24e7ded6d98a99017d617aa2d870df457ac"
+        }
+      ],
+      "envelope_u_hex": "aefa08d4ecaebfca9859a0e6fd9b00f77f98f8c72453e153f370700f8f897b48d2630eee22e93922d51c01824abebdd80a8adede2708c577932868d9ba25898dccb60e6a278100dfcb134b911394599458e73b4ba8bb89eadd35d966e0b29c47",
+      "envelope_body_hex": "35ebc39565192d88d650fb2a296641844485564844cc2c60acbbf9",
+      "expected_decryption_shares_hex": [
+        {
+          "index": 1,
+          "bytes_hex": "979ead969ccf0562461cebc10cc7163ede1b9083edaf1332ae50acb51622ca151e67d947139eadc3685ba76e173b20b8"
+        },
+        {
+          "index": 2,
+          "bytes_hex": "a38aeadda0aca8ef8ca7c408f5e9ff2ed9af3f6b9e98993e697fcac2ba05df5fb657503a5eb24eb5b2bc963e3282a43d"
+        },
+        {
+          "index": 3,
+          "bytes_hex": "af4a8b62cf55cf5144526e43e233471dc02923e0b9e7442c92277bfa8290cd41fb6f0f94ee29f758d5731e27e9bb5d79"
+        },
+        {
+          "index": 4,
+          "bytes_hex": "af9d2d3ecbd65b5d5cd73e9d5b290c2559d47b74fbc599b269e34d106c5e2ea23b6121b7c2e420f858f4255a8c6c0c98"
+        },
+        {
+          "index": 5,
+          "bytes_hex": "838fc8dfd5921aa3d99a940e7ca0309471346f877bc1edca11e1b0acdada8c011275b0cb3edfae9d9d2c52c2441b1f93"
+        }
+      ]
+    },
+    {
+      "label": "empty-plaintext-2-of-3",
+      "chain_id": 7,
+      "key_epoch_id": 2,
+      "threshold": 2,
+      "n": 3,
+      "plaintext_hex": "",
+      "user_nonce_hex": "2222222222222222222222222222222222222222222222222222222222222222",
+      "u_scalar_hex": "72473537171f41a57207b7fb6e7f4177f678e5d57f76aab863f083572db82567",
+      "master_secret_hex": "73e4ca8e183b1d9f5352808de93dd0fa104c4e4a9ab9565f188e9c6e4687571c",
+      "poly_coeffs_hex": [
+        "73e4ca8e183b1d9f5352808de93dd0fa104c4e4a9ab9565f188e9c6e4687571c",
+        "0a944518b1fe3ce60c61c8cf9f324b5f5b323f51c5fcc1d291adb49eaa188955"
+      ],
+      "id_hex": "91c840aa64e75670c7d7faf8423f78cc51eac48b2611bea509e60d47511ab0d1",
+      "master_pub_compressed_hex": "80e3bf960dc88dc85330f4b5be46e2a2258f84dc651e3bff99f0d523ec02494eee092fdb4f19de9330919893edd4b6e1094213cc864e35ec098e1d2554e5e70ff2bba83360e5bc62fabdd213500f5a3538aa87b5522d2859158dd91d65703c6b",
+      "share_pubs_compressed_hex": [
+        {
+          "index": 1,
+          "bytes_hex": "91b38b6525adc20f29a57d996fe4c05f00a91a30e56ee4d699cf0f24b4c2396eea91b27a70faf2e624448e2a77736a66120cc27ad947825c7b38613f8ef675c6be65f67ae55b488616c542cfd62e394a0e2c0c599d05df117157fc4023b12f15"
+        },
+        {
+          "index": 2,
+          "bytes_hex": "b9fde2c07591ba9fc67c1204e805088507dbfb0b4c9a2a39d41ff3246b397fd90c2f3228f14440c85acb154a6ed433c41077b1e6635469290d41c930d25fc885c90871551fdb8f6e95072ea8d218e475e4f4e9a6a80889b7768c1648931e8869"
+        },
+        {
+          "index": 3,
+          "bytes_hex": "b414187d87b3728eeac30198bb6ac1e9307851a27ac9fc5d4524b808d0bdb058a4323791da799f855f45a300af49c7ba0c1dcb95c67cccf2693db5145d29bc546ffb2ffb0ffe1fe599f1dfbb4f328a27bb1d82ccd1799fbaed5fb577a3d49745"
+        }
+      ],
+      "secret_shares_hex": [
+        {
+          "index": 1,
+          "scalar_hex": "0a8b6853a09bdd3d2c7a71557ece445417c0e99960b7bc32aa3c510df09fe070"
+        },
+        {
+          "index": 2,
+          "scalar_hex": "151fad6c529a1a2338dc3a251e008fb372f328eb26b47e053bea05ac9ab869c5"
+        },
+        {
+          "index": 3,
+          "scalar_hex": "1fb3f28504985709453e02f4bd32db12ce25683cecb13fd7cd97ba4b44d0f31a"
+        }
+      ],
+      "envelope_u_hex": "b825532b19e539bf12bd0fd9f83c7df41cf0ff6e7fada47223a191e088160110cafd6cff6ae17883a5705f782969d4b41692a8fea866349b956392413545906abd87a7fb9722b4fba2eb37a651988251d68a85d450c9df16a93274696f4a1f0f",
+      "envelope_body_hex": "a79f69bde4c79f0f6b3b2e016baa4f12",
+      "expected_decryption_shares_hex": [
+        {
+          "index": 1,
+          "bytes_hex": "a9ee6a352e6e7178e1264dee86ca212c41c1465d8d571776024e153f1ab1969da18cd66e775e957a10992b7dd940a290"
+        },
+        {
+          "index": 2,
+          "bytes_hex": "8dca0dbe263743e8dc883e312c445330742cd548603ae720760e0e9cd769fc141509010179e1bcf0edfc15e3e3620a9c"
+        },
+        {
+          "index": 3,
+          "bytes_hex": "a5f613c8e6d90b1fa5cd33224dcade22750f459acf7f342a387f2dfb859202d9992db1be45e4e7a2b11b38b89bbafe26"
+        }
+      ]
+    },
+    {
+      "label": "large-4-of-7",
+      "chain_id": 100,
+      "key_epoch_id": 42,
+      "threshold": 4,
+      "n": 7,
+      "plaintext_hex": "41414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141",
+      "user_nonce_hex": "3333333333333333333333333333333333333333333333333333333333333333",
+      "u_scalar_hex": "0056820ad97ca3baac7f0cc8546f32ed2d39102447e6fa11e19c33b027aa078d",
+      "master_secret_hex": "043268ca2ff6638105aaacdd77cca6bb8411ed71788b0ab59f90fddf0708b12e",
+      "poly_coeffs_hex": [
+        "043268ca2ff6638105aaacdd77cca6bb8411ed71788b0ab59f90fddf0708b12e",
+        "0511b567db411b18919b365b9e75734ee1d3623e9767ee4caffea88ded6bc0aa",
+        "35058c8dfd82b8af5dd8165f750919d528c9a0f441317f27d4e66a65d1a07472",
+        "1b99e1a029645b45f56bb9a914dcc7bd06a85120e3e4fda083636cac6d9b42b7"
+      ],
+      "id_hex": "ae491dfa4f426b4454ddd5316263ac43d2bcfbecabecddd2e62c9dd26896e3c7",
+      "master_pub_compressed_hex": "8ca7c8c11683294d3b06aea26077c8e42e315e0d6806df016ff2f6f8213cbcd630aa1d693e6e53e7efd19b7342f04fcd0ede2aa96964fb5dfd86a06fac7442ff53f0f83e9ce810166ff92038649a00f53799b39ccba76b444b2d98bd0967f907",
+      "share_pubs_compressed_hex": [
+        {
+          "index": 1,
+          "bytes_hex": "add69c06893c2bdd680dd4a6040d8ff6e406ea04d85b6877021408a48b580509a97d8512c3c4a964d5f2952ac8e75a0519998f8f71c2ec38cc7fcabdcfac9e1a58512f9cac025610f11fa6eae605ab4b7ae81b432a1a77190fad61cb00e96cb0"
+        },
+        {
+          "index": 2,
+          "bytes_hex": "b9e6a422795adaee2afa228e8ede0693fadca394bc9e1966277c7d5bea6f08a37f7adfe58daccdc38ac9798f7dc1430a0d730b9d23134908316157687f7a667ce1acbec4882d1faa3da0c13c02addfb0706be9bdb1ed42ecb3fa6df77c2c37b1"
+        },
+        {
+          "index": 3,
+          "bytes_hex": "aa5e050f0bbe34a7f1f9f1f48cd08ed006569946bfb9ae1595aa164541fb5f4fdb3da15eb318b862eab9961b73b707480c13108c7e522382f16f6c65402eba667e4d1361b9257aa024d01e8009ef0db87b02ec84d8ef8b593e4dd3ff05e306a5"
+        },
+        {
+          "index": 4,
+          "bytes_hex": "997bc89762413a9a0f8b62747e0cb0da08b23a66e73fac703606ce144855349568c155317350bfca15d02e88da296e770d4b084880324455581f7ea27ad2ce46709e74edfb0565a2137255b9275e3fad94599d6c0051eb0336a43a06139ee7e0"
+        },
+        {
+          "index": 5,
+          "bytes_hex": "b64c2ccdb03fc0e9d554bafebc84a2c42c05b6d235575654972c12263a44d75b3a2cf2ad302e45a2e9ff870da4e06d3103ce64f84fdb8cb3b6a851a9bd5e0a57367ba6843243af456a98b41fc393d9a0612dbf3af09f55a9aa9308086f7eb68a"
+        },
+        {
+          "index": 6,
+          "bytes_hex": "a5a75075a3fad569496e56af053881d1cd01ddfad2a7ade060f4a678a7256c054767337f98f7f443fc059435e0e9f29f0e4a1ecea4a8a033db412e2bfd4ca78a9ddece97188326443316b847a000f4ea91cfcaaad17dd58bd4440cb0b117ea11"
+        },
+        {
+          "index": 7,
+          "bytes_hex": "b026998f063b3abe4572a038d6a04318fca6aa888e2cf86318d963b5c80f3e7c9b7672c64b2f80510321aea7bbe20c61159ae54125f7c95f33249a1cea9741d931ee3759059682c6870d884193e5d55f9779f469d0ad002092dbcde9adb0164d"
+        }
+      ],
+      "secret_shares_hex": [
+        {
+          "index": 1,
+          "scalar_hex": "59e38c60321e928eea89b341a027fb9c955741c5350975caa7d97d7f33b02901"
+        },
+        {
+          "index": 2,
+          "scalar_hex": "63721cd9aacddec6b1f1b84312dcaa8624e8d2bdcb4dbcf56e435df8953c19ff"
+        },
+        {
+          "index": 3,
+          "scalar_hex": "528bbca468c0ee83e92f3dd0437589e106fae31d92b775fa07232b56bd501471"
+        },
+        {
+          "index": 4,
+          "scalar_hex": "58de0e2e3ab468221d8ec5d7a57d70160fc1b5a6e2a6369c86cd71a53d8fa8a0"
+        },
+        {
+          "index": 5,
+          "scalar_hex": "34290c91c5c774b4a922fa3fa2dd5b88bfb3e919127b38a20196bcf0a79e66d4"
+        },
+        {
+          "index": 6,
+          "scalar_hex": "161a5a3cd8b6ba9719385cf6af2022a1eb05c036799611ce8bd399448d1fdf56"
+        },
+        {
+          "index": 7,
+          "scalar_hex": "305f999d423ee024fb1b6feb3dd09bca65eb7dc16f5657e639d892ac7fb7a26f"
+        }
+      ],
+      "envelope_u_hex": "b3ee33b2a0fc17108e82795a9089e9174d72c0cf014d731663cd02d04ca5e9bc7a146afa29dc5f9958e4cfeeb412022510c25620821501ca3b7704d6d850581662c4e22b1fb07f9f621e2ee71dde91380470278c747586de9cabd7670ccda943",
+      "envelope_body_hex": "977cf121672970ceb591a439dfb74cdad0e4b3ab9cc56b65047400635fb290fc3418f258a81486ebdf67ef095331ef9fedb743789bdab7a3d6920293ce34f9c093dfb01de9599622ab17a8527f36d6a5c1fe2f502ce4e37fb7a51b09856899191e61b62322fac47f092ad706befb3acb2be8b9f34d1ff856b4104a9de7b7c4c18af700525952ef5caec26ecb783a004a089a544d875d2b2385f40eb4f1a52a5aef87805d43c53e6b0f63915051ea846854ed04f1932d973cc8a3e51e4ee208830ca17ad059e1ddd123f1389fa4bf1a8274ecf6748c0e3a9b668ea8ab9d857ba237ce20aa2863cd4da26e48f2a6951150d74f14dd0227fc394f3b95fc75c46abcba1c4bdda659d69775f3b28f063fc3df",
+      "expected_decryption_shares_hex": [
+        {
+          "index": 1,
+          "bytes_hex": "a9e73c580876daafd65868de4d869af402baf1af50cb6bff9313567f442cb0d71220cbc05f5944782c4885aa8d51f479"
+        },
+        {
+          "index": 2,
+          "bytes_hex": "aefb7c4613281925b8a85e5bd1ecbe3cc3388c0607683455fe41f8cd0b8fd35b2a16bd26bd59e50edf11848b6f5d3630"
+        },
+        {
+          "index": 3,
+          "bytes_hex": "a3dc7c0a6bf87425c8fb4b51893b44361605b39b885275657aa671149ab5bfcac2698fe0b181750dc5c2b7a3c2d1d8a8"
+        },
+        {
+          "index": 4,
+          "bytes_hex": "b27b349ced6732f22082f090c9c060757ffae3a92cf7e21a9c8cbc12854a3b0fcd01a16c0ecbd4f05c7d72c219cc2d3a"
+        },
+        {
+          "index": 5,
+          "bytes_hex": "8643d0fe45865a92735ead64929e2e472b776e97efa245e5415b51c20abd36d2c440c028edecbe2e15c57a964c0b92f1"
+        },
+        {
+          "index": 6,
+          "bytes_hex": "a20ef339f5f81ce7d11bc151b17997ffe3116b6f7e1bbc329f8c50f0613add591d2e180eaedb0a4a20c5fc8f257b0fee"
+        },
+        {
+          "index": 7,
+          "bytes_hex": "afcecd2a9b5860fefa58357714efcac6de1f8650159b2807c0086d09a3b4f79d9808b3ffa35a775e81178046e7279635"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New `ethexe/tpke/` crate — **Boneh-Franklin identity-based threshold public-key encryption on BLS12-381**, the cryptographic primitive for upcoming private-transaction support on Malachite-based ethexe (gh#5419).

This PR lands **Lane A** of a 4-lane plan: a self-contained, isolated crate with no consumers in the workspace yet. Lanes B/C/D (Malachite-glue hook, RPC + CLI, DB migration) will follow.

Operational model (v1): **PoA network, centralized dealer, no DKG**. Operator runs an offline dealer ceremony to Shamir-split a master secret into n shares for n validators; only `t`-of-`n` shares can decrypt any given ciphertext.

## Construction

Type-3 pairing on BLS12-381 (`e: G1 × G2 → GT`):

- `Q_id = H_to_G1(id, DST)` (RFC 9380 SSWU_RO suite, version-locked DST)
- Master pub `AggPub = S · g2 ∈ G2`, share pubs `PSᵢ = Sᵢ · g2 ∈ G2`
- Ciphertext: `(U = u · g2, id, ChaCha20-Poly1305(K, plaintext, aad))` where `K = HKDF-SHA256(e(Q_id, AggPub)^u, "ethexe-tpke-dem-v1" ‖ id ‖ U)` and `aad = id ‖ U ‖ chain_id ‖ key_epoch_id`
- Decryption shares `Dᵢ = Sᵢ · Q_id ∈ G1` (48 B compressed)
- Combine via Lagrange-in-the-exponent: `D = Σ λᵢ · Dᵢ = S · Q_id`, decrypt via `z' = e(D, U)`

**IND-CCA via the AEAD layer.** Each ciphertext is identity-bound, so a leaked decryption share only decrypts that one tx (per-tx blast radius, not mempool-wide).

Identity-binding includes `chain_id` and `key_epoch_id` so a ciphertext encrypted for one chain/key-epoch can't be replayed against another. Mandatory 32-byte user nonce inside the ID input blocks known-plaintext attacks on the identity.

## Public API

```rust
// Dealer (one-time, off-chain):
let mut dealer = MasterSecretKey::deal(threshold, n, &mut rng)?;
let master_pub = dealer.master_pub;
let shares     = dealer.shares;       // distribute Sᵢ to validator i
let share_pubs = dealer.share_pubs;   // publish PSᵢ
let _secret    = dealer.take_master_secret();  // one-shot extractor

// User encryption:
let id  = derive_id(chain_id, key_epoch_id, &plaintext, &user_nonce);
let env = encrypt(&master_pub, &id, chain_id, key_epoch_id, &plaintext, &mut rng)?;

// Validator i emits a share after Effect::Decide:
let share = share_i.decrypt_share(&env)?;

// Anyone verifies a share:
share_pub_i.verify(&env, &share)?;

// Combine t shares to plaintext:
let plaintext = combine(&env, &shares, chain_id, key_epoch_id, threshold)?;
```

## Test coverage

**21 tests passing** (`cargo nextest run -p ethexe-tpke`):

- Roundtrip in 4-of-7, 3-of-5, 2-of-3 configurations; arbitrary t-subsets recover the same plaintext.
- AEAD malleability: bit-flip in body → `AeadAuth`; wrong AAD chain_id → `AeadAuth`.
- Per-tx share isolation: mutated id breaks share verification.
- Share validation: wrong validator index, duplicate index, zero index all rejected.
- Cross-envelope share mixing rejected with `ShareEnvelopeMismatch`.
- Dealer hygiene: `take_master_secret` is one-shot; `Clone` drops the secret.
- Threshold bounds: `deal(0, 3)` and `deal(5, 3)` rejected.
- SCALE codec roundtrip for `EncryptedEnvelope`.
- 3 property-test cases for compressed-bytes roundtrip on `DecryptionShare` / `MasterPublicKey` / `SharePublicKey`.

**Critical: cross-impl KAT** against an independent `py_ecc` Python reference (`tests/kat/generate.py` + `tests/kat/vectors.json`, 3 vectors: 3-of-5 basic, 2-of-3 empty-plaintext, 4-of-7 large-payload). Cross-checks bit-for-bit:

1. `derive_id` matches
2. Hash-to-G1 matches (via per-validator decryption-share equality)
3. Master pubkey `S·g2` matches
4. Share pubkeys `Sᵢ·g2` match
5. Decryption shares `Sᵢ·Q_id` match
6. Pairing soundness verified by Rust-side encrypt-then-decrypt roundtrip

Catches G1/G2 swap, sign errors, DST drift, scalar-multiplication direction issues. The construction passed the KAT after Codex's plan review caught an algebraic bug in an earlier draft (G2×G2 pairing → corrected to G1×G2).

## Out of scope (followups)

- Wire-up to Malachite's `Effect::Decide` reveal coordinator (Lane B)
- RPC + CLI surface (Lane C)
- DB migration + key-epoch history (Lane D)
- DKG (PoA model uses a trusted dealer; DKG deferred)
- External cryptographer review (gated on mainnet enablement; planned scope: side-channel/CT analysis of ark-bls12-381 ops, cargo-fuzz target for `EncryptedEnvelope::decode`)

## Test plan

- [x] `cargo nextest run -p ethexe-tpke --no-fail-fast` — 21 / 21 pass
- [x] `cargo fmt -p ethexe-tpke -- --check` clean
- [x] `cargo clippy -p ethexe-tpke --all-targets` clean
- [x] KAT vectors regenerated and committed (`tests/kat/vectors.json`)
- [ ] To regenerate KAT vectors: `python3 -m venv .venv && .venv/bin/pip install py_ecc cryptography && .venv/bin/python ethexe/tpke/tests/kat/generate.py > ethexe/tpke/tests/kat/vectors.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Relates to #5441, #5449, #5450