### PR TITLE
fix(ethexe/malachite-core): wait for WAL advisory lock release in MalachiteService::shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5631,6 +5631,7 @@ dependencies = [
 name = "ethexe-malachite-core"
 version = "1.10.0"
 dependencies = [
+ "advisory-lock",
  "anyhow",
  "arc-malachitebft-app",
  "arc-malachitebft-app-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ alloy = "2.0"
 alloy-chains = "0.2.33"
 alloy-primitives = { version = "1.5.7", default-features = false }
 alloy-sol-types = { version = "1.5.7", default-features = false }
+advisory-lock = "0.3.0"
 anyhow = { version = "1.0.86", default-features = false }
 arbitrary = "1.3.2"
 async-recursion = "1.1.1"

--- a/ethexe/malachite/core/Cargo.toml
+++ b/ethexe/malachite/core/Cargo.toml
@@ -22,6 +22,7 @@ malachitebft-sync.workspace = true
 malachitebft-test.workspace = true
 
 # Async + utilities
+advisory-lock.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
@@ -50,6 +51,7 @@ rocksdb.workspace = true
 gear-workspace-hack.workspace = true
 
 [dev-dependencies]
+advisory-lock.workspace = true
 proptest.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }

--- a/ethexe/malachite/core/src/service.rs
+++ b/ethexe/malachite/core/src/service.rs
@@ -16,6 +16,7 @@ use crate::{
     store::Store,
     types::Address,
 };
+use advisory_lock::{AdvisoryFileLock, FileLockMode};
 use anyhow::{Context as _, Result};
 use bytes::Bytes;
 use futures::{Stream, stream::FusedStream};
@@ -32,10 +33,13 @@ use malachitebft_app_channel::{
 };
 use malachitebft_core_types::ValidatorProof;
 use std::{
+    fs::OpenOptions,
     marker::PhantomData,
+    path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
     task::{Context as TaskContext, Poll},
+    time::Duration,
 };
 use tokio::{sync::mpsc, task::JoinHandle};
 
@@ -49,11 +53,65 @@ pub struct MalachiteService<P: BlockPayload, EXT: Externalities<P>> {
     errors_rx: mpsc::UnboundedReceiver<anyhow::Error>,
     engine: EngineHandle,
     app_handle: JoinHandle<()>,
+    /// Path to the WAL file. [`Self::shutdown`] probes the advisory
+    /// lock on this path before returning so the next service
+    /// opening the same base dir does not race the WAL writer thread.
+    wal_path: PathBuf,
     /// Shared with the inner app loop; [`Self::update_validators`]
     /// writes here, the next `Finalized` / `ConsensusReady` reply reads.
     validator_set: SharedValidatorSet,
     _externalities: Arc<EXT>,
     _phantom: PhantomData<fn() -> P>,
+}
+
+/// Upper bound on how long [`MalachiteService::shutdown`] will wait
+/// for the WAL advisory lock to be released after the engine actor
+/// has stopped. Empirically the writer thread drops the file within
+/// tens of milliseconds; this ceiling guards against pathological CI
+/// scheduling without ever blocking healthy shutdowns.
+const WAL_LOCK_RELEASE_TIMEOUT: Duration = Duration::from_secs(10);
+const WAL_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+/// Block until the WAL file at `wal_path` is no longer locked, or
+/// `timeout` has elapsed.
+///
+/// Malachite's WAL is owned by a [`std::thread`] (see
+/// `arc-malachitebft-engine`'s `wal::thread`); the engine actor's
+/// `post_stop` only sends a `Shutdown` message on a channel, and the
+/// thread releases its [`advisory_lock`] when it later drops the log.
+/// The actor's `JoinHandle` is therefore *not* a sufficient barrier —
+/// the writer thread can still be live (and the lock still held) after
+/// the engine task exits. We probe the lock here so callers of
+/// [`MalachiteService::shutdown`] can immediately re-open the same
+/// base dir without spurious "advisory lock held" errors.
+///
+/// A missing WAL file means we never wrote one; nothing to wait for.
+async fn wait_wal_lock_released(wal_path: &Path, timeout: Duration) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        match OpenOptions::new().read(true).write(true).open(wal_path) {
+            Ok(file) => match AdvisoryFileLock::try_lock(&file, FileLockMode::Exclusive) {
+                Ok(()) => return,
+                Err(_) => {
+                    if tokio::time::Instant::now() >= deadline {
+                        tracing::warn!(
+                            target: "ethexe-malachite-core",
+                            wal = %wal_path.display(),
+                            "WAL advisory lock did not release within {:?}; \
+                             the next service start on the same base dir may fail",
+                            timeout,
+                        );
+                        return;
+                    }
+                    tokio::time::sleep(WAL_LOCK_POLL_INTERVAL).await;
+                }
+            },
+            // No WAL on disk → nothing to wait for. Any other I/O
+            // error (permissions, etc.) is not a lock issue — surface
+            // it lazily on the next `new()` instead of blocking here.
+            Err(_) => return,
+        }
+    }
 }
 
 impl<P: BlockPayload, EXT: Externalities<P>> Drop for MalachiteService<P, EXT> {
@@ -77,13 +135,16 @@ impl<P: BlockPayload, EXT: Externalities<P>> MalachiteService<P, EXT> {
     /// "advisory lock held" errors at the second `new()` call.
     pub async fn shutdown(mut self) {
         self.engine.actor.kill();
-        // Best-effort: wait for the engine and app tasks to drain.
         // `kill` is asynchronous — the actor finishes its current
         // message and then stops, so we await the JoinHandles.
         let _ = (&mut self.engine.handle).await;
         self.app_handle.abort();
         let _ = (&mut self.app_handle).await;
-        // Drop self normally so the channels close.
+        // The engine task exiting doesn't synchronously release the
+        // WAL advisory lock — the writer is a detached std::thread.
+        // Probe the lock so callers can immediately re-open the same
+        // base dir.
+        wait_wal_lock_released(&self.wal_path, WAL_LOCK_RELEASE_TIMEOUT).await;
     }
 }
 
@@ -176,7 +237,7 @@ impl<P: BlockPayload, EXT: Externalities<P>> MalachiteService<P, EXT> {
         let ctx = MalachiteCtx::new();
         let consensus_signer = MalachiteSigner::new(signer.private_key().clone());
         let (channels, engine) = EngineBuilder::new(ctx.clone(), inner_cfg)
-            .with_default_wal(WalContext::new(wal_path, ScaleCodec))
+            .with_default_wal(WalContext::new(wal_path.clone(), ScaleCodec))
             .with_default_network(NetworkContext::new(identity, ScaleCodec))
             .with_default_consensus(ConsensusContext::new(address, consensus_signer))
             .with_default_sync(SyncContext::new(ScaleCodec))
@@ -213,6 +274,7 @@ impl<P: BlockPayload, EXT: Externalities<P>> MalachiteService<P, EXT> {
             errors_rx,
             engine,
             app_handle,
+            wal_path,
             validator_set,
             _externalities: externalities,
             _phantom: PhantomData,

--- a/ethexe/malachite/core/tests/multi_validators.rs
+++ b/ethexe/malachite/core/tests/multi_validators.rs
@@ -631,3 +631,61 @@ proptest! {
         run_churn_scenario(events);
     }
 }
+
+/// Regression test for the WAL advisory-lock release post-condition of
+/// [`MalachiteService::shutdown`].
+///
+/// 3 validators × 50 rapid restart cycles. Each cycle:
+///   - start the cohort, give the WAL pre_start time to arm,
+///   - call `shutdown().await` on every service,
+///   - immediately probe each `consensus.wal` from a fresh fd: a
+///     fresh `try_lock(LOCK_EX)` MUST succeed.
+///
+/// Upstream Malachite owns the WAL file from a detached `std::thread`
+/// (`arc-malachitebft-engine::wal::thread`); the WAL actor's
+/// `post_stop` only sends a `Shutdown` message on a channel, so without
+/// the explicit lock-release wait in `MalachiteService::shutdown` the
+/// writer thread can still be alive (and still holding `flock`) after
+/// the engine actor's `JoinHandle` resolves. The probe below directly
+/// asserts the post-condition that downstream code relies on — that
+/// the same base dir can be re-opened immediately after `shutdown`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn shutdown_releases_wal_advisory_lock() {
+    use advisory_lock::{AdvisoryFileLock, FileLockMode};
+    use std::fs::OpenOptions;
+
+    init_tracing();
+    let setups = make_validators(3);
+    let exts: Vec<Arc<TestExt>> = (0..3).map(|_| Arc::new(TestExt::default())).collect();
+    let wal_paths: Vec<std::path::PathBuf> = setups
+        .iter()
+        .map(|s| s.home.path().join("malachite").join("consensus.wal"))
+        .collect();
+
+    for cycle in 0..50 {
+        let mut services = Vec::with_capacity(3);
+        for (i, setup) in setups.iter().enumerate() {
+            services.push(start_service(setup, &setups, i, Arc::clone(&exts[i])).await);
+        }
+        // Let the WAL actor's pre_start run and the writer std::thread arm.
+        sleep(Duration::from_millis(10)).await;
+        for svc in services {
+            svc.shutdown().await;
+        }
+        // No await between here and the lock probe — we want to catch
+        // the race window the moment shutdown returns.
+        for (i, p) in wal_paths.iter().enumerate() {
+            let f = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(p)
+                .expect("WAL exists after the engine has written to it");
+            AdvisoryFileLock::try_lock(&f, FileLockMode::Exclusive).unwrap_or_else(|e| {
+                panic!(
+                    "cycle {cycle} v{i}: WAL still flocked after \
+                     MalachiteService::shutdown().await returned: {e:?}"
+                )
+            });
+        }
+    }
+}


### PR DESCRIPTION
Closes #5545.

## Summary

\`MalachiteService::shutdown().await\` is the documented restart barrier — by the time it returns, every file lock the service held must be released so the same base dir can be re-opened. For RocksDB that's true (\`Store\` lives inside the app task and is dropped when the task is awaited). For Malachite's WAL it is **not** true today.

Upstream Malachite owns the WAL file from a detached \`std::thread\` (see \`arc-malachitebft-engine::wal::thread\`). The WAL actor's \`post_stop\` only sends a \`Shutdown\` message on a channel; the writer thread releases its \`advisory_lock\` only when it later drops the log. The actor's \`JoinHandle\` resolves as soon as \`post_stop\` returns, so the writer thread can still be alive — and \`flock(LOCK_EX)\` on \`consensus.wal\` still held — when \`MalachiteService::shutdown().await\` returns. The next \`MalachiteService::new\` on the same base dir then panics with \`Failed to acquire exclusive advisory lock\`.

## Fix

After awaiting engine + app handles in \`shutdown\`, probe the WAL advisory lock from a fresh fd. Poll every 25 ms up to a 10 s ceiling. The poll is a no-op when the WAL never existed; on the healthy path the lock is free within milliseconds, so this adds no measurable shutdown latency.

## Test

\`shutdown_releases_wal_advisory_lock\` (new): restarts a 3-validator cohort 50 times and \`try_lock(LOCK_EX)\` on each \`consensus.wal\` from a fresh fd the instant \`shutdown().await\` returns. Without the fix this fails in the first cycle locally with \`AlreadyLocked\` (~120 ms). With the fix all 50 cycles pass in <5 s.

## Diagnosis trail

- Original master flake: https://github.com/gear-tech/gear/actions/runs/26678194627/job/78634373130 (\`seven_validators_full_network_restart\` panic in \`MalachiteService::new\` with the exact \`Failed to acquire exclusive advisory lock\` error string).
- Repro PR (do-not-merge) with a deterministic probe: #5543.
- This PR's branch verified green against the same probe.

## Test plan

- [x] \`cargo nextest run -p ethexe-malachite-core --test multi_validators --release\` — full suite passes locally.
- [x] \`cargo nextest run -p ethexe-malachite-core -E 'test(shutdown_releases_wal_advisory_lock)' --release\` — 50/50 cycles pass.
- [x] \`cargo nextest run -p ethexe-malachite-core -E 'test(seven_validators_full_network_restart)' --release\` ×5 — 5/5 pass.