### PR TITLE
ci(nextest): demote gear-lazy-pages leak detection to non-fatal

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,7 +18,7 @@ slow-timeout = { period = "1m", terminate-after = 5 }
 filter = 'package(ethexe-service)'
 leak-timeout = { period = "10s", result = "pass" }
 
-# gear-lazy-pages pulls in wasmer-vm + mach exception ports on
+# gear-lazy-pages pulls in wasm execution vm + mach exception ports on
 # Apple Silicon; their teardown at process exit occasionally exceeds
 # the default 5s leak window on busy macos-aarch64 runners and trips
 # trivial tests like pages::tests::end_offset as LEAK-FAIL. Same fix

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,6 +18,15 @@ slow-timeout = { period = "1m", terminate-after = 5 }
 filter = 'package(ethexe-service)'
 leak-timeout = { period = "10s", result = "pass" }
 
+# gear-lazy-pages pulls in wasmer-vm + mach exception ports on
+# Apple Silicon; their teardown at process exit occasionally exceeds
+# the default 5s leak window on busy macos-aarch64 runners and trips
+# trivial tests like pages::tests::end_offset as LEAK-FAIL. Same fix
+# pattern as ethexe-service: 10s window with result = pass.
+[[profile.default.overrides]]
+filter = 'package(gear-lazy-pages)'
+leak-timeout = { period = "10s", result = "pass" }
+
 [profile.default.junit]
 path = "junit.xml"
 store-success-output = false


### PR DESCRIPTION
## Summary

- `gear-lazy-pages` tests sporadically trip `LEAK-FAIL` on the `build / unix / macos-aarch64 (debug)` job even though every test passes its assertions (e.g. https://github.com/gear-tech/gear/actions/runs/26409463111/job/77745159307).
- Reproduced on trivial tests like `pages::tests::end_offset` — pure arithmetic, no I/O. The test function returns in <20ms but the binary process does not close its stdout/stderr handles within nextest's default 5s leak window, so nextest marks the run leaky.
- The crate pulls in `wasmer-vm` and (on Apple Silicon) the `mach` exception-ports plumbing; their teardown at process exit can exceed 5s on a busy GHA runner. Same shape as the `ethexe-service` flake fixed in 4857095792.
- Mitigation: 10s leak window with `result = pass` for `gear-lazy-pages`. Leaks still surface in nextest output for inspection but no longer fail the run.

## Test plan

- [ ] CI green on this branch
- [ ] No regression in real lazy-pages test signal (assertion failures, panics) — those are not affected by `leak-timeout` and will still fail the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)