### PR TITLE
fix(ci): tighten staking election-provider logging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -323,6 +323,7 @@ jobs:
             gcli=trace,\
             ethexe=trace,\
             runtime=trace,\
+            runtime::election-provider=debug,\
             syscalls=trace,\
             gwasm=trace"
 


### PR DESCRIPTION
Closes #

## Summary

- Keep workspace `runtime=trace` enabled in CI.
- Lower only `runtime::election-provider` to `debug` to avoid hundreds of thousands of captured trace lines in long staking-rewards tests.
- Fix the workspace release timeout without changing the staking-rewards test itself.

## How to test

- `rtk git diff --check`
- `RUST_LOG=gear=trace,pallet=trace,gsdk=trace,gcli=trace,ethexe=trace,runtime=trace,runtime::election-provider=debug,syscalls=trace,gwasm=trace __GEAR_WASM_BUILDER_NO_BUILD=1 SKIP_WASM_BUILD=1 SKIP_VARA_RUNTIME_WASM_BUILD=1 SKIP_ETHEXE_RUNTIME_WASM_BUILD=1 rtk proxy cargo nextest run -p pallet-gear-staking-rewards inflation_when_nobody_stakes_adds_up --release --profile ci --no-fail-fast`
- `RUST_LOG=gear=trace,pallet=trace,gsdk=trace,gcli=trace,ethexe=trace,runtime=trace,runtime::election-provider=debug,syscalls=trace,gwasm=trace __GEAR_WASM_BUILDER_NO_BUILD=1 SKIP_WASM_BUILD=1 SKIP_VARA_RUNTIME_WASM_BUILD=1 SKIP_ETHEXE_RUNTIME_WASM_BUILD=1 rtk proxy cargo nextest run -p pallet-gear-staking-rewards --release --profile ci --no-fail-fast`

## Notes

- No runtime logic changes; this only narrows the workspace CI log filter for one noisy runtime subtarget.

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): description`)
- [x] Single logical change
- [x] Tests added or updated (if logic changed)
- [x] Docs updated (if needed)
