### PR TITLE
fix(ci): Disable caching for binaries on macOS

### DIFF
--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -88,5 +88,6 @@ runs:
           sdk/cargo-gbuild/test-program -> target
         cache-provider: ${{ steps.env.outputs.cache-provider }}
         cache-all-crates: ${{ inputs.cache-all-crates }}
+        cache-bin: false # https://github.com/Swatinem/rust-cache/issues/341
       env:
         RUNS_ON_S3_BUCKET_CACHE: gear-ci

--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -88,6 +88,6 @@ runs:
           sdk/cargo-gbuild/test-program -> target
         cache-provider: ${{ steps.env.outputs.cache-provider }}
         cache-all-crates: ${{ inputs.cache-all-crates }}
-        cache-bin: false # https://github.com/Swatinem/rust-cache/issues/341
+        cache-bin: ${{ runner.os != 'macOS' }} # https://github.com/Swatinem/rust-cache/issues/341
       env:
         RUNS_ON_S3_BUCKET_CACHE: gear-ci


### PR DESCRIPTION
## Summary

Fixes https://github.com/Swatinem/rust-cache/issues/341 despite the fact we use our own fork but the newest macOS runner

## How to test

Verify if `error: error: unexpected argument 'WHATEVER_SUBCOMMAND' found` appears in jobs

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): description`)
- [x] Single logical change
- [x] Tests added or updated (if logic changed)
- [x] Docs updated (if needed)
