### PR TITLE
fix(protocol/wasmtime-cache): execute compiling.remove outside debug_assert!

### DIFF
--- a/protocol/wasmtime-cache/src/lib.rs
+++ b/protocol/wasmtime-cache/src/lib.rs
@@ -136,7 +136,8 @@ impl Cache {
     fn finish_compile(&self, code_id: CodeId) {
         {
             let mut state = self.state.lock().unwrap();
-            debug_assert!(state.compiling.remove(&code_id));
+            let removed = state.compiling.remove(&code_id);
+            debug_assert!(removed);
         }
 
         self.module_ready.notify_all();


### PR DESCRIPTION
## Summary

- `finish_compile` in `protocol/wasmtime-cache/src/lib.rs` calls `state.compiling.remove(&code_id)` as the argument of `debug_assert!`. The argument of `debug_assert!` is not evaluated in release builds, so the removal becomes a no-op and the code stays in `compiling` after the `CompilePermit` is dropped.
- On a subsequent `get()` for the same `code_id` with an incompatible engine, `cached_module` reserializes/deserializes, fails, pops the LRU entry, and returns `None`. Back in `reserve_compile`, `state.compiling.insert(code_id)` returns `false` because the leftover entry from the previous call is still there. The thread interprets that as "someone else is compiling" and blocks on `module_ready.wait()` forever — there is no other compiler, so nothing will signal.

This reproduces on master (`903c6c452`) as the nextest timeout that took down `build / workspace (release)` in https://github.com/gear-tech/gear/actions/runs/26753861656/job/78854099892:

```
TIMEOUT [ 300.008s] gear-wasmtime-cache::tests::compiles_when_cached_module_cannot_be_deserialized_for_engine
Summary [ 363.578s] 1725 tests run: 1724 passed, 1 timed out, 19 skipped
```

It is also a production-relevant bug: any engine swap (e.g. runtime upgrade) makes every subsequent `get()` for an already-cached `code_id` hang on the condvar permanently.

Fix: extract the `remove` call into a regular statement and pass its result to `debug_assert!`, so the invariant is still checked in dev/test builds but the removal happens in every profile.

## Test plan

- [x] `cargo nextest run -p gear-wasmtime-cache --release` — previously timed out after 300s, now `tests::compiles_when_cached_module_cannot_be_deserialized_for_engine` passes in 4 ms.
- [x] `cargo nextest run -p gear-wasmtime-cache` — both tests still pass in dev mode (the `debug_assert!` invariant remains in effect).
- [ ] CI `build / workspace (release)` job is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)