### PR TITLE
fix: update stale repo structure paths

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -192,18 +192,18 @@ jobs:
         with:
           commit_message: "chore(runtime): update weights"
           file_pattern: >-
-            core/src/gas_metering/schedule.rs
-            pallets/*/src/weights.rs
-            runtime/vara/src/weights/
+            protocol/core/src/gas_metering/schedule.rs
+            vara/pallets/*/src/weights.rs
+            vara/runtime/vara/src/weights/
 
       - name: Create pull request
         if: ${{ inputs.change-type == 'pull_request' }}
         uses: peter-evans/create-pull-request@v8
         with:
           add-paths: |
-            core/src/gas_metering/schedule.rs
-            pallets/*/src/weights.rs
-            runtime/vara/src/weights/
+            protocol/core/src/gas_metering/schedule.rs
+            vara/pallets/*/src/weights.rs
+            vara/runtime/vara/src/weights/
           commit-message: update weights
           branch: weights/patch
           branch-suffix: short-commit-hash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -495,8 +495,8 @@ jobs:
         run: |
           FUZZER_LOGS_PATH=/mnt/fuzzer_logs
           sudo mkdir -p $FUZZER_LOGS_PATH
-          sudo ln -s $FUZZER_LOGS_PATH/artifacts $PWD/utils/runtime-fuzzer/fuzz/artifacts
-          sudo ln -s $FUZZER_LOGS_PATH/proptest-regressions $PWD/utils/runtime-fuzzer/proptest-regressions
+          sudo ln -s $FUZZER_LOGS_PATH/artifacts $PWD/vara/tools/runtime-fuzzer/fuzz/artifacts
+          sudo ln -s $FUZZER_LOGS_PATH/proptest-regressions $PWD/vara/tools/runtime-fuzzer/proptest-regressions
 
       - name: "Install: Rust toolchain"
         uses: ./.github/actions/install-rust

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -374,9 +374,9 @@ jobs:
 
       - name: "Check: Changes in vara_runtime.scale file"
         run: |
-          SCALE_FILE="gsdk/vara_runtime.scale"
+          SCALE_FILE="vara/sdk/gsdk/vara_runtime.scale"
           ./scripts/update-gsdk-metadata.sh
           if [[ $(git diff --stat $SCALE_FILE) != '' ]]; then
-            echo "Changes found in the SCALE metadata ($SCALE_FILE). Please update it following the instructions in \`gsdk/HOW-TO-UPDATE.md\`."
+            echo "Changes found in the SCALE metadata ($SCALE_FILE). Please update it following the instructions in \`vara/sdk/gsdk/HOW-TO-UPDATE.md\`."
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: "Artifact: Production `vara-runtime` metadata"
         run: |
-          cp ./gsdk/vara_runtime_prod.scale "artifact/production_vara_runtime_v${VARA_PROD_SPEC}_metadata.scale"
+          cp ./vara/sdk/gsdk/vara_runtime_prod.scale "artifact/production_vara_runtime_v${VARA_PROD_SPEC}_metadata.scale"
 
       - name: "Artifact: Production `vara-runtime`"
         run: cp target/production/wbuild/vara-runtime/vara_runtime.compact.compressed.wasm "artifact/production_vara_runtime_v${VARA_PROD_SPEC}.wasm"
@@ -95,7 +95,7 @@ jobs:
 
       - name: "Artifact: Development `vara-runtime` metadata"
         run: |
-          cp ./gsdk/vara_runtime.scale "artifact/testnet_vara_runtime_v${VARA_DEV_SPEC}_metadata.scale"
+          cp ./vara/sdk/gsdk/vara_runtime.scale "artifact/testnet_vara_runtime_v${VARA_DEV_SPEC}_metadata.scale"
 
       - name: "Artifact: Production node client and development `vara-runtime`"
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -575,41 +575,41 @@ env_logger = "0.11.8" # lazy-pages-fuzzer
 errno = "0.3" # gear-lazy-pages
 nix = "0.26.4" # gear-lazy-pages
 ipc-channel = "0.19.0" # lazy-pages-fuzzer
-itertools = { version = "0.13", default-features = false } # utils/wasm-builder
-libp2p = "=0.51.4" # gcli (same version as sc-consensus)
-mimalloc = { version = "0.1.46", default-features = false } # node/cli
-nacl = "0.5.3" # gcli
-libfuzzer-sys = "0.4" # utils/runtime-fuzzer/fuzz
-pathdiff = { version = "0.2.1", default-features = false } # utils/wasm-builder
+itertools = { version = "0.13", default-features = false } # sdk/wasm-builder
+libp2p = "=0.51.4" # vara/sdk/gcli (same version as sc-consensus)
+mimalloc = { version = "0.1.46", default-features = false } # vara/node/cli
+nacl = "0.5.3" # vara/sdk/gcli
+libfuzzer-sys = "0.4" # vara/tools/runtime-fuzzer/fuzz
+pathdiff = { version = "0.2.1", default-features = false } # sdk/wasm-builder
 rand_chacha = { version = "0.9.0", default-features = false } # lazy-pages-fuzzer
-rand_pcg = "0.3.1" # pallets/gear
-rustc_version = "0.4.1" # utils/wasm-builder, sandbox, sandbox/host
-schnorrkel = "0.11.4" # gcli
-scopeguard = { version = "1.2.0", default-features = false } # pallets/gear
+rand_pcg = "0.3.1" # vara/pallets/gear
+rustc_version = "0.4.1" # sdk/wasm-builder, protocol/sandbox, protocol/sandbox/host
+schnorrkel = "0.11.4" # vara/sdk/gcli
+scopeguard = { version = "1.2.0", default-features = false } # vara/pallets/gear
 hyper = "1.4.1" # ethexe/rpc
-tabled = "0.10.0" # utils/regression-analysis
-thousands = "0.2.0" # utils/regression-analysis
-toml = "0.8.14" # utils/wasm-builder
+tabled = "0.10.0" # vara/tools/regression-analysis
+thousands = "0.2.0" # vara/tools/regression-analysis
+toml = "0.8.14" # sdk/wasm-builder
 tower = "0.4.13" # ethexe/rpc
 tower-http = "0.5.2" # ethexe/rpc
-tracing-appender = "0.2" # utils/node-loader
-trybuild = "1" # gstd/codegen
-wasmprinter = "0.230" # utils/wasm-gen
+tracing-appender = "0.2" # vara/tools/node-loader
+trybuild = "1" # sdk/gstd/codegen
+wasmprinter = "0.230" # protocol/wasm-gen
 fail = "0.5" # gear-common
 heck = "0.5.0" # gsdk-api-gen
-etc = "0.1.19" # gcli
+etc = "0.1.19" # vara/sdk/gcli
 toml_edit = "0.22.12" # crates-io
-directories = "5.0.1" # utils/key-finder
+directories = "5.0.1" # vara/tools/key-finder
 num-traits = { version = "0.2", default-features = false } # gear-core
 glob = "0.3.1" # cargo-gbuild
-smallvec = "1.13.2" # utils/node-wrapper
-fs4 = "0.11.1" # utils/gear-wasmer-cache
-bytes = "1.8.0" # utils/gear-wasmer-cache
-loom = "0.7.2" # utils/gear-wasmer-cache
-wasm-smith = { version = "0.230", features = ["wasmparser"] } # utils/wasm-gen
+smallvec = "1.13.2" # vara/sdk/node-wrapper
+fs4 = "0.11.1" # protocol/wasmer-cache
+bytes = "1.8.0" # protocol/wasmer-cache
+loom = "0.7.2" # protocol/wasmer-cache
+wasm-smith = { version = "0.230", features = ["wasmparser"] } # protocol/wasm-gen
 wasm-encoder = { version = "0.230", default-features = false, features = [
     "wasmparser",
-] } # utils/wasm-instrument
+] } # protocol/wasm-instrument
 async-broadcast = "0.7.2" # ethexe/service
 ip_network = "0.4.1" # ethexe/network
 

--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ kill-rust:
 
 .PHONY: install
 install:
-	@ cargo install --path ./node/cli --force --locked
+	@ cargo install --path ./vara/node/cli --force --locked
 
 .PHONY: typos
 typos:

--- a/protocol/core/src/code/mod.rs
+++ b/protocol/core/src/code/mod.rs
@@ -249,7 +249,7 @@ impl Code {
     ///   (import "env" "memory" (memory 1))
     ///   (export "init" (func $init_export))
     ///   (func $gas_charge
-    ///      <-- gas charge impl --> ;; see utils/wasm-instrument/src/lib.rs
+    ///      <-- gas charge impl --> ;; see protocol/wasm-instrument/src/lib.rs
     ///   )
     ///   (func $f1
     ///      i32.const 123

--- a/protocol/core/src/gas_metering/schedule.rs
+++ b/protocol/core/src/gas_metering/schedule.rs
@@ -3,7 +3,7 @@
 
 #![allow(rustdoc::broken_intra_doc_links, missing_docs)]
 #![doc = r" This is auto-generated module that contains cost schedule from"]
-#![doc = r" `pallets/gear/src/schedule.rs`."]
+#![doc = r" `vara/pallets/gear/src/schedule.rs`."]
 #![doc = r""]
 #![doc = r" See `./scripts/weight-dump.sh` if you want to update it."]
 

--- a/protocol/errors/signal-code-testing.md
+++ b/protocol/errors/signal-code-testing.md
@@ -20,7 +20,7 @@ Our goal is to test _all_ cases where a signal code gets sent and ensure that it
 
 Signal codes might be returned during the program's execution or when a significant event occurs outside the program's execution, such as when a message is removed from the waitlist.
 
-You can find signal codes list in the `SignalCode` enum, located in [core/errors/src/simple.rs](src/simple.rs).
+You can find signal codes list in the `SignalCode` enum, located in [protocol/errors/src/simple.rs](src/simple.rs).
 
 ## Testing technique
 <a name="testing-technique"></a>
@@ -37,7 +37,7 @@ Tests code will be written as if it were written in the `gear` pallet, because a
 ### Execution signal codes (<small>`SignalCode::Execution`</small>)
 <a name="execution"></a>
 
-These signal codes are sent when the program's execution cannot proceed. Every one of these signal codes contains a `SimpleExecutionError` (refer to [core/errors/src/simple.rs](src/simple.rs)) within.
+These signal codes are sent when the program's execution cannot proceed. Every one of these signal codes contains a `SimpleExecutionError` (refer to [protocol/errors/src/simple.rs](src/simple.rs)) within.
 
 #### Userspace panic
 <a name="userspace-panic"></a>

--- a/scripts/benchmarking/run_all_benchmarks.sh
+++ b/scripts/benchmarking/run_all_benchmarks.sh
@@ -42,7 +42,7 @@ ISOLATED_CORE=$(get_isolated_cores | cut -d " " -f1)
 # List of one-time extrinsics to benchmark.
 # They are retrieved automatically from the pallet_gear benchmarks file by their `r` component range 0..1,
 # which defines them as one-time extrinsics.
-mapfile -t ONE_TIME_EXTRINSICS < <(cat "pallets/gear/src/benchmarking/mod.rs" | grep "0 .. 1;" -B 1 | grep -E "{$" | awk '{print $1}')
+mapfile -t ONE_TIME_EXTRINSICS < <(cat "vara/pallets/gear/src/benchmarking/mod.rs" | grep "0 .. 1;" -B 1 | grep -E "{$" | awk '{print $1}')
 
 while getopts 'bmfps:c:v' flag; do
   case "${flag}" in

--- a/scripts/check-fuzzer.sh
+++ b/scripts/check-fuzzer.sh
@@ -17,8 +17,8 @@ main() {
     echo " >> Getting random bytes from /dev/urandom"
     # Fuzzer expects a minimal input size of 350 KiB. Without providing a corpus of the same or larger
     # size fuzzer will stuck for a long time with trying to test the target using 0..100 bytes.
-    mkdir -p utils/runtime-fuzzer/fuzz/corpus/runtime-fuzzer-fuzz
-    dd if=/dev/urandom of=utils/runtime-fuzzer/fuzz/corpus/runtime-fuzzer-fuzz/check-fuzzer-bytes bs=1 count="$INITIAL_INPUT_SIZE"
+    mkdir -p vara/tools/runtime-fuzzer/fuzz/corpus/runtime-fuzzer-fuzz
+    dd if=/dev/urandom of=vara/tools/runtime-fuzzer/fuzz/corpus/runtime-fuzzer-fuzz/check-fuzzer-bytes bs=1 count="$INITIAL_INPUT_SIZE"
 
     echo " >> Running fuzzer with failpoint"
     RUST_BACKTRACE=1 FAILPOINTS=fail_fuzzer=return ./scripts/gear.sh test fuzz "" wlogs > fuzz_run 2>&1

--- a/scripts/check-spec.sh
+++ b/scripts/check-spec.sh
@@ -36,20 +36,27 @@ check_spec() {
     fi
 }
 
-PACKAGES_REQUIRE_BUMP_SPEC="common core core-backend core-processor node pallets runtime-interface"
+PATHS_REQUIRE_BUMP_SPEC="vara/common protocol/core protocol/backend protocol/processor vara/node vara/pallets vara/runtime/interface"
 
 SPEC_ON_MASTER="$(git diff origin/master | sed -n -r "s/^\-[[:space:]]+spec_version: +([0-9]+),$/\1/p")"
-ACTUAL_SPEC_VARA="$(cat $ROOT_DIR/runtime/vara/src/lib.rs | grep "spec_version: " | awk -F " " '{print substr($2, 1, length($2)-1)}')"
+ACTUAL_SPEC_VARA="$(cat $ROOT_DIR/vara/runtime/vara/src/lib.rs | grep "spec_version: " | awk -F " " '{print substr($2, 1, length($2)-1)}')"
 
 if [ -z "$SPEC_ON_MASTER" ]; then
     SPEC_ON_MASTER=$ACTUAL_SPEC_VARA
 fi
 
-for package in $(git diff --name-only origin/master | grep ".rs$" | cut -d "/" -f1 | uniq); do
-    if [[ " ${PACKAGES_REQUIRE_BUMP_SPEC[@]} " =~ " ${package} " ]]; then
-        CHANGES="true"
-    fi
-done
+while read -r path; do
+    case "$path" in
+        *.rs) ;;
+        *) continue ;;
+    esac
+
+    for package in $PATHS_REQUIRE_BUMP_SPEC; do
+        if [[ "$path" == "$package"/* ]]; then
+            CHANGES="true"
+        fi
+    done
+done < <(git diff --name-only origin/master)
 
 EXIT_CODE=0
 

--- a/scripts/src/test.sh
+++ b/scripts/src/test.sh
@@ -62,7 +62,7 @@ run_fuzzer() {
   ROOT_DIR="$1"
   CORPUS_DIR="$2"
   # Navigate to fuzzer dir
-  cd $ROOT_DIR/utils/runtime-fuzzer
+  cd $ROOT_DIR/vara/tools/runtime-fuzzer
 
   if [ "$3" = "wlogs" ]; then
     LOG_TARGETS="debug,syscalls,runtime::sandbox=trace,gear_wasm_gen=trace,runtime_fuzzer=trace,gear_core_backend=trace"

--- a/scripts/unpack-weights.sh
+++ b/scripts/unpack-weights.sh
@@ -37,10 +37,10 @@ fi
 # extract artifacts to the correct directories
 unzip -o $VARA_RUNTIME && rm $VARA_RUNTIME
 
-# apply some patches for `pallets/gear/src/weights.rs`
-cp runtime/vara/src/weights/pallet_gear.rs pallets/gear/src/weights.rs
-sed -i -E 's/\w+::WeightInfo for SubstrateWeight/WeightInfo for SubstrateWeight/' pallets/gear/src/weights.rs
+# apply some patches for `vara/pallets/gear/src/weights.rs`
+cp vara/runtime/vara/src/weights/pallet_gear.rs vara/pallets/gear/src/weights.rs
+sed -i -E 's/\w+::WeightInfo for SubstrateWeight/WeightInfo for SubstrateWeight/' vara/pallets/gear/src/weights.rs
 
-# apply some patches for `pallets/gear-builtin/src/weights.rs`
-cp runtime/vara/src/weights/pallet_gear_builtin.rs pallets/gear-builtin/src/weights.rs
-sed -i -E 's/\w+::WeightInfo for SubstrateWeight/WeightInfo for SubstrateWeight/' pallets/gear-builtin/src/weights.rs
+# apply some patches for `vara/pallets/gear-builtin/src/weights.rs`
+cp vara/runtime/vara/src/weights/pallet_gear_builtin.rs vara/pallets/gear-builtin/src/weights.rs
+sed -i -E 's/\w+::WeightInfo for SubstrateWeight/WeightInfo for SubstrateWeight/' vara/pallets/gear-builtin/src/weights.rs

--- a/scripts/update-gsdk-metadata.sh
+++ b/scripts/update-gsdk-metadata.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This script is used to update the generated code in the gsdk crate
-# Also see `gsdk/HOW-TO-UPDATE.md` for more details
+# Also see `vara/sdk/gsdk/HOW-TO-UPDATE.md` for more details
 
 set -ex
 

--- a/sdk/wasm-proc/README.md
+++ b/sdk/wasm-proc/README.md
@@ -5,7 +5,7 @@
 To install, checkout current repository and:
 
 ```
-cd utils/wasm-proc
+cd sdk/wasm-proc
 cargo install --path ./
 ```
 

--- a/sdk/wasm-proc/src/main.rs
+++ b/sdk/wasm-proc/src/main.rs
@@ -26,7 +26,7 @@ const RT_ALLOWED_IMPORTS: [&str; 78] = [
     "ext_crypto_sr25519_sign_version_1",
     "ext_crypto_sr25519_verify_version_2",
     "ext_crypto_start_batch_verify_version_1",
-    // From `GearRI` (runtime-interface/scr/lib.rs)
+    // From `GearRI` (vara/runtime/interface/src/lib.rs)
     "ext_gear_ri_pre_process_memory_accesses_version_1",
     "ext_gear_ri_pre_process_memory_accesses_version_2",
     "ext_gear_ri_lazy_pages_status_version_1",

--- a/vara/docker/runtime-fuzzer/scripts/fuzzer.sh
+++ b/vara/docker/runtime-fuzzer/scripts/fuzzer.sh
@@ -64,7 +64,7 @@ function start_container_post {
      	--entrypoint "/bin/sh" \
      	-e TERM=xterm-256color \
      	-v "${CORPUS_DIR}:/corpus/main" \
-     	--workdir /gear/utils/runtime-fuzzer \
+        --workdir /gear/vara/tools/runtime-fuzzer \
      	--name ${CONTAINER_NAME_GEAR} ${IMAGE} \
      	-c "cargo install cargo-binutils && \
 		rustup component add llvm-tools && \
@@ -105,7 +105,7 @@ function start_container {
     	docker run -d --pull=always \
         	-e TERM=xterm-256color \
         	-v "${CORPUS_DIR}:/corpus/main" \
-        	-v "${ARTIFACT_DIR}:/gear/utils/runtime-fuzzer/fuzz/artifactis/main" \
+            -v "${ARTIFACT_DIR}:/gear/vara/tools/runtime-fuzzer/fuzz/artifactis/main" \
         	--name ${CONTAINER_NAME} ${IMAGE}
     fi
     # Wait for the container to stop
@@ -210,4 +210,3 @@ case "$1" in
        exit 1
        ;;
 esac
-

--- a/vara/node/authorship/README.md
+++ b/vara/node/authorship/README.md
@@ -13,7 +13,7 @@ whose notion of time is represented by the block `Weight`.
 In the default Substrate's implementation the deadline for the block creation goes through a series of transformations before the proposer actually gets to applying extrinsics to fill the block:
 
 <p align="lift">
-    <img src="../../images/block-proposing-timing.svg" width="80%" alt="Gear">
+    <img src="../../../.github/images/block-proposing-timing.svg" width="80%" alt="Gear">
 </p>
 
 The original "source of truth" in terms of the block creation time is the same - the `SLOT_DURATION` runtime constant. Eventually, the time allocated for processing of extirnsics of all `DispatchClass`'es will constitute almost exactly 1/3 of the overall block time. The same idea is true for the `Runtime` - the `MAXIMUM_BLOCK_WEIGHT` constant calculated as 1/3 of the total possible block `Weight`:
@@ -43,7 +43,7 @@ In Gear we have a special pseudo-inherent that is called `Gear::run()` and has t
 The `Runtime` specifies the so-called `NORMAL_DISPATCH_WEIGHT_RATIO` constant that defines the share of the `DispatchClass::Normal` extrinsics in the overall block weight. In Gear this constant is set to 25% (as opposed to the default 80% in Substrate). This means that the want the `DispatchClass::Normal` extrinsics to take up to 25% of the block time, leaving the rest to `DispatchClass::Mandatory` (including the `Gear::run()`) and `DispatchClass::Operational` extrinsics.
 
 <p align="lift">
-    <img src="../../images/substrate-vs-gear-block.svg" width="80%" alt="Gear">
+    <img src="../../../.github/images/substrate-vs-gear-block.svg" width="80%" alt="Gear">
 </p>
 
 The question, therefore, is how we should partition the proposal `duration` in the `BlockBuilder` (in terms of time) to maintain the desired proportion between the extrinsics application and the message queue processing.
@@ -51,7 +51,7 @@ The question, therefore, is how we should partition the proposal `duration` in t
 In the ideal world the synchronization between the time taken so far by the proposer and the used weight is always maintained so that we can rely on the `Runtime` weights to predict how many more extrinsics we can take from the transaction pool so that the `Gear::run()` has as much time as it thinks it has to do messages processing.
 
 <p align="lift">
-    <img src="../../images/time-weight-synchronization.svg" width="80%" alt="Gear">
+    <img src="../../../.github/images/time-weight-synchronization.svg" width="80%" alt="Gear">
 </p>
 
 

--- a/vara/pallets/gear/src/tests.rs
+++ b/vara/pallets/gear/src/tests.rs
@@ -8487,7 +8487,7 @@ fn test_create_program_with_value_lt_ed() {
 // then it has on it's balance. Such message send will end up without any error/trap. So all in all execution will end
 // up successfully with messages sent from program with total value more than was provided to the program.
 //
-// Again init message won't be added to the queue, because of the check here (https://github.com/gear-tech/gear/blob/master/pallets/gear/src/manager.rs#L351-L364).
+// Again init message won't be added to the queue, because of the check here (https://github.com/gear-tech/gear/blob/master/vara/pallets/gear/src/manager.rs#L351-L364).
 // But it's is not preferable to enter that `if` clause.
 #[test]
 fn test_create_program_with_exceeding_value() {

--- a/vara/tools/runtime-fuzzer/README.md
+++ b/vara/tools/runtime-fuzzer/README.md
@@ -14,7 +14,7 @@ Pre-requirements:
 Running fuzzer on the local machine:
 
 ```bash
-cd utils/runtime-fuzzer
+cd vara/tools/runtime-fuzzer
 
 # Fuzzer expects a minimal input size of 350 KiB. Without providing a corpus of the same or larger
 # size fuzzer will stuck for a long time with trying to test the target using 0..100 bytes.

--- a/vara/tools/weight-diff/src/main.rs
+++ b/vara/tools/weight-diff/src/main.rs
@@ -510,7 +510,7 @@ fn main() -> Result<()> {
                 },
                 quote! {
                     //! This is auto-generated module that contains cost schedule from
-                    //! `pallets/gear/src/schedule.rs`.
+                    //! `vara/pallets/gear/src/schedule.rs`.
                     //!
                     //! See `./scripts/weight-dump.sh` if you want to update it.
                 },


### PR DESCRIPTION
Related to #5374

## Summary

Updates leftover path references after the repository structure refactor from #5405.

This fixes CI workflow paths, benchmark and fuzzer scripts, generated schedule comments, README links, `gsdk` metadata paths, and the runtime spec-change detector so they point at the current `protocol/`, `sdk/`, and `vara/` layout.

## How to test

- `git diff --check origin/master...HEAD`
- `bash -n scripts/check-spec.sh scripts/check-fuzzer.sh scripts/src/test.sh scripts/update-gsdk-metadata.sh vara/docker/runtime-fuzzer/scripts/fuzzer.sh scripts/benchmarking/run_all_benchmarks.sh scripts/unpack-weights.sh`
- `git grep` stale pre-#5405 path patterns, excluding agent files and generated contract ABIs

## Notes

No tracking issue is linked, per request.

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): description`)
- [x] Single logical change
- [x] Tests added or updated (if logic changed)
- [x] Docs updated (if needed)
