### PR TITLE
fix(ethexe): deliver already resolved promises

### DIFF
--- a/ethexe/rpc/src/apis/injected/promise_manager.rs
+++ b/ethexe/rpc/src/apis/injected/promise_manager.rs
@@ -45,6 +45,8 @@ pub struct PromiseSubscriptionManager {
 pub enum RegisterSubscriberError {
     #[error("Subscriber for this transaction already exists, tx_hash={0}")]
     AlreadyRegistered(HashOf<InjectedTransaction>),
+    #[error("Promise for this transaction is already resolved, tx_hash={0}")]
+    AlreadyResolved(HashOf<InjectedTransaction>, SignedPromise),
 }
 
 type TimeoutReceiver = tokio::time::Timeout<oneshot::Receiver<SignedPromise>>;
@@ -90,11 +92,27 @@ impl PromiseSubscriptionManager {
         &self,
         tx_hash: HashOf<InjectedTransaction>,
     ) -> Result<PendingSubscriber, RegisterSubscriberError> {
+        if let Some(promise) = self.db.promise(tx_hash)
+            && let Some(compact) = self.db.compact_promise(tx_hash)
+            && let Ok(signed_promise) = compact.restore(promise)
+        {
+            return Err(RegisterSubscriberError::AlreadyResolved(tx_hash, signed_promise));
+        }
+
         match self.subscribers.entry(tx_hash) {
             Entry::Occupied(_) => Err(RegisterSubscriberError::AlreadyRegistered(tx_hash)),
             Entry::Vacant(entry) => {
                 let (sender, receiver) = oneshot::channel();
                 entry.insert(sender);
+
+                if let Some(promise) = self.db.promise(tx_hash)
+                    && let Some(compact) = self.db.compact_promise(tx_hash)
+                    && let Ok(signed_promise) = compact.restore(promise)
+                {
+                    self.dispatch_promise(signed_promise.clone());
+                    return Err(RegisterSubscriberError::AlreadyResolved(tx_hash, signed_promise));
+                }
+
                 Ok(PendingSubscriber::new(&self.db, tx_hash, receiver))
             }
         }
@@ -161,6 +179,37 @@ impl PromiseSubscriptionManager {
     #[cfg(test)]
     pub fn subscribers_count(&self) -> usize {
         self.subscribers.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethexe_common::{PrivateKey, db::InjectedStorageRW, mock::Mock};
+
+    fn make_signed_promise() -> SignedPromise {
+        SignedPromise::create(PrivateKey::random(), Promise::mock(())).expect("signed promise")
+    }
+
+    #[test]
+    fn register_subscriber_returns_already_resolved_for_available_promise() {
+        let db = Database::memory();
+        let manager = PromiseSubscriptionManager::new(db.clone());
+
+        let signed_promise = make_signed_promise();
+        let tx_hash = signed_promise.data().tx_hash;
+        db.set_promise(signed_promise.data());
+        db.set_compact_promise(signed_promise.compact());
+
+        match manager.try_register_subscriber(tx_hash) {
+            Err(RegisterSubscriberError::AlreadyResolved(actual_tx_hash, actual_promise)) => {
+                assert_eq!(actual_tx_hash, tx_hash);
+                assert_eq!(actual_promise, signed_promise);
+            }
+            res => panic!("unexpected registration result: {res:?}"),
+        }
+
+        assert_eq!(manager.subscribers_count(), 0);
     }
 }
 

--- a/ethexe/rpc/src/apis/injected/server.rs
+++ b/ethexe/rpc/src/apis/injected/server.rs
@@ -19,7 +19,9 @@
 use crate::{RpcEvent, errors, metrics::InjectedApiMetrics};
 
 use super::{
-    InjectedServer, promise_manager::PromiseSubscriptionManager, relay::TransactionsRelayer,
+    InjectedServer,
+    promise_manager::{PromiseSubscriptionManager, RegisterSubscriberError},
+    relay::TransactionsRelayer,
     spawner,
 };
 use ethexe_common::{
@@ -120,7 +122,12 @@ impl InjectedApi {
 
         let pending_subscriber = match self.manager.try_register_subscriber(tx_hash) {
             Ok(subscriber) => subscriber,
-            Err(err) => {
+            Err(RegisterSubscriberError::AlreadyResolved(_, signed_promise)) => {
+                let sink = pending.accept().await?;
+                spawner::send_to_sink(sink, signed_promise).await;
+                return Ok(());
+            }
+            Err(err @ RegisterSubscriberError::AlreadyRegistered(_)) => {
                 return Err(errors::bad_request(err).into());
             }
         };


### PR DESCRIPTION
### Motivation

- Prevent registering subscription watchers for transactions that already have a resolved promise in the database so subscribers do not wait indefinitely.
- Immediately deliver an existing `SignedPromise` to new watchers instead of making them wait or creating redundant entries.

### Description

- Added `RegisterSubscriberError::AlreadyResolved(HashOf<InjectedTransaction>, SignedPromise)` to represent an immediately-available promise.
- Updated `try_register_subscriber` to check the database for an existing promise before registering and again after inserting the sender, to either return `AlreadyResolved` or dispatch the promise via `dispatch_promise` and avoid leaving a subscriber registered.
- Updated `send_transaction_and_watch` to handle `AlreadyResolved` by accepting the subscription sink and sending the existing `SignedPromise` immediately using `spawner::send_to_sink`, returning early with `Ok(())`.
- Imported `RegisterSubscriberError` where needed and added a unit test `register_subscriber_returns_already_resolved_for_available_promise` to `promise_manager.rs` that verifies registration returns `AlreadyResolved` and that no subscriber remains registered.

### Testing

- Added unit test `register_subscriber_returns_already_resolved_for_available_promise` which sets a promise and compact promise in the in-memory `Database` and asserts `try_register_subscriber` returns `AlreadyResolved` and leaves zero subscribers; this test was executed and passed under `cargo test`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a9a97c308832790c02b73eb22dcd0)