### PR TITLE
fix(pallet-gear-builtin/tests): tighten gas_allowance_respected heuristics

### DIFF
--- a/vara/pallets/gear-builtin/src/tests/proxy.rs
+++ b/vara/pallets/gear-builtin/src/tests/proxy.rs
@@ -138,7 +138,7 @@ fn gas_allowance_respected() {
         .weight
         .ref_time();
 
-        let gas_cost_send_message_to_broker = 680_000_000; // Heuristic value
+        let broker_gas_allowance = 1;
 
         System::reset_events();
 
@@ -151,10 +151,7 @@ fn gas_allowance_respected() {
             0,
             false,
         ));
-        run_for_n_blocks(
-            1,
-            Some(gas_cost_send_message_to_broker + gas_cost_proxy_message),
-        );
+        run_for_n_blocks(1, Some(broker_gas_allowance + gas_cost_proxy_message));
 
         // The dispatch is still in the queue
         assert!(!message_queue_empty());

--- a/vara/pallets/gear-builtin/src/tests/staking.rs
+++ b/vara/pallets/gear-builtin/src/tests/staking.rs
@@ -593,13 +593,7 @@ fn gas_allowance_respected() {
 
         assert_staking_events(contract_account_id, 100 * UNITS, EventType::Bonded);
 
-        // Estimate the gas cost for sending a message to `staking-broker` contract (without any
-        // outgoing messages).
-        // TODO: find a way to use `calculate_gas_info` here for more precise estimation.
-        // To block the contract from sending any messages, we provide an illegal payload. But
-        // we have to use the "actual" `calculate_gas_info` (since `cfg(test)` is not propagated
-        // to the dependencies), and that one doesn't allow calculating gas for failed dispatches.
-        let gas_to_engage_staking_broker = 880_000_000_u64; // Heuristic value
+        let broker_gas_allowance = 1_u64;
 
         let gas_cost = pallet_staking::Call::<Test>::bond {
             value: 100 * UNITS,
@@ -613,7 +607,7 @@ fn gas_allowance_respected() {
 
         // With insufficient gas allowance, the message should not be processed
         send_bond_message(contract_id, 100 * UNITS, None);
-        run_for_n_blocks(1, Some(gas_to_engage_staking_broker + gas_cost));
+        run_for_n_blocks(1, Some(broker_gas_allowance + gas_cost));
 
         // No staking events have taken place
         assert_no_staking_events();


### PR DESCRIPTION
Closes #5552.

Both `pallet-gear-builtin::tests::{proxy,staking}::gas_allowance_respected` rely on hardcoded broker-WASM heuristics that drifted above actual cost after the weights regen in #5532, so the "constrained" block allowance ended up sufficient to drain the queue.

The tests only need the allowance to be insufficient, not approximate; replacing the heuristic with `1` (renamed to `broker_gas_allowance` to express intent) keeps the structure but makes the test robust to future weight drift. Verified green on stripped CI run `26784196291`.