### PR TITLE
docs(ethexe): document public items across ethexe crates

### DIFF
--- a/ethexe/blob-loader/src/lib.rs
+++ b/ethexe/blob-loader/src/lib.rs
@@ -53,15 +53,20 @@ use reqwest::Client;
 use std::{collections::HashSet, fmt, num::NonZero, pin::Pin, task::Poll};
 use tokio::{sync::OnceCell, time::Duration};
 
+/// Output event emitted by [`BlobLoader`] when a code blob has been fetched and decoded.
 #[derive(Clone, PartialEq, Eq)]
 pub enum BlobLoaderEvent {
+    /// A code blob was successfully retrieved and decoded; carries the raw WASM bytes paired with its [`CodeId`].
     BlobLoaded(CodeAndIdUnchecked),
 }
 
+/// Error type for blob-loading operations; returned by [`BlobLoader::new`] and [`BlobLoaderService::load_codes`].
 #[derive(thiserror::Error, Debug)]
 pub enum BlobLoaderError {
+    /// An Ethereum JSON-RPC transport failure occurred while communicating with the execution-layer node.
     #[error("transport error: {0}")]
     Transport(#[from] RpcError<TransportErrorKind>),
+    /// The local database has no [`CodeBlobInfo`] for the requested [`CodeId`], so the originating transaction cannot be located.
     #[error("failed to get code blob info for: {0}")]
     CodeBlobInfoNotFound(CodeId),
 }
@@ -101,13 +106,24 @@ enum ReaderError {
 type LoaderResult<T> = Result<T, BlobLoaderError>;
 type ReaderResult<T> = Result<T, ReaderError>;
 
+/// Object-safe interface used by `ethexe-service` to drive blob loading.
+///
+/// Combines a fused [`Stream`] of [`BlobLoaderEvent`] results with imperative methods for
+/// enqueuing new codes and inspecting the pending queue. Implementors must be `Send + Unpin`
+/// so they can be stored as `Box<dyn BlobLoaderService>` inside the async service loop.
 pub trait BlobLoaderService:
     Stream<Item = LoaderResult<BlobLoaderEvent>> + FusedStream + Send + Unpin
 {
+    /// Enqueue a set of [`CodeId`]s for blob fetching.
+    ///
+    /// Already-pending ids are silently skipped. Returns an error if the database has no
+    /// [`CodeBlobInfo`] for a requested id.
     fn load_codes(&mut self, codes: HashSet<CodeId>) -> LoaderResult<()>;
 
+    /// Wrap `self` in a [`Box`] for type-erasure as `Box<dyn BlobLoaderService>`.
     fn into_box(self) -> Box<dyn BlobLoaderService>;
 
+    /// Returns the number of [`CodeId`]s currently awaiting a blob fetch response.
     fn pending_codes_len(&self) -> usize;
 }
 
@@ -119,11 +135,16 @@ impl fmt::Debug for BlobLoaderEvent {
     }
 }
 
+/// Configuration for connecting to the Ethereum execution-layer and beacon-layer RPC endpoints.
 #[derive(Clone)]
 pub struct ConsensusLayerConfig {
+    /// WebSocket or HTTP URL of the Ethereum execution-layer JSON-RPC endpoint.
     pub ethereum_rpc: String,
+    /// HTTP base URL of the Ethereum beacon-node REST API (used to fetch blob sidecars and genesis time).
     pub ethereum_beacon_rpc: String,
+    /// Expected duration of a single beacon slot; used to convert block timestamps to slot numbers.
     pub beacon_block_time: Duration,
+    /// Number of fetch attempts before giving up on a single blob; must be non-zero.
     pub attempts: NonZero<u8>,
 }
 
@@ -258,9 +279,16 @@ impl ConsensusLayerBlobReader {
     }
 }
 
+/// Marker trait for database types that [`BlobLoader`] can use to look up code blob metadata.
+///
+/// Blanket-implemented for every type satisfying `CodesStorageRO + OnChainStorageRO + Unpin + Send + Clone + 'static`.
 pub trait Database: CodesStorageRO + OnChainStorageRO + Unpin + Send + Clone + 'static {}
 impl<T: CodesStorageRO + OnChainStorageRO + Unpin + Send + Clone + 'static> Database for T {}
 
+/// Concrete [`BlobLoaderService`] implementation that fetches EIP-4844 blobs from an Ethereum beacon node.
+///
+/// Constructed with [`BlobLoader::new`]. Internally drives a [`FuturesUnordered`] pool of
+/// in-flight blob fetch futures, one per queued [`CodeId`].
 pub struct BlobLoader<DB: Database> {
     futures: FuturesUnordered<BoxFuture<'static, ReaderResult<CodeAndIdUnchecked>>>,
     codes_loading: HashSet<CodeId>,
@@ -298,6 +326,9 @@ impl<DB: Database> FusedStream for BlobLoader<DB> {
 }
 
 impl<DB: Database> BlobLoader<DB> {
+    /// Create a new `BlobLoader` by connecting to the execution-layer RPC specified in `consensus_cfg`.
+    ///
+    /// Returns a [`BlobLoaderError::Transport`] error if the RPC connection cannot be established.
     pub async fn new(db: DB, consensus_cfg: ConsensusLayerConfig) -> LoaderResult<Self> {
         Ok(Self {
             futures: FuturesUnordered::new(),

--- a/ethexe/common/src/consensus.rs
+++ b/ethexe/common/src/consensus.rs
@@ -20,7 +20,9 @@ pub const MAX_BATCH_SIZE_LIMIT: u64 = 120 * 1024;
 /// The default batch size - 100 KB.
 pub const DEFAULT_BATCH_SIZE_LIMIT: u64 = 100 * 1024;
 
+/// A [`BatchCommitmentValidationRequest`] that has been ECDSA-verified, binding the request to its sender's address.
 pub type VerifiedValidationRequest = VerifiedData<BatchCommitmentValidationRequest>;
+/// A [`BatchCommitmentValidationReply`] that has been ECDSA-verified, binding the reply to its sender's address.
 pub type VerifiedValidationReply = VerifiedData<BatchCommitmentValidationReply>;
 
 // TODO #4553: temporary implementation, should be improved
@@ -72,6 +74,7 @@ impl ProtocolTimelines {
 #[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, Hash)]
 pub struct BatchCommitmentValidationRequest {
     // Digest of batch commitment to validate
+    /// Keccak256 digest of the [`BatchCommitment`] that subordinate validators are asked to verify.
     pub digest: Digest,
     /// Optional head MB hash of the chain commitment.
     /// The hash of the most recent finalized `ethexe_malachite_core::Block` envelope covered by this batch.
@@ -85,6 +88,7 @@ pub struct BatchCommitmentValidationRequest {
 }
 
 impl BatchCommitmentValidationRequest {
+    /// Constructs a validation request from a [`BatchCommitment`], extracting its digest, code IDs, and presence flags.
     pub fn new(batch: &BatchCommitment) -> Self {
         let codes = batch
             .code_commitments

--- a/ethexe/common/src/db.rs
+++ b/ethexe/common/src/db.rs
@@ -41,17 +41,21 @@ pub struct BlockMeta {
     pub latest_era_validators_committed: Option<u64>,
 }
 
+/// Read-only access to a content-addressed byte store keyed by [`H256`] hash.
 #[auto_impl::auto_impl(&, Box)]
 pub trait HashStorageRO {
+    /// Retrieves the raw byte blob stored under `hash`, or `None` if absent.
     fn read_by_hash(&self, hash: H256) -> Option<Vec<u8>>;
 }
 
+/// Read-only access to per-block [`BlockMeta`] records.
 #[auto_impl::auto_impl(&, Box)]
 pub trait BlockMetaStorageRO {
     /// NOTE: if `BlockMeta` doesn't exist in the database, it will return the default value.
     fn block_meta(&self, block_hash: H256) -> BlockMeta;
 }
 
+/// Read-write access to per-block [`BlockMeta`] records.
 #[auto_impl::auto_impl(&)]
 pub trait BlockMetaStorageRW: BlockMetaStorageRO {
     /// NOTE: if `BlockMeta` doesn't exist in the database,
@@ -59,35 +63,58 @@ pub trait BlockMetaStorageRW: BlockMetaStorageRO {
     fn mutate_block_meta(&self, block_hash: H256, f: impl FnOnce(&mut BlockMeta));
 }
 
+/// Read-only access to Gear program code storage (original blobs, instrumented variants, and metadata).
 #[auto_impl::auto_impl(&, Box)]
 pub trait CodesStorageRO {
+    /// Returns `true` if the original WASM blob for `code_id` is present.
     fn original_code_exists(&self, code_id: CodeId) -> bool;
+    /// Returns the raw WASM blob stored under `code_id`, if present.
     fn original_code(&self, code_id: CodeId) -> Option<Vec<u8>>;
+    /// Returns the [`CodeId`] of the code associated with a deployed program.
     fn program_code_id(&self, program_id: ActorId) -> Option<CodeId>;
+    /// Returns `true` if an instrumented variant of `code_id` for `runtime_id` exists.
     fn instrumented_code_exists(&self, runtime_id: u32, code_id: CodeId) -> bool;
+    /// Returns the instrumented code for the given runtime version and code ID.
     fn instrumented_code(&self, runtime_id: u32, code_id: CodeId) -> Option<InstrumentedCode>;
+    /// Returns the metadata record associated with a code ID.
     fn code_metadata(&self, code_id: CodeId) -> Option<CodeMetadata>;
+    /// Returns the on-chain validation result for a code ID: `Some(true)` if valid,
+    /// `Some(false)` if invalid, `None` if not yet determined.
     fn code_valid(&self, code_id: CodeId) -> Option<bool>;
+    /// Returns the set of all code IDs that have been validated as valid.
     fn valid_codes(&self) -> BTreeSet<CodeId>;
 }
 
+/// Read-write access to Gear program code storage.
 #[auto_impl::auto_impl(&)]
 pub trait CodesStorageRW: CodesStorageRO {
+    /// Stores the raw WASM blob and returns its computed [`CodeId`].
     fn set_original_code(&self, code: &[u8]) -> CodeId;
+    /// Associates a deployed program with its [`CodeId`].
     fn set_program_code_id(&self, program_id: ActorId, code_id: CodeId);
+    /// Stores an instrumented code variant for the given runtime version.
     fn set_instrumented_code(&self, runtime_id: u32, code_id: CodeId, code: InstrumentedCode);
+    /// Stores metadata for a code ID.
     fn set_code_metadata(&self, code_id: CodeId, code_metadata: CodeMetadata);
+    /// Records the on-chain validation result for a code ID.
     fn set_code_valid(&self, code_id: CodeId, valid: bool);
 }
 
+/// Read-only access to Ethereum on-chain block and validator data as observed by the ethexe node.
 #[auto_impl::auto_impl(&, Box)]
 pub trait OnChainStorageRO {
+    /// Returns the [`BlockHeader`] for the given Ethereum block hash.
     fn block_header(&self, block_hash: H256) -> Option<BlockHeader>;
+    /// Returns the decoded [`BlockEvent`] list emitted in the given Ethereum block.
     fn block_events(&self, block_hash: H256) -> Option<Vec<BlockEvent>>;
+    /// Returns blob location metadata for a code uploaded via EIP-4844.
     fn code_blob_info(&self, code_id: CodeId) -> Option<CodeBlobInfo>;
+    /// Returns `true` if the block has been fully synced (header + events persisted).
     fn block_synced(&self, block_hash: H256) -> bool;
+    /// Returns the validator set committed for the given era index.
     fn validators(&self, era_index: u64) -> Option<ValidatorsVec>;
 
+    /// Convenience accessor that pairs the block hash with its header into [`SimpleBlockData`].
     fn block_simple_data(&self, block_hash: H256) -> Option<SimpleBlockData> {
         self.block_header(block_hash).map(|header| SimpleBlockData {
             hash: block_hash,
@@ -96,15 +123,22 @@ pub trait OnChainStorageRO {
     }
 }
 
+/// Read-write access to Ethereum on-chain block and validator data.
 #[auto_impl::auto_impl(&)]
 pub trait OnChainStorageRW: OnChainStorageRO {
+    /// Persists the [`BlockHeader`] for the given block hash.
     fn set_block_header(&self, block_hash: H256, header: BlockHeader);
+    /// Persists the decoded [`BlockEvent`] list for the given block hash.
     fn set_block_events(&self, block_hash: H256, events: &[BlockEvent]);
+    /// Persists EIP-4844 blob location metadata for the given code ID.
     fn set_code_blob_info(&self, code_id: CodeId, code_info: CodeBlobInfo);
+    /// Records the validator set for the given era index.
     fn set_validators(&self, era_index: u64, validator_set: ValidatorsVec);
+    /// Marks the block as fully synced (header + events persisted).
     fn set_block_synced(&self, block_hash: H256);
 }
 
+/// Read-only access to injected transaction and promise storage.
 #[auto_impl::auto_impl(&)]
 pub trait InjectedStorageRO {
     /// Returns the transactions by its hash.
@@ -120,12 +154,16 @@ pub trait InjectedStorageRO {
     fn receipt(&self, hash: HashOf<InjectedTransaction>) -> Option<SignedTxReceipt>;
 }
 
+/// Read-write access to injected transaction and promise storage.
 #[auto_impl::auto_impl(&)]
 pub trait InjectedStorageRW: InjectedStorageRO {
+    /// Persists a signed injected transaction, keyed by its hash.
     fn set_injected_transaction(&self, tx: SignedInjectedTransaction);
 
+    /// Persists a promise associated with the transaction identified by its hash.
     fn set_promise(&self, promise: &Promise);
 
+    /// Persists a signed receipt for the transaction identified by its hash.
     fn set_receipt(&self, receipt: &SignedTxReceipt);
 }
 
@@ -136,8 +174,11 @@ pub trait InjectedStorageRW: InjectedStorageRO {
 )]
 #[display("MB(height {height}, parent {parent}, transactions_hash {transactions_hash})")]
 pub struct CompactMb {
+    /// Hash of the parent MB in the MB chain.
     pub parent: H256,
+    /// Monotonically increasing MB sequence number.
     pub height: u64,
+    /// CAS key under which the [`Transactions`] blob for this MB is stored.
     pub transactions_hash: H256,
 }
 
@@ -146,10 +187,14 @@ pub struct CompactMb {
 /// ancestor to be persisted.
 #[derive(Debug, Clone, Default, Encode, Decode, TypeInfo, PartialEq, Eq, Hash)]
 pub struct MbMeta {
+    /// Set to `true` once the compute pipeline has processed this MB and written
+    /// its per-row state (`mb_program_states`, `mb_outcome`, `mb_schedule`).
     pub computed: bool,
+    /// Hash of the most recent Ethereum block that was advanced up to for this MB.
     pub last_advanced_eb: H256,
 }
 
+/// Read-only access to MB (micro-block) chain storage.
 #[auto_impl::auto_impl(&, Box)]
 pub trait MbStorageRO {
     /// Static identity (parent + height + `transactions_hash`).
@@ -158,48 +203,86 @@ pub trait MbStorageRO {
     fn mb_compact_block(&self, mb_hash: H256) -> Option<CompactMb>;
     /// Read the [`Transactions`] blob from CAS by its content hash.
     fn transactions(&self, transactions_hash: H256) -> Option<Transactions>;
+    /// Returns the program state map produced after executing this MB.
     fn mb_program_states(&self, mb_hash: H256) -> Option<ProgramStates>;
+    /// Returns the list of state transitions that resulted from executing this MB.
     fn mb_outcome(&self, mb_hash: H256) -> Option<Vec<StateTransition>>;
+    /// Returns the task schedule produced by executing this MB.
     fn mb_schedule(&self, mb_hash: H256) -> Option<Schedule>;
+    /// Returns the dynamic metadata for an MB; returns the default value if absent.
     fn mb_meta(&self, mb_hash: H256) -> MbMeta;
 }
 
+/// Read-write access to MB (micro-block) chain storage.
 #[auto_impl::auto_impl(&)]
 pub trait MbStorageRW: MbStorageRO {
+    /// Persists the static identity record for an MB.
     fn set_mb_compact_block(&self, mb_hash: H256, compact: CompactMb);
     /// Write a [`Transactions`] blob into the CAS and return its hash
     /// (the value stored in [`CompactMb::transactions_hash`]).
     fn set_transactions(&self, transactions: Transactions) -> H256;
+    /// Persists the program state map produced after executing an MB.
     fn set_mb_program_states(&self, mb_hash: H256, program_states: ProgramStates);
+    /// Persists the state transition outcome of an MB.
     fn set_mb_outcome(&self, mb_hash: H256, outcome: Vec<StateTransition>);
+    /// Persists the task schedule produced by executing an MB.
     fn set_mb_schedule(&self, mb_hash: H256, schedule: Schedule);
+    /// Mutates the dynamic metadata for an MB in place; creates a default record if absent.
     fn mutate_mb_meta(&self, mb_hash: H256, f: impl FnOnce(&mut MbMeta));
 }
 
+/// Aggregated data for a block that has passed the preparation phase.
+///
+/// Collects all information needed by the compute pipeline: the block header, its
+/// decoded events, the inherited chain-wide bookkeeping (validator era, codes queue,
+/// last committed hashes), so that compute can proceed without further storage reads.
 pub struct PreparedBlockData {
+    /// Header of the prepared Ethereum block.
     pub header: BlockHeader,
+    /// Decoded events emitted in this block.
     pub events: Vec<BlockEvent>,
+    /// Highest era index for which a validator set has been committed on-chain.
     pub latest_era_with_committed_validators: u64,
+    /// Queue of code IDs waiting for on-chain validation commitment.
     pub codes_queue: VecDeque<CodeId>,
+    /// Hash of the last batch commitment submitted to the Router contract.
     pub last_committed_batch: Digest,
+    /// Hash of the last committed MB.
     pub last_committed_mb: H256,
+    /// Hash of the last committed Ethereum block.
     pub last_committed_eb: H256,
 }
 
+/// Static configuration stored in the database at initialization time.
+///
+/// Written once when the node first starts and verified on subsequent starts to
+/// detect database/configuration mismatches.
 #[derive(Debug, Clone, Encode, Decode, TypeInfo, PartialEq, Eq)]
 pub struct DBConfig {
+    /// Database schema version; bumped on breaking schema changes.
     pub version: u32,
+    /// Ethereum chain ID the node is connected to.
     pub chain_id: u64,
+    /// Address of the Router contract on Ethereum.
     pub router_address: Address,
+    /// Protocol timeline configuration (era lengths, transition heights, etc.).
     pub timelines: ProtocolTimelines,
+    /// Hash of the Ethereum block at which the node began syncing.
     pub genesis_block_hash: H256,
+    /// Maximum number of validators allowed per era.
     pub max_validators: u16,
 }
 
+/// Mutable global state persisted in the database and updated as the node advances.
+///
+/// Updated frequently (every block / MB) and read under a `RwLock` via [`GlobalsStorageRO`].
 #[derive(Debug, Clone, Encode, Decode, TypeInfo, PartialEq, Eq)]
 pub struct DBGlobals {
+    /// Hash of the first Ethereum block the node started syncing from.
     pub start_block_hash: H256,
+    /// The latest Ethereum block for which syncing has completed.
     pub latest_synced_eb: SimpleBlockData,
+    /// Hash of the latest Ethereum block that has been fully prepared.
     pub latest_prepared_eb_hash: H256,
     /// Latest MB BFT-finalized by Malachite. Rows
     /// (`mb_program_states`/`mb_outcome`/`mb_schedule`) may not yet
@@ -217,18 +300,24 @@ mod std_interfaces {
     use super::{DBConfig, DBGlobals};
     use std::sync::RwLockReadGuard;
 
+    /// Read-only access to the node's mutable global state under an `RwLock`.
     #[auto_impl::auto_impl(&, Box)]
     pub trait GlobalsStorageRO {
+        /// Returns a shared read guard over the current [`DBGlobals`].
         fn globals(&self) -> RwLockReadGuard<'_, DBGlobals>;
     }
 
+    /// Read-write access to the node's mutable global state under an `RwLock`.
     #[auto_impl::auto_impl(&, Box)]
     pub trait GlobalsStorageRW: GlobalsStorageRO {
+        /// Applies `f` to the [`DBGlobals`] under an exclusive write lock and returns its result.
         fn globals_mutate<R>(&self, f: impl FnMut(&mut DBGlobals) -> R) -> R;
     }
 
+    /// Read-only access to the static [`DBConfig`] stored in the database.
     #[auto_impl::auto_impl(&, Box)]
     pub trait ConfigStorageRO {
+        /// Returns a shared read guard over the [`DBConfig`].
         fn config(&self) -> RwLockReadGuard<'_, DBConfig>;
     }
 }
@@ -240,13 +329,17 @@ pub use std_interfaces::{ConfigStorageRO, GlobalsStorageRO, GlobalsStorageRW};
 mod mock_interfaces {
     use super::{DBConfig, DBGlobals};
 
+    /// Test helper for directly overwriting the stored [`DBGlobals`].
     #[auto_impl::auto_impl(&, Box)]
     pub trait SetGlobals {
+        /// Replaces the stored globals with `globals`.
         fn set_globals(&self, globals: DBGlobals);
     }
 
+    /// Test helper for directly overwriting the stored [`DBConfig`].
     #[auto_impl::auto_impl(&, Box)]
     pub trait SetConfig {
+        /// Replaces the stored config with `config`.
         fn set_config(&self, config: DBConfig);
     }
 }

--- a/ethexe/common/src/events/mirror.rs
+++ b/ethexe/common/src/events/mirror.rs
@@ -9,125 +9,195 @@ use scale_info::TypeInfo;
 
 // TODO: consider to sort events in same way as in IMirror.sol
 
+/// Emitted by a Mirror contract when a user requests to top up its owned (non-executable) balance.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, TypeInfo, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct OwnedBalanceTopUpRequestedEvent {
+    /// Amount of value (in native token units) requested to be added.
     pub value: u128,
 }
 
+/// Emitted by a Mirror contract when a user requests to top up the program's executable balance.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, TypeInfo, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExecutableBalanceTopUpRequestedEvent {
+    /// Amount of value (in native token units) requested to be added.
     pub value: u128,
 }
 
+/// Emitted by a Mirror contract when an outgoing message from the program is successfully delivered.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, TypeInfo, Hash)]
 pub struct MessageEvent {
+    /// Unique identifier of the outgoing message.
     pub id: MessageId,
+    /// Actor the message was sent to.
     pub destination: ActorId,
+    /// Encoded message payload.
     pub payload: Vec<u8>,
+    /// Value transferred with the message (in native token units).
     pub value: u128,
 }
 
+/// Emitted by a Mirror contract when a message call to the destination actor failed.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, TypeInfo, Hash)]
 pub struct MessageCallFailedEvent {
+    /// Unique identifier of the message whose call failed.
     pub id: MessageId,
+    /// Intended destination actor for the failed call.
     pub destination: ActorId,
+    /// Value that was attached to the failed call (in native token units).
     pub value: u128,
 }
 
+/// Emitted by a Mirror contract when a user requests to queue a new message for the program.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, TypeInfo, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct MessageQueueingRequestedEvent {
+    /// Unique identifier assigned to the queued message.
     pub id: MessageId,
+    /// Actor that submitted the queueing request.
     pub source: ActorId,
+    /// Encoded message payload.
     pub payload: Vec<u8>,
+    /// Value attached to the message (in native token units).
     pub value: u128,
+    /// Whether the message is a reply call rather than a plain handle dispatch.
     pub call_reply: bool,
 }
 
+/// Emitted by a Mirror contract when the program sends a reply message successfully.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, TypeInfo, Hash)]
 pub struct ReplyEvent {
+    /// Encoded reply payload.
     pub payload: Vec<u8>,
+    /// Value transferred with the reply (in native token units).
     pub value: u128,
+    /// Identifier of the message this reply is responding to.
     pub reply_to: MessageId,
+    /// Code indicating the outcome of the reply (success, error category, etc.).
     pub reply_code: ReplyCode,
 }
 
+/// Emitted by a Mirror contract when a reply call from the program failed to be delivered.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, TypeInfo, Hash)]
 pub struct ReplyCallFailedEvent {
+    /// Value that was attached to the failed reply (in native token units).
     pub value: u128,
+    /// Identifier of the message that was being replied to.
     pub reply_to: MessageId,
+    /// Code indicating the intended outcome of the reply.
     pub reply_code: ReplyCode,
 }
 
+/// Emitted by a Mirror contract when a user requests to queue a reply to a specific message.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, TypeInfo, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReplyQueueingRequestedEvent {
+    /// Identifier of the message being replied to.
     pub replied_to: MessageId,
+    /// Actor that submitted the reply queueing request.
     pub source: ActorId,
+    /// Encoded reply payload.
     pub payload: Vec<u8>,
+    /// Value attached to the reply (in native token units).
     pub value: u128,
 }
 
+/// Emitted by a Mirror contract after the program's state hash is updated following execution.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, TypeInfo, Hash)]
 pub struct StateChangedEvent {
+    /// New state hash stored in the Mirror after the state transition.
     pub state_hash: H256,
 }
 
+/// Emitted by a Mirror contract when a user successfully claims value from a mailbox message.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, TypeInfo, Hash)]
 pub struct ValueClaimedEvent {
+    /// Identifier of the mailbox message whose value was claimed.
     pub claimed_id: MessageId,
+    /// Amount of value claimed (in native token units).
     pub value: u128,
 }
 
+/// Emitted by a Mirror contract when a user requests to claim value from a mailbox message.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, TypeInfo, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValueClaimingRequestedEvent {
+    /// Identifier of the mailbox message to claim value from.
     pub claimed_id: MessageId,
+    /// Actor that submitted the claim request.
     pub source: ActorId,
 }
 
+/// Emitted by a Mirror contract when transferring locked value to the program's inheritor failed.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, TypeInfo, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct TransferLockedValueToInheritorFailedEvent {
+    /// Actor designated as the inheritor that was the intended recipient.
     pub inheritor: ActorId,
+    /// Amount of value that could not be transferred (in native token units).
     pub value: u128,
 }
 
+/// Emitted by a Mirror contract when the value transfer accompanying a reply failed.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, TypeInfo, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReplyTransferFailedEvent {
+    /// Actor that was the intended recipient of the transferred value.
     pub destination: ActorId,
+    /// Amount of value that failed to transfer (in native token units).
     pub value: u128,
 }
 
+/// Emitted by a Mirror contract when a value claim attempt for a mailbox message failed.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, TypeInfo, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValueClaimFailedEvent {
+    /// Identifier of the mailbox message whose value could not be claimed.
     pub claimed_id: MessageId,
+    /// Amount of value that failed to be claimed (in native token units).
     pub value: u128,
 }
 
+/// All events that a Mirror contract can emit, covering both user requests and execution outcomes.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, TypeInfo, Hash)]
 pub enum Event {
+    /// A user requested to top up the program's owned (non-executable) balance.
     OwnedBalanceTopUpRequested(OwnedBalanceTopUpRequestedEvent),
+    /// A user requested to top up the program's executable balance.
     ExecutableBalanceTopUpRequested(ExecutableBalanceTopUpRequestedEvent),
+    /// The program emitted an outgoing message that was successfully delivered.
     Message(MessageEvent),
+    /// An outgoing message call from the program failed.
     MessageCallFailed(MessageCallFailedEvent),
+    /// A user requested to queue a new message for the program.
     MessageQueueingRequested(MessageQueueingRequestedEvent),
+    /// The program sent a reply message successfully.
     Reply(ReplyEvent),
+    /// A reply call from the program failed.
     ReplyCallFailed(ReplyCallFailedEvent),
+    /// A user requested to queue a reply for the program.
     ReplyQueueingRequested(ReplyQueueingRequestedEvent),
+    /// The program's state hash was updated after execution.
     StateChanged(StateChangedEvent),
+    /// A user successfully claimed value from a mailbox message.
     ValueClaimed(ValueClaimedEvent),
+    /// A user requested to claim value from a mailbox message.
     ValueClaimingRequested(ValueClaimingRequestedEvent),
+    /// Transferring locked value to the program's inheritor failed.
     TransferLockedValueToInheritorFailed(TransferLockedValueToInheritorFailedEvent),
+    /// The value transfer accompanying a reply failed.
     ReplyTransferFailed(ReplyTransferFailedEvent),
+    /// A value claim attempt for a mailbox message failed.
     ValueClaimFailed(ValueClaimFailedEvent),
 }
 
 impl Event {
+    /// Converts this event into a [`RequestEvent`] if it represents a user-initiated request.
+    ///
+    /// Returns `None` for execution-outcome variants (`StateChanged`, `ValueClaimed`,
+    /// `Message`, `MessageCallFailed`, `Reply`, `ReplyCallFailed`,
+    /// `TransferLockedValueToInheritorFailed`, `ReplyTransferFailed`, `ValueClaimFailed`).
     pub fn to_request(self) -> Option<RequestEvent> {
         Some(match self {
             Self::OwnedBalanceTopUpRequested(event) => {
@@ -152,12 +222,21 @@ impl Event {
     }
 }
 
+/// Subset of [`Event`] containing only user-initiated request events from a Mirror contract.
+///
+/// These are the events that drive state transitions on the observer side;
+/// execution-outcome events are excluded. Produced via [`Event::to_request`].
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub enum RequestEvent {
+    /// A user requested to top up the program's owned balance.
     OwnedBalanceTopUpRequested(OwnedBalanceTopUpRequestedEvent),
+    /// A user requested to top up the program's executable balance.
     ExecutableBalanceTopUpRequested(ExecutableBalanceTopUpRequestedEvent),
+    /// A user requested to queue a new message for the program.
     MessageQueueingRequested(MessageQueueingRequestedEvent),
+    /// A user requested to queue a reply for the program.
     ReplyQueueingRequested(ReplyQueueingRequestedEvent),
+    /// A user requested to claim value from a mailbox message.
     ValueClaimingRequested(ValueClaimingRequestedEvent),
 }

--- a/ethexe/common/src/events/mod.rs
+++ b/ethexe/common/src/events/mod.rs
@@ -5,28 +5,36 @@ use gprimitives::ActorId;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 
+/// Events emitted by the Mirror contract (per-program proxy on Ethereum).
 pub mod mirror;
+/// Events emitted by the Router contract (central co-processor contract on Ethereum).
 pub mod router;
+/// Events emitted by the WrappedVara ERC-20 token contract.
 pub mod wvara;
 
 pub use mirror::{Event as MirrorEvent, RequestEvent as MirrorRequestEvent};
 pub use router::{Event as RouterEvent, RequestEvent as RouterRequestEvent};
 pub use wvara::Event as WVaraEvent;
 
+/// A decoded on-chain event originating from either a Mirror or the Router contract within a single Ethereum block.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, TypeInfo, Hash)]
 pub enum BlockEvent {
+    /// An event emitted by the Mirror contract at the given `actor_id`.
     Mirror {
         actor_id: ActorId,
         event: MirrorEvent,
     },
+    /// An event emitted by the Router contract.
     Router(RouterEvent),
 }
 
 impl BlockEvent {
+    /// Constructs a [`BlockEvent::Mirror`] variant from the given actor and event.
     pub fn mirror(actor_id: ActorId, event: MirrorEvent) -> Self {
         Self::Mirror { actor_id, event }
     }
 
+    /// Converts this event into a [`BlockRequestEvent`] if it represents an action that requires processing, returning `None` for purely informational events.
     pub fn to_request(self) -> Option<BlockRequestEvent> {
         Some(match self {
             Self::Mirror { actor_id, event } => BlockRequestEvent::Mirror {
@@ -50,10 +58,13 @@ impl From<RouterEvent> for BlockEvent {
     }
 }
 
+/// A subset of [`BlockEvent`] containing only events that represent actionable requests requiring computation or state changes.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub enum BlockRequestEvent {
+    /// A request-type event from the Router contract.
     Router(RouterRequestEvent),
+    /// A request-type event from the Mirror contract at the given `actor_id`.
     Mirror {
         actor_id: ActorId,
         event: MirrorRequestEvent,
@@ -61,6 +72,7 @@ pub enum BlockRequestEvent {
 }
 
 impl BlockRequestEvent {
+    /// Constructs a [`BlockRequestEvent::Mirror`] variant from the given actor and event.
     pub fn mirror(actor_id: ActorId, event: MirrorRequestEvent) -> Self {
         Self::Mirror { actor_id, event }
     }

--- a/ethexe/common/src/events/router.rs
+++ b/ethexe/common/src/events/router.rs
@@ -8,8 +8,13 @@ use scale_info::TypeInfo;
 
 // TODO: consider to sort events in same way as in IRouter.sol
 
+/// Emitted when all commitments in a batch have been applied on-chain.
+///
+/// Carries the Keccak256 `digest` of the committed batch, matching
+/// the `Gear.batchCommitmentHash(...)` value from the Router contract.
 #[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BatchCommittedEvent {
+    /// Keccak256 digest of the committed batch.
     pub digest: Digest,
 }
 
@@ -22,61 +27,101 @@ pub struct MBCommittedEvent(pub H256);
 #[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EBCommittedEvent(pub H256);
 
+/// Emitted when a previously requested code validation completes and its `CodeState` changes.
 #[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CodeGotValidatedEvent {
+    /// Blake2b hash of the WASM blob that was validated.
     pub code_id: CodeId,
+    /// `true` if the code is valid and may be used for program creation.
     pub valid: bool,
 }
 
+/// Requesting event signalling that validators must download and validate a WASM code blob
+/// referenced by the given transaction.
 #[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct CodeValidationRequestedEvent {
+    /// Expected blake2b hash of the WASM blob.
     pub code_id: CodeId,
+    /// Block timestamp at which the request was submitted.
     pub timestamp: u64,
+    /// Ethereum transaction hash containing the blob to validate.
     pub tx_hash: H256,
 }
 
+/// Emitted when an on-chain authority updates the Router's computation settings.
+///
+/// Validators must apply the new settings starting from the next block.
 #[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct ComputationSettingsChangedEvent {
+    /// Gas threshold per computation unit; the default mirrors [`COMPUTATION_THRESHOLD`](crate::gear::COMPUTATION_THRESHOLD) (2_500_000_000) from the Router contract.
     pub threshold: u64,
+    /// Amount of WVara charged from a program's execution balance per second of computation.
     pub wvara_per_second: u128,
 }
 
+/// Emitted when a new program is created in the co-processor and its Ethereum Mirror deployed.
+///
+/// Validators must initialize the program with a zeroed state hash internally.
 #[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct ProgramCreatedEvent {
+    /// Identifier of the newly created program.
     pub actor_id: ActorId,
+    /// Blake2b hash of the WASM code used to create the program.
     pub code_id: CodeId,
 }
 
+/// Emitted when the Router's storage slot is wiped, invalidating all previously existing codes
+/// and programs. Validators must wipe their databases immediately upon receiving this event.
 #[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct StorageSlotChangedEvent {
+    /// The new storage slot value after the wipe.
     pub slot: H256,
 }
 
+/// Emitted when the validator set for an upcoming era has been committed on-chain.
+///
+/// Serves as both an informational and requesting event: validators must apply the new
+/// set internally at the start of the indicated era.
 #[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValidatorsCommittedForEraEvent {
+    /// Zero-based index of the era for which the validator set was committed.
     pub era_index: u64,
 }
 
+/// All events that can be emitted by the Router contract and observed by the off-chain layer.
 #[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Event {
+    /// A batch of state transitions was committed on-chain.
     BatchCommitted(BatchCommittedEvent),
+    /// The announces chain head was committed; updates `last_committed_mb`.
     MBCommitted(MBCommittedEvent),
+    /// Latest folded-in Ethereum block hash was committed; updates `last_committed_eb`.
     EBCommitted(EBCommittedEvent),
+    /// A code validation request was resolved with a pass/fail result.
     CodeGotValidated(CodeGotValidatedEvent),
+    /// A new code validation request was submitted by a user.
     CodeValidationRequested(CodeValidationRequestedEvent),
+    /// The Router's computation settings (gas threshold and WVara rate) were updated.
     ComputationSettingsChanged(ComputationSettingsChangedEvent),
+    /// A new program and its Mirror contract were created.
     ProgramCreated(ProgramCreatedEvent),
     // TODO: on review ask about backward compatibility
+    /// The Router's storage slot changed, invalidating all prior state.
     StorageSlotChanged(StorageSlotChangedEvent),
+    /// The validator set for an upcoming era was committed.
     ValidatorsCommittedForEra(ValidatorsCommittedForEraEvent),
 }
 
 impl Event {
+    /// Converts this event into a [`RequestEvent`] if it carries an actionable validator request.
+    ///
+    /// Returns `None` for purely informational events (`BatchCommitted`, `MBCommitted`,
+    /// `EBCommitted`, `CodeGotValidated`) that require no validator action.
     pub fn to_request(self) -> Option<RequestEvent> {
         Some(match self {
             Self::CodeValidationRequested(event) => RequestEvent::CodeValidationRequested(event),
@@ -96,12 +141,20 @@ impl Event {
     }
 }
 
+/// Subset of [`Event`] variants that require an active validator response or state change.
+///
+/// Purely informational events (batch/MB/EB committed, code got validated) are excluded.
 #[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub enum RequestEvent {
+    /// Validators must download and validate the referenced WASM blob.
     CodeValidationRequested(CodeValidationRequestedEvent),
+    /// Validators must apply updated gas threshold and WVara rate from the next block.
     ComputationSettingsChanged(ComputationSettingsChangedEvent),
+    /// Validators must initialize a new program with a zeroed state hash.
     ProgramCreated(ProgramCreatedEvent),
+    /// Validators must wipe their databases due to a storage slot reset.
     StorageSlotChanged(StorageSlotChangedEvent),
+    /// Validators must register the new validator set for the given era.
     ValidatorsCommittedForEra(ValidatorsCommittedForEraEvent),
 }

--- a/ethexe/common/src/events/wvara.rs
+++ b/ethexe/common/src/events/wvara.rs
@@ -4,22 +4,33 @@
 use gprimitives::{ActorId, U256};
 use parity_scale_codec::{Decode, Encode};
 
+/// Decoded representation of a WrappedVara ERC-20 `Transfer` log entry.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, Hash)]
 pub struct TransferEvent {
+    /// Sender of the tokens.
     pub from: ActorId,
+    /// Recipient of the tokens.
     pub to: ActorId,
+    /// Amount of tokens transferred, in the token's base unit.
     pub value: u128,
 }
 
+/// Decoded representation of a WrappedVara ERC-20 `Approval` log entry.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, Hash)]
 pub struct ApprovalEvent {
+    /// Token holder granting the allowance.
     pub owner: ActorId,
+    /// Address authorized to spend tokens on behalf of `owner`.
     pub spender: ActorId,
+    /// Approved spending allowance.
     pub value: U256,
 }
 
+/// A decoded WrappedVara ERC-20 contract event, re-exported as `WVaraEvent` from the parent module.
 #[derive(Clone, Debug, PartialEq, Eq, Decode, Encode, Hash)]
 pub enum Event {
+    /// A token transfer occurred.
     Transfer(TransferEvent),
+    /// A spending allowance was set or updated.
     Approval(ApprovalEvent),
 }

--- a/ethexe/common/src/gear.rs
+++ b/ethexe/common/src/gear.rs
@@ -13,7 +13,9 @@ use scale_info::TypeInfo;
 use sha3::Digest as _;
 
 // TODO: support query from router.
+/// Default gas threshold for a single computation unit, measured in gas units.
 pub const COMPUTATION_THRESHOLD: u64 = 2_500_000_000;
+/// Token reward rate expressed as wVARA (the smallest unit) emitted per second of computation.
 pub const WVARA_PER_SECOND: u128 = 10_000_000_000_000;
 
 /// Gas limit for chunk processing.
@@ -27,23 +29,33 @@ pub const MAX_BLOCK_GAS_LIMIT: u64 = 9_000_000_000_000;
 /// [`CANONICAL_QUARANTINE`] defines the period of blocks to wait before applying canonical events.
 pub const CANONICAL_QUARANTINE: u8 = 16;
 
+/// Aggregated FROST public key represented as an affine point on the elliptic curve.
 #[derive(Clone, Debug, Default, Encode, Decode, PartialEq, Eq)]
 pub struct AggregatedPublicKey {
+    /// X coordinate of the public key point.
     pub x: U256,
+    /// Y coordinate of the public key point.
     pub y: U256,
 }
 
+/// Discriminator for the signature scheme used in a validator commitment.
 #[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
 #[repr(u8)]
 pub enum SignatureType {
+    /// Flexible Round-Optimized Schnorr Threshold (FROST) multi-party signature.
     FROST,
+    /// Standard Ethereum ECDSA signature.
     ECDSA,
 }
 
+/// On-chain addresses of the core ethexe contracts used by the router.
 #[derive(Clone, Debug, Default, Encode, Decode, PartialEq, Eq)]
 pub struct AddressBook {
+    /// Address of the Mirror contract implementation.
     pub mirror: ActorId,
+    /// Address of the Mirror proxy (cloneable beacon).
     pub mirror_proxy: ActorId,
+    /// Address of the WrappedVara ERC-20 contract.
     pub wrapped_vara: ActorId,
 }
 
@@ -51,8 +63,11 @@ pub struct AddressBook {
 /// advanced Ethereum block hash, zero if no ethereum block has been advanced.
 #[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
 pub struct ChainCommitment {
+    /// Ordered list of program state transitions included in this commitment.
     pub transitions: Vec<StateTransition>,
+    /// Hash of the Gear chain head block covered by this commitment.
     pub head: H256,
+    /// Hash of the most recent Ethereum block that has been advanced; zero if none.
     pub last_advanced_eth_block: H256,
 }
 
@@ -70,9 +85,12 @@ impl ToDigest for ChainCommitment {
     }
 }
 
+/// Validator commitment recording whether a given code blob passed validation.
 #[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
 pub struct CodeCommitment {
+    /// Identifier of the code blob being committed.
     pub id: CodeId,
+    /// `true` if the code passed validation; `false` if it was rejected.
     pub valid: bool,
 }
 
@@ -86,9 +104,12 @@ impl ToDigest for CodeCommitment {
     }
 }
 
+/// Commitment to the total operator rewards for a batch, with a Merkle root for individual claims.
 #[derive(Clone, Debug, Default, Encode, Decode, PartialEq, Eq)]
 pub struct OperatorRewardsCommitment {
+    /// Total reward amount distributed to operators.
     pub amount: U256,
+    /// Merkle root of the per-operator reward tree used to verify individual claims.
     pub root: H256,
 }
 
@@ -101,16 +122,23 @@ impl ToDigest for OperatorRewardsCommitment {
     }
 }
 
+/// Reward allocation for a single staker vault.
 #[derive(Clone, Debug, Default, Encode, Decode, PartialEq, Eq)]
 pub struct StakerRewards {
+    /// Ethereum address of the vault receiving the rewards.
     pub vault: Address,
+    /// Amount of rewards allocated to this vault.
     pub amount: U256,
 }
 
+/// Commitment to the full staker reward distribution for a batch.
 #[derive(Clone, Debug, Default, Encode, Decode, PartialEq, Eq)]
 pub struct StakerRewardsCommitment {
+    /// Per-vault reward allocations that sum to `total_amount`.
     pub distribution: Vec<StakerRewards>,
+    /// Total reward amount across all vaults.
     pub total_amount: U256,
+    /// Address of the ERC-20 token in which rewards are denominated.
     pub token: Address,
 }
 
@@ -134,9 +162,12 @@ impl ToDigest for StakerRewardsCommitment {
     }
 }
 
+/// Combined reward commitment covering both operator and staker reward distributions for a batch.
 #[derive(Clone, Debug, Default, Encode, Decode, PartialEq, Eq)]
 pub struct RewardsCommitment {
+    /// Reward commitment for node operators.
     pub operators: OperatorRewardsCommitment,
+    /// Reward commitment for stakers across vaults.
     pub stakers: StakerRewardsCommitment,
     /// Rewards for timestamp. Represented as u48 in router contract.
     pub timestamp: u64,
@@ -178,9 +209,13 @@ pub struct BatchCommitment {
     /// ... etc.
     pub expiry: u8,
 
+    /// Optional commitment to chain state transitions; absent when no programs were executed.
     pub chain_commitment: Option<ChainCommitment>,
+    /// Commitments to code blob validation results included in this batch.
     pub code_commitments: Vec<CodeCommitment>,
+    /// Optional commitment to a validator set change; absent when the set is unchanged.
     pub validators_commitment: Option<ValidatorsCommitment>,
+    /// Optional commitment to reward distributions; absent when no rewards are issued.
     pub rewards_commitment: Option<RewardsCommitment>,
 }
 
@@ -209,20 +244,29 @@ impl ToDigest for BatchCommitment {
     }
 }
 
+/// Block-count durations governing era rotation, validator election, and validation scheduling.
 #[derive(Clone, Debug, Default, Encode, Decode, PartialEq, Eq)]
 pub struct Timelines {
+    /// Number of Ethereum blocks in one era.
     pub era: u64,
+    /// Number of blocks before era end at which the election is held.
     pub election: u64,
+    /// Number of blocks to wait after a chain head before requesting validation.
     pub validation_delay: u64,
 }
 
+/// Commitment to a new validator set, including the FROST key material and era index.
 #[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
 pub struct ValidatorsCommitment {
     /// Does the batch have aggregated public key in validators commitment.
     pub has_aggregated_public_key: bool,
+    /// Combined FROST public key for the new validator set; meaningful only when `has_aggregated_public_key` is `true`.
     pub aggregated_public_key: AggregatedPublicKey,
+    /// Raw bytes of the verifiable secret-sharing commitment for the DKG round.
     pub verifiable_secret_sharing_commitment: Vec<u8>,
+    /// Ordered list of Ethereum addresses of the new validators.
     pub validators: ValidatorsVec,
+    /// Index of the era that this validator set will govern.
     pub era_index: u64,
 }
 
@@ -256,11 +300,15 @@ impl ToDigest for ValidatorsCommitment {
     }
 }
 
+/// Tracks the validation lifecycle of a code blob on-chain.
 #[derive(Clone, Copy, Debug, Default, Encode, Decode, PartialEq, Eq)]
 pub enum CodeState {
+    /// The code has not been seen or its state is unrecognized.
     #[default]
     Unknown,
+    /// Validation of the code has been requested but not yet committed.
     ValidationRequested,
+    /// The code has been validated and accepted by the validator set.
     Validated,
 }
 
@@ -276,27 +324,39 @@ impl From<u8> for CodeState {
     }
 }
 
+/// Identifies the last Ethereum block that was fully committed by the router.
 #[derive(Clone, Debug, Default, Encode, Decode, PartialEq, Eq)]
 pub struct CommittedBlockInfo {
+    /// Hash of the committed Ethereum block.
     pub hash: H256,
     /// represented as u48 in router contract.
     pub timestamp: u64,
 }
 
+/// On-chain parameters controlling how computation costs are priced and billed.
 #[derive(Clone, Debug, Default, Encode, Decode, PartialEq, Eq)]
 pub struct ComputationSettings {
+    /// Gas threshold per computation unit; mirrors `COMPUTATION_THRESHOLD` when read from the router.
     pub threshold: u64,
+    /// wVARA token units charged per second of computation; mirrors `WVARA_PER_SECOND`.
     pub wvara_per_second: u128,
 }
 
+/// A Gear message included in a [`StateTransition`], mirroring the on-chain `Gear.Message` struct.
 #[derive(Clone, Debug, Default, Encode, Decode, TypeInfo, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct Message {
+    /// Unique identifier of the message.
     pub id: MessageId,
+    /// Program or user account that should receive the message.
     pub destination: ActorId,
+    /// Encoded message payload bytes.
     pub payload: Vec<u8>,
+    /// Value (in the smallest token unit) attached to the message.
     pub value: u128,
+    /// Present when the message is a reply; carries the origin message id and reply code.
     pub reply_details: Option<ReplyDetails>,
+    /// When `true`, the message is treated as a synchronous call rather than an async send.
     pub call: bool,
 }
 
@@ -329,6 +389,7 @@ impl ToDigest for Message {
 }
 
 impl Message {
+    /// Converts a `StoredMessage` into a [`Message`], discarding the source and setting `call`.
     pub fn from_stored(value: StoredMessage, call: bool) -> Self {
         let (id, _source, destination, payload, value, details) = value.into_parts();
         Self {
@@ -342,20 +403,27 @@ impl Message {
     }
 }
 
+/// Aggregate protocol counters read from the router contract.
 #[derive(Clone, Debug, Default, Encode, Decode, PartialEq, Eq)]
 pub struct ProtocolData {
     // flatten mapping of codes CodeId => CodeState
     // flatten mapping of program to codes ActorId => CodeId
+    /// Total number of programs registered in the router.
     pub programs_count: U256,
+    /// Number of code blobs that have been successfully validated.
     pub validated_codes_count: U256,
 }
 
 #[derive(Clone, Debug, Default, Encode, Decode, TypeInfo, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct StateTransition {
+    /// Identifier of the program whose state changed.
     pub actor_id: ActorId,
+    /// Hash of the program's new state after execution.
     pub new_state_hash: H256,
+    /// `true` when the program called `gr_exit` and is no longer active.
     pub exited: bool,
+    /// Program that inherits the exited program's balance; zero address if not applicable.
     pub inheritor: ActorId,
     /// We represent `value_to_receive` as `u128` and `bool` because each non-zero byte costs 16 gas,
     /// and each zero byte costs 4 gas (see <https://evm.codes/about#gascosts>).
@@ -400,11 +468,15 @@ impl ToDigest for StateTransition {
     }
 }
 
+/// A request to transfer value from an expired or claimed mailbox message to a destination.
 #[derive(Clone, Debug, Default, Encode, Decode, TypeInfo, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValueClaim {
+    /// Identifier of the mailbox message whose value is being claimed.
     pub message_id: MessageId,
+    /// Address that should receive the claimed value.
     pub destination: ActorId,
+    /// Amount of value (in smallest token unit) to transfer.
     pub value: u128,
 }
 
@@ -422,6 +494,7 @@ impl ToDigest for ValueClaim {
     }
 }
 
+/// Distinguishes messages that originate from the canonical Gear chain from those injected externally.
 #[derive(
     Clone,
     Copy,
@@ -438,15 +511,21 @@ impl ToDigest for ValueClaim {
 )]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub enum MessageType {
+    /// Message produced by normal Gear chain execution.
     #[default]
     Canonical,
+    /// Message injected from an external source (e.g., an Ethereum cross-chain call).
     Injected,
 }
 
+/// Identifying information about the Ethereum genesis block used to anchor the ethexe deployment.
 #[derive(Debug)]
 pub struct GenesisBlockInfo {
+    /// Hash of the genesis Ethereum block.
     pub hash: H256,
+    /// Block number of the genesis Ethereum block.
     pub number: u32,
+    /// Unix timestamp of the genesis Ethereum block, in seconds.
     pub timestamp: u64,
 }
 

--- a/ethexe/common/src/hash.rs
+++ b/ethexe/common/src/hash.rs
@@ -28,6 +28,10 @@ fn shortname<T: Any>() -> &'static str {
         .expect("name is empty")
 }
 
+/// A typed wrapper around [`H256`] that carries phantom type information about what was hashed.
+///
+/// The phantom type `T` prevents accidentally mixing hashes of different content types at
+/// compile time. Serialization, encoding, and ordering ignore `T` and operate on the raw hash.
 #[derive(Encode, Decode, TypeInfo, derive_more::Into, derive_more::Display)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(transparent))]
@@ -102,6 +106,7 @@ impl<T> HashOf<T> {
         self.hash
     }
 
+    /// Returns a [`HashOf<T>`] whose underlying hash is all zeros.
     pub fn zero() -> Self {
         Self {
             hash: H256::zero(),
@@ -109,6 +114,7 @@ impl<T> HashOf<T> {
         }
     }
 
+    /// Returns a [`HashOf<T>`] with a cryptographically random underlying hash.
     #[cfg(feature = "mock")]
     pub fn random() -> Self {
         Self {
@@ -124,6 +130,8 @@ impl<T> Default for HashOf<T> {
     }
 }
 
+/// An optional typed hash: a newtype over `Option<HashOf<T>>` that represents a hash which may
+/// be absent (e.g., a parent pointer for the genesis block or an unset field).
 #[derive(
     Encode, Decode, PartialEq, Eq, derive_more::Into, derive_more::From, derive_more::Display,
 )]
@@ -157,30 +165,37 @@ impl<T> Hash for MaybeHashOf<T> {
 }
 
 impl<T> MaybeHashOf<T> {
+    /// Returns a [`MaybeHashOf<T>`] with no hash present.
     pub const fn empty() -> Self {
         Self(None)
     }
 
+    /// Returns `true` if no hash is present.
     pub const fn is_empty(&self) -> bool {
         self.0.is_none()
     }
 
+    /// Constructs a [`MaybeHashOf<T>`] from an `Option<HashOf<T>>`.
     pub fn from_inner(inner: Option<HashOf<T>>) -> Self {
         Self(inner)
     }
 
+    /// Returns the contained `Option<HashOf<T>>`.
     pub fn to_inner(self) -> Option<HashOf<T>> {
         self.0
     }
 
+    /// Applies `f` to the inner [`HashOf<T>`] if present, returning `None` otherwise.
     pub fn map<U>(&self, f: impl FnOnce(HashOf<T>) -> U) -> Option<U> {
         self.to_inner().map(f)
     }
 
+    /// Applies `f` to the inner hash if present; returns `U::default()` when absent.
     pub fn map_or_default<U: Default>(&self, f: impl FnOnce(HashOf<T>) -> U) -> U {
         self.map(f).unwrap_or_default()
     }
 
+    /// Applies a fallible `f` to the inner hash if present; returns `Ok(U::default())` when absent.
     pub fn try_map_or_default<U: Default>(
         &self,
         f: impl FnOnce(HashOf<T>) -> Result<U>,
@@ -188,6 +203,7 @@ impl<T> MaybeHashOf<T> {
         self.map(f).unwrap_or_else(|| Ok(Default::default()))
     }
 
+    /// Replaces `self` with `other` if `other` is `Some`; leaves `self` unchanged when `other` is `None`.
     pub fn replace(&mut self, other: Option<Self>) {
         if let Some(other) = other {
             *self = other;

--- a/ethexe/common/src/injected.rs
+++ b/ethexe/common/src/injected.rs
@@ -30,10 +30,16 @@ pub const MAX_INJECTED_TX_SALT_SIZE: usize = 32;
 /// always admissible.
 pub const MAX_INJECTED_TRANSACTIONS_SIZE_PER_MB: usize = 127 * 1024;
 
+/// Outcome returned by a node when it receives a [`SignedInjectedTransaction`].
+///
+/// Callers use this to decide whether to keep a promise subscription open:
+/// only `Accept` guarantees a future reply.
 #[cfg_attr(feature = "std", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Debug, Clone, Encode, Decode, Eq, PartialEq)]
 pub enum InjectedTransactionAcceptance {
+    /// Transaction was accepted into the local mempool for the first time.
     Accept,
+    /// Transaction was rejected and will not be executed; no promise will follow.
     Reject { reason: String },
 }
 
@@ -48,17 +54,24 @@ impl<E: ToString> From<Result<(), E>> for InjectedTransactionAcceptance {
     }
 }
 
+/// An [`InjectedTransaction`] bundled with its ECDSA signature and sender address.
 pub type SignedInjectedTransaction = SignedMessage<InjectedTransaction>;
 
+/// A [`SignedInjectedTransaction`] paired with the validator it is directed to.
 #[cfg_attr(feature = "std", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", derive(Hash))]
 #[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
 pub struct AddressedInjectedTransaction {
     /// Address of validator the transaction intended for
     pub recipient: Address,
+    /// The signed transaction payload addressed to `recipient`.
     pub tx: SignedInjectedTransaction,
 }
 
+/// A cross-chain message injected from Ethereum into the Gear runtime.
+///
+/// The `MessageId` derived from this transaction equals its hash (`tx_hash`).
+/// Use [`InjectedTransaction::to_message_id`] to obtain it.
 /// IMPORTANT: message id == tx hash.
 #[cfg_attr(feature = "std", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", derive(Hash))]
@@ -175,7 +188,9 @@ impl ToDigest for Promise {
 /// The hashes of [`Promise`] parts.
 #[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
 pub struct CompactPromise {
+    /// Hash of the [`InjectedTransaction`] this promise corresponds to.
     pub tx_hash: HashOf<InjectedTransaction>,
+    /// `blake2b` hash of the full [`ReplyInfo`] body.
     pub reply_hash: HashOf<ReplyInfo>,
 }
 
@@ -198,7 +213,12 @@ mod sealed {
     impl Sealed for super::CompactPromise {}
 }
 
+/// Sealed marker trait implemented by [`Promise`] and [`CompactPromise`].
+///
+/// Provides uniform access to the originating transaction hash regardless of
+/// which promise representation is stored in a [`Receipt`].
 pub trait PromiseKind: sealed::Sealed {
+    /// Returns the hash of the [`InjectedTransaction`] this promise covers.
     fn tx_hash(&self) -> HashOf<InjectedTransaction>;
 }
 
@@ -230,12 +250,14 @@ impl PromiseKind for CompactPromise {
 )]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub enum Receipt<P> {
+    /// The transaction was executed and a reply promise is available.
     Promise(P),
     /// No promise, transaction wasn't executed.
     Purged(PurgedTransaction),
 }
 
 impl<P: PromiseKind> Receipt<P> {
+    /// Returns the hash of the [`InjectedTransaction`] this receipt covers.
     pub fn tx_hash(&self) -> HashOf<InjectedTransaction> {
         match self {
             Self::Promise(promise) => promise.tx_hash(),
@@ -315,6 +337,10 @@ pub enum TryFillPromiseResult {
 }
 
 impl UnfilledPromiseReceipt {
+    /// Attempts to upgrade this receipt to a [`SignedTxReceipt`] using the full `promise` body.
+    ///
+    /// Returns [`TryFillPromiseResult::HashesMismatch`] if `promise` does not match the stored
+    /// compact hashes; returns [`TryFillPromiseResult::Filled`] on success.
     pub fn try_fill_with(self, promise: Promise) -> TryFillPromiseResult {
         if self.0 != promise.to_compact() {
             return TryFillPromiseResult::HashesMismatch(self);
@@ -332,7 +358,9 @@ impl UnfilledPromiseReceipt {
 #[cfg_attr(feature = "std", derive(serde::Deserialize, serde::Serialize))]
 #[display("Injected transaction wasn't executed: tx_hash={tx_hash}, reason={reason}")]
 pub struct PurgedTransaction {
+    /// Hash of the transaction that was not executed.
     pub tx_hash: HashOf<InjectedTransaction>,
+    /// Reason the transaction was dropped without execution.
     pub reason: TransactionPurgedReason,
 }
 
@@ -366,6 +394,7 @@ pub enum TransactionPurgedReason {
 }
 
 impl TransactionPurgedReason {
+    /// Returns the `#[repr(u8)]` discriminant of this variant, used in digest hashing.
     pub fn variant_index(&self) -> u8 {
         *self as u8
     }

--- a/ethexe/common/src/lib.rs
+++ b/ethexe/common/src/lib.rs
@@ -68,18 +68,26 @@
 
 extern crate alloc;
 
+/// Validation request/reply messages and timeline helpers for the 2-of-3 batch commitment protocol.
 pub mod consensus;
+/// Storage trait abstractions (`*StorageRO` / `*StorageRW`) and block-metadata types; concrete backends live in `ethexe-db`.
 pub mod db;
+/// On-chain event model: `BlockEvent` (Mirror/Router variants) and the `WVaraEvent` token-event type.
 pub mod events;
+/// Protocol commitment types (`BatchCommitment`, `ChainCommitment`, `CodeCommitment`, etc.) and `StateTransition`.
 pub mod gear;
 mod hash;
+/// Injected transactions, promises, and receipts for inbound cross-chain messaging.
 pub mod injected;
+/// Sequencer block-payload shape (`Transactions`, `Transaction`) consumed by the compute layer.
 pub mod malachite;
+/// Validator network messages (`ValidatorMessage` and signed/verified variants).
 pub mod network;
 mod primitives;
 mod utils;
 mod validators;
 
+/// Test helpers and proptest fixtures (enabled by the `mock` feature).
 #[cfg(feature = "mock")]
 pub mod mock;
 
@@ -88,6 +96,7 @@ pub use gsigner::{
     SignedData, SignedMessage, ToDigest, VerifiedData,
 };
 pub use validators::{EmptyValidatorsError, ValidatorsVec};
+/// secp256k1 crypto re-exports from `gsigner` for use without the full `gsigner` dependency surface.
 pub mod ecdsa {
     pub use gsigner::secp256k1::{
         ContractSignature, PrivateKey, PublicKey, Signature, SignedData, SignedMessage,
@@ -115,7 +124,11 @@ pub const DEFAULT_COMMITMENT_DELAY_LIMIT: core::num::NonZero<u8> =
 pub const MAX_TOUCHED_PROGRAMS_PER_MB: u32 = 128;
 
 // Soft limits for one MB processing. Stops execution if any of them is exceeded.
+/// Maximum number of outgoing messages produced by a single MB before execution stops.
 pub const OUTGOING_MESSAGES_SOFT_LIMIT: u32 = 128;
+/// Maximum total byte size of outgoing messages produced by a single MB before execution stops.
 pub const OUTGOING_MESSAGES_BYTES_SOFT_LIMIT: u32 = 32 * 1024;
+/// Maximum number of call-reply messages produced by a single MB before execution stops.
 pub const CALL_REPLY_SOFT_LIMIT: u32 = 4;
+/// Maximum number of program state modifications allowed per MB; half of [`MAX_TOUCHED_PROGRAMS_PER_MB`].
 pub const PROGRAM_MODIFICATIONS_SOFT_LIMIT: u32 = MAX_TOUCHED_PROGRAMS_PER_MB / 2;

--- a/ethexe/common/src/malachite.rs
+++ b/ethexe/common/src/malachite.rs
@@ -51,6 +51,7 @@ pub struct ProgressTasksLimits {}
 #[derive(Clone, Debug, Default, PartialEq, Eq, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct ProcessQueuesLimits {
+    /// Maximum gas the executor may consume while draining message queues in this block.
     pub gas_allowance: u64,
 }
 
@@ -74,6 +75,7 @@ impl Transaction {
 pub struct Transactions(pub Vec<Transaction>);
 
 impl Transactions {
+    /// Wraps an ordered list of transactions into a [`Transactions`] block payload.
     pub fn new(transactions: Vec<Transaction>) -> Self {
         Self(transactions)
     }

--- a/ethexe/common/src/mock.rs
+++ b/ethexe/common/src/mock.rs
@@ -46,7 +46,13 @@ where
         .current()
 }
 
+/// Constructs a mock value of `Self` from the given `args`.
+///
+/// Implemented automatically for every type that satisfies `Arbitrary` via the
+/// blanket impl below. Explicit impls are provided for types that need custom
+/// behaviour (e.g. [`Promise`]).
 pub trait Mock<Args = ()> {
+    /// Returns a mock instance of `Self`.
     fn mock(args: Args) -> Self;
 }
 
@@ -60,6 +66,10 @@ where
     }
 }
 
+/// Parameters controlling how a [`BlockHeader`] mock is generated.
+///
+/// When `parent_hash` is `None` a random value is chosen; supply a concrete
+/// hash to produce a header that chains from a known predecessor.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct BlockHeaderParams {
     parent_hash: Option<H256>,
@@ -79,6 +89,10 @@ impl From<H256> for BlockHeaderParams {
     }
 }
 
+/// Parameters controlling how a [`ChainCommitment`] mock is generated.
+///
+/// When `head` is `None` a random block hash is used; supply one to anchor the
+/// commitment to a known chain head.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ChainCommitmentParams {
     head: Option<H256>,
@@ -96,6 +110,10 @@ impl From<H256> for ChainCommitmentParams {
     }
 }
 
+/// Parameters controlling how a [`BlockChain`] mock is generated.
+///
+/// `len` is the number of non-genesis blocks; `validators` is the validator set
+/// written to the DB for each era that the generated blocks span.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct BlockChainParams {
     len: u32,
@@ -117,6 +135,10 @@ impl From<(u32, ValidatorsVec)> for BlockChainParams {
     }
 }
 
+/// Parameters controlling how an [`AddressedInjectedTransaction`] mock is generated.
+///
+/// When `signer` is `None` a random secp256k1 private key is drawn; supply one
+/// to produce a transaction signed by a known key.
 #[derive(Debug, Clone, Default)]
 pub struct AddressedInjectedTransactionParams {
     signer: Option<PrivateKey>,
@@ -182,6 +204,7 @@ fn limited_bytes_strategy<const N: usize>(
         .boxed()
 }
 
+/// Returns a proptest strategy that generates an arbitrary [`ScheduledTask`] variant.
 pub fn scheduled_task_strategy() -> BoxedStrategy<ScheduledTask> {
     prop_oneof![
         (
@@ -219,6 +242,8 @@ pub fn scheduled_task_strategy() -> BoxedStrategy<ScheduledTask> {
     .boxed()
 }
 
+/// Returns a proptest strategy that generates an arbitrary [`Schedule`] (a `BTreeMap` of
+/// block-number to task sets).
 pub fn schedule_strategy() -> BoxedStrategy<Schedule> {
     collection::btree_map(
         any::<u32>(),
@@ -484,47 +509,66 @@ impl Mock<HashOf<InjectedTransaction>> for Promise {
     }
 }
 
+/// On-chain data available after a block has been synced from Ethereum.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SyncedBlockData {
+    /// The block header (height, timestamp, parent hash).
     pub header: BlockHeader,
+    /// Decoded on-chain events emitted in this block.
     pub events: Vec<BlockEvent>,
 }
 
+/// Data recorded after the block preparation phase has completed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PreparedBlockData {
+    /// Queue of code IDs awaiting on-chain validation at this block.
     pub codes_queue: VecDeque<CodeId>,
+    /// Digest of the last batch commitment committed before this block.
     pub last_committed_batch: Digest,
+    /// Hash of the last committed micro-block at this block height.
     pub last_committed_mb: H256,
 }
 
+/// Complete mock representation of a single Ethereum block, combining both
+/// synced and preparation-phase data used by tests that drive the full pipeline.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockFullData {
+    /// Block hash.
     pub hash: H256,
+    /// Data available after the sync phase; `None` if not yet synced.
     pub synced: Option<SyncedBlockData>,
+    /// Data available after the preparation phase; `None` if not yet prepared.
     pub prepared: Option<PreparedBlockData>,
 }
 
 impl BlockFullData {
+    /// Returns the synced data. Panics if the block has not been synced.
     #[track_caller]
     pub fn as_synced(&self) -> &SyncedBlockData {
         self.synced.as_ref().expect("block not synced")
     }
 
+    /// Returns a mutable reference to the synced data. Panics if the block has not been synced.
     #[track_caller]
     pub fn as_synced_mut(&mut self) -> &mut SyncedBlockData {
         self.synced.as_mut().expect("block not synced")
     }
 
+    /// Returns the preparation-phase data. Panics if the block has not been prepared.
     #[track_caller]
     pub fn as_prepared(&self) -> &PreparedBlockData {
         self.prepared.as_ref().expect("block is not prepared")
     }
 
+    /// Returns a mutable reference to the preparation-phase data. Panics if the block has not been prepared.
     #[track_caller]
     pub fn as_prepared_mut(&mut self) -> &mut PreparedBlockData {
         self.prepared.as_mut().expect("block is not prepared")
     }
 
+    /// Constructs a [`SimpleBlockData`] from this block's hash and synced header.
+    ///
+    /// Panics if the block has not been synced.
     #[track_caller]
     pub fn to_simple(&self) -> SimpleBlockData {
         SimpleBlockData {
@@ -534,24 +578,33 @@ impl BlockFullData {
     }
 }
 
+/// Instrumented code together with its metadata, as stored after successful validation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstrumentedCodeData {
+    /// Gas-metered and stack-checked WASM code ready for execution.
     pub instrumented: InstrumentedCode,
+    /// Metadata associated with the code (e.g. limits, version).
     pub meta: CodeMetadata,
 }
 
+/// All data associated with a code blob in the mock database.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CodeData {
+    /// Raw WASM bytes as received from the beacon chain blob.
     pub original_bytes: Vec<u8>,
+    /// Ethereum transaction metadata for the blob submission: timestamp of the containing block and the transaction hash.
     pub blob_info: CodeBlobInfo,
+    /// Instrumented code and metadata; `None` if the code has not been validated yet.
     pub instrumented: Option<InstrumentedCodeData>,
 }
 
 impl CodeData {
+    /// Returns the instrumented code data. Panics if the code has not been instrumented.
     pub fn as_instrumented(&self) -> &InstrumentedCodeData {
         self.instrumented.as_ref().expect("code not instrumented")
     }
 
+    /// Returns a mutable reference to the instrumented code data. Panics if the code has not been instrumented.
     pub fn as_instrumented_mut(&mut self) -> &mut InstrumentedCodeData {
         self.instrumented.as_mut().expect("code not instrumented")
     }
@@ -562,6 +615,7 @@ impl CodeData {
 /// `mb_program_states` is left unwritten.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct MockComputedMbData {
+    /// Program state hashes and queue sizes after this micro-block was computed.
     pub program_states: ProgramStates,
 }
 
@@ -588,6 +642,7 @@ pub struct MbFullData {
 }
 
 impl MbFullData {
+    /// Returns the computed MB data. Panics if this MB has not been marked as computed.
     #[track_caller]
     pub fn as_computed(&self) -> &MockComputedMbData {
         self.computed
@@ -595,6 +650,7 @@ impl MbFullData {
             .expect("MB not marked computed in this mock chain")
     }
 
+    /// Returns a mutable reference to the computed MB data. Panics if this MB has not been marked as computed.
     #[track_caller]
     pub fn as_computed_mut(&mut self) -> &mut MockComputedMbData {
         self.computed
@@ -603,14 +659,23 @@ impl MbFullData {
     }
 }
 
+/// In-memory mock of an entire Ethereum block chain with associated MB chain and code store.
+///
+/// Used in proptest and integration tests to populate a database via [`BlockChain::setup`]
+/// and then exercise the ethexe pipeline against a realistic, self-consistent state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockChain {
+    /// Ordered sequence of Ethereum blocks; `blocks[0]` is a genesis-parent sentinel.
     pub blocks: VecDeque<BlockFullData>,
     /// One MB per `blocks[i]`. `mbs[0]` is a sentinel — see [`MbFullData`].
     pub mbs: VecDeque<MbFullData>,
+    /// Code blobs keyed by code ID.
     pub codes: BTreeMap<CodeId, CodeData>,
+    /// Validator set written to the DB for every era spanned by the chain.
     pub validators: ValidatorsVec,
+    /// DB configuration written by [`BlockChain::setup`].
     pub config: DBConfig,
+    /// DB globals written by [`BlockChain::setup`].
     pub globals: DBGlobals,
 }
 
@@ -622,6 +687,7 @@ impl BlockChain {
         &self.mbs[idx]
     }
 
+    /// `mbs[idx]` mutable accessor. Panics on out-of-range.
     #[track_caller]
     pub fn mb_at_mut(&mut self, idx: usize) -> &mut MbFullData {
         &mut self.mbs[idx]
@@ -635,6 +701,8 @@ impl BlockChain {
 }
 
 impl BlockChain {
+    /// Writes all blocks, MB rows, codes, validators, config, and globals into `db`
+    /// and returns `self` unchanged so callers can chain further setup steps.
     #[track_caller]
     pub fn setup<DB>(self, db: &DB) -> Self
     where
@@ -866,6 +934,7 @@ impl Arbitrary for BlockChain {
 }
 
 impl SimpleBlockData {
+    /// Writes this block's header and an empty event list into `db`, marks it synced, and returns `self`.
     pub fn setup<DB>(self, db: &DB) -> Self
     where
         DB: OnChainStorageRW,
@@ -876,6 +945,9 @@ impl SimpleBlockData {
         self
     }
 
+    /// Returns a new [`SimpleBlockData`] that immediately follows this block.
+    ///
+    /// The hash is incremented by one and the timestamp advances by 10 units.
     pub fn next_block(self) -> Self {
         Self {
             hash: H256::from_low_u64_be(self.hash.to_low_u64_be() + 1),
@@ -889,6 +961,7 @@ impl SimpleBlockData {
 }
 
 impl BlockData {
+    /// Writes this block's header and events into `db`, marks it synced, and returns `self`.
     pub fn setup<DB>(self, db: &DB) -> Self
     where
         DB: OnChainStorageRW,

--- a/ethexe/common/src/network.rs
+++ b/ethexe/common/src/network.rs
@@ -10,12 +10,20 @@ use core::hash::Hash;
 use parity_scale_codec::{Decode, Encode};
 use sha3::Keccak256;
 
+/// A validator network message carrying a [`BatchCommitmentValidationRequest`] payload.
 pub type ValidatorRequest = ValidatorMessage<BatchCommitmentValidationRequest>;
+/// A validator network message carrying a [`BatchCommitmentValidationReply`] payload.
 pub type ValidatorReply = ValidatorMessage<BatchCommitmentValidationReply>;
 
+/// A typed validator network message scoped to a consensus era.
+///
+/// Wraps an arbitrary payload `T` together with the era index so that
+/// receivers can reject stale messages from a previous era.
 #[derive(Debug, Clone, Encode, Decode, Eq, PartialEq, Hash)]
 pub struct ValidatorMessage<T> {
+    /// The consensus era this message belongs to.
     pub era_index: u64,
+    /// The inner message payload.
     pub payload: T,
 }
 
@@ -27,13 +35,22 @@ impl<T: ToDigest> ToDigest for ValidatorMessage<T> {
     }
 }
 
+/// A signed, unverified validator message exchanged over the P2P network.
+///
+/// Variants correspond to the two validator message kinds. Signatures must be
+/// verified via [`SignedValidatorMessage::into_verified`] before acting on the
+/// contained data.
 #[derive(Debug, Clone, Encode, Decode, Eq, PartialEq, derive_more::Unwrap, derive_more::From)]
 pub enum SignedValidatorMessage {
+    /// A validator's request for peers to validate a batch commitment.
     RequestBatchValidation(SignedData<ValidatorRequest>),
+    /// A validator's approval reply for a batch commitment validation request.
     ApproveBatch(SignedData<ValidatorReply>),
 }
 
 impl SignedValidatorMessage {
+    /// Converts this signed message into a [`VerifiedValidatorMessage`], asserting that the ECDSA
+    /// signature was already verified at construction time; this call performs no cryptographic work.
     pub fn into_verified(self) -> VerifiedValidatorMessage {
         match self {
             SignedValidatorMessage::RequestBatchValidation(request) => {
@@ -44,14 +61,21 @@ impl SignedValidatorMessage {
     }
 }
 
+/// A validator message whose ECDSA signature has been verified.
+///
+/// Callers can trust that [`VerifiedValidatorMessage::address`] returns the
+/// actual signer address and that the payload has not been tampered with.
 #[cfg_attr(feature = "serde", derive(Hash))]
 #[derive(Debug, Clone, Eq, PartialEq, derive_more::Unwrap, derive_more::From)]
 pub enum VerifiedValidatorMessage {
+    /// A verified batch-validation request from a coordinator.
     RequestBatchValidation(VerifiedData<ValidatorRequest>),
+    /// A verified batch-approval reply from a subordinate validator.
     ApproveBatch(VerifiedData<ValidatorReply>),
 }
 
 impl VerifiedValidatorMessage {
+    /// Returns the consensus era index carried by this message.
     pub fn era_index(&self) -> u64 {
         match self {
             VerifiedValidatorMessage::RequestBatchValidation(request) => request.data().era_index,
@@ -59,6 +83,7 @@ impl VerifiedValidatorMessage {
         }
     }
 
+    /// Returns the Ethereum address of the validator who signed this message.
     pub fn address(&self) -> Address {
         match self {
             VerifiedValidatorMessage::RequestBatchValidation(request) => request.address(),

--- a/ethexe/common/src/primitives.rs
+++ b/ethexe/common/src/primitives.rs
@@ -12,17 +12,23 @@ use gprimitives::{ActorId, CodeId, H256, MessageId};
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 
+/// Maps each active program's [`ActorId`] to its current [`StateHashWithQueueSize`].
 pub type ProgramStates = BTreeMap<ActorId, StateHashWithQueueSize>;
 
+/// Metadata describing a single block in the GearExe chain.
 #[derive(Debug, Clone, Copy, Default, Encode, Decode, TypeInfo, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct BlockHeader {
+    /// Sequential block number (height) in the chain, starting from 0.
     pub height: u32,
+    /// Unix timestamp of the block in seconds.
     pub timestamp: u64,
+    /// Hash of the preceding block; `H256::zero()` for the genesis block.
     pub parent_hash: H256,
 }
 
 impl BlockHeader {
+    /// Constructs a deterministic placeholder header at the given `height` for testing.
     pub fn dummy(height: u32) -> Self {
         let mut parent_hash = [0; 32];
         parent_hash[..4].copy_from_slice(&height.to_le_bytes());
@@ -35,14 +41,19 @@ impl BlockHeader {
     }
 }
 
+/// Full block data including the block hash, header, and all on-chain events.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockData {
+    /// Cryptographic hash that uniquely identifies this block.
     pub hash: H256,
+    /// Block metadata (height, timestamp, parent hash).
     pub header: BlockHeader,
+    /// Ordered list of events emitted during this block.
     pub events: Vec<BlockEvent>,
 }
 
 impl BlockData {
+    /// Returns a [`SimpleBlockData`] containing only the hash and header, dropping the events.
     pub fn to_simple(&self) -> SimpleBlockData {
         SimpleBlockData {
             hash: self.hash,
@@ -51,12 +62,15 @@ impl BlockData {
     }
 }
 
+/// Lightweight block descriptor carrying only the hash and header, without events.
 #[derive(
     Debug, derive_more::Display, Copy, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Default,
 )]
 #[display("Block(hash: {hash}, height: {}, parent: {}, ts: {})", header.height, header.parent_hash, header.timestamp)]
 pub struct SimpleBlockData {
+    /// Cryptographic hash that uniquely identifies this block.
     pub hash: H256,
+    /// Block metadata (height, timestamp, parent hash).
     pub header: BlockHeader,
 }
 
@@ -66,6 +80,7 @@ pub enum PromisePolicy {
     /// Emits promises in execution process.
     Enabled,
     // Do not emit promises in execution process.
+    /// Does not emit promises during execution.
     #[default]
     Disabled,
 }
@@ -81,15 +96,20 @@ pub enum PromiseEmissionMode {
     ConsensusDriven,
 }
 
+/// Combines a program's state hash with the sizes of its canonical and injected message queues.
 #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy, Default, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize))]
 pub struct StateHashWithQueueSize {
+    /// Hash of the program's current state.
     pub hash: H256,
+    /// Number of pending messages in the canonical (on-chain) queue.
     pub canonical_queue_size: u8,
+    /// Number of pending messages in the injected (cross-chain) queue.
     pub injected_queue_size: u8,
 }
 
 impl StateHashWithQueueSize {
+    /// Returns a zeroed instance with an empty state hash and no queued messages.
     pub fn zero() -> Self {
         Self {
             hash: H256::zero(),
@@ -99,19 +119,28 @@ impl StateHashWithQueueSize {
     }
 }
 
+/// Metadata about the Ethereum transaction that submitted a code blob.
 #[derive(Debug, Clone, Default, Encode, Decode, TypeInfo, PartialEq, Eq)]
 pub struct CodeBlobInfo {
+    /// Unix timestamp (in seconds) of the block containing the submission transaction.
     pub timestamp: u64,
+    /// Hash of the Ethereum transaction that carried the code blob.
     pub tx_hash: H256,
 }
 
+/// A WASM code blob paired with an unverified `CodeId`; the caller asserts consistency.
+///
+/// Use [`CodeAndId::from_unchecked`] to promote this to a verified [`CodeAndId`].
 #[derive(Clone, PartialEq, Eq, derive_more::Debug)]
 pub struct CodeAndIdUnchecked {
+    /// Raw WASM bytecode.
     #[debug("{:#x} bytes", code.len())]
     pub code: Vec<u8>,
+    /// Claimed identifier; not guaranteed to equal `blake2(code)` until verified.
     pub code_id: CodeId,
 }
 
+/// A WASM code blob whose `CodeId` is guaranteed to equal `blake2(code)`.
 #[derive(Clone, PartialEq, Eq, derive_more::Debug)]
 pub struct CodeAndId {
     #[debug("{:#x} bytes", code.len())]
@@ -120,15 +149,18 @@ pub struct CodeAndId {
 }
 
 impl CodeAndId {
+    /// Creates a `CodeAndId` by computing the `CodeId` from `blake2(code)`.
     pub fn new(code: Vec<u8>) -> Self {
         let code_id = CodeId::generate(&code);
         Self { code, code_id }
     }
 
+    /// Returns a reference to the raw WASM bytecode.
     pub fn code(&self) -> &[u8] {
         &self.code
     }
 
+    /// Returns the verified `CodeId` (blake2 hash of the code).
     pub fn code_id(&self) -> CodeId {
         self.code_id
     }
@@ -147,6 +179,7 @@ impl CodeAndId {
         Self { code, code_id }
     }
 
+    /// Converts into a [`CodeAndIdUnchecked`], relinquishing the consistency guarantee.
     pub fn into_unchecked(self) -> CodeAndIdUnchecked {
         CodeAndIdUnchecked {
             code: self.code,
@@ -160,8 +193,10 @@ impl CodeAndId {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode, TypeInfo)]
 pub struct ProtocolTimelines {
     // The genesis timestamp of the GearExe network in seconds.
+    /// Unix timestamp (in seconds) at which the GearExe network was launched.
     pub genesis_ts: u64,
     // The duration of an era in seconds.
+    /// Duration of a single era in seconds.
     pub era: NonZeroU64,
     /// The election duration in seconds before the end of an era when the next set of validators elected.
     ///  (start of era)[ - - - - - - - - - - - - + - - - - ] (end of era)

--- a/ethexe/common/src/utils.rs
+++ b/ethexe/common/src/utils.rs
@@ -23,6 +23,10 @@ pub const fn u64_into_uint48_be_bytes_lossy(val: u64) -> [u8; 6] {
     [b1, b2, b3, b4, b5, b6]
 }
 
+/// Persists a fully prepared block into the database by writing its header, events, and metadata.
+///
+/// Marks the block as synced and populates its [`BlockMeta`] with commit and queue information
+/// derived from `block_data`.
 pub fn setup_block_in_db<DB: OnChainStorageRW + BlockMetaStorageRW>(
     db: &DB,
     block_hash: H256,

--- a/ethexe/common/src/validators.rs
+++ b/ethexe/common/src/validators.rs
@@ -44,6 +44,7 @@ impl TypeInfo for ValidatorsVec {
     }
 }
 
+/// Error returned when attempting to construct a [`ValidatorsVec`] from an empty collection.
 #[derive(Debug, Display)]
 #[display("ValidatorsVec cannot be created from an empty collection")]
 pub struct EmptyValidatorsError;

--- a/ethexe/db/src/database.rs
+++ b/ethexe/db/src/database.rs
@@ -130,6 +130,7 @@ impl Key {
 }
 
 impl dyn KVDatabase + '_ {
+    /// Returns the stored database version, or `None` if the config key is absent.
     pub fn version(&self) -> Result<Option<u32>> {
         self.get(&Key::Config.to_bytes())
             .map(|data| {
@@ -138,6 +139,7 @@ impl dyn KVDatabase + '_ {
             .transpose()
     }
 
+    /// Reads and decodes the [`DBConfig`] stored under the `Config` key; errors if absent or corrupt.
     pub fn config(&self) -> Result<DBConfig> {
         self.get(&Key::Config.to_bytes())
             .context("Database config is not found")
@@ -146,6 +148,7 @@ impl dyn KVDatabase + '_ {
             })
     }
 
+    /// Reads and decodes the [`DBGlobals`] stored under the `Globals` key; errors if absent or corrupt.
     pub fn globals(&self) -> Result<DBGlobals> {
         self.get(&Key::Globals.to_bytes())
             .context("Database globals are not found")
@@ -154,10 +157,12 @@ impl dyn KVDatabase + '_ {
             })
     }
 
+    /// Encodes and persists `config` under the `Config` key, replacing any prior value.
     pub fn set_config(&self, config: DBConfig) {
         self.put(&Key::Config.to_bytes(), config.encode());
     }
 
+    /// Encodes and persists `globals` under the `Globals` key, replacing any prior value.
     pub fn set_globals(&self, globals: DBGlobals) {
         self.put(&Key::Globals.to_bytes(), globals.encode());
     }
@@ -317,8 +322,15 @@ impl Storage for dyn CASDatabase + '_ {
     }
 }
 
+/// An untyped pairing of a [`KVDatabase`] and a [`CASDatabase`] backend.
+///
+/// Used during database construction and migration before the typed [`Database`] wrapper is built.
+/// Both fields are exposed publicly so callers can supply pre-initialized backends via
+/// [`RawDatabase::from_one`] or [`RawDatabase::from_refs`].
 pub struct RawDatabase {
+    /// Key-value backend for structured metadata.
     pub kv: Box<dyn KVDatabase>,
+    /// Content-addressable backend for immutable blobs.
     pub cas: Box<dyn CASDatabase>,
 }
 
@@ -332,6 +344,7 @@ impl Clone for RawDatabase {
 }
 
 impl RawDatabase {
+    /// Constructs a `RawDatabase` by cloning both roles from a single backend that implements both traits.
     pub fn from_one<DB: CASDatabase + KVDatabase>(db: &DB) -> Self {
         Self {
             kv: KVDatabase::clone_boxed(db),
@@ -339,6 +352,7 @@ impl RawDatabase {
         }
     }
 
+    /// Constructs a `RawDatabase` by cloning each backend from separate trait-object references.
     pub fn from_refs(cas: &dyn CASDatabase, kv: &dyn KVDatabase) -> Self {
         Self {
             kv: kv.clone_boxed(),
@@ -712,6 +726,16 @@ impl InjectedStorageRW for RawDatabase {
     }
 }
 
+/// Typed, domain-aware database handle used by all ethexe services.
+///
+/// Wraps a [`RawDatabase`] and implements every storage-role trait declared in
+/// `ethexe-common::db` (block metadata, on-chain data, codes, injected transactions,
+/// mirror block storage, globals, config) as well as the runtime `Storage` trait.
+/// Globals and config are cached in `Arc<RwLock<_>>` fields so that in-process reads
+/// bypass the underlying backend after initial load.
+///
+/// Construct via [`Database::try_from_raw`]; the constructor rejects any backend whose
+/// stored version does not match [`VERSION`].
 #[derive(derive_more::Debug, Clone)]
 #[debug("Database(CAS + KV)")]
 pub struct Database {
@@ -721,6 +745,9 @@ pub struct Database {
 }
 
 impl Database {
+    /// Opens a [`Database`] from a [`RawDatabase`], verifying that the stored version matches [`VERSION`].
+    ///
+    /// Returns an error if the config key is absent, corrupt, or contains a mismatched version number.
     pub fn try_from_raw(raw: RawDatabase) -> Result<Self> {
         let config = raw.kv.config()?;
 
@@ -743,6 +770,7 @@ impl Database {
         Ok(db)
     }
 
+    /// Creates an in-memory [`Database`] initialized with default config and globals, for use in tests.
     #[cfg(feature = "mock")]
     #[track_caller]
     pub fn memory() -> Self {
@@ -805,6 +833,7 @@ impl Database {
         }
     }
 
+    /// Returns a reference to the underlying content-addressable backend.
     pub fn cas(&self) -> &dyn CASDatabase {
         self.raw.cas.as_ref()
     }

--- a/ethexe/db/src/iterator.rs
+++ b/ethexe/db/src/iterator.rs
@@ -27,6 +27,10 @@ use std::{
     hash::{DefaultHasher, Hash, Hasher},
 };
 
+/// Blanket storage trait required by [`DatabaseIterator`].
+///
+/// Combines read-only on-chain, block-meta, codes, MB, and program-state
+/// storage into one bound so iterator impls only need a single type parameter.
 pub trait DatabaseIteratorStorage:
     OnChainStorageRO + BlockMetaStorageRO + CodesStorageRO + MbStorageRO + Storage
 {
@@ -326,6 +330,7 @@ node! {
 }
 
 impl Node {
+    /// Converts the node into a `DatabaseIteratorError` if it is an `Error` variant.
     pub fn into_error(self) -> Option<DatabaseIteratorError> {
         match self {
             Node::Error(error) => Some(error),
@@ -340,42 +345,76 @@ impl From<MemoryPagesNode> for Node {
     }
 }
 
+/// Describes a missing database record encountered during iteration.
+///
+/// Emitted as `Node::Error` in place of the expected `Node` variant when a
+/// content-addressed lookup returns `None`.  Callers can collect these to
+/// identify gaps in the database without aborting the walk.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, derive_more::IsVariant)]
 pub enum DatabaseIteratorError {
     /* block */
+    /// Block header absent for the given block hash.
     NoBlockHeader(H256),
+    /// Block events absent for the given block hash.
     NoBlockEvents(H256),
+    /// Codes queue absent for the given block hash.
     NoBlockCodesQueue(H256),
 
     /* MB */
+    /// Compact MB record absent for the given MB hash.
     NoMb(H256),
+    /// Program states record absent for the given MB hash.
     NoMbProgramStates(H256),
+    /// Schedule record absent for the given MB hash.
     NoMbSchedule(H256),
+    /// Outcome (state transitions) absent for the given MB hash.
     NoMbOutcome(H256),
 
     /* memory */
+    /// Memory pages index absent for the given hash.
     NoMemoryPages(HashOf<MemoryPages>),
+    /// Memory pages region absent for the given hash.
     NoMemoryPagesRegion(HashOf<MemoryPagesRegion>),
+    /// Page data buffer absent for the given hash.
     NoPageData(HashOf<PageBuf>),
 
     /* code */
+    /// Code validity flag absent for the given code ID.
     NoCodeValid(CodeId),
+    /// Original WASM bytes absent for the given code ID.
     NoOriginalCode(CodeId),
+    /// Instrumented code absent for the given code ID.
     NoInstrumentedCode(CodeId),
+    /// Code metadata absent for the given code ID.
     NoCodeMetadata(CodeId),
 
     /* rest */
+    /// Message queue absent for the given hash.
     NoMessageQueue(HashOf<MessageQueue>),
+    /// Waitlist absent for the given hash.
     NoWaitlist(HashOf<Waitlist>),
+    /// Dispatch stash absent for the given hash.
     NoDispatchStash(HashOf<DispatchStash>),
+    /// Mailbox absent for the given hash.
     NoMailbox(HashOf<Mailbox>),
+    /// User mailbox absent for the given hash.
     NoUserMailbox(HashOf<UserMailbox>),
+    /// Allocations absent for the given hash.
     NoAllocations(HashOf<Allocations>),
+    /// Program state absent for the given state hash.
     NoProgramState(H256),
+    /// Payload absent for the given hash.
     NoPayload(HashOf<Payload>),
+    /// Code ID mapping absent for the given program actor ID.
     NoProgramCodeId(ActorId),
 }
 
+/// Breadth-first iterator that traverses all database records reachable from a starting [`Node`].
+///
+/// Each call to `next` yields one `Node`, expanding its children onto an internal queue.
+/// Already-visited nodes (identified by [`node_hash`]) are skipped to prevent cycles and
+/// duplicate visits.  Missing records are surfaced as `Node::Error` variants rather than
+/// silently omitted, so callers can detect gaps without stopping iteration.
 pub struct DatabaseIterator<S> {
     storage: S,
     stack: VecDeque<Node>,
@@ -411,6 +450,7 @@ impl<S> DatabaseIterator<S>
 where
     S: DatabaseIteratorStorage,
 {
+    /// Creates a new iterator starting from `node` with an empty visited set.
     pub fn new(storage: S, node: impl Into<Node>) -> Self {
         let mut this = Self {
             storage,
@@ -421,6 +461,11 @@ where
         this
     }
 
+    /// Creates a new iterator starting from `node`, pre-populating the visited set with `skip_nodes`.
+    ///
+    /// Use this when a prior walk has already covered certain nodes and a follow-up walk should
+    /// not revisit them.  Node identity values suitable for `skip_nodes` are produced by
+    /// [`node_hash`].
     pub fn with_skip_nodes(storage: S, node: impl Into<Node>, skip_nodes: HashSet<u64>) -> Self {
         let mut this = Self {
             storage,
@@ -860,6 +905,10 @@ where
     }
 }
 
+/// Returns a 64-bit identity hash for a `Node` used by [`DatabaseIterator`] to skip duplicates.
+///
+/// Computed with `DefaultHasher` over the node's `Hash` impl.  The value is not stable across
+/// Rust versions or processes; it is only meaningful within a single iterator session.
 pub fn node_hash(node: &Node) -> u64 {
     let mut hasher = DefaultHasher::new();
     node.hash(&mut hasher);

--- a/ethexe/db/src/lib.rs
+++ b/ethexe/db/src/lib.rs
@@ -67,6 +67,7 @@ pub use rocks::RocksDatabase;
 #[cfg(feature = "mock")]
 pub use migrations::create_initialized_empty_memory_db;
 
+/// Computes the Blake2 hash of `data`, matching the key returned by [`CASDatabase::write`].
 pub fn hash(data: &[u8]) -> H256 {
     gear_core::utils::hash(data).into()
 }
@@ -107,11 +108,13 @@ pub trait KVDatabase: Send + Sync {
     /// Put (insert) value by key.
     fn put(&self, key: &[u8], data: Vec<u8>);
 
+    /// Iterate over all `(key, value)` pairs whose key starts with `prefix`.
     fn iter_prefix<'a>(
         &'a self,
         prefix: &'a [u8],
     ) -> Box<dyn Iterator<Item = (Vec<u8>, Vec<u8>)> + 'a>;
 
+    /// Returns `true` if the database contains no entries.
     fn is_empty(&self) -> bool;
 }
 

--- a/ethexe/db/src/mem.rs
+++ b/ethexe/db/src/mem.rs
@@ -6,6 +6,10 @@ use dashmap::DashMap;
 use gprimitives::H256;
 use std::sync::Arc;
 
+/// In-memory database backend implementing both [`CASDatabase`] and [`KVDatabase`].
+///
+/// Uses a single shared [`DashMap`] for all storage, so cloned instances share the same
+/// underlying map. Intended for tests and mocks; data is lost when the last reference is dropped.
 #[derive(Debug, Default, Clone)]
 pub struct MemDb {
     // TODO: using Vec as key is not optimal, consider using to use another data structure.

--- a/ethexe/db/src/migrations/init.rs
+++ b/ethexe/db/src/migrations/init.rs
@@ -19,6 +19,14 @@ use ethexe_runtime_common::{RUNTIME_ID, ScheduleRestorer, state::Storage};
 use futures::{TryStreamExt, stream::FuturesUnordered};
 use gprimitives::{CodeId, H256};
 
+/// Bring a [`RawDatabase`] up to [`LATEST_VERSION`], running any required migrations, and
+/// return a typed [`Database`] handle.
+///
+/// If the KV store is empty the database is bootstrapped from scratch via [`initialize_empty_db`].
+/// If it already contains data, the stored version is read and any pending migration steps are
+/// applied before the configuration is validated against the live Ethereum RPC.  Returns an error
+/// if the version cannot be reached, if migration fails, or if the config does not match what was
+/// recorded at first-time initialization.
 pub async fn initialize_db(config: InitConfig, db: RawDatabase) -> Result<Database> {
     log::info!("Initializing database to version {LATEST_VERSION}...");
 
@@ -72,6 +80,13 @@ async fn validate_db(config: InitConfig, db: &RawDatabase) -> Result<()> {
     Ok(())
 }
 
+/// Perform a first-time initialization of a freshly empty [`RawDatabase`].
+///
+/// Connects to the Ethereum RPC specified in `config`, reads the Router contract's genesis-block
+/// info and timeline parameters, optionally imports pre-genesis program state via
+/// [`GenesisInitializer`], writes the genesis block record, and persists both [`DBConfig`] and
+/// [`DBGlobals`] so the database is ready for normal operation.  The function is also called by
+/// the `"mock"` feature helper `create_initialized_empty_memory_db`.
 pub async fn initialize_empty_db(config: InitConfig, db: &RawDatabase) -> Result<()> {
     let provider = RootProvider::connect(&config.ethereum_rpc).await?;
     let chain_id = provider.get_chain_id().await?;

--- a/ethexe/db/src/migrations/mod.rs
+++ b/ethexe/db/src/migrations/mod.rs
@@ -17,10 +17,16 @@ mod init;
 mod migration;
 mod v1;
 
+/// The database schema version produced by the current code.
 pub const LATEST_VERSION: u32 = v1::VERSION;
 
+/// The oldest database schema version that can be upgraded to [`LATEST_VERSION`] via [`MIGRATIONS`].
+/// Databases older than this must be wiped and re-initialized.
 pub const OLDEST_SUPPORTED_VERSION: u32 = v1::VERSION;
 
+/// Ordered list of schema upgrade steps covering every version in
+/// `[OLDEST_SUPPORTED_VERSION, LATEST_VERSION)`. Currently empty because
+/// only one schema version exists; entries will be added as new versions land.
 pub const MIGRATIONS: &[&dyn Migration] = &[];
 
 const _: () = assert!(
@@ -28,21 +34,38 @@ const _: () = assert!(
     "Wrong number of migrations available"
 );
 
+/// Future returned by [`GenesisInitializer::process_code`] that resolves to
+/// the instrumented form and metadata of a code blob, or `None` if the code
+/// is invalid and initialization should abort.
 pub type CodeProcessingFuture =
     BoxFuture<'static, anyhow::Result<Option<(InstrumentedCode, CodeMetadata)>>>;
 
+/// Supplies genesis-time state needed to seed an empty database during first-run initialization.
 pub trait GenesisInitializer {
+    /// Returns the full state dump that seeds the genesis micro-block.
     fn get_genesis_data(&mut self) -> anyhow::Result<StateDump>;
+    /// Instruments and validates raw WASM `code` identified by `code_id`.
+    ///
+    /// Returns `None` if the code is invalid; the caller aborts initialization in that case.
     fn process_code(&mut self, code_id: CodeId, code: Vec<u8>) -> CodeProcessingFuture;
 }
 
+/// Configuration passed to database initialization and migration routines.
 pub struct InitConfig {
+    /// WebSocket or HTTP URL of the Ethereum JSON-RPC endpoint.
     pub ethereum_rpc: String,
+    /// Address of the deployed `Router` contract on the target chain.
     pub router_address: Address,
+    /// Duration of a consensus slot in seconds, used to configure protocol timelines.
     pub slot_duration_secs: u64,
+    /// Optional provider of genesis state; when `None`, the genesis micro-block is empty.
     pub genesis_initializer: Option<Box<dyn GenesisInitializer>>,
 }
 
+/// Creates an in-memory [`Database`] seeded with the genesis state described by `config`.
+///
+/// Intended for tests and tooling; the backing store is a [`MemDb`] that is discarded when
+/// the returned handle is dropped.
 #[cfg(feature = "mock")]
 pub async fn create_initialized_empty_memory_db(config: InitConfig) -> anyhow::Result<Database> {
     let raw = RawDatabase::from_one(&MemDb::default());

--- a/ethexe/db/src/migrations/v1.rs
+++ b/ethexe/db/src/migrations/v1.rs
@@ -1,4 +1,5 @@
 // Copyright (C) Gear Technologies Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
+/// Schema version number for the v1 database layout.
 pub const VERSION: u32 = 1;

--- a/ethexe/db/src/overlay.rs
+++ b/ethexe/db/src/overlay.rs
@@ -7,12 +7,18 @@ use gear_core::utils;
 use gprimitives::H256;
 use std::{collections::HashSet, sync::Arc};
 
+/// A [`CASDatabase`] that layers an in-memory [`MemDb`] over a persistent backend.
+///
+/// Reads are served from the in-memory layer first; writes always go to the in-memory layer only,
+/// leaving the backing database unmodified. Useful for staging content-addressed writes before
+/// deciding whether to commit them.
 pub struct CASOverlay {
     db: Box<dyn CASDatabase>,
     mem: MemDb,
 }
 
 impl CASOverlay {
+    /// Creates a new overlay backed by `db`.
     pub fn new(db: Box<dyn CASDatabase>) -> Self {
         Self {
             db,
@@ -42,6 +48,13 @@ impl CASDatabase for CASOverlay {
     }
 }
 
+/// A [`KVDatabase`] that layers an in-memory [`MemDb`] over a persistent backend, with
+/// explicit key erasure tracking.
+///
+/// Reads check the in-memory layer first; keys removed via [`KVDatabase::take`] are recorded in
+/// `erased_keys` so that subsequent reads do not fall through to the backing store. Writes
+/// (`put`) clear the erasure mark for the key and write only to memory, leaving the backing
+/// database unmodified.
 pub struct KVOverlay {
     db: Box<dyn KVDatabase>,
     mem: MemDb,
@@ -49,6 +62,7 @@ pub struct KVOverlay {
 }
 
 impl KVOverlay {
+    /// Creates a new overlay backed by `db`.
     pub fn new(db: Box<dyn KVDatabase>) -> Self {
         Self {
             db,

--- a/ethexe/db/src/rocks.rs
+++ b/ethexe/db/src/rocks.rs
@@ -108,6 +108,10 @@ impl KVDatabase for RocksDatabase {
     }
 }
 
+/// [`Iterator`] over RocksDB entries whose keys begin with a given byte prefix.
+///
+/// Yields `(key, value)` pairs in lexicographic order and stops as soon as a key
+/// that does not start with the prefix is encountered or the underlying iterator is exhausted.
 pub struct PrefixIterator<'a> {
     prefix: &'a [u8],
     prefix_iter: DBIteratorWithThreadMode<'a, DB>,

--- a/ethexe/db/src/verifier.rs
+++ b/ethexe/db/src/verifier.rs
@@ -19,51 +19,93 @@ use std::{
     hash::Hash,
 };
 
+/// Enumerates all integrity violations detected during chain or database verification.
+///
+/// Each variant corresponds to a specific invariant that must hold for a well-formed
+/// ethexe database. Errors are collected (not fatal) so a single verification pass
+/// can surface multiple violations at once.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum IntegrityVerifierError {
+    /// Wraps a low-level [`DatabaseIteratorError`] produced while traversing the DB.
     DatabaseIterator(DatabaseIteratorError),
 
     /* block */
+    /// The block has not been marked as synced in the database.
     BlockIsNotSynced(H256),
+    /// The block metadata `prepared` flag is `false`.
     BlockIsNotPrepared(H256),
+    /// The block metadata is missing a `last_committed_batch` entry.
     NoBlockLastCommittedBatch(H256),
+    /// The block metadata is missing a `last_committed_mb` entry.
     NoBlockLastCommittedMb(H256),
+    /// The block metadata is missing a `latest_era_validators_committed` entry.
     NoBlockLatestEraValidatorsCommitted(H256),
+    /// No block header record exists for the given block hash.
     NoBlockHeader(H256),
 
     /* block header */
+    /// The parent block header cannot be found in the database.
     NoParentBlockHeader(H256),
+    /// The child block height is not exactly `parent_height + 1`.
     InvalidBlockParentHeight {
+        /// Stored height of the parent block.
         parent_height: u32,
+        /// Stored height of the child block.
         height: u32,
     },
+    /// The child block timestamp is earlier than its parent's timestamp.
     InvalidParentTimestamp {
+        /// Timestamp of the parent block.
         parent_timestamp: u64,
+        /// Timestamp of the child block.
         timestamp: u64,
     },
 
     /* code */
+    /// The code validity flag is set to `false` in the database.
     CodeIsNotValid,
+    /// The `original_code_len` stored in the code metadata does not match the actual blob length.
     InvalidCodeLenInMetadata {
+        /// Identifier of the offending code blob.
         code_id: CodeId,
+        /// Length recorded in the metadata.
         metadata_len: u32,
+        /// Actual byte length of the stored original code blob.
         original_len: u32,
     },
 
     /* rest */
+    /// The compact mb record referenced by `mb_hash` is absent from the database.
     MbNotFound(H256),
+    /// A scheduled task's expiry height is not greater than the mb's current height.
     MbScheduleHasExpiredTasks {
+        /// Hash of the mb block the tasks belong to.
         mb_hash: H256,
+        /// Block height at which the tasks were scheduled to expire.
         expiry: u32,
+        /// Number of expired tasks found.
         tasks: usize,
     },
+    /// The cached queue size stored alongside a [`MessageQueue`] hash does not match
+    /// the actual number of messages in the queue.
     InvalidCachedMessageQueueSize {
+        /// Hash of the message queue.
         hash: HashOf<MessageQueue>,
+        /// Size recorded in the cache entry.
         cached_size: u8,
+        /// Actual size obtained by decoding the queue.
         actual_size: u8,
     },
 }
 
+/// Walks a chain segment in the database and accumulates all integrity violations found.
+///
+/// Implements [`DatabaseVisitor`] so it can be driven by `walk()` over any node type.
+/// Errors are not returned eagerly; call [`verify_chain`] for a complete pass or
+/// [`into_errors`] to consume accumulated errors after manual visitor calls.
+///
+/// [`verify_chain`]: IntegrityVerifier::verify_chain
+/// [`into_errors`]: IntegrityVerifier::into_errors
 pub struct IntegrityVerifier {
     db: Database,
     errors: Vec<IntegrityVerifierError>,
@@ -73,6 +115,7 @@ pub struct IntegrityVerifier {
 }
 
 impl IntegrityVerifier {
+    /// Creates a new verifier backed by the given [`Database`].
     pub fn new(db: Database) -> Self {
         Self {
             db,
@@ -83,6 +126,12 @@ impl IntegrityVerifier {
         }
     }
 
+    /// Walks all blocks from `head` down to `bottom` (inclusive) and verifies
+    /// every reachable database record.
+    ///
+    /// Returns `Ok(())` when no violations are found, or `Err` containing the
+    /// full list of collected [`IntegrityVerifierError`]s. In debug builds the
+    /// list is asserted to contain no duplicates.
     pub fn verify_chain(
         mut self,
         head: H256,
@@ -111,6 +160,11 @@ impl IntegrityVerifier {
         }
     }
 
+    /// Consumes the verifier and returns all accumulated errors.
+    ///
+    /// Useful when driving the visitor manually via `walk()` rather than through [`verify_chain`].
+    ///
+    /// [`verify_chain`]: IntegrityVerifier::verify_chain
     pub fn into_errors(self) -> Vec<IntegrityVerifierError> {
         self.errors
     }

--- a/ethexe/db/src/visitor.rs
+++ b/ethexe/db/src/visitor.rs
@@ -24,11 +24,25 @@ macro_rules! define_visitor {
     ($( $variant:ident($node:ident { $( $field:ident: $ty:ty, )* }) )*) => {
         paste::paste! {
             #[auto_impl::auto_impl(&mut, Box)]
+            /// Callback-based traversal over the database graph.
+            ///
+            /// Implementations receive one `visit_*` call per [`Node`] variant that the
+            /// [`walk`] helper encounters.  All `visit_*` methods have a default no-op body,
+            /// so only the variants of interest need to be overridden.
             pub trait DatabaseVisitor: Sized {
+                /// Returns a reference to the underlying storage used during traversal.
                 fn db(&self) -> &dyn DatabaseIteratorStorage;
 
+                /// Returns a heap-allocated clone of the underlying storage.
+                ///
+                /// Required so [`walk`] can construct a new [`DatabaseIterator`] that owns its
+                /// own storage handle without borrowing `self`.
                 fn clone_boxed_db(&self) -> Box<dyn DatabaseIteratorStorage>;
 
+                /// Called when the iterator encounters a missing or invalid database record.
+                ///
+                /// The default [`walk`] loop does not abort on errors; implementations must
+                /// decide whether to log, accumulate, or propagate them.
                 fn on_db_error(&mut self, error: DatabaseIteratorError);
 
                 $(
@@ -45,6 +59,9 @@ crate::iterator::for_each_node!(define_visitor);
 macro_rules! define_visit_node {
     ($( $variant:ident($node:ident { $( $field:ident: $ty:ty, )* }) )*) => {
         paste::paste! {
+            /// Dispatches a single [`Node`] to the corresponding `visit_*` method on `visitor`.
+            ///
+            /// Error nodes are routed to [`DatabaseVisitor::on_db_error`] instead.
             pub fn visit_node(visitor: &mut impl DatabaseVisitor, node: Node) {
                 match node {
                     $(
@@ -66,6 +83,11 @@ macro_rules! define_visit_node {
 
 crate::iterator::for_each_node!(define_visit_node);
 
+/// Traverses the database graph starting from `node`, calling [`visit_node`] for every
+/// reachable [`Node`] in breadth-first order.
+///
+/// Internally creates a [`DatabaseIterator`] seeded with a storage clone obtained from
+/// `visitor.clone_boxed_db()`, so no external storage handle is required at the call site.
 pub fn walk(visitor: &mut impl DatabaseVisitor, node: impl Into<Node>) {
     DatabaseIterator::new(visitor.clone_boxed_db(), node.into())
         .for_each(|node| visit_node(visitor, node));

--- a/ethexe/ethereum/src/abi/mod.rs
+++ b/ethexe/ethereum/src/abi/mod.rs
@@ -10,6 +10,7 @@ pub use middleware_abi::IMiddleware;
 pub use mirror_abi::IMirror;
 pub use router_abi::{Gear, IRouter};
 
+/// ABI bindings for the `Gear` library contract, generated from `abi/Gear.json`.
 pub mod gear_abi {
     alloy::sol!(
         #[sol(rpc)]
@@ -19,6 +20,7 @@ pub mod gear_abi {
     );
 }
 
+/// ABI bindings for the `IMiddleware` interface, generated from `abi/Middleware.json`.
 pub mod middleware_abi {
     alloy::sol!(
         #[sol(rpc)]
@@ -127,6 +129,7 @@ pub mod symbiotic_abi {
         "abi/SlasherFactory.json"
     );
 
+    /// ABI bindings for the `DefaultStakerRewardsFactory` contract.
     pub mod staker_rewards_factory {
         alloy::sol!(
             #[sol(rpc)]
@@ -135,6 +138,7 @@ pub mod symbiotic_abi {
         );
     }
 
+    /// ABI bindings for the `DefaultStakerRewards` contract.
     pub mod staker_rewards {
         alloy::sol!(
             #[sol(rpc)]
@@ -144,6 +148,7 @@ pub mod symbiotic_abi {
     }
 }
 
+/// Conversion utilities between Gear/Ethereum primitive types and `alloy` primitive types.
 pub mod utils {
     use alloy::{
         primitives::{FixedBytes, Uint},
@@ -154,8 +159,11 @@ pub mod utils {
 
     pub use alloy::primitives::Bytes;
 
+    /// A 32-byte fixed-length array as used in Solidity `bytes32`.
     pub type Bytes32 = FixedBytes<32>;
+    /// A 256-bit unsigned integer as used in Solidity `uint256`.
     pub type Uint256 = Uint<256, 4>;
+    /// A 48-bit unsigned integer as used in Solidity `uint48`.
     pub type Uint48 = Uint<48, 1>;
 
     sol! {
@@ -170,59 +178,72 @@ pub mod utils {
         }
     }
 
+    /// Converts a `ActorId` to an Ethereum address by taking the lower 20 bytes.
     pub fn actor_id_to_address_lossy(actor_id: ActorId) -> alloy::primitives::Address {
         actor_id.to_address_lossy().to_fixed_bytes().into()
     }
 
+    /// Converts an Ethereum address to an `ActorId` by zero-extending to 32 bytes.
     pub fn address_to_actor_id(address: alloy::primitives::Address) -> ActorId {
         (*address.into_word()).into()
     }
 
+    /// Converts a `Bytes32` value to a `CodeId`.
     pub fn bytes32_to_code_id(bytes: Bytes32) -> CodeId {
         bytes.0.into()
     }
 
+    /// Converts a `Bytes32` value to an `H256`.
     pub fn bytes32_to_h256(bytes: Bytes32) -> H256 {
         bytes.0.into()
     }
 
+    /// Converts a `Bytes32` value to a `MessageId`.
     pub fn bytes32_to_message_id(bytes: Bytes32) -> MessageId {
         bytes.0.into()
     }
 
+    /// Converts a `CodeId` to a `Bytes32` value.
     pub fn code_id_to_bytes32(code_id: CodeId) -> Bytes32 {
         code_id.into_bytes().into()
     }
 
+    /// Converts a `MessageId` to a `Bytes32` value.
     pub fn message_id_to_bytes32(message_id: MessageId) -> Bytes32 {
         message_id.into_bytes().into()
     }
 
+    /// Converts an `H256` value to a `Bytes32`.
     pub fn h256_to_bytes32(h256: H256) -> Bytes32 {
         h256.0.into()
     }
 
+    /// Converts a `u64` to a `Uint48`, clamping to `Uint48::MAX` if the value exceeds 48 bits.
     pub fn u64_to_uint48_lossy(value: u64) -> Uint48 {
         Uint48::try_from(value).unwrap_or(Uint48::MAX)
     }
 
+    /// Converts a `Uint48` to a `u64`.
     pub fn uint48_to_u64(value: Uint48) -> u64 {
         let [limb] = value.into_limbs();
         limb
     }
 
+    /// Converts a `Uint256` to a `u128`, discarding the upper 128 bits.
     pub fn uint256_to_u128_lossy(value: Uint256) -> u128 {
         let [low, high, ..] = value.into_limbs();
 
         ((high as u128) << 64) | (low as u128)
     }
 
+    /// Converts a `gprimitives::U256` to an `alloy` `Uint256` via little-endian byte representation.
     pub fn u256_to_uint256(value: U256) -> Uint256 {
         let mut bytes = [0u8; Uint256::BYTES];
         value.to_little_endian(&mut bytes);
         Uint256::from_le_bytes(bytes)
     }
 
+    /// Converts an `alloy` `Uint256` to a `gprimitives::U256` via little-endian byte representation.
     pub fn uint256_to_u256(value: Uint256) -> U256 {
         let bytes: [u8; Uint256::BYTES] = value.to_le_bytes();
         U256::from_little_endian(&bytes)

--- a/ethexe/ethereum/src/deploy.rs
+++ b/ethexe/ethereum/src/deploy.rs
@@ -50,18 +50,24 @@ pub struct EthereumDeployer {
     verifiable_secret_sharing_commitment: Option<Vec<u8>>,
 }
 
+/// Customizable parameters controlling which contracts to deploy and their timeline configuration.
 #[derive(Debug, Copy, Clone)]
 pub struct ContractsDeploymentParams {
     // whether to deploy middleware contract
+    /// Whether to deploy the Middleware contract alongside the Router.
     pub with_middleware: bool,
 
     // customizable timelines
+    /// Duration of a validator era in seconds.
     pub era_duration: u64,
+    /// Duration of the validator election period in seconds.
     pub election_duration: u64,
 }
 
+/// Configuration for a Symbiotic operator, used when registering an operator in the middleware.
 #[derive(Debug)]
 pub struct SymbioticOperatorConfig {
+    /// Amount of collateral the operator stakes, in the smallest token unit.
     pub stake: U256,
 }
 
@@ -104,31 +110,39 @@ impl EthereumDeployer {
         })
     }
 
+    /// Enables Middleware contract deployment. Mirrors [`ContractsDeploymentParams::with_middleware`].
     pub fn with_middleware(mut self) -> Self {
         self.params.with_middleware = true;
         self
     }
 
+    /// Sets the era duration (in seconds) passed to the Router initializer.
     pub fn with_era_duration(mut self, era_duration: u64) -> Self {
         self.params.era_duration = era_duration;
         self
     }
 
+    /// Sets the election duration (in seconds) passed to the Router initializer.
     pub fn with_election_duration(mut self, election_duration: u64) -> Self {
         self.params.election_duration = election_duration;
         self
     }
 
+    /// Replaces all deployment parameters at once with the given [`ContractsDeploymentParams`].
     pub fn with_params(mut self, new_params: ContractsDeploymentParams) -> Self {
         self.params = new_params;
         self
     }
 
+    /// Sets the validator set that will be registered in the Router on deployment.
     pub fn with_validators(mut self, validators: ValidatorsVec) -> Self {
         self.validators = validators;
         self
     }
 
+    /// Provides the serialized VSS commitment passed to the Router initializer.
+    ///
+    /// When not set, an empty byte slice is passed.
     pub fn with_verifiable_secret_sharing_commitment(
         mut self,
         verifiable_secret_sharing_commitment: Vec<u8>,
@@ -137,6 +151,7 @@ impl EthereumDeployer {
         self
     }
 
+    /// Deploys all configured contracts and returns an initialized [`Ethereum`] instance.
     pub async fn deploy(mut self) -> Result<Ethereum> {
         self.deploy_contracts().await?;
         self.ethereum.initialize_addresses().await?;

--- a/ethexe/ethereum/src/lib.rs
+++ b/ethexe/ethereum/src/lib.rs
@@ -104,17 +104,26 @@ use mirror::Mirror;
 use router::{Router, RouterQuery};
 use std::time::Duration;
 
+/// Raw ABI bindings generated from the ethexe Solidity contracts.
 pub mod abi;
+/// Deployment helpers for spinning up the full ethexe contract set in local/test environments.
 pub mod deploy;
+/// Typed wrapper around the Middleware.sol validator-election/permissions contract.
 pub mod middleware;
+/// Typed wrapper around the Mirror.sol per-program proxy contract.
 pub mod mirror;
+/// Typed wrapper around the Router.sol central co-processor contract.
 pub mod router;
+/// Typed wrapper around the WrappedVara ERC-20 contract.
 pub mod wvara;
 
+/// Re-export of `alloy::primitives` for downstream crates that need Ethereum primitive types.
 pub mod primitives {
     pub use alloy::primitives::*;
 }
 
+/// Concrete alloy provider stack used throughout this crate, pre-configured with gas, nonce,
+/// chain-id, wallet, and blob-gas fillers on top of an HTTP/WS root provider.
 pub type AlloyProvider = FillProvider<
     JoinFill<
         JoinFill<
@@ -129,6 +138,10 @@ pub type AlloyProvider = FillProvider<
     RootProvider,
 >;
 
+/// Fluent builder for [`Ethereum`].
+///
+/// Callers must set at least `signer` and `sender_address` before calling [`EthereumBuilder::build`];
+/// all other fields fall back to the defaults declared on [`Ethereum`].
 #[derive(Debug, Clone, Default)]
 pub struct EthereumBuilder {
     rpc_url: Option<String>,
@@ -276,6 +289,12 @@ pub(crate) struct Eip712PermitData {
     pub s: B256,
 }
 
+/// Central Ethereum connection: holds a signed [`AlloyProvider`] and resolves on-chain addresses
+/// for the Router, WrappedVara, and Middleware contracts.
+///
+/// Obtain an instance via [`EthereumBuilder`]. Once built, use [`Ethereum::router`],
+/// [`Ethereum::mirror`], [`Ethereum::wrapped_vara`], and [`Ethereum::middleware`] to get typed
+/// contract handles.
 #[derive(Clone)]
 pub struct Ethereum {
     router: AlloyAddress,
@@ -368,6 +387,7 @@ impl Ethereum {
         Ok(())
     }
 
+    /// Returns the underlying key signer used for transaction signing.
     pub fn signer(&self) -> &Signer {
         &self.signer
     }
@@ -376,14 +396,17 @@ impl Ethereum {
         Sender::new(self.signer.clone(), self.sender_address).expect("infallible")
     }
 
+    /// Returns the Ethereum address that signs and pays for submitted transactions.
     pub fn sender_address(&self) -> Address {
         self.sender_address
     }
 
+    /// Returns a clone of the underlying [`AlloyProvider`].
     pub fn provider(&self) -> AlloyProvider {
         self.provider.clone()
     }
 
+    /// Fetches the chain ID from the connected Ethereum node.
     pub async fn chain_id(&self) -> Result<u64> {
         self.provider.get_chain_id().await.map_err(Into::into)
     }
@@ -419,10 +442,12 @@ impl Ethereum {
         Ok(SimpleBlockData { hash, header })
     }
 
+    /// Fetches the latest Ethereum block and returns its hash and header.
     pub async fn get_latest_block(&self) -> Result<SimpleBlockData> {
         Self::get_latest_block_inner(&self.provider()).await
     }
 
+    /// Fetches a specific Ethereum block by block ID and returns its hash and header.
     pub async fn get_block(&self, block_id: impl IntoBlockId) -> Result<SimpleBlockData> {
         Self::get_block_inner(&self.provider(), block_id).await
     }
@@ -467,10 +492,12 @@ impl Ethereum {
         Ok(Eip712PermitData { deadline, v, r, s })
     }
 
+    /// Returns a write handle for the Mirror.sol proxy contract deployed for `actor_id`.
     pub fn mirror(&self, actor_id: ActorId) -> Mirror {
         Mirror::new(actor_id.into(), self.wvara, self.sender(), self.provider())
     }
 
+    /// Returns a write handle for the Router.sol central co-processor contract.
     pub fn router(&self) -> Router {
         Router::new(
             self.router,
@@ -482,10 +509,15 @@ impl Ethereum {
         )
     }
 
+    /// Returns a write handle for the WrappedVara ERC-20 contract.
     pub fn wrapped_vara(&self) -> WVara {
         WVara::new(self.wvara, self.provider())
     }
 
+    /// Returns a write handle for the Middleware.sol validator-election contract.
+    ///
+    /// Panics if the middleware address was not resolved (i.e., the contract set was deployed
+    /// without the `with_middleware` flag on [`deploy::EthereumDeployer`]).
     pub fn middleware(&self) -> Middleware {
         assert_ne!(
             self.middleware,
@@ -589,6 +621,8 @@ impl SignerSync for Sender {
     }
 }
 
+/// Extension trait for [`PendingTransactionBuilder`] that adds retry-aware receipt retrieval,
+/// `MessageQueueingRequested` log extraction, and revert-reason surfacing.
 #[async_trait::async_trait]
 pub trait TryGetReceipt<N: Network> {
     /// Works like `self.get_receipt().await`, but retries a few times if rpc returns a null response.
@@ -713,6 +747,7 @@ use crate::wvara::WVara;
 
 /// A helping trait for converting various types into `alloy::eips::BlockId`.
 pub trait IntoBlockId {
+    /// Converts this value into an `alloy::eips::BlockId`.
     fn into_block_id(self) -> BlockId;
 }
 

--- a/ethexe/ethereum/src/middleware/mod.rs
+++ b/ethexe/ethereum/src/middleware/mod.rs
@@ -17,8 +17,10 @@ type QueryInstance = IMiddleware::IMiddlewareInstance<RootProvider>;
 /// Trait for executing elections in the blockchain
 #[async_trait::async_trait]
 pub trait ElectionProvider: Send + Sync {
+    /// Returns a heap-allocated clone of this provider as a trait object.
     fn clone_boxed(&self) -> Box<dyn ElectionProvider>;
 
+    /// Queries the validator set elected at the given timestamp, limited to `max_validators` entries.
     async fn make_election_at(&self, ts: u64, max_validators: u128) -> Result<ValidatorsVec>;
 }
 
@@ -28,6 +30,9 @@ impl<T: ElectionProvider> From<T> for Box<dyn ElectionProvider> {
     }
 }
 
+/// Client wrapper around the on-chain `IMiddleware` contract that sends transactions.
+///
+/// Provides write access (signed provider) alongside a read-only [`MiddlewareQuery`] view.
 #[derive(Clone)]
 pub struct Middleware {
     instance: Instance,
@@ -40,10 +45,12 @@ impl Middleware {
         }
     }
 
+    /// Returns the on-chain address of the deployed Middleware contract.
     pub fn address(&self) -> LocalAddress {
         LocalAddress(*self.instance.address().0)
     }
 
+    /// Returns a read-only query handle backed by the root (unauthenticated) provider.
     pub fn query(&self) -> MiddlewareQuery {
         MiddlewareQuery(QueryInstance::new(
             *self.instance.address(),
@@ -52,6 +59,9 @@ impl Middleware {
     }
 }
 
+/// Read-only view of the `IMiddleware` contract, using an unauthenticated root provider.
+///
+/// Implements [`ElectionProvider`] to retrieve on-chain validator elections without signing.
 #[derive(Clone)]
 pub struct MiddlewareQuery(QueryInstance);
 
@@ -78,14 +88,19 @@ impl ElectionProvider for MiddlewareQuery {
 }
 
 impl MiddlewareQuery {
+    /// Constructs a [`MiddlewareQuery`] from an explicit contract address and root provider.
     pub fn from_provider(middleware_address: impl Into<Address>, provider: RootProvider) -> Self {
         Self(QueryInstance::new(middleware_address.into(), provider))
     }
 
+    /// Queries the Router contract address registered in the Middleware contract.
     pub async fn router(&self) -> Result<LocalAddress> {
         Ok(self.0.router().call().await?.into())
     }
 }
+/// Test double for [`ElectionProvider`] that returns predefined validator sets keyed by timestamp.
+///
+/// Intended for unit and integration tests where contract calls should be avoided.
 #[derive(Clone)]
 pub struct MockElectionProvider {
     predefined_election_at: Arc<RwLock<HashMap<u64, ValidatorsVec>>>,
@@ -109,12 +124,14 @@ impl ElectionProvider for MockElectionProvider {
 }
 
 impl MockElectionProvider {
+    /// Creates an empty mock with no predefined elections registered yet.
     pub fn new() -> Self {
         Self {
             predefined_election_at: Arc::new(Default::default()),
         }
     }
 
+    /// Registers a validator set to be returned by [`make_election_at`](ElectionProvider::make_election_at) for the given timestamp.
     pub async fn set_predefined_election_at(&self, ts: u64, validators: ValidatorsVec) {
         tracing::trace!(timestamp = ts, validators = ?validators, "set election result");
         self.predefined_election_at

--- a/ethexe/ethereum/src/mirror/events.rs
+++ b/ethexe/ethereum/src/mirror/events.rs
@@ -25,6 +25,8 @@ use gear_core::message::ReplyCode;
 use gprimitives::ActorId;
 use signatures::*;
 
+/// Keccak-256 topic-0 signature hashes for every `IMirror` event, plus the `REQUESTS` and `ALL`
+/// slices used to build log filters.
 pub mod signatures {
     use super::*;
 
@@ -46,6 +48,8 @@ pub mod signatures {
         VALUE_CLAIM_FAILED: ValueClaimFailed,
     }
 
+    /// Topic-0 signatures for events that originate from an on-chain user request, as opposed to
+    /// events that record the outcome of program execution.
     pub const REQUESTS: &[B256] = &[
         OWNED_BALANCE_TOP_UP_REQUESTED,
         EXECUTABLE_BALANCE_TOP_UP_REQUESTED,
@@ -55,6 +59,9 @@ pub mod signatures {
     ];
 }
 
+/// Attempts to decode a raw Ethereum log into a [`MirrorEvent`].
+///
+/// Returns `Ok(None)` when the log's topic-0 is not a known `IMirror` event signature.
 pub fn try_extract_event(log: &Log) -> Result<Option<MirrorEvent>> {
     let Some(topic0) = log.topic0().filter(|&v| ALL.contains(v)) else {
         return Ok(None);
@@ -107,6 +114,10 @@ pub fn try_extract_event(log: &Log) -> Result<Option<MirrorEvent>> {
     Ok(Some(event))
 }
 
+/// Attempts to decode a raw Ethereum log into a [`MirrorRequestEvent`].
+///
+/// Returns `Ok(None)` when the log's topic-0 is not one of the request-type event signatures
+/// listed in [`signatures::REQUESTS`].
 pub fn try_extract_request_event(log: &Log) -> Result<Option<MirrorRequestEvent>> {
     if log.topic0().filter(|&v| REQUESTS.contains(v)).is_none() {
         return Ok(None);
@@ -119,6 +130,7 @@ pub fn try_extract_request_event(log: &Log) -> Result<Option<MirrorRequestEvent>
     Ok(Some(request_event))
 }
 
+/// Builder that subscribes to all `IMirror` events on a given Mirror contract.
 pub struct AllEventsBuilder<'a> {
     query: &'a MirrorQuery,
 }
@@ -128,6 +140,7 @@ impl<'a> AllEventsBuilder<'a> {
         Self { query }
     }
 
+    /// Subscribes to all `IMirror` event types and yields decoded [`MirrorEvent`] values.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<MirrorEvent>> + Unpin + use<>> {
@@ -160,6 +173,7 @@ impl<'a> AllEventsBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `StateChanged` events on a Mirror contract.
 pub struct StateChangedEventBuilder<'a> {
     event: Event<&'a RootProvider, IMirror::StateChanged>,
 }
@@ -171,6 +185,7 @@ impl<'a> StateChangedEventBuilder<'a> {
         }
     }
 
+    /// Subscribes to `StateChanged` events and yields decoded event–log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<(StateChangedEvent, Log), Error>> + Unpin + use<>> {
@@ -183,6 +198,7 @@ impl<'a> StateChangedEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `MessageQueueingRequested` events, optionally filtered by sender.
 pub struct MessageQueueingRequestedEventBuilder<'a> {
     event: Event<&'a RootProvider, IMirror::MessageQueueingRequested>,
     source: Option<ActorId>,
@@ -196,11 +212,13 @@ impl<'a> MessageQueueingRequestedEventBuilder<'a> {
         }
     }
 
+    /// Restricts the subscription to events whose `source` topic matches `source`.
     pub fn source(mut self, source: ActorId) -> Self {
         self.source = Some(source);
         self
     }
 
+    /// Subscribes to `MessageQueueingRequested` events and yields decoded event–log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<
@@ -219,6 +237,7 @@ impl<'a> MessageQueueingRequestedEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `ReplyQueueingRequested` events, optionally filtered by sender.
 pub struct ReplyQueueingRequestedEventBuilder<'a> {
     event: Event<&'a RootProvider, IMirror::ReplyQueueingRequested>,
     source: Option<ActorId>,
@@ -232,11 +251,13 @@ impl<'a> ReplyQueueingRequestedEventBuilder<'a> {
         }
     }
 
+    /// Restricts the subscription to events whose `source` topic matches `source`.
     pub fn source(mut self, source: ActorId) -> Self {
         self.source = Some(source);
         self
     }
 
+    /// Subscribes to `ReplyQueueingRequested` events and yields decoded event–log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<(ReplyQueueingRequestedEvent, Log), Error>> + Unpin + use<>>
@@ -254,6 +275,7 @@ impl<'a> ReplyQueueingRequestedEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `ValueClaimingRequested` events, optionally filtered by claimer.
 pub struct ValueClaimingRequestedEventBuilder<'a> {
     event: Event<&'a RootProvider, IMirror::ValueClaimingRequested>,
     source: Option<ActorId>,
@@ -267,11 +289,13 @@ impl<'a> ValueClaimingRequestedEventBuilder<'a> {
         }
     }
 
+    /// Restricts the subscription to events whose `source` topic matches `source`.
     pub fn source(mut self, source: ActorId) -> Self {
         self.source = Some(source);
         self
     }
 
+    /// Subscribes to `ValueClaimingRequested` events and yields decoded event–log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<(ValueClaimingRequestedEvent, Log), Error>> + Unpin + use<>>
@@ -289,6 +313,7 @@ impl<'a> ValueClaimingRequestedEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `OwnedBalanceTopUpRequested` events on a Mirror contract.
 pub struct OwnedBalanceTopUpRequestedEventBuilder<'a> {
     event: Event<&'a RootProvider, IMirror::OwnedBalanceTopUpRequested>,
 }
@@ -300,6 +325,7 @@ impl<'a> OwnedBalanceTopUpRequestedEventBuilder<'a> {
         }
     }
 
+    /// Subscribes to `OwnedBalanceTopUpRequested` events and yields decoded event–log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<
@@ -314,6 +340,7 @@ impl<'a> OwnedBalanceTopUpRequestedEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `ExecutableBalanceTopUpRequested` events on a Mirror contract.
 pub struct ExecutableBalanceTopUpRequestedEventBuilder<'a> {
     event: Event<&'a RootProvider, IMirror::ExecutableBalanceTopUpRequested>,
 }
@@ -325,6 +352,7 @@ impl<'a> ExecutableBalanceTopUpRequestedEventBuilder<'a> {
         }
     }
 
+    /// Subscribes to `ExecutableBalanceTopUpRequested` events and yields decoded event–log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<
@@ -339,6 +367,7 @@ impl<'a> ExecutableBalanceTopUpRequestedEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to outgoing `Message` events, optionally filtered by destination.
 pub struct MessageEventBuilder<'a> {
     event: Event<&'a RootProvider, IMirror::Message>,
     destination: Option<ActorId>,
@@ -352,11 +381,13 @@ impl<'a> MessageEventBuilder<'a> {
         }
     }
 
+    /// Restricts the subscription to events whose `destination` topic matches `destination`.
     pub fn with_destination(mut self, destination: ActorId) -> Self {
         self.destination = Some(destination);
         self
     }
 
+    /// Subscribes to `Message` events and yields decoded event–log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<(MessageEvent, Log), Error>> + Unpin + use<>> {
@@ -373,6 +404,7 @@ impl<'a> MessageEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `MessageCallFailed` events on a Mirror contract.
 pub struct MessageCallFailedEventBuilder<'a> {
     event: Event<&'a RootProvider, IMirror::MessageCallFailed>,
     destination: Option<ActorId>,
@@ -386,6 +418,7 @@ impl<'a> MessageCallFailedEventBuilder<'a> {
         }
     }
 
+    /// Subscribes to `MessageCallFailed` events and yields decoded event–log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<(MessageCallFailedEvent, Log), Error>> + Unpin + use<>>
@@ -403,6 +436,7 @@ impl<'a> MessageCallFailedEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `Reply` events, optionally filtered by reply code.
 pub struct ReplyEventBuilder<'a> {
     event: Event<&'a RootProvider, IMirror::Reply>,
     reply_code: Option<ReplyCode>,
@@ -416,11 +450,15 @@ impl<'a> ReplyEventBuilder<'a> {
         }
     }
 
+    /// Restricts the subscription to events whose `replyCode` topic matches `reply_code`.
+    ///
+    /// The four-byte encoded reply code is right-padded with zeros to 32 bytes (left-aligned) before use as a topic filter.
     pub fn reply_code(mut self, reply_code: ReplyCode) -> Self {
         self.reply_code = Some(reply_code);
         self
     }
 
+    /// Subscribes to `Reply` events and yields decoded event–log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<(ReplyEvent, Log), Error>> + Unpin + use<>> {
@@ -438,6 +476,7 @@ impl<'a> ReplyEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `ReplyCallFailed` events, optionally filtered by reply code.
 pub struct ReplyCallFailedEventBuilder<'a> {
     event: Event<&'a RootProvider, IMirror::ReplyCallFailed>,
     reply_code: Option<ReplyCode>,
@@ -451,11 +490,15 @@ impl<'a> ReplyCallFailedEventBuilder<'a> {
         }
     }
 
+    /// Restricts the subscription to events whose `replyCode` topic matches `reply_code`.
+    ///
+    /// The four-byte encoded reply code is right-padded with zeros to 32 bytes (left-aligned) before use as a topic filter.
     pub fn reply_code(mut self, reply_code: ReplyCode) -> Self {
         self.reply_code = Some(reply_code);
         self
     }
 
+    /// Subscribes to `ReplyCallFailed` events and yields decoded event–log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<(ReplyCallFailedEvent, Log), Error>> + Unpin + use<>>
@@ -474,6 +517,7 @@ impl<'a> ReplyCallFailedEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `ValueClaimed` events on a Mirror contract.
 pub struct ValueClaimedEventBuilder<'a> {
     event: Event<&'a RootProvider, IMirror::ValueClaimed>,
 }
@@ -485,6 +529,7 @@ impl<'a> ValueClaimedEventBuilder<'a> {
         }
     }
 
+    /// Subscribes to `ValueClaimed` events and yields decoded event–log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<(ValueClaimedEvent, Log), Error>> + Unpin + use<>> {
@@ -497,6 +542,7 @@ impl<'a> ValueClaimedEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `TransferLockedValueToInheritorFailed` events on a Mirror contract.
 pub struct TransferLockedValueToInheritorFailedEventBuilder<'a> {
     event: Event<&'a RootProvider, IMirror::TransferLockedValueToInheritorFailed>,
 }
@@ -508,6 +554,7 @@ impl<'a> TransferLockedValueToInheritorFailedEventBuilder<'a> {
         }
     }
 
+    /// Subscribes to `TransferLockedValueToInheritorFailed` events and yields decoded event–log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<
@@ -524,6 +571,7 @@ impl<'a> TransferLockedValueToInheritorFailedEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `ReplyTransferFailed` events on a Mirror contract.
 pub struct ReplyTransferFailedEventBuilder<'a> {
     event: Event<&'a RootProvider, IMirror::ReplyTransferFailed>,
 }
@@ -535,6 +583,7 @@ impl<'a> ReplyTransferFailedEventBuilder<'a> {
         }
     }
 
+    /// Subscribes to `ReplyTransferFailed` events and yields decoded event–log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<(ReplyTransferFailedEvent, Log), Error>> + Unpin + use<>>
@@ -548,6 +597,7 @@ impl<'a> ReplyTransferFailedEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `ValueClaimFailed` events on a Mirror contract.
 pub struct ValueClaimFailedEventBuilder<'a> {
     event: Event<&'a RootProvider, IMirror::ValueClaimFailed>,
 }
@@ -559,6 +609,7 @@ impl<'a> ValueClaimFailedEventBuilder<'a> {
         }
     }
 
+    /// Subscribes to `ValueClaimFailed` events and yields decoded event–log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<(ValueClaimFailedEvent, Log), Error>> + Unpin + use<>>

--- a/ethexe/ethereum/src/mirror/mod.rs
+++ b/ethexe/ethereum/src/mirror/mod.rs
@@ -35,16 +35,25 @@ use serde::Serialize;
 
 pub mod events;
 
+/// Information about a successfully claimed value from a Mirror program.
 #[derive(Debug, Clone, Serialize)]
 pub struct ClaimInfo {
+    /// Identifier of the message whose locked value was claimed.
     pub message_id: MessageId,
+    /// Account that received the claimed value.
     pub actor_id: ActorId,
+    /// Amount of value transferred, in the smallest denomination.
     pub value: u128,
 }
 
 type Instance = IMirror::IMirrorInstance<AlloyProvider>;
 type QueryInstance = IMirror::IMirrorInstance<RootProvider>;
 
+/// Write-capable handle to a deployed Mirror contract (one per Gear program on Ethereum).
+///
+/// Wraps an Alloy provider with a wallet signer so callers can send transactions
+/// (`send_message`, `send_reply`, `claim_value`, balance top-ups) and subscribe to
+/// real-time events via [`Mirror::query`].
 pub struct Mirror {
     instance: Instance,
     wvara_address: AlloyAddress,
@@ -65,11 +74,13 @@ impl Mirror {
         }
     }
 
+    /// Returns the Gear [`ActorId`] that corresponds to this Mirror's Ethereum address.
     pub fn actor_id(&self) -> ActorId {
         let address = Address(*self.instance.address().0);
         address.into()
     }
 
+    /// Returns a read-only [`MirrorQuery`] handle bound to the same contract address.
     pub fn query(&self) -> MirrorQuery {
         MirrorQuery(QueryInstance::new(
             *self.instance.address(),
@@ -77,10 +88,12 @@ impl Mirror {
         ))
     }
 
+    /// Returns a [`WVara`] handle for the Wrapped Vara token contract associated with this Mirror.
     pub fn wvara(&self) -> WVara {
         WVara::new(self.wvara_address, self.instance.provider().clone())
     }
 
+    /// Subscribes to `StateChanged` events and returns the first new state hash observed.
     pub async fn wait_for_state_change(&self) -> Result<H256> {
         let mut stream = self.query().events().state_changed().subscribe().await?;
 
@@ -93,6 +106,7 @@ impl Mirror {
         Err(anyhow!("Failed to define if state changed"))
     }
 
+    /// Sends a message to the program and returns `(transaction_hash, message_id)` on success.
     pub async fn send_message(
         &self,
         payload: impl AsRef<[u8]>,
@@ -104,6 +118,7 @@ impl Mirror {
             .await
     }
 
+    /// Sends a message and returns the full `TransactionReceipt` together with the `MessageId`.
     pub async fn send_message_with_receipt(
         &self,
         payload: impl AsRef<[u8]>,
@@ -131,6 +146,7 @@ impl Mirror {
     }
 
     // TODO: remove gsobol's code that exposes alloy internals
+    /// Submits a `sendMessage` call and returns a pending transaction builder without waiting for confirmation.
     pub async fn send_message_pending(
         &self,
         payload: impl AsRef<[u8]>,
@@ -145,6 +161,7 @@ impl Mirror {
             .map_err(Into::into)
     }
 
+    /// Subscribes to `Reply` events and returns the first reply addressed to `message_id`.
     pub async fn wait_for_reply(&self, message_id: MessageId) -> Result<ReplyInfo> {
         let mut stream = self.query().events().reply().subscribe().await?;
 
@@ -171,6 +188,7 @@ impl Mirror {
         Err(anyhow!("Failed to wait for reply"))
     }
 
+    /// Sends a reply to `replied_to` and returns `(transaction_hash, message_id)` on success.
     pub async fn send_reply(
         &self,
         replied_to: MessageId,
@@ -182,6 +200,7 @@ impl Mirror {
             .map(|(receipt, message_id)| ((*receipt.transaction_hash).into(), message_id))
     }
 
+    /// Sends a reply to `replied_to` and returns the full `TransactionReceipt` together with the derived `MessageId`.
     pub async fn send_reply_with_receipt(
         &self,
         replied_to: MessageId,
@@ -204,12 +223,14 @@ impl Mirror {
         Ok((receipt, message_id))
     }
 
+    /// Claims the value locked in message `claimed_id` and returns the transaction hash.
     pub async fn claim_value(&self, claimed_id: MessageId) -> Result<H256> {
         self.claim_value_with_receipt(claimed_id)
             .await
             .map(|receipt| (*receipt.transaction_hash).into())
     }
 
+    /// Claims the value locked in message `claimed_id` and returns the full `TransactionReceipt`.
     pub async fn claim_value_with_receipt(
         &self,
         claimed_id: MessageId,
@@ -223,6 +244,7 @@ impl Mirror {
         Ok(receipt)
     }
 
+    /// Subscribes to `ValueClaimed` events and returns [`ClaimInfo`] once the event matching `message_id` is seen.
     pub async fn wait_for_value_claim(&self, message_id: MessageId) -> Result<ClaimInfo> {
         let mut stream = self.query().events().value_claimed().subscribe().await?;
 
@@ -243,12 +265,14 @@ impl Mirror {
         Err(anyhow!("Failed to wait for value claimed"))
     }
 
+    /// Tops up the program's executable balance by `value` and returns the transaction hash.
     pub async fn executable_balance_top_up(&self, value: u128) -> Result<H256> {
         self.executable_balance_top_up_with_receipt(value)
             .await
             .map(|receipt| (*receipt.transaction_hash).into())
     }
 
+    /// Tops up the program's executable balance by `value` and returns the full `TransactionReceipt`.
     pub async fn executable_balance_top_up_with_receipt(
         &self,
         value: u128,
@@ -262,12 +286,14 @@ impl Mirror {
         Ok(receipt)
     }
 
+    /// Tops up the executable balance using an EIP-712 permit (no prior approval transaction needed) and returns the transaction hash.
     pub async fn executable_balance_top_up_with_permit(&self, value: u128) -> Result<H256> {
         self.executable_balance_top_up_with_permit_and_receipt(value)
             .await
             .map(|receipt| (*receipt.transaction_hash).into())
     }
 
+    /// Tops up the executable balance using an EIP-712 permit and returns the full `TransactionReceipt`.
     pub async fn executable_balance_top_up_with_permit_and_receipt(
         &self,
         value: u128,
@@ -292,12 +318,14 @@ impl Mirror {
         Ok(receipt)
     }
 
+    /// Transfers any value locked in this Mirror to its inheritor program and returns the transaction hash.
     pub async fn transfer_locked_value_to_inheritor(&self) -> Result<H256> {
         self.transfer_locked_value_to_inheritor_with_receipt()
             .await
             .map(|receipt| (*receipt.transaction_hash).into())
     }
 
+    /// Transfers any value locked in this Mirror to its inheritor program and returns the full `TransactionReceipt`.
     pub async fn transfer_locked_value_to_inheritor_with_receipt(
         &self,
     ) -> Result<TransactionReceipt> {
@@ -310,12 +338,14 @@ impl Mirror {
         Ok(receipt)
     }
 
+    /// Sends a plain ETH transfer of `value` to the Mirror contract to top up its owned balance, returning the transaction hash.
     pub async fn owned_balance_top_up(&self, value: u128) -> Result<H256> {
         self.owned_balance_top_up_with_receipt(value)
             .await
             .map(|receipt| (*receipt.transaction_hash).into())
     }
 
+    /// Sends a plain ETH transfer of `value` to the Mirror contract to top up its owned balance, returning the full `TransactionReceipt`.
     pub async fn owned_balance_top_up_with_receipt(
         &self,
         value: u128,
@@ -332,9 +362,14 @@ impl Mirror {
     }
 }
 
+/// Read-only handle for querying Mirror contract state and subscribing to its events.
+///
+/// Obtained via [`Mirror::query`] or constructed directly with [`MirrorQuery::new`].
+/// Uses an unauthenticated [`RootProvider`] so no wallet is required.
 pub struct MirrorQuery(QueryInstance);
 
 impl MirrorQuery {
+    /// Creates a new `MirrorQuery` bound to `mirror_address` using the given provider.
     pub fn new(provider: RootProvider, mirror_address: Address) -> Self {
         Self(QueryInstance::new(
             AlloyAddress::new(mirror_address.0),
@@ -342,10 +377,12 @@ impl MirrorQuery {
         ))
     }
 
+    /// Returns a [`MirrorEvents`] builder for subscribing to or filtering Mirror contract events.
     pub fn events(&self) -> MirrorEvents<'_> {
         MirrorEvents { query: self }
     }
 
+    /// Returns the native ETH balance of the Mirror contract address.
     pub async fn balance(&self) -> Result<u128> {
         self.0
             .provider()
@@ -355,6 +392,7 @@ impl MirrorQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the address of the Router contract that governs this Mirror.
     pub async fn router(&self) -> Result<Address> {
         self.0
             .router()
@@ -364,10 +402,12 @@ impl MirrorQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the latest committed state hash of the program from the Mirror contract.
     pub async fn state_hash(&self) -> Result<H256> {
         self.state_hash_at(BlockId::latest()).await
     }
 
+    /// Returns the program's state hash as it was at the specified block.
     pub async fn state_hash_at(&self, id: impl IntoBlockId) -> Result<H256> {
         self.0
             .stateHash()
@@ -378,6 +418,7 @@ impl MirrorQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the current nonce of the Mirror contract, used to sequence state transitions.
     pub async fn nonce(&self) -> Result<U256> {
         self.0
             .nonce()
@@ -387,10 +428,12 @@ impl MirrorQuery {
             .map_err(Into::into)
     }
 
+    /// Returns `true` if the underlying Gear program has called `gr_exit` and the Mirror is in the exited state.
     pub async fn exited(&self) -> Result<bool> {
         self.0.exited().call().await.map_err(Into::into)
     }
 
+    /// Returns the actor that inherits this program's locked value after it exits or terminates.
     pub async fn inheritor(&self) -> Result<ActorId> {
         self.0
             .inheritor()
@@ -400,6 +443,7 @@ impl MirrorQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the actor that originally initialized this program via `upload_program`.
     pub async fn initializer(&self) -> Result<ActorId> {
         self.0
             .initializer()
@@ -410,71 +454,90 @@ impl MirrorQuery {
     }
 }
 
+/// Factory for per-event-type subscription builders scoped to a single Mirror contract.
+///
+/// Obtained via [`MirrorQuery::events`]. Each method returns a typed builder that can
+/// be subscribed to as a live stream or used to fetch historical logs.
 pub struct MirrorEvents<'a> {
     query: &'a MirrorQuery,
 }
 
 impl<'a> MirrorEvents<'a> {
+    /// Returns a builder that subscribes to all event types emitted by the Mirror contract.
     pub fn all(&self) -> AllEventsBuilder<'a> {
         AllEventsBuilder::new(self.query)
     }
 
+    /// Returns a builder for `StateChanged` events (emitted when the program state hash updates).
     pub fn state_changed(&self) -> StateChangedEventBuilder<'a> {
         StateChangedEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for `MessageQueueingRequested` events (emitted when a user queues a message to the program).
     pub fn message_queueing_requested(&self) -> MessageQueueingRequestedEventBuilder<'a> {
         MessageQueueingRequestedEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for `ReplyQueueingRequested` events (emitted when a user queues a reply).
     pub fn reply_queueing_requested(&self) -> ReplyQueueingRequestedEventBuilder<'a> {
         ReplyQueueingRequestedEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for `ValueClaimingRequested` events (emitted when a user requests to claim locked value).
     pub fn value_claiming_requested(&self) -> ValueClaimingRequestedEventBuilder<'a> {
         ValueClaimingRequestedEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for `OwnedBalanceTopUpRequested` events (emitted when the owned balance is topped up via plain ETH transfer).
     pub fn owned_balance_top_up_requested(&self) -> OwnedBalanceTopUpRequestedEventBuilder<'a> {
         OwnedBalanceTopUpRequestedEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for `ExecutableBalanceTopUpRequested` events (emitted when the executable balance is topped up).
     pub fn executable_balance_top_up_requested(
         &self,
     ) -> ExecutableBalanceTopUpRequestedEventBuilder<'a> {
         ExecutableBalanceTopUpRequestedEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for `Message` events (emitted when the program sends an outgoing message).
     pub fn message(&self) -> MessageEventBuilder<'a> {
         MessageEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for `MessageCallFailed` events (emitted when an outgoing message call fails).
     pub fn message_call_failed(&self) -> MessageCallFailedEventBuilder<'a> {
         MessageCallFailedEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for `Reply` events (emitted when the program sends a reply to a queued message).
     pub fn reply(&self) -> ReplyEventBuilder<'a> {
         ReplyEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for `ReplyCallFailed` events (emitted when a reply call fails on-chain).
     pub fn reply_call_failed(&self) -> ReplyCallFailedEventBuilder<'a> {
         ReplyCallFailedEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for `ValueClaimed` events (emitted when locked value is successfully claimed).
     pub fn value_claimed(&self) -> ValueClaimedEventBuilder<'a> {
         ValueClaimedEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for `TransferLockedValueToInheritorFailed` events (emitted when inheritor value transfer fails).
     pub fn transfer_locked_value_to_inheritor_failed(
         &self,
     ) -> TransferLockedValueToInheritorFailedEventBuilder<'a> {
         TransferLockedValueToInheritorFailedEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for `ReplyTransferFailed` events (emitted when value transfer as part of a reply fails).
     pub fn reply_transfer_failed(&self) -> ReplyTransferFailedEventBuilder<'a> {
         ReplyTransferFailedEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for `ValueClaimFailed` events (emitted when a value claim attempt fails).
     pub fn value_claim_failed(&self) -> ValueClaimFailedEventBuilder<'a> {
         ValueClaimFailedEventBuilder::new(self.query)
     }

--- a/ethexe/ethereum/src/router/events.rs
+++ b/ethexe/ethereum/src/router/events.rs
@@ -27,6 +27,8 @@ use futures::{Stream, StreamExt};
 use gprimitives::CodeId;
 use signatures::*;
 
+/// Keccak-256 topic-0 signature hashes for every `IRouter` event, plus the `REQUESTS` and `ALL`
+/// slices used to build log filters.
 pub mod signatures {
     use super::*;
 
@@ -43,6 +45,8 @@ pub mod signatures {
         VALIDATORS_COMMITTED_FOR_ERA: ValidatorsCommittedForEra,
     }
 
+    /// Topic-0 signatures for events that originate from an on-chain user or validator request,
+    /// as opposed to events that record execution outcomes.
     pub const REQUESTS: &[B256] = &[
         CODE_VALIDATION_REQUESTED,
         COMPUTATION_SETTINGS_CHANGED,
@@ -52,6 +56,10 @@ pub mod signatures {
     ];
 }
 
+/// Attempts to decode an Ethereum log into a [`RouterEvent`].
+///
+/// Returns `Ok(None)` when the log's topic-0 does not match any known Router event signature,
+/// and `Err` when the log matches but decoding fails.
 pub fn try_extract_event(log: &Log) -> Result<Option<RouterEvent>> {
     let Some(topic0) = log.topic0().filter(|&v| ALL.contains(v)) else {
         return Ok(None);
@@ -99,6 +107,10 @@ pub fn try_extract_event(log: &Log) -> Result<Option<RouterEvent>> {
     Ok(Some(event))
 }
 
+/// Attempts to decode an Ethereum log into a [`RouterRequestEvent`].
+///
+/// Returns `Ok(None)` when the log does not match a request-category event signature (see
+/// `signatures::REQUESTS`), and `Err` when it matches but decoding fails.
 pub fn try_extract_request_event(log: &Log) -> Result<Option<RouterRequestEvent>> {
     if log.topic0().filter(|&v| REQUESTS.contains(v)).is_none() {
         return Ok(None);
@@ -111,6 +123,10 @@ pub fn try_extract_request_event(log: &Log) -> Result<Option<RouterRequestEvent>
     Ok(Some(request_event))
 }
 
+/// Builder that subscribes to all Router contract events at once.
+///
+/// Call [`AllEventsBuilder::subscribe`] to open a live stream of every [`RouterEvent`] variant
+/// emitted by the Router contract address bound to the underlying [`RouterQuery`].
 pub struct AllEventsBuilder<'a> {
     query: &'a RouterQuery,
 }
@@ -120,6 +136,7 @@ impl<'a> AllEventsBuilder<'a> {
         Self { query }
     }
 
+    /// Subscribes to all Router events and returns a live stream of decoded [`RouterEvent`]s.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<RouterEvent>> + Unpin + use<>> {
@@ -147,6 +164,7 @@ impl<'a> AllEventsBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `BatchCommitted` events from the Router contract.
 pub struct BatchCommittedEventBuilder<'a> {
     event: Event<&'a RootProvider, IRouter::BatchCommitted>,
 }
@@ -158,6 +176,7 @@ impl<'a> BatchCommittedEventBuilder<'a> {
         }
     }
 
+    /// Subscribes to `BatchCommitted` events and returns a live stream of decoded event/log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<(BatchCommittedEvent, Log), Error>> + Unpin + use<>> {
@@ -170,6 +189,7 @@ impl<'a> BatchCommittedEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `MBCommitted` (announces-chain head committed) events from the Router contract.
 pub struct MBCommittedEventBuilder<'a> {
     event: Event<&'a RootProvider, IRouter::MBCommitted>,
 }
@@ -181,6 +201,7 @@ impl<'a> MBCommittedEventBuilder<'a> {
         }
     }
 
+    /// Subscribes to `MBCommitted` events and returns a live stream of decoded event/log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<(MBCommittedEvent, Log), Error>> + Unpin + use<>> {
@@ -193,6 +214,7 @@ impl<'a> MBCommittedEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `EBCommitted` (Ethereum-block committed) events from the Router contract.
 pub struct EBCommittedEventBuilder<'a> {
     event: Event<&'a RootProvider, IRouter::EBCommitted>,
 }
@@ -204,6 +226,7 @@ impl<'a> EBCommittedEventBuilder<'a> {
         }
     }
 
+    /// Subscribes to `EBCommitted` events and returns a live stream of decoded event/log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<(EBCommittedEvent, Log), Error>> + Unpin + use<>> {
@@ -216,6 +239,9 @@ impl<'a> EBCommittedEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `CodeGotValidated` events from the Router contract.
+///
+/// Optionally filter by validation outcome using [`CodeGotValidatedEventBuilder::valid`].
 pub struct CodeGotValidatedEventBuilder<'a> {
     event: Event<&'a RootProvider, IRouter::CodeGotValidated>,
     valid: Option<bool>,
@@ -229,11 +255,13 @@ impl<'a> CodeGotValidatedEventBuilder<'a> {
         }
     }
 
+    /// Restricts the subscription to events where the `valid` indexed field equals `valid`.
     pub fn valid(mut self, valid: bool) -> Self {
         self.valid = Some(valid);
         self
     }
 
+    /// Subscribes to `CodeGotValidated` events and returns a live stream of decoded event/log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<(CodeGotValidatedEvent, Log), Error>> + Unpin + use<>>
@@ -250,6 +278,7 @@ impl<'a> CodeGotValidatedEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `CodeValidationRequested` events from the Router contract.
 pub struct CodeValidationRequestedEventBuilder<'a> {
     event: Event<&'a RootProvider, IRouter::CodeValidationRequested>,
 }
@@ -261,6 +290,10 @@ impl<'a> CodeValidationRequestedEventBuilder<'a> {
         }
     }
 
+    /// Subscribes to `CodeValidationRequested` events and returns a live stream of decoded event/log pairs.
+    ///
+    /// The stream enriches each event with the originating transaction hash and block timestamp,
+    /// returning an error if either field is absent from the log.
     pub async fn subscribe(
         self,
     ) -> Result<
@@ -285,6 +318,7 @@ impl<'a> CodeValidationRequestedEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `ValidatorsCommittedForEra` events from the Router contract.
 pub struct ValidatorsCommittedForEraEventBuilder<'a> {
     event: Event<&'a RootProvider, IRouter::ValidatorsCommittedForEra>,
 }
@@ -296,6 +330,7 @@ impl<'a> ValidatorsCommittedForEraEventBuilder<'a> {
         }
     }
 
+    /// Subscribes to `ValidatorsCommittedForEra` events and returns a live stream of decoded event/log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<
@@ -310,6 +345,7 @@ impl<'a> ValidatorsCommittedForEraEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `ComputationSettingsChanged` events from the Router contract.
 pub struct ComputationSettingsChangedEventBuilder<'a> {
     event: Event<&'a RootProvider, IRouter::ComputationSettingsChanged>,
 }
@@ -321,6 +357,7 @@ impl<'a> ComputationSettingsChangedEventBuilder<'a> {
         }
     }
 
+    /// Subscribes to `ComputationSettingsChanged` events and returns a live stream of decoded event/log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<
@@ -335,6 +372,9 @@ impl<'a> ComputationSettingsChangedEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `ProgramCreated` events from the Router contract.
+///
+/// Optionally filter by the code identifier using [`ProgramCreatedEventBuilder::code_id`].
 pub struct ProgramCreatedEventBuilder<'a> {
     event: Event<&'a RootProvider, IRouter::ProgramCreated>,
     code_id: Option<CodeId>,
@@ -348,11 +388,13 @@ impl<'a> ProgramCreatedEventBuilder<'a> {
         }
     }
 
+    /// Restricts the subscription to events where the `codeId` indexed field matches `code_id`.
     pub fn code_id(mut self, code_id: CodeId) -> Self {
         self.code_id = Some(code_id);
         self
     }
 
+    /// Subscribes to `ProgramCreated` events and returns a live stream of decoded event/log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<(ProgramCreatedEvent, Log), Error>> + Unpin + use<>> {
@@ -369,6 +411,7 @@ impl<'a> ProgramCreatedEventBuilder<'a> {
     }
 }
 
+/// Builder that subscribes to `StorageSlotChanged` events from the Router contract.
 pub struct StorageSlotChangedEventBuilder<'a> {
     event: Event<&'a RootProvider, IRouter::StorageSlotChanged>,
 }
@@ -380,6 +423,7 @@ impl<'a> StorageSlotChangedEventBuilder<'a> {
         }
     }
 
+    /// Subscribes to `StorageSlotChanged` events and returns a live stream of decoded event/log pairs.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<(StorageSlotChangedEvent, Log), Error>> + Unpin + use<>>

--- a/ethexe/ethereum/src/router/mod.rs
+++ b/ethexe/ethereum/src/router/mod.rs
@@ -43,11 +43,17 @@ use gprimitives::{ActorId, CodeId, H256};
 use serde::Serialize;
 use std::collections::HashMap;
 
+/// Event type definitions and builder helpers for the Router contract.
 pub mod events;
 
 type Instance = IRouter::IRouterInstance<AlloyProvider>;
 type QueryInstance = IRouter::IRouterInstance<RootProvider>;
 
+/// Writable handle to the on-chain `IRouter` contract.
+///
+/// Holds an authenticated `Sender` and an EIP-1559 fee estimator so callers can
+/// submit state-mutating transactions (code validation, program creation, batch
+/// commitment) without managing connection details directly.
 #[derive(Clone)]
 pub struct Router {
     instance: Instance,
@@ -80,10 +86,12 @@ impl Router {
         }
     }
 
+    /// Returns the Ethereum address of the deployed Router contract.
     pub fn address(&self) -> Address {
         Address(*self.instance.address().0)
     }
 
+    /// Returns a read-only [`RouterQuery`] bound to the same contract address and underlying provider.
     pub fn query(&self) -> RouterQuery {
         RouterQuery {
             instance: QueryInstance::new(
@@ -93,16 +101,19 @@ impl Router {
         }
     }
 
+    /// Returns a [`WVara`] handle pointing at the Wrapped Vara token contract associated with this router.
     pub fn wvara(&self) -> WVara {
         WVara::new(self.wvara_address, self.instance.provider().clone())
     }
 
+    /// Updates the Mirror implementation address in the Router contract and returns the transaction hash.
     pub async fn set_mirror(&self, new_mirror: Address) -> Result<H256> {
         self.set_mirror_with_receipt(new_mirror)
             .await
             .map(|receipt| (*receipt.transaction_hash).into())
     }
 
+    /// Updates the Mirror implementation address in the Router contract and returns the full transaction receipt.
     pub async fn set_mirror_with_receipt(&self, new_mirror: Address) -> Result<TransactionReceipt> {
         let new_mirror = AlloyAddress::new(new_mirror.0);
         let builder = self.instance.setMirror(new_mirror);
@@ -114,6 +125,7 @@ impl Router {
         Ok(receipt)
     }
 
+    /// Calls the contract's `reinitialize` function and returns the transaction receipt.
     pub async fn reinitialize(&self) -> Result<TransactionReceipt> {
         let builder = self.instance.reinitialize();
         let receipt = builder
@@ -124,12 +136,14 @@ impl Router {
         Ok(receipt)
     }
 
+    /// Looks up and records the genesis block hash in the Router contract, returning the transaction hash.
     pub async fn lookup_genesis_hash(&self) -> Result<H256> {
         self.lookup_genesis_hash_with_receipt()
             .await
             .map(|receipt| (*receipt.transaction_hash).into())
     }
 
+    /// Looks up and records the genesis block hash in the Router contract, returning the full transaction receipt.
     pub async fn lookup_genesis_hash_with_receipt(&self) -> Result<TransactionReceipt> {
         let builder = self.instance.lookupGenesisHash();
         let receipt = builder
@@ -140,12 +154,16 @@ impl Router {
         Ok(receipt)
     }
 
+    /// Submits a code blob for validation via EIP-7594 blob-sidecar transaction, returning the transaction hash and derived `CodeId`.
     pub async fn request_code_validation(&self, code: &[u8]) -> Result<(H256, CodeId)> {
         self.request_code_validation_with_receipt(code)
             .await
             .map(|(receipt, code_id)| ((*receipt.transaction_hash).into(), code_id))
     }
 
+    /// Submits a code blob for validation via EIP-7594 blob-sidecar transaction, returning the full receipt and derived `CodeId`.
+    ///
+    /// Prepares an EIP-712 permit for the required base fee before sending.
     pub async fn request_code_validation_with_receipt(
         &self,
         code: &[u8],
@@ -176,6 +194,7 @@ impl Router {
         Ok((receipt, code_id))
     }
 
+    /// Subscribes to `CodeGotValidated` events and blocks until the given `code_id` is confirmed, returning the result.
     pub async fn wait_for_code_validation(&self, code_id: CodeId) -> Result<CodeValidationResult> {
         let router_query = self.query();
         let mut stream = router_query
@@ -206,6 +225,7 @@ impl Router {
         Err(anyhow!("Failed to define if code is validated"))
     }
 
+    /// Creates a new program from the given `code_id` and `salt`, returning the transaction hash and the assigned `ActorId`.
     pub async fn create_program(
         &self,
         code_id: CodeId,
@@ -217,6 +237,7 @@ impl Router {
             .map(|(receipt, actor_id)| ((*receipt.transaction_hash).into(), actor_id))
     }
 
+    /// Creates a new program and returns the full transaction receipt together with the assigned `ActorId`.
     pub async fn create_program_with_receipt(
         &self,
         code_id: CodeId,
@@ -254,6 +275,7 @@ impl Router {
         Ok((receipt, actor_id))
     }
 
+    /// Creates a new program and seeds it with an initial executable WVara balance, returning the transaction hash and `ActorId`.
     pub async fn create_program_with_executable_balance(
         &self,
         code_id: CodeId,
@@ -271,6 +293,9 @@ impl Router {
         .map(|(receipt, actor_id)| ((*receipt.transaction_hash).into(), actor_id))
     }
 
+    /// Creates a new program with an initial executable WVara balance and returns the full receipt together with the `ActorId`.
+    ///
+    /// Uses an EIP-712 permit to authorize the token transfer without a separate approval transaction.
     pub async fn create_program_with_executable_balance_and_receipt(
         &self,
         code_id: CodeId,
@@ -323,6 +348,7 @@ impl Router {
         Ok((receipt, actor_id))
     }
 
+    /// Creates a new program and registers an ABI interface actor for it, returning the transaction hash and the assigned `ActorId`.
     pub async fn create_program_with_abi_interface(
         &self,
         code_id: CodeId,
@@ -340,6 +366,7 @@ impl Router {
         .map(|(receipt, actor_id)| ((*receipt.transaction_hash).into(), actor_id))
     }
 
+    /// Creates a new program with an ABI interface actor and returns the full receipt together with the assigned `ActorId`.
     pub async fn create_program_with_abi_interface_with_receipt(
         &self,
         code_id: CodeId,
@@ -381,6 +408,7 @@ impl Router {
         Ok((receipt, actor_id))
     }
 
+    /// Creates a new program with both an ABI interface and an initial executable WVara balance, returning the transaction hash and `ActorId`.
     pub async fn create_program_with_abi_interface_and_executable_balance(
         &self,
         code_id: CodeId,
@@ -400,6 +428,9 @@ impl Router {
         .map(|(receipt, actor_id)| ((*receipt.transaction_hash).into(), actor_id))
     }
 
+    /// Creates a new program with an ABI interface and an initial executable WVara balance, returning the full receipt and `ActorId`.
+    ///
+    /// Uses an EIP-712 permit to authorize the token transfer without a separate approval transaction.
     pub async fn create_program_with_abi_interface_and_executable_balance_with_receipt(
         &self,
         code_id: CodeId,
@@ -458,6 +489,7 @@ impl Router {
         Ok((receipt, actor_id))
     }
 
+    /// Submits a batch commitment with ECDSA signatures and waits for the receipt, returning the transaction hash.
     pub async fn commit_batch(
         &self,
         commitment: BatchCommitment,
@@ -470,6 +502,10 @@ impl Router {
             .map(|receipt| H256(receipt.transaction_hash.0))
     }
 
+    /// Builds and broadcasts a batch commitment transaction, returning a [`PendingTransactionBuilder`] for further awaiting.
+    ///
+    /// Estimates gas with a state override that sets `reserved = 1` on the Router storage so the simulation can bypass the `Gear.blockIsPredecessor()` check,
+    /// then applies the configured EIP-1559 fee cap and a hard gas-limit cap before sending.
     pub async fn commit_batch_pending(
         &self,
         commitment: BatchCommitment,
@@ -567,20 +603,30 @@ impl Router {
     }
 }
 
+/// Outcome of a code validation event observed from the Router contract.
 #[derive(Clone, Debug, Serialize)]
 pub struct CodeValidationResult {
+    /// Whether the submitted code was accepted as valid by the validators.
     pub valid: bool,
+    /// Hash of the transaction that carried the `CodeGotValidated` event, if available.
     pub tx_hash: Option<H256>,
+    /// Hash of the block containing the validation event, if available.
     pub block_hash: Option<H256>,
+    /// Number of the block containing the validation event, if available.
     pub block_number: Option<u64>,
 }
 
+/// Read-only handle for querying on-chain state from the `IRouter` contract.
+///
+/// Uses an unauthenticated `RootProvider` so no private key is required.
+/// Obtain an instance via [`Router::query`] or [`RouterQuery::new`].
 #[derive(Clone)]
 pub struct RouterQuery {
     instance: QueryInstance,
 }
 
 impl RouterQuery {
+    /// Connects to the given JSON-RPC endpoint and constructs a `RouterQuery` for the specified contract address.
     pub async fn new(rpc_url: &str, router_address: impl Into<AlloyAddress>) -> Result<Self> {
         let provider = ProviderBuilder::default().connect(rpc_url).await?;
 
@@ -589,22 +635,26 @@ impl RouterQuery {
         })
     }
 
+    /// Constructs a `RouterQuery` from an already-connected provider without performing a network call.
     pub fn from_provider(router_address: impl Into<AlloyAddress>, provider: RootProvider) -> Self {
         Self {
             instance: QueryInstance::new(router_address.into(), provider),
         }
     }
 
+    /// Returns a [`RouterEvents`] helper that exposes typed event subscription builders for this query.
     pub fn events(&self) -> RouterEvents<'_> {
         RouterEvents { query: self }
     }
 
     // TODO: move StorageView into ethexe-common and export
 
+    /// Fetches the full contract storage snapshot at the latest block.
     pub async fn storage_view(&self) -> Result<IRouter::StorageView> {
         self.storage_view_at(BlockId::latest()).await
     }
 
+    /// Fetches the full contract storage snapshot at the given block.
     pub async fn storage_view_at(&self, id: impl IntoBlockId) -> Result<IRouter::StorageView> {
         self.instance
             .storageView()
@@ -614,6 +664,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the hash of the Ethereum block used as the genesis anchor for this Router deployment.
     pub async fn genesis_block_hash(&self) -> Result<H256> {
         self.instance
             .genesisBlockHash()
@@ -623,6 +674,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the timestamp of the genesis block used as the Router's starting point.
     pub async fn genesis_timestamp(&self) -> Result<u64> {
         self.instance
             .genesisTimestamp()
@@ -632,6 +684,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the digest of the most recently committed batch.
     pub async fn latest_committed_batch_hash(&self) -> Result<Digest> {
         self.instance
             .latestCommittedBatchHash()
@@ -641,6 +694,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the timestamp of the most recently committed batch.
     pub async fn latest_committed_batch_timestamp(&self) -> Result<u64> {
         self.instance
             .latestCommittedBatchTimestamp()
@@ -650,6 +704,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the address of the Mirror implementation contract used by the Router for program proxies.
     pub async fn mirror_impl(&self) -> Result<Address> {
         self.instance
             .mirrorImpl()
@@ -659,6 +714,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the address of the Wrapped Vara (WVara) ERC-20 token contract linked to this Router.
     pub async fn wvara_address(&self) -> Result<Address> {
         self.instance
             .wrappedVara()
@@ -668,6 +724,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the address of the Middleware contract responsible for validator election and permissions.
     pub async fn middleware_address(&self) -> Result<Address> {
         self.instance
             .middleware()
@@ -677,6 +734,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the aggregated FROST public key of the current validator set used for signature verification.
     pub async fn validators_aggregated_public_key(&self) -> Result<AggregatedPublicKey> {
         self.instance
             .validatorsAggregatedPublicKey()
@@ -689,6 +747,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the raw bytes of the verifiable secret sharing commitment for the current validator set.
     pub async fn validators_verifiable_secret_sharing_commitment(&self) -> Result<Vec<u8>> {
         self.instance
             .validatorsVerifiableSecretSharingCommitment()
@@ -698,6 +757,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns `true` if every address in `validators` is a member of the current validator set.
     pub async fn are_validators(
         &self,
         validators: impl IntoIterator<Item = Address>,
@@ -710,6 +770,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns `true` if the given address is a member of the current validator set.
     pub async fn is_validator(&self, validator: Address) -> Result<bool> {
         let address: AlloyAddress = validator.into();
         self.instance
@@ -719,6 +780,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the signing threshold as a `(numerator, denominator)` fraction of the validator count required to commit a batch.
     pub async fn signing_threshold_fraction(&self) -> Result<(u128, u128)> {
         self.instance
             .signingThresholdFraction()
@@ -728,10 +790,12 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the list of current validators at the latest block.
     pub async fn validators(&self) -> Result<ValidatorsVec> {
         self.validators_at(BlockId::latest()).await
     }
 
+    /// Returns the list of validators at the specified block.
     pub async fn validators_at(&self, id: impl IntoBlockId) -> Result<ValidatorsVec> {
         let validators: Vec<_> = self
             .instance
@@ -744,6 +808,7 @@ impl RouterQuery {
         validators.try_into().map_err(Into::into)
     }
 
+    /// Returns the number of validators in the current set.
     pub async fn validators_count(&self) -> Result<u64> {
         self.instance
             .validatorsCount()
@@ -753,6 +818,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the minimum number of validator signatures required to commit a batch.
     pub async fn validators_threshold(&self) -> Result<u64> {
         self.instance
             .validatorsThreshold()
@@ -762,6 +828,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the on-chain computation settings that govern program execution parameters.
     pub async fn compute_settings(&self) -> Result<ComputationSettings> {
         self.instance
             .computeSettings()
@@ -771,6 +838,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the validation state of a single code blob identified by `code_id`.
     pub async fn code_state(&self, code_id: CodeId) -> Result<CodeState> {
         self.instance
             .codeState(code_id.into_bytes().into())
@@ -780,6 +848,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the validation states for multiple code blobs at the latest block.
     pub async fn codes_states(
         &self,
         code_ids: impl IntoIterator<Item = CodeId>,
@@ -797,6 +866,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the validation states for multiple code blobs at the specified block.
     pub async fn codes_states_at(
         &self,
         code_ids: impl IntoIterator<Item = CodeId>,
@@ -816,6 +886,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the `CodeId` of the code backing the given program, or `None` if the program does not exist.
     pub async fn program_code_id(&self, program_id: ActorId) -> Result<Option<CodeId>> {
         let program_id = Address::try_from(program_id).expect("infallible");
         let program_id = AlloyAddress::new(program_id.0);
@@ -824,6 +895,7 @@ impl RouterQuery {
         Ok(code_id)
     }
 
+    /// Returns the `CodeId` for each program in the given list at the latest block.
     pub async fn programs_code_ids(
         &self,
         program_ids: impl IntoIterator<Item = ActorId>,
@@ -844,6 +916,7 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the `CodeId` for each program in the given list at the specified block.
     pub async fn programs_code_ids_at(
         &self,
         program_ids: impl IntoIterator<Item = ActorId>,
@@ -866,10 +939,12 @@ impl RouterQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the total number of programs registered in the Router at the latest block.
     pub async fn programs_count(&self) -> Result<u64> {
         self.programs_count_at(BlockId::latest()).await
     }
 
+    /// Returns the total number of programs registered in the Router at the specified block.
     pub async fn programs_count_at(&self, id: impl IntoBlockId) -> Result<u64> {
         let count = self
             .instance
@@ -882,10 +957,12 @@ impl RouterQuery {
         Ok(count)
     }
 
+    /// Returns the total number of validated code blobs at the latest block.
     pub async fn validated_codes_count(&self) -> Result<u64> {
         self.validated_codes_count_at(BlockId::latest()).await
     }
 
+    /// Returns the total number of validated code blobs at the specified block.
     pub async fn validated_codes_count_at(&self, id: impl IntoBlockId) -> Result<u64> {
         let count = self
             .instance
@@ -898,16 +975,19 @@ impl RouterQuery {
         Ok(count)
     }
 
+    /// Returns the base WVara fee charged per code validation request.
     pub async fn request_code_validation_base_fee(&self) -> Result<u128> {
         let base_fee = self.instance.requestCodeValidationBaseFee().call().await?;
         Ok(base_fee.try_into().expect("infallible"))
     }
 
+    /// Returns the extra WVara fee that may be charged on top of the base fee for code validation.
     pub async fn request_code_validation_extra_fee(&self) -> Result<u128> {
         let extra_fee = self.instance.requestCodeValidationExtraFee().call().await?;
         Ok(extra_fee.try_into().expect("infallible"))
     }
 
+    /// Returns the Router's configured timeline parameters governing era and batch scheduling.
     pub async fn timelines(&self) -> Result<Timelines> {
         self.instance
             .timelines()
@@ -918,47 +998,58 @@ impl RouterQuery {
     }
 }
 
+/// Factory for typed event subscription builders scoped to a single [`RouterQuery`].
 pub struct RouterEvents<'a> {
     query: &'a RouterQuery,
 }
 
 impl<'a> RouterEvents<'a> {
+    /// Returns a builder that subscribes to all Router contract events.
     pub fn all(&self) -> AllEventsBuilder<'a> {
         AllEventsBuilder::new(self.query)
     }
 
+    /// Returns a builder for subscribing to `BatchCommitted` events.
     pub fn batch_committed(&self) -> BatchCommittedEventBuilder<'a> {
         BatchCommittedEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for subscribing to `MBCommitted` (announces-chain head committed) events.
     pub fn mb_committed(&self) -> MBCommittedEventBuilder<'a> {
         MBCommittedEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for subscribing to `EBCommitted` (Ethereum-block committed) events.
     pub fn eb_committed(&self) -> EBCommittedEventBuilder<'a> {
         EBCommittedEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for subscribing to `CodeGotValidated` events.
     pub fn code_got_validated(&self) -> CodeGotValidatedEventBuilder<'a> {
         CodeGotValidatedEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for subscribing to `CodeValidationRequested` events.
     pub fn code_validation_requested(&self) -> CodeValidationRequestedEventBuilder<'a> {
         CodeValidationRequestedEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for subscribing to `ValidatorsCommittedForEra` events.
     pub fn validators_committed_for_era(&self) -> ValidatorsCommittedForEraEventBuilder<'a> {
         ValidatorsCommittedForEraEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for subscribing to `ComputationSettingsChanged` events.
     pub fn computation_settings_changed(&self) -> ComputationSettingsChangedEventBuilder<'a> {
         ComputationSettingsChangedEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for subscribing to `ProgramCreated` events.
     pub fn program_created(&self) -> ProgramCreatedEventBuilder<'a> {
         ProgramCreatedEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for subscribing to `StorageSlotChanged` events.
     pub fn storage_slot_changed(&self) -> StorageSlotChangedEventBuilder<'a> {
         StorageSlotChangedEventBuilder::new(self.query)
     }

--- a/ethexe/ethereum/src/wvara/events.rs
+++ b/ethexe/ethereum/src/wvara/events.rs
@@ -20,6 +20,8 @@ use ethexe_common::{
 use futures::{Stream, StreamExt};
 use signatures::*;
 
+/// Keccak-256 topic-0 signature hashes for every `IWrappedVara` event, plus `REQUESTS` and `ALL`
+/// slices used to build Ethereum log filters.
 pub mod signatures {
     use super::*;
 
@@ -29,9 +31,14 @@ pub mod signatures {
         APPROVAL: Approval,
     }
 
+    /// Subset of event signatures that represent user-initiated requests; currently only `Transfer`.
     pub const REQUESTS: &[B256] = &[TRANSFER];
 }
 
+/// Attempts to decode an Ethereum log into a [`WVaraEvent`].
+///
+/// Returns `Ok(None)` when the log's topic-0 does not match any known `IWrappedVara` event
+/// signature, and `Err` when decoding a matching log fails.
 pub fn try_extract_event(log: &Log) -> Result<Option<WVaraEvent>> {
     let Some(topic0) = log.topic0().filter(|&v| ALL.contains(v)) else {
         return Ok(None);
@@ -46,6 +53,8 @@ pub fn try_extract_event(log: &Log) -> Result<Option<WVaraEvent>> {
     Ok(Some(event))
 }
 
+/// Builder that subscribes to all `IWrappedVara` events (`Transfer` and `Approval`) on a given
+/// contract address and yields them as a unified [`WVaraEvent`] stream.
 pub struct AllEventsBuilder<'a> {
     query: &'a WVaraQuery,
 }
@@ -55,6 +64,7 @@ impl<'a> AllEventsBuilder<'a> {
         Self { query }
     }
 
+    /// Subscribes to all `IWrappedVara` log events and returns a stream of decoded [`WVaraEvent`]s.
     pub async fn subscribe(self) -> Result<impl Stream<Item = Result<WVaraEvent>> + Unpin + use<>> {
         let filter = Filter::new()
             .address(*self.query.0.address())
@@ -73,6 +83,8 @@ impl<'a> AllEventsBuilder<'a> {
     }
 }
 
+/// Builder for subscribing to `IWrappedVara::Transfer` events, with optional indexed filters
+/// on the `from` and `to` address topics.
 pub struct TransferEventBuilder<'a> {
     event: Event<&'a RootProvider, IWrappedVara::Transfer>,
     from: Option<Address>,
@@ -88,16 +100,19 @@ impl<'a> TransferEventBuilder<'a> {
         }
     }
 
+    /// Restricts the subscription to transfers originating from `from`.
     pub fn from(mut self, from: Address) -> Self {
         self.from = Some(from);
         self
     }
 
+    /// Restricts the subscription to transfers directed to `to`.
     pub fn to(mut self, to: Address) -> Self {
         self.to = Some(to);
         self
     }
 
+    /// Subscribes with the configured topic filters and returns a stream of `(TransferEvent, Log)` pairs.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<(TransferEvent, Log), Error>> + Unpin + use<>> {
@@ -118,6 +133,8 @@ impl<'a> TransferEventBuilder<'a> {
     }
 }
 
+/// Builder for subscribing to `IWrappedVara::Approval` events, with optional indexed filters
+/// on the `owner` and `spender` address topics.
 pub struct ApprovalEventBuilder<'a> {
     event: Event<&'a RootProvider, IWrappedVara::Approval>,
     owner: Option<Address>,
@@ -133,16 +150,19 @@ impl<'a> ApprovalEventBuilder<'a> {
         }
     }
 
+    /// Restricts the subscription to approvals granted by `owner`.
     pub fn owner(mut self, owner: Address) -> Self {
         self.owner = Some(owner);
         self
     }
 
+    /// Restricts the subscription to approvals granted to `spender`.
     pub fn spender(mut self, spender: Address) -> Self {
         self.spender = Some(spender);
         self
     }
 
+    /// Subscribes with the configured topic filters and returns a stream of `(ApprovalEvent, Log)` pairs.
     pub async fn subscribe(
         self,
     ) -> Result<impl Stream<Item = Result<(ApprovalEvent, Log), Error>> + Unpin + use<>> {

--- a/ethexe/ethereum/src/wvara/mod.rs
+++ b/ethexe/ethereum/src/wvara/mod.rs
@@ -17,11 +17,16 @@ use events::{AllEventsBuilder, ApprovalEventBuilder, TransferEventBuilder};
 use gprimitives::{ActorId, H256, U256};
 use gsigner::Address;
 
+/// Event builders and event-extraction utilities for the WrappedVara ERC-20 contract.
 pub mod events;
 
 type Instance = IWrappedVara::IWrappedVaraInstance<AlloyProvider>;
 type QueryInstance = IWrappedVara::IWrappedVaraInstance<RootProvider>;
 
+/// Transaction-sending handle for the WrappedVara ERC-20 contract.
+///
+/// Wraps a signing provider and exposes mutating ERC-20 operations (transfer, approve, mint).
+/// Use [`WVara::query`] to obtain a read-only [`WVaraQuery`] backed by the same contract address.
 pub struct WVara(Instance);
 
 impl WVara {
@@ -29,10 +34,12 @@ impl WVara {
         Self(Instance::new(address, provider))
     }
 
+    /// Returns the on-chain address of the WrappedVara contract.
     pub fn address(&self) -> Address {
         (*self.0.address()).into()
     }
 
+    /// Creates a read-only [`WVaraQuery`] bound to the same contract address and root provider.
     pub fn query(&self) -> WVaraQuery {
         WVaraQuery(QueryInstance::new(
             *self.0.address(),
@@ -40,12 +47,14 @@ impl WVara {
         ))
     }
 
+    /// Transfers `value` tokens to `to`, returning the transaction hash on success.
     pub async fn transfer(&self, to: ActorId, value: u128) -> Result<H256> {
         self.transfer_with_receipt(to, value)
             .await
             .map(|receipt| (*receipt.transaction_hash).into())
     }
 
+    /// Transfers `value` tokens to `to`, returning the full transaction receipt on success.
     pub async fn transfer_with_receipt(
         &self,
         to: ActorId,
@@ -60,12 +69,14 @@ impl WVara {
         Ok(receipt)
     }
 
+    /// Transfers `value` tokens from `from` to `to` using the caller's allowance, returning the transaction hash.
     pub async fn transfer_from(&self, from: ActorId, to: ActorId, value: u128) -> Result<H256> {
         self.transfer_from_with_receipt(from, to, value)
             .await
             .map(|receipt| (*receipt.transaction_hash).into())
     }
 
+    /// Transfers `value` tokens from `from` to `to`, returning the full transaction receipt.
     pub async fn transfer_from_with_receipt(
         &self,
         from: ActorId,
@@ -83,12 +94,14 @@ impl WVara {
         Ok(receipt)
     }
 
+    /// Approves `spender` to spend up to `value` tokens on behalf of the caller, returning the transaction hash.
     pub async fn approve(&self, spender: ActorId, value: u128) -> Result<H256> {
         self.approve_with_receipt(spender, value)
             .await
             .map(|receipt| (*receipt.transaction_hash).into())
     }
 
+    /// Approves `spender` to spend up to `value` tokens, returning the full transaction receipt.
     pub async fn approve_with_receipt(
         &self,
         spender: ActorId,
@@ -97,12 +110,14 @@ impl WVara {
         self._approve_with_receipt(spender, U256::from(value)).await
     }
 
+    /// Approves `spender` to spend an unlimited amount (`U256::MAX`) of tokens, returning the transaction hash.
     pub async fn approve_all(&self, spender: ActorId) -> Result<H256> {
         self.approve_all_with_receipt(spender)
             .await
             .map(|receipt| (*receipt.transaction_hash).into())
     }
 
+    /// Approves `spender` for an unlimited allowance, returning the full transaction receipt.
     pub async fn approve_all_with_receipt(&self, spender: ActorId) -> Result<TransactionReceipt> {
         self._approve_with_receipt(spender, U256::MAX).await
     }
@@ -123,12 +138,14 @@ impl WVara {
         Ok(receipt)
     }
 
+    /// Mints `amount` new tokens to `to`, returning the transaction hash on success.
     pub async fn mint(&self, to: ActorId, amount: u128) -> Result<H256> {
         self.mint_with_receipt(to, amount)
             .await
             .map(|receipt| (*receipt.transaction_hash).into())
     }
 
+    /// Mints `amount` new tokens to `to`, returning the full transaction receipt on success.
     pub async fn mint_with_receipt(&self, to: ActorId, amount: u128) -> Result<TransactionReceipt> {
         let builder = self.0.mint(to.into(), AlloyU256::from(amount));
         let receipt = builder
@@ -140,9 +157,14 @@ impl WVara {
     }
 }
 
+/// Read-only query handle for the WrappedVara ERC-20 contract.
+///
+/// Uses a root (unsigned) provider, so no transactions can be sent.
+/// Obtain via [`WVara::query`] or construct directly with [`WVaraQuery::new`].
 pub struct WVaraQuery(QueryInstance);
 
 impl WVaraQuery {
+    /// Constructs a `WVaraQuery` connected to `rpc_url` and bound to `router_address`.
     pub async fn new(rpc_url: &str, router_address: Address) -> Result<Self> {
         let provider = ProviderBuilder::default().connect(rpc_url).await?;
 
@@ -152,10 +174,12 @@ impl WVaraQuery {
         )))
     }
 
+    /// Returns a [`WVaraEvents`] handle for subscribing to contract events.
     pub fn events(&self) -> WVaraEvents<'_> {
         WVaraEvents { query: self }
     }
 
+    /// Returns the ERC-20 token name.
     pub async fn name(&self) -> Result<String> {
         self.0
             .name()
@@ -165,6 +189,7 @@ impl WVaraQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the ERC-20 token symbol.
     pub async fn symbol(&self) -> Result<String> {
         self.0
             .symbol()
@@ -174,10 +199,12 @@ impl WVaraQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the number of decimal places used by the token.
     pub async fn decimals(&self) -> Result<u8> {
         self.0.decimals().call().await.map_err(Into::into)
     }
 
+    /// Returns the total token supply; truncates silently if the on-chain value exceeds `u128::MAX`.
     pub async fn total_supply(&self) -> Result<u128> {
         self.0
             .totalSupply()
@@ -187,6 +214,7 @@ impl WVaraQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the token balance of `address`; truncates silently if the value exceeds `u128::MAX`.
     pub async fn balance_of(&self, address: ActorId) -> Result<u128> {
         self.0
             .balanceOf(address.into())
@@ -196,6 +224,7 @@ impl WVaraQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the remaining number of tokens that `spender` is allowed to spend on behalf of `owner`.
     pub async fn allowance(&self, owner: ActorId, spender: ActorId) -> Result<U256> {
         self.0
             .allowance(owner.into(), spender.into())
@@ -205,6 +234,7 @@ impl WVaraQuery {
             .map_err(Into::into)
     }
 
+    /// Returns the EIP-2612 permit nonce for `owner`, used to prevent replay attacks.
     pub async fn nonces(&self, owner: ActorId) -> Result<U256> {
         self.0
             .nonces(owner.into())
@@ -231,19 +261,26 @@ impl WVaraQuery {
     }
 }
 
+/// Entry point for subscribing to WrappedVara contract events.
+///
+/// Obtained from [`WVaraQuery::events`]. Each method returns a typed builder
+/// that can be further filtered before calling `subscribe`.
 pub struct WVaraEvents<'a> {
     query: &'a WVaraQuery,
 }
 
 impl<'a> WVaraEvents<'a> {
+    /// Returns a builder that subscribes to all WrappedVara events (Transfer and Approval).
     pub fn all(&self) -> AllEventsBuilder<'a> {
         AllEventsBuilder::new(self.query)
     }
 
+    /// Returns a builder for subscribing to ERC-20 Transfer events, optionally filtered by `from` or `to`.
     pub fn transfer(&self) -> TransferEventBuilder<'a> {
         TransferEventBuilder::new(self.query)
     }
 
+    /// Returns a builder for subscribing to ERC-20 Approval events, optionally filtered by `owner` or `spender`.
     pub fn approval(&self) -> ApprovalEventBuilder<'a> {
         ApprovalEventBuilder::new(self.query)
     }

--- a/ethexe/observer/src/lib.rs
+++ b/ethexe/observer/src/lib.rs
@@ -79,6 +79,7 @@ pub use sync::SyncError;
 use sync::{ChainSync, SyncResult};
 
 mod sync;
+/// Utility types and traits for loading block data from the Ethereum chain.
 pub mod utils;
 
 #[cfg(test)]
@@ -90,12 +91,16 @@ type HeadersSubscriptionFuture = BoxFuture<'static, TransportResult<Subscription
 /// It is needed to measure time taken for syncing a block.
 type SyncFuture = future_timing::Timed<BoxFuture<'static, SyncResult<H256>>>;
 
+/// Events emitted by [`ObserverService`] as it tracks the Ethereum chain.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ObserverEvent {
+    /// A new chain head was received; contains the raw block data.
     Block(SimpleBlockData),
+    /// All blocks up to and including the given hash have been synced into the local database.
     BlockSynced(H256),
 }
 
+/// Configuration supplied to [`ObserverService::new`].
 pub struct ObserverConfig<'a> {
     /// Ethereum RPC endpoint.
     pub rpc: &'a str,
@@ -138,6 +143,11 @@ struct RuntimeConfig {
 }
 
 // TODO #4552: make tests for observer service
+/// Watches the Ethereum chain and surfaces each new head and completed back-fill as an [`ObserverEvent`].
+///
+/// Implements `futures::Stream<Item = Result<ObserverEvent>>`. Construct with [`ObserverService::new`]
+/// and poll via `StreamExt::next`. The stream never terminates on its own; subscription failures
+/// are retried with exponential backoff and recoverable RPC errors are skipped rather than propagated.
 pub struct ObserverService {
     provider: RootProvider,
     config: RuntimeConfig,
@@ -253,6 +263,10 @@ impl FusedStream for ObserverService {
 }
 
 impl ObserverService {
+    /// Creates a new `ObserverService`.
+    ///
+    /// Resolves the router address from the database config, queries the middleware address
+    /// from the Router contract, connects the alloy provider, and starts the block-header subscription.
     pub async fn new(db: Database, config: ObserverConfig<'_>) -> Result<Self> {
         let ObserverConfig {
             rpc,
@@ -300,14 +314,17 @@ impl ObserverService {
         })
     }
 
+    /// Returns a reference to the underlying alloy `RootProvider`.
     pub fn provider(&self) -> &RootProvider {
         &self.provider
     }
 
+    /// Returns a fresh [`EthereumBlockLoader`] bound to the configured router address.
     pub fn block_loader(&self) -> EthereumBlockLoader {
         EthereumBlockLoader::new(self.provider.clone(), self.config.router_address)
     }
 
+    /// Returns a fresh `RouterQuery` for read-only queries against the Router contract.
     pub fn router_query(&self) -> RouterQuery {
         RouterQuery::from_provider(self.config.router_address, self.provider.clone())
     }

--- a/ethexe/observer/src/sync.rs
+++ b/ethexe/observer/src/sync.rs
@@ -30,12 +30,15 @@ use std::collections::HashMap;
 /// retries on the next chain head); `Fatal` propagates.
 #[derive(Debug, thiserror::Error)]
 pub enum SyncError {
+    /// Transient RPC or transport failure; the caller may retry on the next chain head.
     #[error("RPC error during sync: {0:?}")]
     RpcError(anyhow::Error),
+    /// Non-recoverable error; propagates and stops the sync loop.
     #[error(transparent)]
     Fatal(anyhow::Error),
 }
 
+/// Convenience alias for results that may fail with [`SyncError`].
 pub type SyncResult<T> = std::result::Result<T, SyncError>;
 
 type Result<T, E = anyhow::Error> = std::result::Result<T, E>;

--- a/ethexe/observer/src/utils.rs
+++ b/ethexe/observer/src/utils.rs
@@ -30,10 +30,17 @@ const LOGS_CHUNK_SIZE: u64 = 256;
 /// Maximum number of in-flight log chunk requests issued by [`alloy::contract::ChunkedEvent`].
 const LOGS_MAX_CONCURRENCY: usize = 8;
 
+/// A block selector for Ethereum RPC queries.
+///
+/// Wraps the three addressing modes accepted by the observer: a specific block hash,
+/// the chain head, or the latest finalized block.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, derive_more::From)]
 pub enum BlockId {
+    /// A block identified by its 32-byte hash.
     Hash(H256),
+    /// The latest (head) block as reported by the provider.
     Latest,
+    /// The latest finalized block as reported by the provider.
     Finalized,
 }
 
@@ -47,15 +54,30 @@ impl BlockId {
     }
 }
 
+/// Abstracts fetching Ethereum block data (headers and decoded events) from a provider.
 #[allow(async_fn_in_trait)]
 pub trait BlockLoader {
+    /// Fetches the minimal block descriptor (hash + header) for a single block selector.
     async fn load_simple(&self, block: BlockId) -> Result<SimpleBlockData>;
 
+    /// Fetches the full [`BlockData`] for a block identified by hash.
+    ///
+    /// If `header` is `None` the implementation also fetches the header from the provider;
+    /// if a pre-fetched header is supplied it is used directly to save a round-trip.
     async fn load(&self, block: H256, header: Option<BlockHeader>) -> Result<BlockData>;
 
+    /// Fetches full [`BlockData`] for every block whose height falls within `range`.
+    ///
+    /// Returns a map keyed by block hash. An empty range returns an empty map without
+    /// making any RPC calls.
     async fn load_many(&self, range: RangeInclusive<u64>) -> Result<HashMap<H256, BlockData>>;
 }
 
+/// alloy-backed [`BlockLoader`] that fetches block headers and router/mirror logs from Ethereum.
+///
+/// Logs are retrieved using alloy's chunked-event helper, which splits a block range into
+/// windows of at most `logs_chunk_size` blocks and issues up to `logs_max_concurrency`
+/// concurrent requests, falling back to per-block queries on failure.
 #[derive(Debug, Clone)]
 pub struct EthereumBlockLoader {
     provider: RootProvider,
@@ -65,6 +87,7 @@ pub struct EthereumBlockLoader {
 }
 
 impl EthereumBlockLoader {
+    /// Creates a new loader with default chunk and concurrency settings.
     pub fn new(provider: RootProvider, router_address: Address) -> Self {
         Self {
             provider,
@@ -74,11 +97,13 @@ impl EthereumBlockLoader {
         }
     }
 
+    /// Overrides the number of blocks per log-fetch window (default [`LOGS_CHUNK_SIZE`]).
     pub fn with_logs_chunk_size(mut self, chunk_size: u64) -> Self {
         self.logs_chunk_size = chunk_size;
         self
     }
 
+    /// Overrides the maximum number of concurrent log-chunk requests (default [`LOGS_MAX_CONCURRENCY`]).
     pub fn with_logs_max_concurrency(mut self, max_concurrency: usize) -> Self {
         self.logs_max_concurrency = max_concurrency;
         self

--- a/ethexe/runtime/common/src/ext.rs
+++ b/ethexe/runtime/common/src/ext.rs
@@ -25,6 +25,13 @@ use gear_core_errors::{ExtError, ReplyCode};
 use gear_lazy_pages_common::{GlobalsAccessConfig, ProcessAccessError};
 use gprimitives::{ActorId, MessageId, ReservationId};
 
+/// Externalities implementation for the ethexe runtime.
+///
+/// Wraps [`core_processor::Ext`] and delegates all standard syscalls to it,
+/// while explicitly panicking on syscalls that are unavailable in the ethexe
+/// context (signals, reservations, `wait`, `random`, `create_program`).
+/// Delayed `wake` (non-zero `delay`) is also rejected because ethexe does not
+/// support deferred waking.
 pub struct Ext<RI: RuntimeInterface> {
     core: CoreExt<RI::LazyPages>,
 }

--- a/ethexe/runtime/common/src/journal.rs
+++ b/ethexe/runtime/common/src/journal.rs
@@ -35,16 +35,28 @@ use gsys::GasMultiplier;
 pub const WAIT_UP_TO_SAFE_DURATION: u32 = 64;
 
 // Handles unprocessed journal notes during chunk processing.
+/// [`JournalHandler`] implementation used outside the runtime WASM to apply journal notes
+/// that cannot be handled inside the runtime (e.g. routing dispatches, updating waitlists).
 pub struct NativeJournalHandler<'a, S: Storage + ?Sized> {
+    /// The program whose message chunk is currently being processed.
     pub program_id: ActorId,
+    /// The type of the message being executed (canonical or injected).
     pub message_type: MessageType,
+    /// Whether the current execution was triggered by a `call_reply` RPC request.
     pub call_reply: bool,
+    /// Holds mutable access to per-program states and pending transitions.
     pub controller: TransitionController<'a, S>,
+    /// Tracks remaining gas budget for the entire block.
     pub gas_allowance_counter: &'a GasAllowanceCounter,
+    /// Gas budget assigned to this single execution chunk.
     pub chunk_gas_limit: u64,
+    /// Set to `true` when the block-level gas allowance is exhausted mid-chunk.
     pub out_of_gas: &'a mut bool,
+    /// Remaining count of outgoing messages allowed in this chunk.
     pub outgoing_messages_limiter: &'a mut u32,
+    /// Remaining byte budget for outgoing message payloads in this chunk.
     pub outgoing_messages_bytes_limiter: &'a mut u32,
+    /// Remaining count of call-reply messages allowed in this chunk.
     pub call_reply_limiter: &'a mut u32,
 }
 
@@ -482,23 +494,34 @@ impl<S: Storage + ?Sized> JournalHandler for NativeJournalHandler<'_, S> {
 }
 
 // Handles unprocessed journal notes during message processing in the runtime.
+/// Aggregated result produced by [`RuntimeJournalHandler`] for one execution pass.
+///
+/// Collects dispatch outcomes and gas-burn events so callers can apply
+/// cross-program effects (e.g. updating transitions) after the WASM run.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RuntimeQueueReport {
+    /// Dispatch outcomes recorded during the execution pass.
     pub dispatched: Vec<RuntimeDispatchReport>,
+    /// Gas-burn events recorded during the execution pass.
     pub gas_burned: Vec<RuntimeGasBurnReport>,
 }
 
 impl RuntimeQueueReport {
+    /// Merges `other` into `self` by appending all its dispatched and gas-burn records.
     pub fn extend(&mut self, other: Self) {
         self.dispatched.extend(other.dispatched);
         self.gas_burned.extend(other.gas_burned);
     }
 }
 
+/// Outcome record for a single dispatched message, produced by [`RuntimeJournalHandler`].
 #[derive(Clone, Debug)]
 pub struct RuntimeDispatchReport {
+    /// The identifier of the dispatched message.
     pub message_id: MessageId,
+    /// The actor that sent the message.
     pub source: ActorId,
+    /// The execution result of the dispatch.
     pub outcome: DispatchOutcome,
 }
 
@@ -512,10 +535,16 @@ impl PartialEq for RuntimeDispatchReport {
 
 impl Eq for RuntimeDispatchReport {}
 
+/// Gas-burn record for a single message, produced by [`RuntimeJournalHandler`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RuntimeGasBurnReport {
+    /// The identifier of the message that consumed gas.
     pub message_id: MessageId,
+    /// The amount of gas burned.
     pub amount: u64,
+    /// `true` when the burn is deducted from the program's `executable_balance`; `false` only for
+    /// panicked injected messages on their first execution attempt when `gas_burned` is at or
+    /// below `INJECTED_MESSAGE_PANIC_GAS_CHARGE_THRESHOLD`.
     pub charged_to_executable_balance: bool,
 }
 
@@ -569,18 +598,30 @@ fn dispatch_outcome_eq(left: &DispatchOutcome, right: &DispatchOutcome) -> bool 
     }
 }
 
+/// [`JournalHandler`] that runs inside the runtime WASM to handle journal notes immediately
+/// (page updates, allocations, dispatch outcomes, gas burns) and forwards the rest to
+/// [`NativeJournalHandler`] for post-execution processing.
 pub struct RuntimeJournalHandler<'s, S>
 where
     S: Storage,
 {
+    /// Content-addressed storage used to persist updated program state.
     pub storage: &'s S,
+    /// Mutable program state mutated in-place as journal notes are applied.
     pub program_state: &'s mut ProgramState,
+    /// Block-level gas allowance counter shared across all executions in the block.
     pub gas_allowance_counter: &'s mut GasAllowanceCounter,
+    /// Conversion factor from gas units to token value.
     pub gas_multiplier: &'s GasMultiplier,
+    /// Type of the message being executed.
     pub message_type: MessageType,
+    /// `true` for the first execution attempt of a message (affects injected-panic accounting).
     pub is_first_execution: bool,
+    /// Set to `true` when a `StopProcessing` note is encountered.
     pub stop_processing: bool,
+    /// Whether the current execution was triggered by a `call_reply` RPC request.
     pub call_reply: bool,
+    /// Per-chunk outgoing message and reply limits.
     pub limiter: &'s mut Limiter,
 }
 
@@ -588,6 +629,13 @@ impl<S> RuntimeJournalHandler<'_, S>
 where
     S: Storage,
 {
+    /// Processes a batch of journal notes, handling page/allocation/dispatch/gas-burn notes
+    /// in-place and returning the remainder for [`NativeJournalHandler`] to apply.
+    ///
+    /// Returns `(unhandled_notes, maybe_new_state_hash, report)`.  `maybe_new_state_hash`
+    /// is `Some` when at least one note was consumed by this handler (i.e. not forwarded to the
+    /// catch-all unhandled branch); this includes `StopProcessing` and gas-burn notes that may
+    /// not alter persistent `program_state` fields.
     // Returns unhandled journal notes, new program state hash, and runtime queue report
     pub fn handle_journal_with_report<I>(
         &mut self,

--- a/ethexe/runtime/common/src/lib.rs
+++ b/ethexe/runtime/common/src/lib.rs
@@ -102,6 +102,7 @@ mod transitions;
 // TODO: consider format.
 /// Version of the runtime.
 pub const VERSION: u32 = 1;
+/// Unique identifier for this runtime variant, used to distinguish runtime instances.
 pub const RUNTIME_ID: u32 = 1;
 
 /// Maximum number of outgoing messages per execution of one dispatch.
@@ -115,27 +116,49 @@ pub const MAX_OUTGOING_MESSAGES_BYTES_PER_RUN: u32 = 4 * 1024;
 /// Maximum number of call replies per process_queue run.
 pub const MAX_CALL_REPLIES_PER_RUN: u32 = 1;
 
+/// Ordered journal output from a single [`process_queue`] run.
+///
+/// Each entry is `(journal_notes, message_type, is_call_reply)` where `journal_notes` are the
+/// unhandled [`JournalNote`]s for one dispatch, `message_type` identifies whether the dispatch
+/// came from the canonical or injected queue, and `is_call_reply` marks call-reply dispatches.
 pub type ProgramJournals = Vec<(Vec<JournalNote>, MessageType, bool)>;
 
 /// Context passed to the runtime in order to
 /// run message queue processing for specified program.
 #[derive(Debug, Encode, Decode)]
 pub struct ProcessQueueContext {
+    /// The program whose queue is being processed.
     pub program_id: ActorId,
+    /// Content-addressed root of the program's current state in storage.
     pub state_root: H256,
+    /// Whether to process the canonical or injected message queue.
     pub queue_type: MessageType,
+    /// Gas-instrumented WASM code for the program.
     pub instrumented_code: InstrumentedCode,
+    /// Metadata describing the code (exports, instrumentation status, etc.).
     pub code_metadata: CodeMetadata,
+    /// Block-level gas budget counter; decremented as dispatches are executed.
     pub gas_allowance: GasAllowanceCounter,
+    /// Block metadata (height, timestamp, etc.) available to the program during execution.
     pub block_info: BlockInfo,
+    /// Controls whether reply promises are published for injected dispatches.
     pub promise_policy: PromisePolicy,
 }
 
+/// Seam between portable runtime logic and the embedding environment.
+///
+/// Extends [`Storage`] with host services that are environment-specific: lazy-page
+/// initialization, randomness provision, state-hash notification, and promise publishing.
+/// Implementors supply the concrete [`LazyPagesInterface`] type used during WASM execution.
 pub trait RuntimeInterface: Storage {
+    /// The lazy-pages backend used to demand-page WASM program memory during execution.
     type LazyPages: LazyPagesInterface + 'static;
 
+    /// Initializes lazy-pages protection for the current WASM program before execution starts.
     fn init_lazy_pages(&self);
+    /// Returns `(random_seed_bytes, block_number)` for use as randomness inside a program.
     fn random_data(&self) -> (Vec<u8>, u32);
+    /// Notifies the environment that the program's state hash has been updated to `state_hash`.
     fn update_state_hash(&self, state_hash: &H256);
     /// Publish a promise produced during execution to the compute service layer.
     /// The implementation is expected to forward it to external subscribers.
@@ -149,11 +172,18 @@ pub trait RuntimeInterface: Storage {
 /// along with writing the updated state to the storage.
 /// By design updates are stored in-memory inside the [`InBlockTransitions`].
 pub struct TransitionController<'a, S: Storage + ?Sized> {
+    /// Read/write access to the content-addressed program state storage.
     pub storage: &'a S,
+    /// In-block accumulator of per-program state-hash and queue-size changes.
     pub transitions: &'a mut InBlockTransitions,
 }
 
 impl<S: Storage + ?Sized> TransitionController<'_, S> {
+    /// Reads the current [`ProgramState`] for `program_id`, passes it to `f` together with
+    /// the storage and transitions, then writes the modified state back to storage and records
+    /// the new state hash and queue sizes in [`InBlockTransitions`].
+    ///
+    /// Panics if `program_id` is not tracked in `transitions` or its state cannot be read from storage.
     pub fn update_state<T>(
         &mut self,
         program_id: ActorId,
@@ -187,6 +217,11 @@ impl<S: Storage + ?Sized> TransitionController<'_, S> {
     }
 }
 
+/// Dequeues and executes all pending dispatches for one program within the block's gas budget.
+///
+/// Returns the accumulated [`ProgramJournals`] and the total gas spent. This is the
+/// legacy entry point that discards the detailed [`RuntimeQueueReport`]; prefer
+/// [`process_queue_with_report`] when the report is needed.
 pub fn process_queue<RI>(ctx: ProcessQueueContext, ri: &RI) -> (ProgramJournals, u64)
 where
     RI: RuntimeInterface + 'static,
@@ -196,6 +231,12 @@ where
     (journals, gas_spent)
 }
 
+/// Dequeues and executes all pending dispatches for one program within the block's gas budget,
+/// returning a detailed execution report alongside the journals and gas spent.
+///
+/// Iterates the queue indicated by `ctx.queue_type`, processes each dispatch with the
+/// configured [`BlockConfig`], applies journal notes via [`RuntimeJournalHandler`], and stops
+/// early on a `StopProcessing` note or when per-run limits are exceeded.
 pub fn process_queue_with_report<RI>(
     mut ctx: ProcessQueueContext,
     ri: &RI,
@@ -513,6 +554,9 @@ where
         .unwrap_or_else(|err| unreachable!("{err}"))
 }
 
+/// Packs two `u32` values into a single `i64` for WASM FFI return-value passing.
+///
+/// The `high` word occupies bits 32–63 and `low` occupies bits 0–31 of the result.
 pub const fn pack_u32_to_i64(low: u32, high: u32) -> i64 {
     let mut result = 0u64;
     result |= (high as u64) << 32;
@@ -520,6 +564,7 @@ pub const fn pack_u32_to_i64(low: u32, high: u32) -> i64 {
     result as i64
 }
 
+/// Unpacks an `i64` produced by [`pack_u32_to_i64`] back into `(low, high)` `u32` words.
 pub const fn unpack_i64_to_u32(val: i64) -> (u32, u32) {
     let val = val as u64;
     let high = (val >> 32) as u32;

--- a/ethexe/runtime/common/src/schedule.rs
+++ b/ethexe/runtime/common/src/schedule.rs
@@ -15,7 +15,10 @@ use gear_core::tasks::TaskHandler;
 use gear_core_errors::SuccessReplyReason;
 use gprimitives::{ActorId, H256, MessageId, ReservationId};
 
+/// Implements [`TaskHandler`] for the ethexe runtime, executing scheduled tasks
+/// against program state via a [`TransitionController`].
 pub struct Handler<'a, S: Storage> {
+    /// Provides access to storage and mutable in-block transition state.
     pub controller: TransitionController<'a, S>,
 }
 
@@ -222,6 +225,9 @@ impl Restorer {
         Ok(restorer)
     }
 
+    /// Registers pending wake tasks from a program's waitlist into the schedule.
+    ///
+    /// Entries whose expiry is at or before `current_block` are skipped.
     pub fn waitlist(&mut self, program_id: ActorId, waitlist: &Waitlist) {
         for (
             &message_id,
@@ -244,6 +250,9 @@ impl Restorer {
         }
     }
 
+    /// Registers pending mailbox-removal tasks for a single user's mailbox entries.
+    ///
+    /// Entries whose expiry is at or before `current_block` are skipped.
     pub fn user_mailbox(
         &mut self,
         program_id: ActorId,
@@ -265,6 +274,10 @@ impl Restorer {
         }
     }
 
+    /// Registers pending send tasks from a program's dispatch stash into the schedule.
+    ///
+    /// Stashed entries destined for a user produce `SendUserMessage` tasks; those destined for a
+    /// program produce `SendDispatch` tasks. Entries at or before `current_block` are skipped.
     pub fn stash(&mut self, program_id: ActorId, stash: &DispatchStash) {
         for (
             &message_id,
@@ -293,6 +306,7 @@ impl Restorer {
         }
     }
 
+    /// Consumes the restorer and returns the reconstructed [`Schedule`].
     pub fn restore(self) -> Schedule {
         self.schedule
     }

--- a/ethexe/runtime/common/src/state.rs
+++ b/ethexe/runtime/common/src/state.rs
@@ -21,6 +21,7 @@ use ethexe_common::{
     HashOf, MaybeHashOf,
     gear::{Message, MessageType},
 };
+/// Re-export of `gear_core::program::ProgramState` as `InitStatus` for use in ethexe state.
 pub use gear_core::program::ProgramState as InitStatus;
 use gear_core::{
     buffer::Payload,
@@ -63,7 +64,9 @@ fn option_string<S: ToString>(value: &Option<S>) -> String {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Encode, Decode)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub enum PayloadLookup {
+    /// Payload bytes held inline.
     Direct(Payload),
+    /// Payload is stored in the database; this variant carries its content-addressed hash.
     Stored(HashOf<Payload>),
 }
 
@@ -83,10 +86,12 @@ impl PayloadLookup {
     /// Lower len to be stored in storage instead of holding value itself; 1 KB.
     pub const STORING_THRESHOLD: usize = 1024;
 
+    /// Returns a [`PayloadLookup::Direct`] variant with an empty payload.
     pub const fn empty() -> Self {
         Self::Direct(Payload::new())
     }
 
+    /// Returns `true` only when the payload is [`Direct`](PayloadLookup::Direct) and has zero bytes.
     pub fn is_empty(&self) -> bool {
         if let Self::Direct(payload) = self {
             payload.is_empty()
@@ -95,6 +100,10 @@ impl PayloadLookup {
         }
     }
 
+    /// Ensures the payload is persisted in storage, converting a `Direct` variant to `Stored`.
+    ///
+    /// Returns the content hash of the payload. If already `Stored`, returns the existing hash
+    /// without writing again.
     pub fn force_stored<S: Storage>(&mut self, storage: &S) -> HashOf<Payload> {
         let hash = match self {
             Self::Direct(payload) => {
@@ -109,6 +118,7 @@ impl PayloadLookup {
         hash
     }
 
+    /// Resolves the payload to its bytes, fetching from storage if necessary.
     pub fn query<S: Storage>(self, storage: &S) -> Result<Payload> {
         match self {
             Self::Direct(payload) => Ok(payload),
@@ -229,15 +239,22 @@ impl<S: Storage> ModifiableStorage<MemoryPages> for S {
 }
 
 // TODO(romanm): consider to make it into general primitive: `HashOf`, `SizedHashOf`, `MaybeHashOf`, `SizedMaybeHashOf`
+/// A [`MessageQueue`] hash paired with a cached count of pending messages.
+///
+/// The `cached_queue_size` is a saturating `u8` snapshot of the queue length, propagated to
+/// the parent [`ProgramState`] so callers can gauge queue depth without fetching the full queue.
 #[derive(Clone, Copy, Debug, Decode, Encode, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct MessageQueueHashWithSize {
+    /// Content-addressed hash of the [`MessageQueue`], or empty if the queue is absent.
     pub hash: MaybeHashOf<MessageQueue>,
     // NOTE: only here to propagate queue size to the parent state (`StateHashWithQueueSize`).
+    /// Saturating snapshot of the queue length; capped at `u8::MAX`.
     pub cached_queue_size: u8,
 }
 
 impl MessageQueueHashWithSize {
+    /// Reads the [`MessageQueue`] from storage, returning an empty queue if the hash is absent.
     pub fn query<S: Storage + ?Sized>(&self, storage: &S) -> Result<MessageQueue> {
         self.hash.try_map_or_default(|hash| {
             storage.message_queue(hash).ok_or(anyhow!(
@@ -246,6 +263,8 @@ impl MessageQueueHashWithSize {
         })
     }
 
+    /// Loads the queue, applies `f`, then re-serializes it, updating both `hash` and
+    /// `cached_queue_size` atomically.
     pub fn modify_queue<S: Storage + ?Sized, T>(
         &mut self,
         storage: &S,
@@ -262,6 +281,7 @@ impl MessageQueueHashWithSize {
         r
     }
 
+    /// Returns `true` if the queue hash is absent (no messages queued).
     pub fn is_empty(&self) -> bool {
         self.hash.is_empty()
     }
@@ -299,6 +319,7 @@ impl<S: Storage> ModifiableStorage<Waitlist> for S {
     }
 }
 
+/// State of a program that is currently active (not exited or terminated).
 #[derive(Copy, Clone, Debug, Decode, Encode, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct ActiveProgram {
@@ -312,19 +333,25 @@ pub struct ActiveProgram {
     pub initialized: bool,
 }
 
+/// Lifecycle state of a Gear program.
 #[derive(Copy, Clone, Debug, Decode, Encode, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub enum Program {
+    /// Program is running; contains its runtime state.
     Active(ActiveProgram),
+    /// Program has called `gr_exit`; the inheritor `ActorId` receives its remaining balance.
     Exited(ActorId),
+    /// Program initialization failed; the inheritor `ActorId` receives its remaining balance.
     Terminated(ActorId),
 }
 
 impl Program {
+    /// Returns `true` if the program is in the `Active` state.
     pub fn is_active(&self) -> bool {
         matches!(self, Self::Active(_))
     }
 
+    /// Returns `true` if the program is active and its initialization has completed.
     pub fn is_initialized(&self) -> bool {
         matches!(
             self,
@@ -359,6 +386,7 @@ pub struct ProgramState {
 }
 
 impl ProgramState {
+    /// Returns the zero (freshly created, uninitialized) program state with no messages and no balance.
     pub const fn zero() -> Self {
         Self {
             program: Program::Active(ActiveProgram {
@@ -383,10 +411,13 @@ impl ProgramState {
         }
     }
 
+    /// Returns `true` if this state equals [`ProgramState::zero()`].
     pub fn is_zero(&self) -> bool {
         *self == Self::zero()
     }
 
+    /// Returns `true` when the program is uninitialized and all queues are empty,
+    /// meaning an `Init` message must be sent before the program can proceed.
     pub fn requires_init_message(&self) -> bool {
         if !matches!(
             self.program,
@@ -403,6 +434,8 @@ impl ProgramState {
             && self.waitlist_hash.is_empty()
     }
 
+    /// Returns a mutable reference to either the canonical or injected queue
+    /// based on the supplied [`MessageType`].
     pub fn queue_from_msg_type(
         &mut self,
         message_type: MessageType,
@@ -414,6 +447,10 @@ impl ProgramState {
     }
 }
 
+/// An ethexe runtime dispatch: a message together with its routing metadata.
+///
+/// Wraps a Gear message with the additional context needed by the ethexe runtime
+/// (dispatch kind, source, payload lookup, Ethereum `call` flag, and execution context).
 #[derive(Clone, Debug, Encode, Decode, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct Dispatch {
@@ -439,6 +476,7 @@ pub struct Dispatch {
 }
 
 impl Dispatch {
+    /// Creates an `Init` or `Handle` dispatch, writing the payload to storage if it is large.
     #[expect(clippy::too_many_arguments)]
     pub fn new<S: Storage + ?Sized>(
         storage: &S,
@@ -471,6 +509,7 @@ impl Dispatch {
         })
     }
 
+    /// Creates a `Reply` dispatch for the given `replied_to` message, writing the payload to storage.
     pub fn new_reply<S: Storage + ?Sized>(
         storage: &S,
         replied_to: MessageId,
@@ -493,6 +532,7 @@ impl Dispatch {
         ))
     }
 
+    /// Constructs a `Reply` dispatch from an already-resolved [`PayloadLookup`].
     pub fn reply(
         reply_to: MessageId,
         source: ActorId,
@@ -515,6 +555,8 @@ impl Dispatch {
         }
     }
 
+    /// Converts a `gear_core` [`StoredDispatch`] into an ethexe [`Dispatch`], persisting its
+    /// payload via `storage`.
     pub fn from_core_stored<S: Storage + ?Sized>(
         storage: &S,
         value: StoredDispatch,
@@ -541,6 +583,8 @@ impl Dispatch {
         }
     }
 
+    /// Converts this dispatch into an `ethexe_common::gear::Message` bound for `destination`,
+    /// resolving the payload from storage if needed.
     pub fn into_message<S: Storage>(self, storage: &S, destination: ActorId) -> Message {
         let Self {
             id,
@@ -564,10 +608,13 @@ impl Dispatch {
     }
 }
 
+/// Wraps a value with a block-number expiry.
 #[derive(Clone, Default, Debug, Encode, Decode, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct Expiring<T> {
+    /// The wrapped value.
     pub value: T,
+    /// Block number at which this entry expires and should be removed.
     pub expiry: u32,
 }
 
@@ -591,29 +638,36 @@ impl<T> From<(T, u32)> for Expiring<T> {
     derive_more::IntoIterator,
 )]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+/// FIFO queue of [`Dispatch`] entries for a single program.
 pub struct MessageQueue(VecDeque<Dispatch>);
 
 impl MessageQueue {
+    /// Returns `true` if the queue contains no dispatches.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
+    /// Returns the number of dispatches in the queue.
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
+    /// Appends a dispatch to the back of the queue.
     pub fn queue(&mut self, dispatch: Dispatch) {
         self.0.push_back(dispatch);
     }
 
+    /// Removes and returns the dispatch at the front of the queue.
     pub fn dequeue(&mut self) -> Option<Dispatch> {
         self.0.pop_front()
     }
 
+    /// Returns a reference to the dispatch at the front without removing it.
     pub fn peek(&self) -> Option<&Dispatch> {
         self.0.front()
     }
 
+    /// Writes the queue to storage and returns its hash, or an empty hash if the queue is empty.
     pub fn store<S: Storage + ?Sized>(self, storage: &S) -> MaybeHashOf<Self> {
         MaybeHashOf::from_inner((!self.0.is_empty()).then(|| storage.write_message_queue(self)))
     }
@@ -622,10 +676,12 @@ impl MessageQueue {
 /// Methods introduced due to solution to #4513.
 /// Remove when becomes unnecessary.
 impl MessageQueue {
+    /// Removes all dispatches from the queue without returning them.
     pub fn clear(&mut self) {
         self.0.clear()
     }
 
+    /// Removes and returns the dispatch at the back of the queue.
     pub fn pop_back(&mut self) -> Option<Dispatch> {
         self.0.pop_back()
     }
@@ -644,6 +700,10 @@ impl MessageQueue {
     derive_more::AsRef,
 )]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+/// Map of suspended dispatches keyed by [`MessageId`], each with a block-number expiry.
+///
+/// Programs are placed on the waitlist when they await a reply. They are woken and re-queued
+/// when the matching reply arrives or the expiry block is reached.
 pub struct Waitlist {
     #[as_ref]
     inner: BTreeMap<MessageId, Expiring<Dispatch>>,
@@ -653,6 +713,7 @@ pub struct Waitlist {
 }
 
 impl Waitlist {
+    /// Suspends `dispatch` until it is woken or expires at `expiry` block.
     pub fn wait(&mut self, dispatch: Dispatch, expiry: u32) {
         self.changed = true;
 
@@ -666,18 +727,23 @@ impl Waitlist {
         debug_assert!(r.is_none())
     }
 
+    /// Removes and returns the dispatch for `message_id`, or `None` if it is not waiting.
     pub fn wake(&mut self, message_id: &MessageId) -> Option<Expiring<Dispatch>> {
         self.inner
             .remove(message_id)
             .inspect(|_| self.changed = true)
     }
 
+    /// Persists the waitlist to storage if it was modified, returning the new hash.
+    ///
+    /// Returns `None` if the waitlist was not modified since it was last loaded.
     pub fn store<S: Storage>(self, storage: &S) -> Option<MaybeHashOf<Self>> {
         self.changed.then(|| {
             MaybeHashOf::from_inner((!self.inner.is_empty()).then(|| storage.write_waitlist(self)))
         })
     }
 
+    /// Consumes the waitlist and returns the underlying map.
     pub fn into_inner(self) -> BTreeMap<MessageId, Expiring<Dispatch>> {
         self.into()
     }
@@ -696,9 +762,14 @@ impl Waitlist {
     derive_more::AsRef,
 )]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+/// Temporary storage for dispatches that are awaiting forwarding to either a program or a user.
+///
+/// Each entry carries an optional [`ActorId`] that, when `Some`, identifies the target user;
+/// `None` means the dispatch is destined for a program.
 pub struct DispatchStash(BTreeMap<MessageId, Expiring<(Dispatch, Option<ActorId>)>>);
 
 impl DispatchStash {
+    /// Stashes a dispatch intended to be forwarded to a program, expiring at `expiry` block.
     pub fn add_to_program(&mut self, dispatch: Dispatch, expiry: u32) {
         let r = self.0.insert(
             dispatch.id,
@@ -710,6 +781,7 @@ impl DispatchStash {
         debug_assert!(r.is_none());
     }
 
+    /// Stashes a dispatch intended to be forwarded to `user_id`, expiring at `expiry` block.
     pub fn add_to_user(&mut self, dispatch: Dispatch, expiry: u32, user_id: ActorId) {
         let r = self.0.insert(
             dispatch.id,
@@ -721,6 +793,9 @@ impl DispatchStash {
         debug_assert!(r.is_none());
     }
 
+    /// Removes and returns the dispatch stashed for program delivery.
+    ///
+    /// Panics if the message is not found or was stashed for user delivery.
     pub fn remove_to_program(&mut self, message_id: &MessageId) -> Dispatch {
         let Expiring {
             value: (dispatch, user_id),
@@ -737,6 +812,9 @@ impl DispatchStash {
         dispatch
     }
 
+    /// Removes and returns the dispatch and its target user stashed for user delivery.
+    ///
+    /// Panics if the message is not found or was stashed for program delivery.
     pub fn remove_to_user(&mut self, message_id: &MessageId) -> (Dispatch, ActorId) {
         let Expiring {
             value: (dispatch, user_id),
@@ -752,20 +830,26 @@ impl DispatchStash {
         (dispatch, user_id)
     }
 
+    /// Writes the stash to storage and returns its hash, or an empty hash if the stash is empty.
     pub fn store<S: Storage>(self, storage: &S) -> MaybeHashOf<Self> {
         MaybeHashOf::from_inner((!self.0.is_empty()).then(|| storage.write_dispatch_stash(self)))
     }
 }
 
+/// A message held in a user's mailbox, retaining its payload, value, and origin type.
 #[derive(Clone, Default, Debug, Encode, Decode, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct MailboxMessage {
+    /// Payload bytes or a reference to payload stored in the database.
     pub payload: PayloadLookup,
+    /// Value (tokens) attached to the message.
     pub value: Value,
+    /// Whether the message originated from the canonical or injected queue.
     pub message_type: MessageType,
 }
 
 impl MailboxMessage {
+    /// Constructs a [`MailboxMessage`] from its components.
     pub fn new(payload: PayloadLookup, value: Value, message_type: MessageType) -> Self {
         Self {
             payload,
@@ -785,6 +869,7 @@ impl From<Dispatch> for MailboxMessage {
     }
 }
 
+/// Per-user mailbox: a map from [`MessageId`] to an expiring [`MailboxMessage`].
 #[derive(Clone, Default, Debug, Encode, Decode, PartialEq, Eq, Hash, derive_more::Into)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct UserMailbox(BTreeMap<MessageId, Expiring<MailboxMessage>>);
@@ -807,6 +892,7 @@ impl UserMailbox {
         MaybeHashOf::from_inner((!self.0.is_empty()).then(|| storage.write_user_mailbox(self)))
     }
 
+    /// Constructs a [`UserMailbox`] from an existing map; available in tests and mock builds.
     #[cfg(any(test, feature = "mock"))]
     pub fn from_inner(inner: BTreeMap<MessageId, Expiring<MailboxMessage>>) -> Self {
         Self(inner)
@@ -832,6 +918,8 @@ impl AsRef<BTreeMap<MessageId, Expiring<MailboxMessage>>> for UserMailbox {
     derive_more::AsRef,
 )]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+/// Top-level mailbox for a program, mapping each user [`ActorId`] to a hash of their
+/// [`UserMailbox`].  The `changed` flag enables write-back only when mutations occurred.
 pub struct Mailbox {
     #[as_ref]
     inner: BTreeMap<ActorId, HashOf<UserMailbox>>,
@@ -841,6 +929,7 @@ pub struct Mailbox {
 }
 
 impl Mailbox {
+    /// Adds `message` to `user_id`'s mailbox and immediately persists the updated user mailbox.
     pub fn add_and_store_user_mailbox<S: Storage + ?Sized>(
         &mut self,
         storage: &S,
@@ -864,6 +953,9 @@ impl Mailbox {
         let _ = self.inner.insert(user_id, hash);
     }
 
+    /// Removes `message_id` from `user_id`'s mailbox and persists the change.
+    ///
+    /// Returns the removed [`Expiring<MailboxMessage>`] if it existed, or `None`.
     pub fn remove_and_store_user_mailbox<S: Storage + ?Sized>(
         &mut self,
         storage: &S,
@@ -896,12 +988,16 @@ impl Mailbox {
         value
     }
 
+    /// Persists the mailbox to storage if it was modified, returning the new hash.
+    ///
+    /// Returns `None` when no modifications were made.
     pub fn store<S: Storage>(self, storage: &S) -> Option<MaybeHashOf<Self>> {
         self.changed.then(|| {
             MaybeHashOf::from_inner((!self.inner.is_empty()).then(|| storage.write_mailbox(self)))
         })
     }
 
+    /// Resolves all per-user mailbox hashes and returns a nested map of all mailboxed messages.
     pub fn into_values<S: Storage>(
         self,
         storage: &S,
@@ -923,6 +1019,11 @@ impl Mailbox {
     }
 }
 
+/// Content-addressed index of a program's WASM memory pages, split into fixed-size regions.
+///
+/// Each entry in the inner array is a `MaybeHashOf<MemoryPagesRegion>` covering
+/// `PAGES_PER_REGION` consecutive [`GearPage`]s.  Only touched pages need to be
+/// loaded, matching the lazy-page model used at the native layer.
 #[derive(Clone, Debug, Encode, Decode, PartialEq, Eq, Hash, derive_more::Into)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct MemoryPages(MemoryPagesInner);
@@ -972,10 +1073,12 @@ impl MemoryPages {
     pub const PAGES_PER_REGION: usize = Self::MAX_PAGES / Self::REGIONS_AMOUNT;
     const _DIVISIBILITY_ASSERT: () = assert!(Self::MAX_PAGES.is_multiple_of(Self::REGIONS_AMOUNT));
 
+    /// Returns the [`RegionIdx`] that contains `page`.
     pub fn page_region(page: GearPage) -> RegionIdx {
         RegionIdx((u32::from(page) as usize / Self::PAGES_PER_REGION) as u8)
     }
 
+    /// Inserts or updates the given pages in the relevant regions, persisting changed regions.
     pub fn update_and_store_regions<S: Storage>(
         &mut self,
         storage: &S,
@@ -1022,6 +1125,7 @@ impl MemoryPages {
         }
     }
 
+    /// Removes the given pages from their regions and persists changed regions.
     pub fn remove_and_store_regions<S: Storage>(&mut self, storage: &S, pages: &Vec<GearPage>) {
         let mut updated_regions = BTreeMap::new();
 
@@ -1062,42 +1166,55 @@ impl MemoryPages {
         }
     }
 
+    /// Writes the pages index to storage and returns its content hash. Because the inner array
+    /// always has `REGIONS_AMOUNT` entries, the hash is always non-empty.
     pub fn store<S: Storage>(self, storage: &S) -> MaybeHashOf<Self> {
         MaybeHashOf::from_inner((!self.0.is_empty()).then(|| storage.write_memory_pages(self)))
     }
 
+    /// Returns a copy of the underlying [`MemoryPagesInner`] array.
     pub fn to_inner(&self) -> MemoryPagesInner {
         self.0
     }
 }
 
+/// One region of a program's memory pages: a map from [`GearPage`] to its content hash.
 #[derive(Clone, Default, Debug, Encode, Decode, PartialEq, Eq, Hash, derive_more::Into)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct MemoryPagesRegion(MemoryPagesRegionInner);
 
+/// Inner map type for [`MemoryPagesRegion`].
 pub type MemoryPagesRegionInner = BTreeMap<GearPage, HashOf<PageBuf>>;
 
 impl MemoryPagesRegion {
+    /// Writes this region to storage, returning its hash (or empty if the region contains no pages).
     pub fn store<S: Storage>(self, storage: &S) -> MaybeHashOf<Self> {
         MaybeHashOf::from_inner(
             (!self.0.is_empty()).then(|| storage.write_memory_pages_region(self)),
         )
     }
 
+    /// Returns a reference to the underlying [`MemoryPagesRegionInner`] map.
     pub fn as_inner(&self) -> &MemoryPagesRegionInner {
         &self.0
     }
 
+    /// Constructs a [`MemoryPagesRegion`] from an existing map; available in tests and mock builds.
     #[cfg(any(test, feature = "mock"))]
     pub fn from_inner(inner: MemoryPagesRegionInner) -> Self {
         Self(inner)
     }
 }
 
+/// Zero-based index into the [`MemoryPages`] regions array.
 #[derive(Clone, Copy, Debug, Encode, Decode, PartialEq, Eq, PartialOrd, Ord, derive_more::Into)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct RegionIdx(u8);
 
+/// WASM page allocations for an active program, stored as an interval tree of [`WasmPage`]s.
+///
+/// The `changed` flag defers serialization: only call [`store`](Allocations::store) if an
+/// update was actually performed.
 #[derive(Clone, Default, Debug, Encode, Decode, PartialEq, Eq, Hash, derive_more::Into)]
 pub struct Allocations {
     inner: IntervalsTree<WasmPage>,
@@ -1107,10 +1224,13 @@ pub struct Allocations {
 }
 
 impl Allocations {
+    /// Returns the number of disjoint intervals in the allocation tree.
     pub fn tree_len(&self) -> u32 {
         self.inner.intervals_amount() as u32
     }
 
+    /// Replaces the allocation tree with `allocations` and returns the [`GearPage`]s that were
+    /// deallocated (present before but absent after the update).
     pub fn update(&mut self, allocations: IntervalsTree<WasmPage>) -> Vec<GearPage> {
         let removed_pages: Vec<_> = self
             .inner
@@ -1127,6 +1247,9 @@ impl Allocations {
         removed_pages
     }
 
+    /// Persists the allocations to storage if they were modified, returning the new hash.
+    ///
+    /// Returns `None` when no modifications were made since last load.
     pub fn store<S: Storage>(self, storage: &S) -> Option<MaybeHashOf<Self>> {
         self.changed.then(|| {
             MaybeHashOf::from_inner(
@@ -1136,6 +1259,12 @@ impl Allocations {
     }
 }
 
+/// Content-addressed backing store for all ethexe runtime state objects.
+///
+/// Implementors must be able to read and write every state primitive (program state, queues,
+/// waitlist, stash, mailboxes, memory pages, allocations, payloads, and page buffers) using
+/// their content hash as the key.  The trait is blanket-implemented for `&T` and `Box<T>` via
+/// `auto_impl`.
 #[auto_impl::auto_impl(&, Box)]
 pub trait Storage {
     /// Reads program state by state hash.
@@ -1236,12 +1365,14 @@ pub trait Storage {
 /// [`QueryableStorage`] is a extension over [`Storage`] which provides methods to query
 /// runtime primitives from it.
 pub trait QueryableStorage<T>: Storage {
+    /// Reads `T` from storage by `hash`, returning a default value when the hash is absent.
     fn query(&self, hash: &MaybeHashOf<T>) -> Result<T>;
 }
 
 /// [`ModifiableStorage`] is a extension over [`Storage`] which provides method to modify
 /// runtime primitives by its hash.
 pub trait ModifiableStorage<T>: QueryableStorage<T> {
+    /// Loads `T` by `hash`, applies `f`, writes the result back, and updates `hash` in place.
     fn modify<U>(&self, hash: &mut MaybeHashOf<T>, f: impl FnOnce(&mut T) -> U) -> U;
 }
 

--- a/ethexe/runtime/common/src/transitions.rs
+++ b/ethexe/runtime/common/src/transitions.rs
@@ -31,15 +31,23 @@ pub struct InBlockTransitions {
     program_creations: BTreeMap<ActorId, CodeId>,
 }
 
+/// Output of [`InBlockTransitions::finalize`]: the set of state transitions
+/// and updated metadata produced after processing all modifications in a block.
 #[derive(Debug, Clone, Default)]
 pub struct FinalizedBlockTransitions {
+    /// Non-noop state transitions to be committed on-chain, one per modified program.
     pub transitions: Vec<StateTransition>,
+    /// Latest program states (hash + queue sizes) after applying all block modifications.
     pub states: ProgramStates,
+    /// Carry-over task schedule with due tasks already consumed.
     pub schedule: Schedule,
+    /// Programs newly registered in this block, as `(ActorId, CodeId)` pairs.
     pub program_creations: Vec<(ActorId, CodeId)>,
 }
 
 impl InBlockTransitions {
+    /// Creates a new [`InBlockTransitions`] for the given block, seeded with parent-block program
+    /// states and the carried-over schedule.
     pub fn new(block_height: u32, states: ProgramStates, schedule: Schedule) -> Self {
         Self {
             block_height,
@@ -49,26 +57,33 @@ impl InBlockTransitions {
         }
     }
 
+    /// Returns `true` if `actor_id` is a known program (present in the current state map).
     pub fn is_program(&self, actor_id: &ActorId) -> bool {
         self.states.contains_key(actor_id)
     }
 
+    /// Returns the current `StateHashWithQueueSize` for `actor_id`, or `None` if unknown.
     pub fn state_of(&self, actor_id: &ActorId) -> Option<StateHashWithQueueSize> {
         self.states.get(actor_id).copied()
     }
 
+    /// Returns the number of programs tracked in the current state map.
     pub fn states_amount(&self) -> usize {
         self.states.len()
     }
 
+    /// Returns an iterator over all `(ActorId, StateHashWithQueueSize)` entries in the state map.
     pub fn states_iter(&self) -> Iter<'_, ActorId, StateHashWithQueueSize> {
         self.states.iter()
     }
 
+    /// Returns the `ActorId`s of all programs currently tracked.
     pub fn known_programs(&self) -> Vec<ActorId> {
         self.states.keys().copied().collect()
     }
 
+    /// Returns all outgoing messages queued across every in-progress transition, paired with the
+    /// sending program's `ActorId`.
     pub fn current_messages(&self) -> Vec<(ActorId, Message)> {
         self.modifications
             .iter()
@@ -76,6 +91,7 @@ impl InBlockTransitions {
             .collect()
     }
 
+    /// Returns the number of programs that have pending (non-finalized) modifications.
     pub fn modifications_len(&self) -> usize {
         self.modifications.len()
     }
@@ -90,6 +106,8 @@ impl InBlockTransitions {
         due.into_values().flatten().collect()
     }
 
+    /// Schedules `task` to fire `in_blocks` blocks from the current height and returns the
+    /// absolute block number at which it will execute.
     pub fn schedule_task(&mut self, in_blocks: NonZero<u32>, task: ScheduledTask) -> u32 {
         let scheduled_block = self.block_height + u32::from(in_blocks);
 
@@ -101,6 +119,8 @@ impl InBlockTransitions {
         scheduled_block
     }
 
+    /// Removes a previously scheduled `task` from block `expiry`. Returns an error if the block
+    /// or the specific task is not found in the schedule.
     pub fn remove_task(&mut self, expiry: u32, task: &ScheduledTask) -> Result<()> {
         let block_tasks = self
             .schedule
@@ -119,16 +139,22 @@ impl InBlockTransitions {
         Ok(())
     }
 
+    /// Registers a newly created program: inserts it into the state map with a zero state,
+    /// opens a pending modification entry for it, and records the `(actor_id, code_id)` pair.
     pub fn register_new(&mut self, actor_id: ActorId, code_id: CodeId) {
         self.states.insert(actor_id, StateHashWithQueueSize::zero());
         self.modifications.insert(actor_id, Default::default());
         self.program_creations.insert(actor_id, code_id);
     }
 
+    /// Returns the map of programs registered (created) during this block.
     pub fn registered_programs(&self) -> &BTreeMap<ActorId, CodeId> {
         &self.program_creations
     }
 
+    /// Updates the state hash and queue sizes for `actor_id` in the current block.
+    ///
+    /// Panics if `actor_id` is not a known program.
     pub fn modify_state(
         &mut self,
         actor_id: ActorId,
@@ -143,6 +169,8 @@ impl InBlockTransitions {
         })
     }
 
+    /// Applies a closure to the [`NonFinalTransition`] for `actor_id`, returning whatever the
+    /// closure returns. Panics if `actor_id` is not a known program.
     pub fn modify_transition<T>(
         &mut self,
         actor_id: ActorId,
@@ -151,6 +179,8 @@ impl InBlockTransitions {
         self.modify(actor_id, |_state, transition| f(transition))
     }
 
+    /// Records a value claim against `actor_id`, accumulating the claimed amount into
+    /// `value_to_receive` for the transition. Panics on overflow or unknown actor.
     pub fn claim_value(&mut self, actor_id: ActorId, claim: ValueClaim) {
         self.modify(actor_id, |_state, transition| {
             transition.value_to_receive = transition
@@ -164,6 +194,9 @@ impl InBlockTransitions {
         });
     }
 
+    /// Low-level accessor that gives the closure mutable access to both the current
+    /// `StateHashWithQueueSize` and the pending [`NonFinalTransition`] for `actor_id`.
+    /// Lazily creates the `NonFinalTransition` entry on first call. Panics if unknown actor.
     pub fn modify<T>(
         &mut self,
         actor_id: ActorId,
@@ -185,6 +218,8 @@ impl InBlockTransitions {
         f(initial_state, transition)
     }
 
+    /// Consumes this instance and produces [`FinalizedBlockTransitions`], discarding noop
+    /// modifications and collecting the rest into `StateTransition` entries ready for commitment.
     pub fn finalize(self) -> FinalizedBlockTransitions {
         let Self {
             states,
@@ -224,10 +259,13 @@ impl InBlockTransitions {
         }
     }
 
+    /// Returns the block height this instance was created for.
     pub fn block_height(&self) -> u32 {
         self.block_height
     }
 
+    /// Constructs an [`InBlockTransitions`] directly from its constituent parts.
+    /// Available only in tests and with the `mock` feature.
     #[cfg(any(test, feature = "mock"))]
     pub fn from_parts(
         block_height: u32,
@@ -245,27 +283,43 @@ impl InBlockTransitions {
         }
     }
 
+    /// Returns a mutable reference to the pending modifications map.
+    /// Available only in tests and with the `mock` feature.
     #[cfg(any(test, feature = "mock"))]
     pub fn modifications_mut(&mut self) -> &mut BTreeMap<ActorId, NonFinalTransition> {
         &mut self.modifications
     }
 
+    /// Returns a mutable reference to the block height.
+    /// Available only in tests and with the `mock` feature.
     #[cfg(any(test, feature = "mock"))]
     pub fn block_height_mut(&mut self) -> &mut u32 {
         &mut self.block_height
     }
 }
 
+/// Accumulated, not-yet-committed changes for a single program within one block.
+///
+/// Holds everything needed to decide whether a `StateTransition` should be emitted at
+/// finalization: whether the state hash changed, whether the program exited, and any
+/// value claims or outgoing messages produced during execution.
 #[derive(Debug, Default, Clone)]
 pub struct NonFinalTransition {
     initial_state: H256,
+    /// The program that inherits value when this program exits, if any.
     pub inheritor: Option<ActorId>,
+    /// Net value (in base units) to be transferred at finalization; negative means outgoing.
     pub value_to_receive: i128,
+    /// Value claims accumulated for this program during the block.
     pub claims: Vec<ValueClaim>,
+    /// Outgoing messages produced by this program during the block.
     pub messages: Vec<Message>,
 }
 
 impl NonFinalTransition {
+    /// Returns `true` when this transition carries no observable effect and can be omitted from
+    /// the committed batch: the program existed before, its state hash is unchanged, it did not
+    /// exit, and it has no value transfers, claims, or outgoing messages.
     pub fn is_noop(&self, current_state: H256) -> bool {
         // check if just created program (always op)
         !self.initial_state.is_zero()
@@ -275,11 +329,15 @@ impl NonFinalTransition {
             && (self.inheritor.is_none() && self.value_to_receive == 0 && self.claims.is_empty() && self.messages.is_empty())
     }
 
+    /// Returns the program's state hash at the start of the block (before any modifications).
+    /// Available only in tests and with the `mock` feature.
     #[cfg(any(test, feature = "mock"))]
     pub fn initial_state(&self) -> H256 {
         self.initial_state
     }
 
+    /// Constructs a [`NonFinalTransition`] with all fields specified explicitly.
+    /// Available only in tests and with the `mock` feature.
     #[cfg(any(test, feature = "mock"))]
     pub fn new(
         initial_state: H256,

--- a/ethexe/runtime/src/wasm/api/instrument.rs
+++ b/ethexe/runtime/src/wasm/api/instrument.rs
@@ -8,6 +8,11 @@ use gear_core::{
 };
 
 // TODO: impl Codec for CodeError, so could be thrown to host via memory.
+/// Validates and instruments raw WASM bytecode for use as a Gear program on the Ethereum execution layer.
+///
+/// Applies gas-metering rules and structural limits from the default [`Schedule`], then returns the
+/// instrumented code together with its metadata. Returns `None` if the input or instrumented output
+/// exceeds the schedule's `code_len` limit, or if validation/instrumentation fails.
 pub fn instrument_code(original_code: Vec<u8>) -> Option<(InstrumentedCode, CodeMetadata)> {
     log::debug!("Runtime::instrument_code(..)");
 

--- a/ethexe/runtime/src/wasm/api/run.rs
+++ b/ethexe/runtime/src/wasm/api/run.rs
@@ -4,6 +4,10 @@
 use crate::wasm::storage::NativeRuntimeInterface;
 use ethexe_runtime_common::{ProcessQueueContext, ProgramJournals, process_queue};
 
+/// Processes the program message queue for one block, returning execution journals and total gas spent.
+///
+/// Delegates to [`process_queue`] with a [`NativeRuntimeInterface`] instance, then
+/// logs each resulting journal note at debug level.
 pub fn run(ctx: ProcessQueueContext) -> (ProgramJournals, u64) {
     log::debug!("You're calling 'run(..)'");
 

--- a/ethexe/runtime/src/wasm/interface/allocator.rs
+++ b/ethexe/runtime/src/wasm/interface/allocator.rs
@@ -9,14 +9,17 @@ interface::declare! {
     pub(super) fn ext_allocator_malloc_version_1(size: i32) -> *mut u8;
 }
 
+/// Frees a previously allocated block of memory via the host allocator syscall.
 pub fn free(ptr: *mut u8) {
     unsafe { sys::ext_allocator_free_version_1(ptr) }
 }
 
+/// Allocates `size` bytes via the host allocator syscall and returns a raw pointer to the block.
 pub fn malloc(size: usize) -> *mut u8 {
     unsafe { sys::ext_allocator_malloc_version_1(size as _) }
 }
 
+/// Global allocator that delegates all allocations to the host runtime via `malloc` and `free`.
 pub struct RuntimeAllocator;
 
 unsafe impl GlobalAlloc for RuntimeAllocator {

--- a/ethexe/runtime/src/wasm/interface/database.rs
+++ b/ethexe/runtime/src/wasm/interface/database.rs
@@ -14,22 +14,26 @@ interface::declare! {
 }
 
 // TODO(romanm): consider to move into separate RI module
+/// Notifies the host of the updated program state hash after execution completes.
 pub fn update_state_hash(hash: &H256) {
     unsafe {
         sys::ext_update_state_hash_version_1(hash.as_ptr() as _);
     }
 }
 
+/// Reads and SCALE-decodes the value stored under `hash`, returning `None` if not found.
 pub fn read<D: Decode>(hash: &H256) -> Option<Result<D, CodecError>> {
     let mut slice = read_raw(hash)?;
 
     Some(D::decode(&mut slice))
 }
 
+/// Reads and SCALE-decodes the value stored under `hash`, panicking if decoding fails.
 pub fn read_unwrapping<D: Decode>(hash: &H256) -> Option<D> {
     read(hash).map(|v| v.unwrap())
 }
 
+/// Returns a byte slice of the value stored under `hash`, or `None` if the key is absent.
 pub fn read_raw(hash: &H256) -> Option<&[u8]> {
     unsafe {
         let ptr_len = sys::ext_database_read_by_hash_version_1(hash.as_ptr() as _);
@@ -41,10 +45,12 @@ pub fn read_raw(hash: &H256) -> Option<&[u8]> {
     }
 }
 
+/// SCALE-encodes `data`, writes it to the host database, and returns the content hash.
 pub fn write(data: impl Encode) -> H256 {
     write_raw(data.encode())
 }
 
+/// Writes raw bytes to the host database and returns their content hash.
 pub fn write_raw(data: impl AsRef<[u8]>) -> H256 {
     let data = data.as_ref();
 

--- a/ethexe/runtime/src/wasm/interface/logging.rs
+++ b/ethexe/runtime/src/wasm/interface/logging.rs
@@ -12,6 +12,10 @@ interface::declare! {
     pub(super) fn ext_logging_max_level_v1() -> i32;
 }
 
+/// Emits a log record through the host logging interface.
+///
+/// Converts `level` and the target/message slices into the representation expected by the
+/// `ext_logging_log_v1` host function and delegates to it.
 pub fn log(level: Level, target: &str, message: &[u8]) {
     let level = level as usize as i32;
     let target = utils::repr_ri_slice(target);
@@ -22,6 +26,10 @@ pub fn log(level: Level, target: &str, message: &[u8]) {
     }
 }
 
+/// Returns the maximum log level accepted by the host, as a `LevelFilter`.
+///
+/// Calls `ext_logging_max_level_v1` and maps its integer return value to the corresponding
+/// `log::LevelFilter` variant, treating any value above 4 as `Trace`.
 pub fn max_level() -> LevelFilter {
     match unsafe { sys::ext_logging_max_level_v1() } {
         0 => LevelFilter::Off,
@@ -33,9 +41,14 @@ pub fn max_level() -> LevelFilter {
     }
 }
 
+/// A `log::Log` implementation that forwards records to the host via [`log`] and [`max_level`].
 pub struct RuntimeLogger;
 
 impl RuntimeLogger {
+    /// Registers `RuntimeLogger` as the global logger and sets the max level from the host.
+    ///
+    /// Registering the logger is idempotent: `log::set_logger` returns an error on repeated calls,
+    /// which is silently ignored. The max level is refreshed from the host on every call.
     pub fn init() {
         static LOGGER: RuntimeLogger = RuntimeLogger;
         let _ = log::set_logger(&LOGGER);

--- a/ethexe/runtime/src/wasm/storage.rs
+++ b/ethexe/runtime/src/wasm/storage.rs
@@ -17,6 +17,12 @@ use gear_core::{buffer::Payload, memory::PageBuf};
 use gear_lazy_pages_interface::{LazyPagesInterface, LazyPagesRuntimeInterface};
 use gprimitives::H256;
 
+/// Runtime interface implementation that routes storage and runtime operations through host-function imports.
+///
+/// Implements both [`Storage`] and [`RuntimeInterface`] by delegating every call to the
+/// corresponding `database_ri` / `promise_ri` host functions exposed by the ethexe executor.
+/// This is the concrete implementation used when the runtime WASM binary executes inside an
+/// ethexe node.
 #[derive(Debug, Clone)]
 pub struct NativeRuntimeInterface;
 

--- a/ethexe/sdk/src/api.rs
+++ b/ethexe/sdk/src/api.rs
@@ -7,12 +7,22 @@ use ethexe_ethereum::Ethereum;
 use gprimitives::ActorId;
 use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 
+/// Root handle for the ethexe SDK, combining an ethexe JSON-RPC WebSocket client with an
+/// Ethereum contract client.
+///
+/// Construct with [`VaraEthApi::new`], then obtain scoped wrappers via [`VaraEthApi::mirror`],
+/// [`VaraEthApi::router`], or [`VaraEthApi::wrapped_vara`]. The struct borrows no external state
+/// and can be shared across tasks by wrapping in `Arc`.
 pub struct VaraEthApi {
     pub(crate) vara_eth_client: WsClient,
     pub(crate) ethereum_client: Ethereum,
 }
 
 impl VaraEthApi {
+    /// Creates a new `VaraEthApi` by connecting a WebSocket JSON-RPC client to `vara_eth_rpc_url`
+    /// and storing the provided `ethereum_client`.
+    ///
+    /// Returns an error if the WebSocket connection cannot be established.
     pub async fn new(vara_eth_rpc_url: &str, ethereum_client: Ethereum) -> Result<Self> {
         let vara_eth_client = WsClientBuilder::new()
             .build(vara_eth_rpc_url)
@@ -24,6 +34,10 @@ impl VaraEthApi {
         })
     }
 
+    /// Returns a [`Mirror`] scoped to the on-chain program identified by `actor_id`.
+    ///
+    /// The returned wrapper borrows `self` and provides per-program operations such as sending
+    /// messages and querying state.
     pub fn mirror(&self, actor_id: ActorId) -> Mirror<'_> {
         let mirror_client = self
             .ethereum_client
@@ -36,6 +50,7 @@ impl VaraEthApi {
         }
     }
 
+    /// Returns a [`Router`] wrapper that exposes Router contract operations and global queries.
     pub fn router(&self) -> Router<'_> {
         let router_client = self.ethereum_client.router();
         let router_query_client = router_client.query();
@@ -46,6 +61,7 @@ impl VaraEthApi {
         }
     }
 
+    /// Returns a [`WVara`] wrapper for the WrappedVara ERC-20 contract operations.
     pub fn wrapped_vara(&self) -> WVara {
         let wvara_client = self.ethereum_client.wrapped_vara();
         let wvara_query_client = wvara_client.query();

--- a/ethexe/sdk/src/mirror.rs
+++ b/ethexe/sdk/src/mirror.rs
@@ -25,6 +25,11 @@ use futures::TryFutureExt;
 use gprimitives::{ActorId, CodeId, H256, MessageId, U256};
 use gsigner::secp256k1::Secp256k1SignerExt;
 
+/// SDK wrapper for a single on-chain Gear program (Mirror contract).
+///
+/// Obtained from [`VaraEthApi::mirror`]; borrows the parent `VaraEthApi` and cannot outlive it.
+/// Combines an Ethereum contract client for write operations with a query client for read-only
+/// calls, and delegates state queries to the ethexe JSON-RPC endpoint.
 pub struct Mirror<'a> {
     pub(crate) api: &'a VaraEthApi,
     pub(crate) mirror_client: EthereumMirror,
@@ -32,18 +37,22 @@ pub struct Mirror<'a> {
 }
 
 impl<'a> Mirror<'a> {
+    /// Returns an event subscription handle for Mirror contract events.
     pub fn events(&self) -> EthereumMirrorEvents<'_> {
         self.mirror_query_client.events()
     }
 
+    /// Returns the `ActorId` of this program as registered on-chain.
     pub fn actor_id(&self) -> ActorId {
         self.mirror_client.actor_id()
     }
 
+    /// Returns the native ETH balance of the Mirror contract address.
     pub async fn balance(&self) -> Result<u128> {
         self.mirror_query_client.balance().await
     }
 
+    /// Returns the `CodeId` of the WASM code deployed for this program.
     pub async fn code_id(&self) -> Result<CodeId> {
         let code_id = self
             .api
@@ -53,14 +62,17 @@ impl<'a> Mirror<'a> {
         Ok(code_id.into())
     }
 
+    /// Waits until the Mirror contract emits a state-change event and returns the new state hash.
     pub async fn wait_for_state_change(&self) -> Result<H256> {
         self.mirror_client.wait_for_state_change().await
     }
 
+    /// Returns the address of the Router contract this Mirror is registered with.
     pub async fn router(&self) -> Result<Address> {
         self.mirror_query_client.router().await
     }
 
+    /// Fetches the current [`ProgramState`] by resolving the on-chain state hash via the RPC node.
     pub async fn state(&self) -> Result<ProgramState> {
         let state_hash = self.state_hash().await?;
         self.api
@@ -70,6 +82,7 @@ impl<'a> Mirror<'a> {
             .await
     }
 
+    /// Fetches the full program state, including queue and storage details, via the RPC node.
     pub async fn full_state(&self) -> Result<FullProgramState> {
         let state_hash = self.state_hash().await?;
         self.api
@@ -79,30 +92,40 @@ impl<'a> Mirror<'a> {
             .await
     }
 
+    /// Returns the current state hash stored in the Mirror contract.
     pub async fn state_hash(&self) -> Result<H256> {
         self.mirror_query_client.state_hash().await
     }
 
+    /// Returns the state hash stored in the Mirror contract at the given block.
     pub async fn state_hash_at(&self, id: impl IntoBlockId) -> Result<H256> {
         self.mirror_query_client.state_hash_at(id).await
     }
 
+    /// Returns the current message nonce of this program, used to derive outgoing `MessageId`s.
     pub async fn nonce(&self) -> Result<U256> {
         self.mirror_query_client.nonce().await
     }
 
+    /// Returns `true` if the program has called `gr_exit` and is no longer executable.
     pub async fn exited(&self) -> Result<bool> {
         self.mirror_query_client.exited().await
     }
 
+    /// Returns the `ActorId` designated to inherit this program's locked value after it exits.
     pub async fn inheritor(&self) -> Result<ActorId> {
         self.mirror_query_client.inheritor().await
     }
 
+    /// Returns the `ActorId` that originally initialized this program.
     pub async fn initializer(&self) -> Result<ActorId> {
         self.mirror_query_client.initializer().await
     }
 
+    /// Calculates the reply the program would produce for a handle message at the current block.
+    ///
+    /// Delegates to [`calculate_reply_for_handle_at`](Self::calculate_reply_for_handle_at) with
+    /// `at = None`.
     pub async fn calculate_reply_for_handle(
         &self,
         payload: impl AsRef<[u8]>,
@@ -112,6 +135,10 @@ impl<'a> Mirror<'a> {
             .await
     }
 
+    /// Calculates the reply the program would produce for a handle message at a specific block hash.
+    ///
+    /// Passes the caller's Ethereum address as the message source. `at = None` means the latest
+    /// committed state.
     pub async fn calculate_reply_for_handle_at(
         &self,
         payload: impl AsRef<[u8]>,
@@ -134,6 +161,8 @@ impl<'a> Mirror<'a> {
             .await
     }
 
+    /// Sends an on-chain handle message to this program and returns the transaction hash and the
+    /// resulting `MessageId`.
     pub async fn send_message(
         &self,
         payload: impl AsRef<[u8]>,
@@ -142,6 +171,8 @@ impl<'a> Mirror<'a> {
         self.mirror_client.send_message(payload, value).await
     }
 
+    /// Sends an on-chain handle message and returns the full Ethereum `TransactionReceipt` together
+    /// with the resulting `MessageId`.
     pub async fn send_message_with_receipt(
         &self,
         payload: impl AsRef<[u8]>,
@@ -205,6 +236,10 @@ impl<'a> Mirror<'a> {
         Ok(transaction)
     }
 
+    /// Submits an injected (off-chain signed) handle message via the ethexe RPC node.
+    ///
+    /// Only zero-value messages are currently supported. Returns the `MessageId` on `Accept`;
+    /// returns an error on `Reject`.
     pub async fn send_message_injected(
         &self,
         payload: impl AsRef<[u8]>,
@@ -230,6 +265,11 @@ impl<'a> Mirror<'a> {
         }
     }
 
+    /// Submits an injected handle message and waits for the node to return a [`Promise`] receipt.
+    ///
+    /// Only zero-value messages are currently supported. Returns the `MessageId` and the `Promise`
+    /// produced by the node. Errors if the transaction is purged (`Receipt::Purged`) or the
+    /// subscription stream closes without producing an event.
     pub async fn send_message_injected_and_watch(
         &self,
         payload: impl AsRef<[u8]>,
@@ -264,10 +304,14 @@ impl<'a> Mirror<'a> {
         Ok((message_id, promise))
     }
 
+    /// Waits until the Mirror contract emits a reply event for the given `message_id` and returns
+    /// the reply details.
     pub async fn wait_for_reply(&self, message_id: MessageId) -> Result<ReplyInfo> {
         self.mirror_client.wait_for_reply(message_id).await
     }
 
+    /// Sends an on-chain reply to a previously received message and returns the transaction hash
+    /// and the resulting `MessageId`.
     pub async fn send_reply(
         &self,
         replied_to: MessageId,
@@ -279,6 +323,8 @@ impl<'a> Mirror<'a> {
             .await
     }
 
+    /// Sends an on-chain reply and returns the full `TransactionReceipt` together with the
+    /// resulting `MessageId`.
     pub async fn send_reply_with_receipt(
         &self,
         replied_to: MessageId,
@@ -290,10 +336,13 @@ impl<'a> Mirror<'a> {
             .await
     }
 
+    /// Claims the value locked in the mailbox for `claimed_id` and returns the transaction hash.
     pub async fn claim_value(&self, claimed_id: MessageId) -> Result<H256> {
         self.mirror_client.claim_value(claimed_id).await
     }
 
+    /// Claims the value locked in the mailbox for `claimed_id` and returns the full
+    /// `TransactionReceipt`.
     pub async fn claim_value_with_receipt(
         &self,
         claimed_id: MessageId,
@@ -303,14 +352,20 @@ impl<'a> Mirror<'a> {
             .await
     }
 
+    /// Waits until the Mirror emits a value-claimed event for `message_id` and returns the claim
+    /// details.
     pub async fn wait_for_value_claim(&self, message_id: MessageId) -> Result<ClaimInfo> {
         self.mirror_client.wait_for_value_claim(message_id).await
     }
 
+    /// Tops up the executable balance of this program by `value` WVara tokens and returns the
+    /// transaction hash.
     pub async fn executable_balance_top_up(&self, value: u128) -> Result<H256> {
         self.mirror_client.executable_balance_top_up(value).await
     }
 
+    /// Tops up the executable balance of this program by `value` WVara tokens and returns the full
+    /// `TransactionReceipt`.
     pub async fn executable_balance_top_up_with_receipt(
         &self,
         value: u128,
@@ -320,12 +375,16 @@ impl<'a> Mirror<'a> {
             .await
     }
 
+    /// Tops up the executable balance using an ERC-20 permit signature (gasless approval) and
+    /// returns the transaction hash.
     pub async fn executable_balance_top_up_with_permit(&self, value: u128) -> Result<H256> {
         self.mirror_client
             .executable_balance_top_up_with_permit(value)
             .await
     }
 
+    /// Tops up the executable balance using an ERC-20 permit signature and returns the full
+    /// `TransactionReceipt`.
     pub async fn executable_balance_top_up_with_permit_and_receipt(
         &self,
         value: u128,
@@ -335,12 +394,15 @@ impl<'a> Mirror<'a> {
             .await
     }
 
+    /// Transfers any value locked in this exited program to its designated inheritor and returns
+    /// the transaction hash.
     pub async fn transfer_locked_value_to_inheritor(&self) -> Result<H256> {
         self.mirror_client
             .transfer_locked_value_to_inheritor()
             .await
     }
 
+    /// Transfers locked value to the inheritor and returns the full `TransactionReceipt`.
     pub async fn transfer_locked_value_to_inheritor_with_receipt(
         &self,
     ) -> Result<TransactionReceipt> {
@@ -349,12 +411,14 @@ impl<'a> Mirror<'a> {
             .await
     }
 
+    /// Tops up the owned (non-executable) balance of this program and returns the transaction hash.
     pub async fn owned_balance_top_up(&self, value: u128) -> Result<H256> {
         self.owned_balance_top_up_with_receipt(value)
             .await
             .map(|receipt| (*receipt.transaction_hash).into())
     }
 
+    /// Tops up the owned balance of this program and returns the full `TransactionReceipt`.
     pub async fn owned_balance_top_up_with_receipt(
         &self,
         value: u128,

--- a/ethexe/sdk/src/router.rs
+++ b/ethexe/sdk/src/router.rs
@@ -19,6 +19,11 @@ use ethexe_ethereum::{
 use ethexe_rpc::ProgramClient;
 use gprimitives::{ActorId, CodeId, H256};
 
+/// Scoped handle for interacting with the on-chain Router contract and its associated queries.
+///
+/// Obtained via [`VaraEthApi::router`]. Write methods delegate to `EthereumRouter` (state-changing
+/// Ethereum transactions); read methods delegate to `EthereumRouterQuery` (view calls). The handle
+/// borrows the parent [`VaraEthApi`] and cannot outlive it.
 pub struct Router<'a> {
     pub(crate) api: &'a VaraEthApi,
     pub(crate) router_client: EthereumRouter,
@@ -26,62 +31,75 @@ pub struct Router<'a> {
 }
 
 impl<'a> Router<'a> {
+    /// Returns a handle for subscribing to and querying Router contract events.
     pub fn events(&self) -> EthereumRouterEvents<'_> {
         self.router_query_client.events()
     }
 
     // TODO: move StorageView into ethexe-common and export
 
+    /// Returns a snapshot of all Router contract storage fields at the latest block.
     pub async fn storage_view(&self) -> Result<StorageView> {
         self.router_query_client.storage_view().await
     }
 
+    /// Returns a snapshot of all Router contract storage fields at the specified block.
     pub async fn storage_view_at(&self, id: impl IntoBlockId) -> Result<StorageView> {
         self.router_query_client.storage_view_at(id).await
     }
 
+    /// Returns the Ethereum block hash that was recorded as the ethexe genesis block.
     pub async fn genesis_block_hash(&self) -> Result<H256> {
         self.router_query_client.genesis_block_hash().await
     }
 
+    /// Returns the Unix timestamp (seconds) of the ethexe genesis block.
     pub async fn genesis_timestamp(&self) -> Result<u64> {
         self.router_query_client.genesis_timestamp().await
     }
 
+    /// Returns the digest of the most recently committed batch.
     pub async fn latest_committed_batch_hash(&self) -> Result<Digest> {
         self.router_query_client.latest_committed_batch_hash().await
     }
 
+    /// Returns the Unix timestamp (seconds) of the most recently committed batch.
     pub async fn latest_committed_batch_timestamp(&self) -> Result<u64> {
         self.router_query_client
             .latest_committed_batch_timestamp()
             .await
     }
 
+    /// Returns the address of the Mirror implementation contract used for program proxies.
     pub async fn mirror_impl(&self) -> Result<Address> {
         self.router_query_client.mirror_impl().await
     }
 
+    /// Returns the address of the WrappedVara ERC-20 contract.
     pub async fn wvara_address(&self) -> Result<Address> {
         self.router_query_client.wvara_address().await
     }
 
+    /// Returns the address of the Middleware contract responsible for validator management.
     pub async fn middleware_address(&self) -> Result<Address> {
         self.router_query_client.middleware_address().await
     }
 
+    /// Returns the FROST aggregated public key of the current validator set.
     pub async fn validators_aggregated_public_key(&self) -> Result<AggregatedPublicKey> {
         self.router_query_client
             .validators_aggregated_public_key()
             .await
     }
 
+    /// Returns the verifiable secret sharing (VSS) commitment bytes for the current validator set.
     pub async fn validators_verifiable_secret_sharing_commitment(&self) -> Result<Vec<u8>> {
         self.router_query_client
             .validators_verifiable_secret_sharing_commitment()
             .await
     }
 
+    /// Returns `true` if every address in `validators` is a member of the current validator set.
     pub async fn are_validators(
         &self,
         validators: impl IntoIterator<Item = Address>,
@@ -89,38 +107,47 @@ impl<'a> Router<'a> {
         self.router_query_client.are_validators(validators).await
     }
 
+    /// Returns `true` if the given address is a member of the current validator set.
     pub async fn is_validator(&self, validator: Address) -> Result<bool> {
         self.router_query_client.is_validator(validator).await
     }
 
+    /// Returns the signing threshold as a `(numerator, denominator)` fraction.
     pub async fn signing_threshold_fraction(&self) -> Result<(u128, u128)> {
         self.router_query_client.signing_threshold_fraction().await
     }
 
+    /// Returns the ordered list of current validator addresses.
     pub async fn validators(&self) -> Result<ValidatorsVec> {
         self.router_query_client.validators().await
     }
 
+    /// Returns the ordered list of validator addresses at the specified block.
     pub async fn validators_at(&self, id: impl IntoBlockId) -> Result<ValidatorsVec> {
         self.router_query_client.validators_at(id).await
     }
 
+    /// Returns the total number of validators in the current set.
     pub async fn validators_count(&self) -> Result<u64> {
         self.router_query_client.validators_count().await
     }
 
+    /// Returns the minimum number of validator signatures required to commit a batch.
     pub async fn validators_threshold(&self) -> Result<u64> {
         self.router_query_client.validators_threshold().await
     }
 
+    /// Returns the current computation settings (gas limits, block parameters, etc.) from the Router.
     pub async fn compute_settings(&self) -> Result<ComputationSettings> {
         self.router_query_client.compute_settings().await
     }
 
+    /// Returns the validation state of a single code blob identified by `code_id`.
     pub async fn code_state(&self, code_id: CodeId) -> Result<CodeState> {
         self.router_query_client.code_state(code_id).await
     }
 
+    /// Returns the validation states for a collection of code blobs at the latest block.
     pub async fn codes_states(
         &self,
         code_ids: impl IntoIterator<Item = CodeId>,
@@ -128,6 +155,7 @@ impl<'a> Router<'a> {
         self.router_query_client.codes_states(code_ids).await
     }
 
+    /// Returns the validation states for a collection of code blobs at the specified block.
     pub async fn codes_states_at(
         &self,
         code_ids: impl IntoIterator<Item = CodeId>,
@@ -136,15 +164,18 @@ impl<'a> Router<'a> {
         self.router_query_client.codes_states_at(code_ids, id).await
     }
 
+    /// Returns the actor IDs of all programs known to the ethexe RPC node.
     pub async fn program_ids(&self) -> Result<Vec<ActorId>> {
         let program_ids = self.api.vara_eth_client.ids().await?;
         Ok(program_ids.into_iter().map(ActorId::from).collect())
     }
 
+    /// Returns the code ID associated with `program_id`, or `None` if the program is not registered.
     pub async fn program_code_id(&self, program_id: ActorId) -> Result<Option<CodeId>> {
         self.router_query_client.program_code_id(program_id).await
     }
 
+    /// Returns the code IDs for a collection of programs at the latest block.
     pub async fn programs_code_ids(
         &self,
         program_ids: impl IntoIterator<Item = ActorId>,
@@ -154,6 +185,7 @@ impl<'a> Router<'a> {
             .await
     }
 
+    /// Returns the code IDs for a collection of programs at the specified block.
     pub async fn programs_code_ids_at(
         &self,
         program_ids: impl IntoIterator<Item = ActorId>,
@@ -164,46 +196,62 @@ impl<'a> Router<'a> {
             .await
     }
 
+    /// Returns the total number of programs registered in the Router at the latest block.
     pub async fn programs_count(&self) -> Result<u64> {
         self.router_query_client.programs_count().await
     }
 
+    /// Returns the total number of programs registered in the Router at the specified block.
     pub async fn programs_count_at(&self, id: impl IntoBlockId) -> Result<u64> {
         self.router_query_client.programs_count_at(id).await
     }
 
+    /// Returns the number of code blobs that have passed validation at the latest block.
     pub async fn validated_codes_count(&self) -> Result<u64> {
         self.router_query_client.validated_codes_count().await
     }
 
+    /// Returns the number of code blobs that had passed validation at the specified block.
     pub async fn validated_codes_count_at(&self, id: impl IntoBlockId) -> Result<u64> {
         self.router_query_client.validated_codes_count_at(id).await
     }
 
+    /// Returns the current era timeline configuration from the Router contract.
     pub async fn timelines(&self) -> Result<Timelines> {
         self.router_query_client.timelines().await
     }
 
+    /// Submits a transaction to update the Mirror implementation address on the Router.
+    ///
+    /// Returns the transaction hash. Use [`set_mirror_with_receipt`] to wait for inclusion.
     pub async fn set_mirror(&self, new_mirror: Address) -> Result<H256> {
         self.router_client.set_mirror(new_mirror).await
     }
 
+    /// Submits a transaction to update the Mirror implementation address and waits for the receipt.
     pub async fn set_mirror_with_receipt(&self, new_mirror: Address) -> Result<TransactionReceipt> {
         self.router_client.set_mirror_with_receipt(new_mirror).await
     }
 
+    /// Triggers a genesis-hash lookup on the Router and returns the transaction hash.
     pub async fn lookup_genesis_hash(&self) -> Result<H256> {
         self.router_client.lookup_genesis_hash().await
     }
 
+    /// Triggers a genesis-hash lookup on the Router and waits for the transaction receipt.
     pub async fn lookup_genesis_hash_with_receipt(&self) -> Result<TransactionReceipt> {
         self.router_client.lookup_genesis_hash_with_receipt().await
     }
 
+    /// Uploads a WASM code blob and requests validator validation, returning `(tx_hash, code_id)`.
+    ///
+    /// The returned `CodeId` is deterministic (blake2 hash of the code). Use
+    /// [`wait_for_code_validation`] to block until validation completes.
     pub async fn request_code_validation(&self, code: &[u8]) -> Result<(H256, CodeId)> {
         self.router_client.request_code_validation(code).await
     }
 
+    /// Uploads a WASM code blob and requests validator validation, returning `(receipt, code_id)`.
     pub async fn request_code_validation_with_receipt(
         &self,
         code: &[u8],
@@ -213,10 +261,15 @@ impl<'a> Router<'a> {
             .await
     }
 
+    /// Polls until the validators reach a decision on `code_id` and returns the result.
     pub async fn wait_for_code_validation(&self, code_id: CodeId) -> Result<CodeValidationResult> {
         self.router_client.wait_for_code_validation(code_id).await
     }
 
+    /// Deploys a program from a validated code blob, returning `(tx_hash, actor_id)`.
+    ///
+    /// `salt` is mixed into the deterministic `ActorId` derivation. `override_initializer` replaces
+    /// the default initializer actor when set.
     pub async fn create_program(
         &self,
         code_id: CodeId,
@@ -228,6 +281,8 @@ impl<'a> Router<'a> {
             .await
     }
 
+    /// Deploys a program from a validated code blob and waits for the receipt, returning
+    /// `(receipt, actor_id)`.
     pub async fn create_program_with_receipt(
         &self,
         code_id: CodeId,
@@ -239,6 +294,8 @@ impl<'a> Router<'a> {
             .await
     }
 
+    /// Deploys a program and seeds it with `initial_executable_balance` WVara, returning
+    /// `(tx_hash, actor_id)`.
     pub async fn create_program_with_executable_balance(
         &self,
         code_id: CodeId,
@@ -256,6 +313,8 @@ impl<'a> Router<'a> {
             .await
     }
 
+    /// Deploys a program with an initial executable balance and waits for the receipt, returning
+    /// `(receipt, actor_id)`.
     pub async fn create_program_with_executable_balance_and_receipt(
         &self,
         code_id: CodeId,
@@ -273,6 +332,7 @@ impl<'a> Router<'a> {
             .await
     }
 
+    /// Deploys a program and associates it with an ABI interface actor, returning `(tx_hash, actor_id)`.
     pub async fn create_program_with_abi_interface(
         &self,
         code_id: CodeId,
@@ -285,6 +345,8 @@ impl<'a> Router<'a> {
             .await
     }
 
+    /// Deploys a program with an ABI interface actor and waits for the receipt, returning
+    /// `(receipt, actor_id)`.
     pub async fn create_program_with_abi_interface_with_receipt(
         &self,
         code_id: CodeId,
@@ -302,6 +364,8 @@ impl<'a> Router<'a> {
             .await
     }
 
+    /// Deploys a program with an ABI interface actor and an initial executable balance, returning
+    /// `(tx_hash, actor_id)`.
     pub async fn create_program_with_abi_interface_and_executable_balance(
         &self,
         code_id: CodeId,
@@ -321,6 +385,8 @@ impl<'a> Router<'a> {
             .await
     }
 
+    /// Deploys a program with an ABI interface actor and an initial executable balance, waits for
+    /// the receipt, and returns `(receipt, actor_id)`.
     pub async fn create_program_with_abi_interface_and_executable_balance_with_receipt(
         &self,
         code_id: CodeId,

--- a/ethexe/sdk/src/wvara.rs
+++ b/ethexe/sdk/src/wvara.rs
@@ -8,40 +8,52 @@ use ethexe_ethereum::wvara::{
 };
 use gprimitives::{ActorId, H256, U256};
 
+/// SDK handle for the WrappedVara ERC-20 contract, bundling a signing client and a read-only query client.
+///
+/// Obtain via [`VaraEthApi::wrapped_vara`]. Methods that mutate state (transfer, approve, mint)
+/// use the signing client; query methods (name, balance_of, allowance, …) use the read-only client.
 pub struct WVara {
     pub(crate) wvara_client: EthereumWVara,
     pub(crate) wvara_query_client: EthereumWVaraQuery,
 }
 
 impl WVara {
+    /// Returns an event-builder facade for subscribing to WrappedVara contract events.
     pub fn events(&self) -> EthereumWVaraEvents<'_> {
         self.wvara_query_client.events()
     }
 
+    /// Returns the ERC-20 token name stored on-chain.
     pub async fn name(&self) -> Result<String> {
         self.wvara_query_client.name().await
     }
 
+    /// Returns the ERC-20 token symbol stored on-chain.
     pub async fn symbol(&self) -> Result<String> {
         self.wvara_query_client.symbol().await
     }
 
+    /// Returns the number of decimal places used by the token (typically 18).
     pub async fn decimals(&self) -> Result<u8> {
         self.wvara_query_client.decimals().await
     }
 
+    /// Returns the total token supply currently in circulation.
     pub async fn total_supply(&self) -> Result<u128> {
         self.wvara_query_client.total_supply().await
     }
 
+    /// Returns the token balance held by `address`.
     pub async fn balance_of(&self, address: ActorId) -> Result<u128> {
         self.wvara_query_client.balance_of(address).await
     }
 
+    /// Transfers `value` tokens to `to`, returning the transaction hash on success.
     pub async fn transfer(&self, to: ActorId, value: u128) -> Result<H256> {
         self.wvara_client.transfer(to, value).await
     }
 
+    /// Transfers `value` tokens to `to`, returning the full transaction receipt on success.
     pub async fn transfer_with_receipt(
         &self,
         to: ActorId,
@@ -50,10 +62,12 @@ impl WVara {
         self.wvara_client.transfer_with_receipt(to, value).await
     }
 
+    /// Transfers `value` tokens from `from` to `to` using the caller's allowance, returning the transaction hash.
     pub async fn transfer_from(&self, from: ActorId, to: ActorId, value: u128) -> Result<H256> {
         self.wvara_client.transfer_from(from, to, value).await
     }
 
+    /// Transfers `value` tokens from `from` to `to` using the caller's allowance, returning the full transaction receipt.
     pub async fn transfer_from_with_receipt(
         &self,
         from: ActorId,
@@ -65,10 +79,12 @@ impl WVara {
             .await
     }
 
+    /// Approves `spender` to spend up to `value` tokens on behalf of the caller, returning the transaction hash.
     pub async fn approve(&self, spender: ActorId, value: u128) -> Result<H256> {
         self.wvara_client.approve(spender, value).await
     }
 
+    /// Approves `spender` to spend up to `value` tokens, returning the full transaction receipt.
     pub async fn approve_with_receipt(
         &self,
         spender: ActorId,
@@ -77,26 +93,32 @@ impl WVara {
         self.wvara_client.approve_with_receipt(spender, value).await
     }
 
+    /// Grants `spender` an unlimited allowance (`U256::MAX`), returning the transaction hash.
     pub async fn approve_all(&self, spender: ActorId) -> Result<H256> {
         self.wvara_client.approve_all(spender).await
     }
 
+    /// Grants `spender` an unlimited allowance (`U256::MAX`), returning the full transaction receipt.
     pub async fn approve_all_with_receipt(&self, spender: ActorId) -> Result<TransactionReceipt> {
         self.wvara_client.approve_all_with_receipt(spender).await
     }
 
+    /// Returns the remaining number of tokens that `spender` is allowed to spend on behalf of `owner`.
     pub async fn allowance(&self, owner: ActorId, spender: ActorId) -> Result<U256> {
         self.wvara_query_client.allowance(owner, spender).await
     }
 
+    /// Returns the EIP-2612 permit nonce for `owner`, used to prevent replay attacks on signed approvals.
     pub async fn nonces(&self, owner: ActorId) -> Result<U256> {
         self.wvara_query_client.nonces(owner).await
     }
 
+    /// Mints `amount` new tokens to `to`, returning the transaction hash on success.
     pub async fn mint(&self, to: ActorId, amount: u128) -> Result<H256> {
         self.wvara_client.mint(to, amount).await
     }
 
+    /// Mints `amount` new tokens to `to`, returning the full transaction receipt on success.
     pub async fn mint_with_receipt(&self, to: ActorId, amount: u128) -> Result<TransactionReceipt> {
         self.wvara_client.mint_with_receipt(to, amount).await
     }

--- a/ethexe/service/utils/src/lib.rs
+++ b/ethexe/service/utils/src/lib.rs
@@ -64,7 +64,12 @@ mod private {
     impl<F> Sealed for &mut FuturesUnordered<F> {}
 }
 
+/// Extends `Option<F>` with a `.maybe()` combinator for use in `tokio::select!` arms.
+///
+/// When the option is `Some`, the inner future is driven to completion. When it is `None`,
+/// the resulting future stays pending forever, so the `select!` arm is silently skipped.
 pub trait OptionFuture<T>: private::Sealed {
+    /// Await the inner future if `Some`, otherwise remain pending indefinitely.
     async fn maybe(self) -> T;
 }
 
@@ -78,9 +83,19 @@ impl<F: Future> OptionFuture<F::Output> for Option<F> {
     }
 }
 
+/// Extends `&mut Option<S>` and `&mut FuturesUnordered<F>` with stream-polling combinators
+/// suitable for `tokio::select!` arms.
+///
+/// A `None` stream or an empty `FuturesUnordered` stays pending, so the owning `select!`
+/// arm is silently skipped rather than resolving or panicking.
 pub trait OptionStreamNext<T>: private::Sealed {
+    /// Poll the next item from an optional stream, yielding `None` when the stream ends.
+    ///
+    /// Panics if called on `&mut FuturesUnordered`; use [`maybe_next_some`](Self::maybe_next_some) instead.
     async fn maybe_next(self) -> Option<T>;
 
+    /// Poll the next item from an optional stream or `FuturesUnordered`, staying pending when
+    /// there are no items rather than returning `None`.
     async fn maybe_next_some(self) -> T;
 }
 

--- a/ethexe/service/utils/src/task_local.rs
+++ b/ethexe/service/utils/src/task_local.rs
@@ -23,12 +23,14 @@ macro_rules! task_local {
     };
 }
 
+/// Task-local storage key providing mutable access to a value scoped to a closure or async task.
 pub struct LocalKey<T: 'static> {
     #[doc(hidden)]
     pub inner: thread::LocalKey<RefCell<Option<T>>>,
 }
 
 impl<T: 'static> LocalKey<T> {
+    /// Sets `value` as the task-local value, calls `f`, then returns the (possibly modified) value together with `f`'s return value.
     pub fn scope<F, R>(&'static self, value: T, f: F) -> (T, R)
     where
         F: FnOnce() -> R,
@@ -39,6 +41,7 @@ impl<T: 'static> LocalKey<T> {
         (value, res)
     }
 
+    /// Provides mutable access to the current task-local value. Panics if no value is set.
     pub fn with_mut<F, R>(&'static self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R,
@@ -49,6 +52,7 @@ impl<T: 'static> LocalKey<T> {
         })
     }
 
+    /// Returns a future that polls `f` with the waker context and a mutable reference to the task-local value on each poll.
     pub fn poll_fn<F, R>(&'static self, mut f: F) -> impl Future<Output = R>
     where
         F: FnMut(&mut Context<'_>, &mut T) -> Poll<R>,


### PR DESCRIPTION
Adds `///` documentation to public items across the ethexe crates, stacked on top of the crate-level docs (#5547).

Closes #5297, closes #5298, closes #5300, closes #5301, closes #5303, closes #5306, closes #5308, closes #5310, closes #5312. Part of #5296.

Supersedes #5541 (closed when its branch was renamed).