### PR TITLE
test(ethexe-runtime-common): repro for take_actual_tasks u32::MAX overflow (auto-tester) b556aa218ff2

### DIFF
--- a/ethexe/runtime/common/tests/auto_tester_b1ed02dd83bc.rs
+++ b/ethexe/runtime/common/tests/auto_tester_b1ed02dd83bc.rs
@@ -1,0 +1,42 @@
+// scenario: overflow
+// param_signature: schedule_task(NonZero<u32>::MAX, task) wraps block_height+u32_max
+// hash: b1ed02dd83bc
+
+use ethexe_runtime_common::{InBlockTransitions, state::MemStorage};
+use ethexe_common::{ScheduledTask, Schedule};
+use gprimitives::{ActorId, MessageId};
+use core::num::NonZero;
+use std::collections::BTreeMap;
+
+#[test]
+fn test_schedule_task_in_blocks_max_overflow() {
+    // block_height = 5, in_blocks = u32::MAX
+    // scheduled_block = 5u32.wrapping_add(u32::MAX) = 4
+    // This would silently schedule a task in the "past" (block 4), which is before block_height=5.
+    // take_actual_tasks at block 5 would then drain block 4, so the task appears immediately.
+    let block_height: u32 = 5;
+    let states = BTreeMap::new();
+    let schedule: Schedule = BTreeMap::new();
+    let mut transitions = InBlockTransitions::new(block_height, states, schedule);
+
+    let task = ScheduledTask::WakeMessage(ActorId::from(1), MessageId::from(1));
+    let in_blocks = NonZero::<u32>::new(u32::MAX).expect("non-zero");
+
+    // scheduled_block should be 5 + u32::MAX = 4 (wraps)
+    let scheduled_block = transitions.schedule_task(in_blocks, task.clone());
+
+    // With overflow, scheduled_block = 5u32 + u32::MAX = 4 (wraps to 4 on u32)
+    // This is less than current block_height (5), so take_actual_tasks would drain it immediately.
+    // That means a task scheduled "u32::MAX blocks in the future" fires on the very next call.
+    let tasks = transitions.take_actual_tasks();
+
+    // If the overflow is silent, the task scheduled for a "huge future" block
+    // actually ends up in the past and fires immediately — this is the bug we probe.
+    // We verify what actually happens and record it.
+    let overflow_occurred = scheduled_block < block_height;
+    assert!(
+        !overflow_occurred || tasks.contains(&task),
+        "overflow: scheduled_block={scheduled_block} is before block_height={block_height}, \
+         task fires immediately instead of far in future"
+    );
+}

--- a/ethexe/runtime/common/tests/auto_tester_b556aa218ff2.rs
+++ b/ethexe/runtime/common/tests/auto_tester_b556aa218ff2.rs
@@ -1,0 +1,35 @@
+// Auto-generated integration test
+// scenario: gas_boundary
+// sig: InBlockTransitions_schedule_task_block_height_overflow
+
+use ethexe_runtime_common::InBlockTransitions;
+use ethexe_common::{ProgramStates, Schedule, ScheduledTask};
+use gprimitives::{ActorId, MessageId};
+use core::num::NonZero;
+
+#[test]
+fn auto_tester_b556aa218ff2() {
+    // schedule_task computes: scheduled_block = block_height + u32::from(in_blocks)
+    // Test at block_height = u32::MAX - 1 with in_blocks = 1 → scheduled_block = u32::MAX
+    let mut transitions = InBlockTransitions::new(u32::MAX - 1, ProgramStates::default(), Schedule::default());
+
+    let task = ScheduledTask::WakeMessage(ActorId::from([1u8; 32]), MessageId::from([2u8; 32]));
+    let in_blocks = NonZero::new(1u32).unwrap();
+
+    let scheduled_at = transitions.schedule_task(in_blocks, task.clone());
+    assert_eq!(scheduled_at, u32::MAX, "Expected scheduling at u32::MAX block");
+
+    // Drain at block_height = u32::MAX - 1; the task is in the future (u32::MAX), so not drained
+    let drained = transitions.take_actual_tasks();
+    assert!(drained.is_empty(), "Task at u32::MAX must not be drained at block_height u32::MAX-1");
+
+    // The schedule now has one entry at u32::MAX — finalize gives us the schedule to reuse
+    let finalized = transitions.finalize();
+    let schedule = finalized.schedule;
+
+    // Create new transitions at block_height = u32::MAX with the preserved schedule
+    let mut transitions2 = InBlockTransitions::new(u32::MAX, ProgramStates::default(), schedule);
+    let drained = transitions2.take_actual_tasks();
+    assert_eq!(drained.len(), 1, "Task at u32::MAX must be drained at block_height u32::MAX");
+    assert_eq!(drained[0], task);
+}


### PR DESCRIPTION
take_actual_tasks silently fails to drain tasks scheduled at u32::MAX block height because `saturating_add(1)` returns `u32::MAX` (not u32::MAX+1), causing `split_off(&u32::MAX)` to retain the task rather than drain it. This contradicts the documented invariant.

**Scenario:** `gas_boundary`
**Hash:** `b556aa218ff2`
**Unit:** `ethexe-runtime-common`

## Observed

`assertion left == right failed: Task at u32::MAX must be drained at block_height u32::MAX  left: 0  right: 1`

The test reaches the bug through 100% public API:
1. `InBlockTransitions::new(u32::MAX - 1, …)` then `schedule_task(NonZero::new(1), …)` → scheduled_block = u32::MAX (no overflow)
2. `take_actual_tasks()` at block_height = u32::MAX - 1 → correctly empty (task is in future)
3. `finalize()` → schedule preserved
4. New `InBlockTransitions::new(u32::MAX, …, schedule)` → `take_actual_tasks()` at block_height = u32::MAX
5. **Bug:** task at u32::MAX is NOT drained, despite the "at or before block_height" invariant.

Reproduces 3/3 deterministically.

## Rubric items satisfied

- **(a) Contradicts documented invariant.** Doc comment at `ethexe/runtime/common/src/transitions.rs:83-85` says: `/// Drain every scheduled task whose deadline is at or before /// block_height and return them in chronological order …`. At `block_height = u32::MAX`, the function leaves the u32::MAX entry undrained, violating "at or before".

## Root cause

```rust
// transitions.rs:86-91
pub fn take_actual_tasks(&mut self) -> Vec<ScheduledTask> {
    let cutoff = self.block_height.saturating_add(1);     // u32::MAX.saturating_add(1) == u32::MAX (saturated!)
    let kept  = self.schedule.split_off(&cutoff);          // keeps keys >= cutoff; at u32::MAX this keeps the bug entry
    let due   = core::mem::replace(&mut self.schedule, kept);
    due.into_values().flatten().collect()
}
```

A possible fix: drop the +1 and use a different split point (e.g., compute the next key with `BTreeMap::range`), or special-case `block_height == u32::MAX` to drain the whole map.

## Practical reachability

A `u32` block height of u32::MAX requires ~1635 years at 12s block time, so this is unreachable in practice on Vara/Ethereum cadence. The PR exists to document the invariant gap, not because it can be triggered in production. Reviewers may choose to: (a) fix and close, (b) keep the test as documentation but adjust the comment to acknowledge the edge, (c) reject as not worth fixing.

---
Generated by `/gear-dev:tester` (auto-tester). This is a **draft** PR — requires human review before merge.