### PR TITLE
[diagnostic, do-not-merge] repro WAL advisory-lock race on master

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -63,18 +63,19 @@ jobs:
       - name: "Build: malachite-core tests"
         run: cargo build -p ethexe-malachite-core --tests --release
 
-      - name: "Test: malachite seven_validators_full_network_restart"
-        # Run the target test 5 times to make a flake-free verdict cheap.
-        # Without the fix this is expected to fail on the very first run;
-        # with the fix all 5 iterations must pass.
+      - name: "Test: malachite WAL race repro"
+        # Run the rapid-restart repro 3 times to make a flake-free verdict
+        # cheap. Without the fix this is expected to fail with a panic
+        # 'Failed to acquire exclusive advisory lock'; with the fix all
+        # 3 iterations must pass.
         run: |
           set -eo pipefail
-          for i in 1 2 3 4 5; do
+          for i in 1 2 3; do
             echo "=== iteration $i ==="
             cargo nextest run \
               -p ethexe-malachite-core \
               --test multi_validators \
-              -E 'test(seven_validators_full_network_restart)' \
+              -E 'test(rapid_restart_exposes_wal_lock_race) or test(seven_validators_full_network_restart)' \
               --release \
               --no-fail-fast
           done

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -3,7 +3,7 @@ name: PR & Merge queue
 on:
   pull_request:
     branches: [master]
-    types: [labeled, synchronize]
+    types: [labeled, synchronize, opened, reopened, ready_for_review]
 
   merge_group:
     types: [checks_requested]
@@ -12,127 +12,71 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Diagnostic branch: strip the CI to ONLY the workspace-release nextest of
+# the malachite seven_validators_full_network_restart test. The original
+# matrix (check + workspace debug + workspace release + ethexe-cli + etc.)
+# is gone so the WAL-lock race repro/fix iteration cycle is minutes
+# instead of an hour. Do NOT carry this PR.yml into the final fix PR.
+
 jobs:
-  gate:
-    name: Skip duplicates
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip.outputs.should_skip }}
-
-      ci_macos: ${{ steps.ci.outputs.macos }}
-      ci_windows: ${{ steps.ci.outputs.windows }}
-      ci_linux_aarch64: ${{ steps.ci.outputs.linux_aarch64 }}
-      ci_release: ${{ steps.ci.outputs.release }}
-      ci_production: ${{ steps.ci.outputs.production }}
-      ci_docker: ${{ steps.ci.outputs.docker }}
-
+  workspace-release-malachite:
+    name: build / workspace (release)
+    runs-on: [kuberunner]
+    timeout-minutes: 90
     steps:
-      - name: Wait a bit for label storms
-        if: ${{ github.event_name == 'pull_request' && github.event.action == 'labeled' }}
-        run: sleep 10
+      - name: "ACTIONS: Checkout"
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
-      - name: Resolve CI labels
-        id: ci
-        env:
-          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
-          MQ_HEAD_REF: ${{ github.event.merge_group.head_ref }}
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
+      - name: "Install: Setup linker"
+        uses: ./.github/actions/setup-linker
+
+      - name: "Install: Rust toolchain"
+        uses: ./.github/actions/install-rust
+
+      - name: "Install: Compilation environment"
+        uses: ./.github/actions/setup-compilation-env
+        with:
+          target: x86_64-unknown-linux-gnu
+
+      - name: "ACTIONS: Setup caching"
+        uses: ./.github/actions/rust-cache
+        with:
+          eu-access-key-id: "${{ secrets.GEAR_CI_S3_EU_ACCESS_KEY_ID }}"
+          eu-secret-access-key: "${{ secrets.GEAR_CI_S3_EU_SECRET_ACCESS_KEY }}"
+          key: "release"
+
+      - name: "Install: Foundry"
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.7.1
+
+      - name: "Show: Versioning"
         run: |
-          LABELS="$PR_LABELS"
+          ./scripts/gear.sh show
+          forge --version
 
-          # In merge_group, pull_request context is absent — fetch labels via API
-          if [ -z "$LABELS" ] && [ -n "$MQ_HEAD_REF" ]; then
-            PR_NUMBER=$(echo "$MQ_HEAD_REF" | sed -E 's#.*/pr-([0-9]+)-.*#\1#')
-            if [ -n "$PR_NUMBER" ]; then
-              LABELS=$(gh api "/repos/$REPO/pulls/$PR_NUMBER" --jq '[.labels[].name] | join(",")')
-            fi
-          fi
+      - name: "Build: Init"
+        run: ./scripts/gear.sh init cargo
 
-          has_label() {
-            case ",$LABELS," in
-              *",$1,"*) return 0 ;;
-              *) return 1 ;;
-            esac
-          }
+      - name: "Build: malachite-core tests"
+        run: cargo build -p ethexe-malachite-core --tests --release
 
-          if [ -n "$MQ_HEAD_REF" ] && has_label "pr: do-not-merge"; then
-            echo "::error::PR is labeled 'pr: do-not-merge' - merge blocked"
-            exit 1
-          fi
-
-          has_full=false
-          if has_label "ci: full"; then
-            has_full=true
-          fi
-
-          set_output() {
-            name="$1"
-            label="$2"
-
-            if [ "$has_full" = "true" ] || has_label "$label"; then
-              echo "$name=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "$name=false" >> "$GITHUB_OUTPUT"
-            fi
-          }
-
-          set_output "macos" "ci: macos"
-          set_output "windows" "ci: windows"
-          set_output "linux_aarch64" "ci: linux-aarch64"
-          set_output "release" "ci: release"
-          set_output "production" "ci: production"
-          set_output "docker" "ci: docker"
-
-      - name: Only run latest workflow-run for this PR
-        id: skip
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR: ${{ github.event.pull_request.number }}
-          RUN_ID: ${{ github.run_id }}
-          WF_REF: ${{ github.workflow_ref }}
+      - name: "Test: malachite seven_validators_full_network_restart"
+        # Run the target test 5 times to make a flake-free verdict cheap.
+        # Without the fix this is expected to fail on the very first run;
+        # with the fix all 5 iterations must pass.
         run: |
-          set -euo pipefail
-
-          wf_path="$(echo "$WF_REF" | sed -E 's#^[^/]*/[^/]*/##; s#@.*$##')"
-          wf_file="$(basename "$wf_path")"
-          echo "workflow file: $wf_file"
-
-          latest_id=$(
-            gh api "/repos/$REPO/actions/workflows/$wf_file/runs?per_page=50" \
-              | jq -r --arg PR "$PR" '
-                  .workflow_runs
-                  | map(select(.pull_requests | any(.number == ($PR|tonumber))))
-                  | sort_by(.run_number)
-                  | last
-                  | .id
-                '
-          )
-
-          echo "latest_id=$latest_id current=$RUN_ID"
-          if [ -n "$latest_id" ] && [ "$latest_id" != "$RUN_ID" ]; then
-            echo "should_skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  check:
-    needs: gate
-    if: ${{ needs.gate.outputs.should_skip != 'true' }}
-    uses: ./.github/workflows/check.yml
-    secrets: inherit
-
-  build:
-    needs: gate
-    if: ${{ needs.gate.outputs.should_skip != 'true' }}
-    uses: ./.github/workflows/build.yml
-    secrets: inherit
-    with:
-      macos: ${{ needs.gate.outputs.ci_macos == 'true' }}
-      windows: ${{ needs.gate.outputs.ci_windows == 'true' }}
-      linux-aarch64: ${{ needs.gate.outputs.ci_linux_aarch64 == 'true' }}
-      release: ${{ needs.gate.outputs.ci_release == 'true' }}
-      production: ${{ needs.gate.outputs.ci_production == 'true' }}
-      docker: ${{ needs.gate.outputs.ci_docker == 'true' }}
+          set -eo pipefail
+          for i in 1 2 3 4 5; do
+            echo "=== iteration $i ==="
+            cargo nextest run \
+              -p ethexe-malachite-core \
+              --test multi_validators \
+              -E 'test(seven_validators_full_network_restart)' \
+              --release \
+              --no-fail-fast
+          done
+        env:
+          RUST_LOG: "ethexe=info,malachite=info"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5631,6 +5631,7 @@ dependencies = [
 name = "ethexe-malachite-core"
 version = "1.10.0"
 dependencies = [
+ "advisory-lock",
  "anyhow",
  "arc-malachitebft-app",
  "arc-malachitebft-app-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ alloy = "2.0"
 alloy-chains = "0.2.33"
 alloy-primitives = { version = "1.5.7", default-features = false }
 alloy-sol-types = { version = "1.5.7", default-features = false }
+advisory-lock = "0.3.0"
 anyhow = { version = "1.0.86", default-features = false }
 arbitrary = "1.3.2"
 async-recursion = "1.1.1"

--- a/ethexe/malachite/core/Cargo.toml
+++ b/ethexe/malachite/core/Cargo.toml
@@ -50,6 +50,7 @@ rocksdb.workspace = true
 gear-workspace-hack.workspace = true
 
 [dev-dependencies]
+advisory-lock.workspace = true
 proptest.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }

--- a/ethexe/malachite/core/tests/multi_validators.rs
+++ b/ethexe/malachite/core/tests/multi_validators.rs
@@ -383,6 +383,15 @@ async fn three_validators_make_progress() {
 /// rebuild them on the same home dirs, run another ~20s. All
 /// validators must continue from where they left off — finalized
 /// heights must remain gap-free across the restart boundary.
+///
+/// CI-PROOF VARIANT: we restart the cohort *several times back-to-back
+/// with no inter-cohort sleep* before continuing the test, so the
+/// WAL advisory-lock race in `MalachiteService::shutdown` (the WAL
+/// writer std::thread outlives the engine actor's join handle and may
+/// still hold `flock` on `consensus.wal` after `shutdown().await`)
+/// is reliably surfaced. This is intentionally not the final shape
+/// of the test; the production fix lives in
+/// `MalachiteService::shutdown`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn seven_validators_full_network_restart() {
     let setups = make_validators(7);
@@ -402,11 +411,20 @@ async fn seven_validators_full_network_restart() {
         svc.shutdown().await;
     }
 
-    // Give the OS a moment to release the listening sockets before
-    // the second cohort comes up on the same home dirs. RocksDB
-    // locks are released by `shutdown().await`; sockets need a
-    // bit more.
-    sleep(Duration::from_secs(2)).await;
+    // Repro: rapid restart cycles on the same home dirs, no sleep
+    // between shutdown and the next `new()`. Without the fix, the
+    // WAL writer thread is still holding the advisory lock on
+    // `consensus.wal` when the next cohort's `new()` runs.
+    for _ in 0..2 {
+        let mut churn = Vec::with_capacity(7);
+        for (i, setup) in setups.iter().enumerate() {
+            let svc = start_service(setup, &setups, i, Arc::clone(&exts[i])).await;
+            churn.push(svc);
+        }
+        for svc in churn {
+            svc.shutdown().await;
+        }
+    }
 
     // ---- second run on the SAME home dirs -------------------------
     let mut services2 = Vec::with_capacity(7);

--- a/ethexe/malachite/core/tests/multi_validators.rs
+++ b/ethexe/malachite/core/tests/multi_validators.rs
@@ -649,3 +649,66 @@ proptest! {
         run_churn_scenario(events);
     }
 }
+
+// --------------------------------------------------------------------
+// CI-PROOF REPRO of the WAL advisory-lock race in
+// `MalachiteService::shutdown`.
+//
+// 3 validators × N cycles. Each cycle:
+//   - start the cohort, let the WAL pre_start arm
+//   - shutdown the cohort
+//   - immediately try to acquire flock on every consensus.wal from
+//     a fresh fd
+//
+// The post-condition of `MalachiteService::shutdown().await` is that
+// every file lock held by the service is released by the time it
+// returns. Without the fix, the upstream WAL writer std::thread
+// (`arc-malachitebft-engine::wal::thread`) is still alive after the
+// engine actor's `JoinHandle` resolves and continues to hold flock
+// on `consensus.wal` for an unbounded amount of time; the probe
+// here fails with `FileLockError`.
+//
+// This test is intentionally not the final shape of the suite; the
+// production fix lives in `MalachiteService::shutdown` on a sister
+// branch. Drop this test once the diagnosis is on record.
+// --------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rapid_restart_exposes_wal_lock_race() {
+    use advisory_lock::{AdvisoryFileLock, FileLockMode};
+    use std::fs::OpenOptions;
+
+    init_tracing();
+    let setups = make_validators(3);
+    let exts: Vec<Arc<TestExt>> = (0..3).map(|_| Arc::new(TestExt::default())).collect();
+    let wal_paths: Vec<std::path::PathBuf> = setups
+        .iter()
+        .map(|s| s.home.path().join("malachite").join("consensus.wal"))
+        .collect();
+
+    for cycle in 0..50 {
+        let mut services = Vec::with_capacity(3);
+        for (i, setup) in setups.iter().enumerate() {
+            services.push(start_service(setup, &setups, i, Arc::clone(&exts[i])).await);
+        }
+        // Let the WAL actor's pre_start run and the writer std::thread arm.
+        sleep(Duration::from_millis(10)).await;
+        for svc in services {
+            svc.shutdown().await;
+        }
+        // No await between here and the lock probe — we want to catch
+        // the race window the moment shutdown returns.
+        for (i, p) in wal_paths.iter().enumerate() {
+            let f = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(p)
+                .expect("WAL exists after the engine has written to it");
+            AdvisoryFileLock::try_lock(&f, FileLockMode::Exclusive).unwrap_or_else(|e| {
+                panic!(
+                    "cycle {cycle} v{i}: WAL still flocked after \
+                     MalachiteService::shutdown().await returned: {e:?}"
+                )
+            });
+        }
+    }
+}


### PR DESCRIPTION
This is a **diagnostic PR**, not for merging.

It modifies \`seven_validators_full_network_restart\` so the WAL advisory-lock race
(\`MalachiteService::shutdown\` returns before the upstream Malachite WAL writer
\`std::thread\` releases \`flock\` on \`consensus.wal\`) is reliably surfaced on CI.

Expected outcome: \`build / workspace (release)\` fails with

\`\`\`
service starts: building Malachite engine: Actor panicked during startup
'Failed to acquire exclusive advisory lock: the file is already locked'
\`\`\`

at \`ethexe/malachite/core/tests/multi_validators.rs:start_service\`. The companion
branch \`gsobol/ethexe/malachite-wal-fix\` applies the production fix in
\`MalachiteService::shutdown\` and is expected to pass under the same conditions.

See https://github.com/gear-tech/gear/actions/runs/26678194627/job/78634373130 for the
original master-side flake this repros.