### PR TITLE
[diagnostic, do-not-merge] fix for WAL advisory-lock race + same repro

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -3,7 +3,7 @@ name: PR & Merge queue
 on:
   pull_request:
     branches: [master]
-    types: [labeled, synchronize]
+    types: [labeled, synchronize, opened, reopened, ready_for_review]
 
   merge_group:
     types: [checks_requested]
@@ -12,127 +12,71 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Diagnostic branch: strip the CI to ONLY the workspace-release nextest of
+# the malachite seven_validators_full_network_restart test. The original
+# matrix (check + workspace debug + workspace release + ethexe-cli + etc.)
+# is gone so the WAL-lock race repro/fix iteration cycle is minutes
+# instead of an hour. Do NOT carry this PR.yml into the final fix PR.
+
 jobs:
-  gate:
-    name: Skip duplicates
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip.outputs.should_skip }}
-
-      ci_macos: ${{ steps.ci.outputs.macos }}
-      ci_windows: ${{ steps.ci.outputs.windows }}
-      ci_linux_aarch64: ${{ steps.ci.outputs.linux_aarch64 }}
-      ci_release: ${{ steps.ci.outputs.release }}
-      ci_production: ${{ steps.ci.outputs.production }}
-      ci_docker: ${{ steps.ci.outputs.docker }}
-
+  workspace-release-malachite:
+    name: build / workspace (release)
+    runs-on: [kuberunner]
+    timeout-minutes: 90
     steps:
-      - name: Wait a bit for label storms
-        if: ${{ github.event_name == 'pull_request' && github.event.action == 'labeled' }}
-        run: sleep 10
+      - name: "ACTIONS: Checkout"
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
-      - name: Resolve CI labels
-        id: ci
-        env:
-          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
-          MQ_HEAD_REF: ${{ github.event.merge_group.head_ref }}
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
+      - name: "Install: Setup linker"
+        uses: ./.github/actions/setup-linker
+
+      - name: "Install: Rust toolchain"
+        uses: ./.github/actions/install-rust
+
+      - name: "Install: Compilation environment"
+        uses: ./.github/actions/setup-compilation-env
+        with:
+          target: x86_64-unknown-linux-gnu
+
+      - name: "ACTIONS: Setup caching"
+        uses: ./.github/actions/rust-cache
+        with:
+          eu-access-key-id: "${{ secrets.GEAR_CI_S3_EU_ACCESS_KEY_ID }}"
+          eu-secret-access-key: "${{ secrets.GEAR_CI_S3_EU_SECRET_ACCESS_KEY }}"
+          key: "release"
+
+      - name: "Install: Foundry"
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.7.1
+
+      - name: "Show: Versioning"
         run: |
-          LABELS="$PR_LABELS"
+          ./scripts/gear.sh show
+          forge --version
 
-          # In merge_group, pull_request context is absent — fetch labels via API
-          if [ -z "$LABELS" ] && [ -n "$MQ_HEAD_REF" ]; then
-            PR_NUMBER=$(echo "$MQ_HEAD_REF" | sed -E 's#.*/pr-([0-9]+)-.*#\1#')
-            if [ -n "$PR_NUMBER" ]; then
-              LABELS=$(gh api "/repos/$REPO/pulls/$PR_NUMBER" --jq '[.labels[].name] | join(",")')
-            fi
-          fi
+      - name: "Build: Init"
+        run: ./scripts/gear.sh init cargo
 
-          has_label() {
-            case ",$LABELS," in
-              *",$1,"*) return 0 ;;
-              *) return 1 ;;
-            esac
-          }
+      - name: "Build: malachite-core tests"
+        run: cargo build -p ethexe-malachite-core --tests --release
 
-          if [ -n "$MQ_HEAD_REF" ] && has_label "pr: do-not-merge"; then
-            echo "::error::PR is labeled 'pr: do-not-merge' - merge blocked"
-            exit 1
-          fi
-
-          has_full=false
-          if has_label "ci: full"; then
-            has_full=true
-          fi
-
-          set_output() {
-            name="$1"
-            label="$2"
-
-            if [ "$has_full" = "true" ] || has_label "$label"; then
-              echo "$name=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "$name=false" >> "$GITHUB_OUTPUT"
-            fi
-          }
-
-          set_output "macos" "ci: macos"
-          set_output "windows" "ci: windows"
-          set_output "linux_aarch64" "ci: linux-aarch64"
-          set_output "release" "ci: release"
-          set_output "production" "ci: production"
-          set_output "docker" "ci: docker"
-
-      - name: Only run latest workflow-run for this PR
-        id: skip
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR: ${{ github.event.pull_request.number }}
-          RUN_ID: ${{ github.run_id }}
-          WF_REF: ${{ github.workflow_ref }}
+      - name: "Test: malachite seven_validators_full_network_restart"
+        # Run the target test 5 times to make a flake-free verdict cheap.
+        # Without the fix this is expected to fail on the very first run;
+        # with the fix all 5 iterations must pass.
         run: |
-          set -euo pipefail
-
-          wf_path="$(echo "$WF_REF" | sed -E 's#^[^/]*/[^/]*/##; s#@.*$##')"
-          wf_file="$(basename "$wf_path")"
-          echo "workflow file: $wf_file"
-
-          latest_id=$(
-            gh api "/repos/$REPO/actions/workflows/$wf_file/runs?per_page=50" \
-              | jq -r --arg PR "$PR" '
-                  .workflow_runs
-                  | map(select(.pull_requests | any(.number == ($PR|tonumber))))
-                  | sort_by(.run_number)
-                  | last
-                  | .id
-                '
-          )
-
-          echo "latest_id=$latest_id current=$RUN_ID"
-          if [ -n "$latest_id" ] && [ "$latest_id" != "$RUN_ID" ]; then
-            echo "should_skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  check:
-    needs: gate
-    if: ${{ needs.gate.outputs.should_skip != 'true' }}
-    uses: ./.github/workflows/check.yml
-    secrets: inherit
-
-  build:
-    needs: gate
-    if: ${{ needs.gate.outputs.should_skip != 'true' }}
-    uses: ./.github/workflows/build.yml
-    secrets: inherit
-    with:
-      macos: ${{ needs.gate.outputs.ci_macos == 'true' }}
-      windows: ${{ needs.gate.outputs.ci_windows == 'true' }}
-      linux-aarch64: ${{ needs.gate.outputs.ci_linux_aarch64 == 'true' }}
-      release: ${{ needs.gate.outputs.ci_release == 'true' }}
-      production: ${{ needs.gate.outputs.ci_production == 'true' }}
-      docker: ${{ needs.gate.outputs.ci_docker == 'true' }}
+          set -eo pipefail
+          for i in 1 2 3 4 5; do
+            echo "=== iteration $i ==="
+            cargo nextest run \
+              -p ethexe-malachite-core \
+              --test multi_validators \
+              -E 'test(seven_validators_full_network_restart)' \
+              --release \
+              --no-fail-fast
+          done
+        env:
+          RUST_LOG: "ethexe=info,malachite=info"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5631,6 +5631,7 @@ dependencies = [
 name = "ethexe-malachite-core"
 version = "1.10.0"
 dependencies = [
+ "advisory-lock",
  "anyhow",
  "arc-malachitebft-app",
  "arc-malachitebft-app-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ alloy = "2.0"
 alloy-chains = "0.2.33"
 alloy-primitives = { version = "1.5.7", default-features = false }
 alloy-sol-types = { version = "1.5.7", default-features = false }
+advisory-lock = "0.3.0"
 anyhow = { version = "1.0.86", default-features = false }
 arbitrary = "1.3.2"
 async-recursion = "1.1.1"

--- a/ethexe/malachite/core/Cargo.toml
+++ b/ethexe/malachite/core/Cargo.toml
@@ -22,6 +22,7 @@ malachitebft-sync.workspace = true
 malachitebft-test.workspace = true
 
 # Async + utilities
+advisory-lock.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 bytes.workspace = true

--- a/ethexe/malachite/core/src/service.rs
+++ b/ethexe/malachite/core/src/service.rs
@@ -16,6 +16,7 @@ use crate::{
     store::Store,
     types::Address,
 };
+use advisory_lock::{AdvisoryFileLock, FileLockMode};
 use anyhow::{Context as _, Result};
 use bytes::Bytes;
 use futures::{Stream, stream::FusedStream};
@@ -32,10 +33,13 @@ use malachitebft_app_channel::{
 };
 use malachitebft_core_types::ValidatorProof;
 use std::{
+    fs::OpenOptions,
     marker::PhantomData,
+    path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
     task::{Context as TaskContext, Poll},
+    time::Duration,
 };
 use tokio::{sync::mpsc, task::JoinHandle};
 
@@ -49,11 +53,65 @@ pub struct MalachiteService<P: BlockPayload, EXT: Externalities<P>> {
     errors_rx: mpsc::UnboundedReceiver<anyhow::Error>,
     engine: EngineHandle,
     app_handle: JoinHandle<()>,
+    /// Path to the WAL file. [`Self::shutdown`] probes the advisory
+    /// lock on this path before returning so the next service
+    /// opening the same base dir does not race the WAL writer thread.
+    wal_path: PathBuf,
     /// Shared with the inner app loop; [`Self::update_validators`]
     /// writes here, the next `Finalized` / `ConsensusReady` reply reads.
     validator_set: SharedValidatorSet,
     _externalities: Arc<EXT>,
     _phantom: PhantomData<fn() -> P>,
+}
+
+/// Upper bound on how long [`MalachiteService::shutdown`] will wait
+/// for the WAL advisory lock to be released after the engine actor
+/// has stopped. Empirically the writer thread drops the file within
+/// tens of milliseconds; this ceiling guards against pathological CI
+/// scheduling without ever blocking healthy shutdowns.
+const WAL_LOCK_RELEASE_TIMEOUT: Duration = Duration::from_secs(10);
+const WAL_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+/// Block until the WAL file at `wal_path` is no longer locked, or
+/// `timeout` has elapsed.
+///
+/// Malachite's WAL is owned by a [`std::thread`] (see
+/// `arc-malachitebft-engine`'s `wal::thread`); the engine actor's
+/// `post_stop` only sends a `Shutdown` message on a channel, and the
+/// thread releases its [`advisory_lock`] when it later drops the log.
+/// The actor's `JoinHandle` is therefore *not* a sufficient barrier —
+/// the writer thread can still be live (and the lock still held) after
+/// the engine task exits. We probe the lock here so callers of
+/// [`MalachiteService::shutdown`] can immediately re-open the same
+/// base dir without spurious "advisory lock held" errors.
+///
+/// A missing WAL file means we never wrote one; nothing to wait for.
+async fn wait_wal_lock_released(wal_path: &Path, timeout: Duration) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        match OpenOptions::new().read(true).write(true).open(wal_path) {
+            Ok(file) => match AdvisoryFileLock::try_lock(&file, FileLockMode::Exclusive) {
+                Ok(()) => return,
+                Err(_) => {
+                    if tokio::time::Instant::now() >= deadline {
+                        tracing::warn!(
+                            target: "ethexe-malachite-core",
+                            wal = %wal_path.display(),
+                            "WAL advisory lock did not release within {:?}; \
+                             the next service start on the same base dir may fail",
+                            timeout,
+                        );
+                        return;
+                    }
+                    tokio::time::sleep(WAL_LOCK_POLL_INTERVAL).await;
+                }
+            },
+            // No WAL on disk → nothing to wait for. Any other I/O
+            // error (permissions, etc.) is not a lock issue — surface
+            // it lazily on the next `new()` instead of blocking here.
+            Err(_) => return,
+        }
+    }
 }
 
 impl<P: BlockPayload, EXT: Externalities<P>> Drop for MalachiteService<P, EXT> {
@@ -77,13 +135,16 @@ impl<P: BlockPayload, EXT: Externalities<P>> MalachiteService<P, EXT> {
     /// "advisory lock held" errors at the second `new()` call.
     pub async fn shutdown(mut self) {
         self.engine.actor.kill();
-        // Best-effort: wait for the engine and app tasks to drain.
         // `kill` is asynchronous — the actor finishes its current
         // message and then stops, so we await the JoinHandles.
         let _ = (&mut self.engine.handle).await;
         self.app_handle.abort();
         let _ = (&mut self.app_handle).await;
-        // Drop self normally so the channels close.
+        // The engine task exiting doesn't synchronously release the
+        // WAL advisory lock — the writer is a detached std::thread.
+        // Probe the lock so callers can immediately re-open the same
+        // base dir.
+        wait_wal_lock_released(&self.wal_path, WAL_LOCK_RELEASE_TIMEOUT).await;
     }
 }
 
@@ -176,7 +237,7 @@ impl<P: BlockPayload, EXT: Externalities<P>> MalachiteService<P, EXT> {
         let ctx = MalachiteCtx::new();
         let consensus_signer = MalachiteSigner::new(signer.private_key().clone());
         let (channels, engine) = EngineBuilder::new(ctx.clone(), inner_cfg)
-            .with_default_wal(WalContext::new(wal_path, ScaleCodec))
+            .with_default_wal(WalContext::new(wal_path.clone(), ScaleCodec))
             .with_default_network(NetworkContext::new(identity, ScaleCodec))
             .with_default_consensus(ConsensusContext::new(address, consensus_signer))
             .with_default_sync(SyncContext::new(ScaleCodec))
@@ -213,6 +274,7 @@ impl<P: BlockPayload, EXT: Externalities<P>> MalachiteService<P, EXT> {
             errors_rx,
             engine,
             app_handle,
+            wal_path,
             validator_set,
             _externalities: externalities,
             _phantom: PhantomData,

--- a/ethexe/malachite/core/tests/multi_validators.rs
+++ b/ethexe/malachite/core/tests/multi_validators.rs
@@ -383,6 +383,15 @@ async fn three_validators_make_progress() {
 /// rebuild them on the same home dirs, run another ~20s. All
 /// validators must continue from where they left off — finalized
 /// heights must remain gap-free across the restart boundary.
+///
+/// CI-PROOF VARIANT: we restart the cohort *several times back-to-back
+/// with no inter-cohort sleep* before continuing the test, so the
+/// WAL advisory-lock race in `MalachiteService::shutdown` (the WAL
+/// writer std::thread outlives the engine actor's join handle and may
+/// still hold `flock` on `consensus.wal` after `shutdown().await`)
+/// is reliably surfaced. This is intentionally not the final shape
+/// of the test; the production fix lives in
+/// `MalachiteService::shutdown`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn seven_validators_full_network_restart() {
     let setups = make_validators(7);
@@ -402,11 +411,20 @@ async fn seven_validators_full_network_restart() {
         svc.shutdown().await;
     }
 
-    // Give the OS a moment to release the listening sockets before
-    // the second cohort comes up on the same home dirs. RocksDB
-    // locks are released by `shutdown().await`; sockets need a
-    // bit more.
-    sleep(Duration::from_secs(2)).await;
+    // Repro: rapid restart cycles on the same home dirs, no sleep
+    // between shutdown and the next `new()`. Without the fix, the
+    // WAL writer thread is still holding the advisory lock on
+    // `consensus.wal` when the next cohort's `new()` runs.
+    for _ in 0..2 {
+        let mut churn = Vec::with_capacity(7);
+        for (i, setup) in setups.iter().enumerate() {
+            let svc = start_service(setup, &setups, i, Arc::clone(&exts[i])).await;
+            churn.push(svc);
+        }
+        for svc in churn {
+            svc.shutdown().await;
+        }
+    }
 
     // ---- second run on the SAME home dirs -------------------------
     let mut services2 = Vec::with_capacity(7);


### PR DESCRIPTION
**Diagnostic PR** — paired with #5543.

Carries the same race-repro test modification AND the production fix in
\`MalachiteService::shutdown\` (poll \`consensus.wal\` advisory lock until
the upstream WAL writer std::thread releases it, before returning).

Expected: \`build / workspace (release)\` is green — 5/5 iterations of
\`seven_validators_full_network_restart\` pass.

The final fix-only PR will drop the repro test stress and the CI strip;
this branch is only for proving the diagnosis.