### PR TITLE
fix(vara.eth): handle program code reinstrumentation failure gracefully

### DIFF
--- a/ethexe/common/src/db.rs
+++ b/ethexe/common/src/db.rs
@@ -66,6 +66,8 @@ pub trait CodesStorageRO {
     fn program_code_id(&self, program_id: ActorId) -> Option<CodeId>;
     fn instrumented_code_exists(&self, runtime_id: u32, code_id: CodeId) -> bool;
     fn instrumented_code(&self, runtime_id: u32, code_id: CodeId) -> Option<InstrumentedCode>;
+
+    // TODO #5562: code valid, metadata, valid codes can be runtime specific, so should be stored with runtime_id as well.
     fn code_metadata(&self, code_id: CodeId) -> Option<CodeMetadata>;
     fn code_valid(&self, code_id: CodeId) -> Option<bool>;
     fn valid_codes(&self) -> BTreeSet<CodeId>;

--- a/ethexe/compute/src/codes.rs
+++ b/ethexe/compute/src/codes.rs
@@ -54,7 +54,7 @@ impl<P: ProcessorExt> CodesSubService<P> {
                 );
                 debug_assert!(
                     self.db
-                        .instrumented_code_exists(ethexe_runtime_common::VERSION, code_id),
+                        .instrumented_code_exists(ethexe_runtime_common::RUNTIME_ID, code_id),
                     "Instrumented code {code_id:?} must exist in database"
                 );
             }
@@ -75,7 +75,7 @@ impl<P: ProcessorExt> CodesSubService<P> {
                     {
                         db.set_original_code(&code);
                         db.set_instrumented_code(
-                            ethexe_runtime_common::VERSION,
+                            ethexe_runtime_common::RUNTIME_ID,
                             code_id,
                             instrumented_code,
                         );
@@ -144,7 +144,7 @@ mod tests {
         db.set_code_valid(code_id, true);
         db.set_original_code(code_and_id.code());
         db.set_instrumented_code(
-            ethexe_runtime_common::VERSION,
+            ethexe_runtime_common::RUNTIME_ID,
             code_id,
             InstrumentedCode::new(
                 vec![5, 6, 7, 8],

--- a/ethexe/compute/src/tests.rs
+++ b/ethexe/compute/src/tests.rs
@@ -375,7 +375,7 @@ async fn process_code_for_already_processed_valid_code_emits_code_processed() ->
     let code_id = db.set_original_code(&code);
 
     db.set_instrumented_code(
-        ethexe_runtime_common::VERSION,
+        ethexe_runtime_common::RUNTIME_ID,
         code_id,
         InstrumentedCode::new(vec![0], InstantiatedSectionSizes::new(0, 0, 0, 0, 0, 0)),
     );

--- a/ethexe/db/src/verifier.rs
+++ b/ethexe/db/src/verifier.rs
@@ -475,7 +475,7 @@ mod tests {
         let code_id = db.set_original_code(ORIGINAL_CODE);
         db.set_code_valid(code_id, true);
         db.set_instrumented_code(
-            ethexe_runtime_common::VERSION,
+            ethexe_runtime_common::RUNTIME_ID,
             code_id,
             InstrumentedCode::new(
                 vec![1, 2, 3, 4, 5],

--- a/ethexe/processor/src/handling/overlaid.rs
+++ b/ethexe/processor/src/handling/overlaid.rs
@@ -170,7 +170,7 @@ impl RunContext for OverlaidRunContext {
         &self,
         program_id: ActorId,
         instrumentation_instance: &mut Option<InstanceWrapper>,
-    ) -> Result<(InstrumentedCode, CodeMetadata)> {
+    ) -> Result<Option<(InstrumentedCode, CodeMetadata)>> {
         let code_id = self
             .inner
             .db

--- a/ethexe/processor/src/handling/run/chunk_execution_spawn.rs
+++ b/ethexe/processor/src/handling/run/chunk_execution_spawn.rs
@@ -17,8 +17,7 @@ pub type ChunkItemOutput = (ActorId, H256, ProgramJournals, u64);
 pub struct ChunkItemInput {
     pub program_id: ActorId,
     pub state_hash: H256,
-    pub instrumented_code: InstrumentedCode,
-    pub code_metadata: CodeMetadata,
+    pub code: Option<(InstrumentedCode, CodeMetadata)>,
 }
 
 /// Spawns in the thread pool tasks for each program in the chunk remembering position of the program in the chunk.
@@ -51,8 +50,7 @@ pub async fn spawn_chunk_execution(
             let ChunkItemInput {
                 program_id,
                 state_hash,
-                instrumented_code,
-                code_metadata,
+                code,
             } = chunk_item;
 
             let mut executor = ctx.inner().instance_creator.instantiate()?;
@@ -63,11 +61,10 @@ pub async fn spawn_chunk_execution(
                         program_id,
                         state_root: state_hash,
                         queue_type,
-                        instrumented_code,
-                        code_metadata,
                         gas_allowance: GasAllowanceCounter::new(gas_allowance_for_chunk),
                         block_info,
                         promise_policy,
+                        code,
                     },
                     promise_sink,
                 )?;

--- a/ethexe/processor/src/handling/run/mod.rs
+++ b/ethexe/processor/src/handling/run/mod.rs
@@ -97,6 +97,7 @@ pub(crate) use chunks_splitting::ActorStateHashWithQueueSize;
 
 use crate::{
     BoundPromiseSink, ProcessorError, Result,
+    handling::run::chunk_execution_spawn::ChunkItemInput,
     host::{InstanceCreator, InstanceWrapper},
 };
 use chunk_execution_processing::ChunkJournalsProcessingOutput;
@@ -114,7 +115,7 @@ use ethexe_runtime_common::{
 };
 use futures::prelude::*;
 use gear_core::{
-    code::{CodeMetadata, InstrumentedCode},
+    code::{CodeMetadata, InstrumentationStatus, InstrumentedCode},
     gas::GasAllowanceCounter,
 };
 use gprimitives::{ActorId, CodeId, H256};
@@ -185,20 +186,18 @@ pub(super) async fn run_for_queue_type(
 fn lazy_instrument_chunk(
     ctx: &mut impl RunContext,
     chunk: Vec<(ActorId, H256)>,
-) -> Result<Vec<chunk_execution_spawn::ChunkItemInput>> {
+) -> Result<Vec<ChunkItemInput>> {
     let mut instrumentation_instance = None;
 
     chunk
         .into_iter()
         .map(|(program_id, state_hash)| {
-            let (instrumented_code, code_metadata) =
-                ctx.program_code(program_id, &mut instrumentation_instance)?;
+            let code = ctx.program_code(program_id, &mut instrumentation_instance)?;
 
-            Ok(chunk_execution_spawn::ChunkItemInput {
+            Ok(ChunkItemInput {
                 program_id,
                 state_hash,
-                instrumented_code,
-                code_metadata,
+                code,
             })
         })
         .collect()
@@ -224,7 +223,7 @@ pub(super) trait RunContext {
         &self,
         program_id: ActorId,
         instrumentation_instance: &mut Option<InstanceWrapper>,
-    ) -> Result<(InstrumentedCode, CodeMetadata)>;
+    ) -> Result<Option<(InstrumentedCode, CodeMetadata)>>;
 
     /// Get reference to inner.
     fn inner(&self) -> &CommonRunContext;
@@ -418,7 +417,7 @@ impl RunContext for CommonRunContext {
         &self,
         program_id: ActorId,
         instrumentation_instance: &mut Option<InstanceWrapper>,
-    ) -> Result<(InstrumentedCode, CodeMetadata)> {
+    ) -> Result<Option<(InstrumentedCode, CodeMetadata)>> {
         let code_id = self
             .transitions
             .registered_programs()
@@ -456,11 +455,27 @@ pub(super) fn instrumented_code_and_metadata(
     instance_creator: &InstanceCreator,
     instrumentation_instance: &mut Option<InstanceWrapper>,
     code_id: CodeId,
-) -> Result<(InstrumentedCode, CodeMetadata)> {
-    if let Some(instrumented_code) = db.instrumented_code(ethexe_runtime_common::VERSION, code_id)
-        && let Some(metadata) = db.code_metadata(code_id)
+) -> Result<Option<(InstrumentedCode, CodeMetadata)>> {
+    let existed_metadata = if let Some(metadata) = db.code_metadata(code_id) {
+        if let InstrumentationStatus::InstrumentationFailed { version } =
+            metadata.instrumentation_status()
+            && version == ethexe_runtime_common::CODES_INSTRUMENTATION_VERSION
+        {
+            log::debug!(
+                "Previous instrumentation attempt for code {code_id} was failed, skipping re-instrumentation"
+            );
+            return Ok(None);
+        }
+        Some(metadata)
+    } else {
+        None
+    };
+
+    if let Some(instrumented_code) =
+        db.instrumented_code(ethexe_runtime_common::RUNTIME_ID, code_id)
+        && let Some(metadata) = existed_metadata
     {
-        return Ok((instrumented_code, metadata));
+        return Ok(Some((instrumented_code, metadata)));
     }
 
     let original_code = db
@@ -473,18 +488,41 @@ pub(super) fn instrumented_code_and_metadata(
     let instance = instrumentation_instance
         .as_mut()
         .expect("instrumentation instance was just initialized");
-    let (instrumented_code, code_metadata) = instance
-        .instrument(&original_code)?
-        .ok_or(ProcessorError::MissingInstrumentedCodeForProgram(code_id))?;
+
+    // Return error if it's wasm runtime instance error. In case it's failed instrumentation - return Ok(None)
+    let Some((instrumented_code, code_metadata)) = instance.instrument(&original_code)? else {
+        log::debug!("Unsuccessful code {code_id} (re-)instrumentation");
+
+        // TODO #5562: not good approach to create fake metadata in case of no existed metadata,
+        // but we need to store the fact of failed instrumentation to avoid repeated attempts of instrumentation in future runs.
+        let metadata = CodeMetadata::new(
+            original_code.len() as u32,
+            existed_metadata
+                .as_ref()
+                .map_or_else(Default::default, |m| m.exports().clone()),
+            existed_metadata
+                .as_ref()
+                .map_or_else(Default::default, |m| m.static_pages()),
+            existed_metadata
+                .as_ref()
+                .map_or_else(Default::default, |m| m.stack_end()),
+            InstrumentationStatus::InstrumentationFailed {
+                version: ethexe_runtime_common::CODES_INSTRUMENTATION_VERSION,
+            },
+        );
+        db.set_code_metadata(code_id, metadata);
+
+        return Ok(None);
+    };
 
     db.set_instrumented_code(
-        ethexe_runtime_common::VERSION,
+        ethexe_runtime_common::RUNTIME_ID,
         code_id,
         instrumented_code.clone(),
     );
     db.set_code_metadata(code_id, code_metadata.clone());
 
-    Ok((instrumented_code, code_metadata))
+    Ok(Some((instrumented_code, code_metadata)))
 }
 
 pub(super) fn states(

--- a/ethexe/processor/src/lib.rs
+++ b/ethexe/processor/src/lib.rs
@@ -184,9 +184,6 @@ pub enum ProcessorError {
     #[error("code id not found for created program {0}")]
     MissingCodeIdForProgram(ActorId),
 
-    #[error("missing instrumented code for code id {0}")]
-    MissingInstrumentedCodeForProgram(CodeId),
-
     #[error("missing original code for code id {0}")]
     MissingOriginalCodeForProgram(CodeId),
 

--- a/ethexe/processor/src/tests.rs
+++ b/ethexe/processor/src/tests.rs
@@ -12,14 +12,18 @@ use ethexe_common::{
         mirror::{ExecutableBalanceTopUpRequestedEvent, MessageQueueingRequestedEvent},
         router::ProgramCreatedEvent,
     },
+    gear::Message,
     mock::*,
 };
-use ethexe_runtime_common::{RUNTIME_ID, WAIT_UP_TO_SAFE_DURATION, state::MessageQueue};
+use ethexe_runtime_common::{
+    CODES_INSTRUMENTATION_VERSION, RUNTIME_ID, WAIT_UP_TO_SAFE_DURATION, state::MessageQueue,
+};
 use gear_core::{
+    code::{CodeMetadata, InstantiatedSectionSizes, InstrumentationStatus, InstrumentedCode},
     ids::prelude::CodeIdExt,
     message::{ErrorReplyReason, ReplyCode, SuccessReplyReason},
 };
-use gear_core_errors::SimpleExecutionError;
+use gear_core_errors::{SimpleExecutionError, SimpleUnavailableActorError};
 use gprimitives::{ActorId, MessageId};
 use parity_scale_codec::Encode;
 use tokio::sync::mpsc;
@@ -372,6 +376,260 @@ async fn process_programs_instruments_valid_code_missing_current_runtime_instrum
 
     assert!(db.instrumented_code(RUNTIME_ID, code_id).is_some());
     assert!(db.code_metadata(code_id).is_some());
+}
+
+/// Create a fresh program and let its first (init) message force lazy
+/// (re)instrumentation under the current runtime via `process_queues`.
+///
+/// `wat` decides whether instrumentation succeeds (`VALID_PROGRAM`) or is
+/// rejected (`INVALID_PROGRAM`); `seed_previous_runtime` pre-stores a stale
+/// instrumented artifact + metadata under the *previous* runtime id, modelling a
+/// program that was instrumented before a runtime bump.
+async fn run_first_dispatch_with_reinstrumentation(
+    wat: &str,
+    seed_previous_runtime: bool,
+) -> (Database, CodeId, Vec<(ActorId, Message)>) {
+    let db = Database::memory();
+
+    let (code_id, code) = utils::wat_to_wasm(wat);
+    assert_eq!(db.set_original_code(&code), code_id);
+    db.set_code_valid(code_id, true);
+
+    if seed_previous_runtime {
+        // Program already had instrumented code under the previous runtime.
+        let prev_runtime_id = RUNTIME_ID - 1;
+        db.set_instrumented_code(
+            prev_runtime_id,
+            code_id,
+            InstrumentedCode::new(vec![0], InstantiatedSectionSizes::new(0, 0, 0, 0, 0, 0)),
+        );
+        db.set_code_metadata(
+            code_id,
+            CodeMetadata::new(
+                code.len() as u32,
+                Default::default(),
+                0.into(),
+                None,
+                InstrumentationStatus::Instrumented {
+                    version: CODES_INSTRUMENTATION_VERSION - 1,
+                    code_len: 1,
+                },
+            ),
+        );
+    }
+
+    // Nothing is instrumented for the current runtime, so execution must (re)instrument.
+    assert!(db.instrumented_code(RUNTIME_ID, code_id).is_none());
+
+    let to_users = create_program_and_run_first_dispatch(db.clone(), code_id).await;
+    (db, code_id, to_users)
+}
+
+/// Create a program for `code_id`, queue one (init) message to it, run the block,
+/// and return the user-facing messages (the program's reply).
+async fn create_program_and_run_first_dispatch(
+    db: Database,
+    code_id: CodeId,
+) -> Vec<(ActorId, Message)> {
+    let mut processor = Processor::new(db.clone()).expect("failed to create processor");
+    let chain = BlockChain::mock(2).setup(&db);
+    let block1 = chain.blocks[1].to_simple();
+
+    let actor_id = ActorId::from(0x10000);
+    let mut handler = setup_handler(db.clone(), block1.header.height);
+    handler
+        .handle_router_event(RouterRequestEvent::ProgramCreated(ProgramCreatedEvent {
+            actor_id,
+            code_id,
+        }))
+        .expect("failed to create new program");
+    handler
+        .handle_mirror_event(
+            actor_id,
+            MirrorRequestEvent::ExecutableBalanceTopUpRequested(
+                ExecutableBalanceTopUpRequestedEvent {
+                    value: 350_000_000_000,
+                },
+            ),
+        )
+        .expect("failed to top up balance");
+    handler
+        .handle_mirror_event(
+            actor_id,
+            MirrorRequestEvent::MessageQueueingRequested(MessageQueueingRequestedEvent {
+                id: MessageId::from(1),
+                source: ActorId::from(10),
+                payload: vec![],
+                value: 0,
+                call_reply: false,
+            }),
+        )
+        .expect("failed to queue message");
+
+    processor
+        .process_queues(
+            handler.transitions,
+            block1.header.height,
+            block1.header.timestamp,
+            DEFAULT_BLOCK_GAS_LIMIT,
+            None,
+        )
+        .await
+        // The whole point of the patch: a failed (re)instrumentation must NOT abort the block.
+        .expect("process_queues must succeed even when (re)instrumentation fails")
+        .current_messages()
+}
+
+fn sole_reply_code(to_users: &[(ActorId, Message)]) -> ReplyCode {
+    assert_eq!(
+        to_users.len(),
+        1,
+        "expected exactly one reply to the source"
+    );
+    to_users[0]
+        .1
+        .reply_details
+        .expect("user message must be a reply")
+        .to_reply_code()
+}
+
+fn assert_reinstrumentation_failed(
+    db: &Database,
+    code_id: CodeId,
+    to_users: &[(ActorId, Message)],
+) {
+    // Failure is persisted as InstrumentationFailed for the current version...
+    assert_eq!(
+        db.code_metadata(code_id)
+            .expect("metadata must be created on failed (re)instrumentation")
+            .instrumentation_status(),
+        InstrumentationStatus::InstrumentationFailed {
+            version: CODES_INSTRUMENTATION_VERSION,
+        },
+    );
+    // ...no instrumented artifact is stored for the current runtime...
+    assert!(db.instrumented_code(RUNTIME_ID, code_id).is_none());
+    // ...and the dispatch gets an explicit "reinstrumentation failed" error reply.
+    assert_eq!(
+        sole_reply_code(to_users),
+        ReplyCode::Error(ErrorReplyReason::UnavailableActor(
+            SimpleUnavailableActorError::ReinstrumentationFailure
+        )),
+    );
+}
+
+fn assert_reinstrumentation_succeeded(
+    db: &Database,
+    code_id: CodeId,
+    to_users: &[(ActorId, Message)],
+) {
+    // Fresh instrumented code + metadata for the current runtime are added...
+    assert!(db.instrumented_code(RUNTIME_ID, code_id).is_some());
+    assert!(matches!(
+        db.code_metadata(code_id)
+            .expect("metadata must be created on successful (re)instrumentation")
+            .instrumentation_status(),
+        InstrumentationStatus::Instrumented { version, .. } if version == CODES_INSTRUMENTATION_VERSION
+    ));
+    // ...and the dispatch produces a normal (non-error) reply.
+    assert!(
+        !sole_reply_code(to_users).is_error(),
+        "expected a normal reply after successful (re)instrumentation"
+    );
+}
+
+/// 1. Stale instrumented code under the previous runtime + a code the current
+///    instrumenter rejects: reinstrumentation fails (`Ok(None)`), the failure is
+///    recorded, and the dispatch gets a `ReinstrumentationFailure` error reply.
+#[tokio::test]
+async fn reinstrumentation_failed_with_previous_runtime_code() {
+    init_logger();
+    let (db, code_id, to_users) =
+        run_first_dispatch_with_reinstrumentation(utils::INVALID_PROGRAM, true).await;
+    assert_reinstrumentation_failed(&db, code_id, &to_users);
+}
+
+/// 2. Stale instrumented code under the previous runtime + a valid code:
+///    reinstrumentation succeeds, fresh artifacts are added, normal reply returned.
+#[tokio::test]
+async fn reinstrumentation_succeeded_with_previous_runtime_code() {
+    init_logger();
+    let (db, code_id, to_users) =
+        run_first_dispatch_with_reinstrumentation(utils::VALID_PROGRAM, true).await;
+    assert_reinstrumentation_succeeded(&db, code_id, &to_users);
+}
+
+/// 3. No instrumented code or metadata at all + a code the current instrumenter
+///    rejects: reinstrumentation fails, the failure is recorded, error reply returned.
+#[tokio::test]
+async fn reinstrumentation_failed_without_existing_code() {
+    init_logger();
+    let (db, code_id, to_users) =
+        run_first_dispatch_with_reinstrumentation(utils::INVALID_PROGRAM, false).await;
+    assert_reinstrumentation_failed(&db, code_id, &to_users);
+}
+
+/// 4. No instrumented code or metadata at all + a valid code: reinstrumentation
+///    succeeds, fresh artifacts are added, normal reply returned.
+#[tokio::test]
+async fn reinstrumentation_succeeded_without_existing_code() {
+    init_logger();
+    let (db, code_id, to_users) =
+        run_first_dispatch_with_reinstrumentation(utils::VALID_PROGRAM, false).await;
+    assert_reinstrumentation_succeeded(&db, code_id, &to_users);
+}
+
+/// 5. A code already recorded as `InstrumentationFailed` for the current version
+///    must NOT be re-instrumented again: the dispatch short-circuits straight to
+///    the error reply. We prove "no retry" by using a perfectly *valid* code — if
+///    it were re-instrumented it would succeed and produce a normal reply with a
+///    fresh artifact; the short-circuit instead keeps the error reply and adds
+///    nothing.
+#[tokio::test]
+async fn reinstrumentation_not_retried_when_already_failed() {
+    init_logger();
+
+    let db = Database::memory();
+    let (code_id, code) = utils::wat_to_wasm(utils::VALID_PROGRAM);
+    assert_eq!(db.set_original_code(&code), code_id);
+    db.set_code_valid(code_id, true);
+    // Pre-record a failure for the CURRENT instrumentation version.
+    db.set_code_metadata(
+        code_id,
+        CodeMetadata::new(
+            code.len() as u32,
+            Default::default(),
+            0.into(),
+            None,
+            InstrumentationStatus::InstrumentationFailed {
+                version: CODES_INSTRUMENTATION_VERSION,
+            },
+        ),
+    );
+    assert!(db.instrumented_code(RUNTIME_ID, code_id).is_none());
+
+    let to_users = create_program_and_run_first_dispatch(db.clone(), code_id).await;
+
+    // Despite the code being instrumentable, the recorded failure short-circuits:
+    // error reply, and crucially NO fresh instrumented artifact was produced.
+    assert_eq!(
+        sole_reply_code(&to_users),
+        ReplyCode::Error(ErrorReplyReason::UnavailableActor(
+            SimpleUnavailableActorError::ReinstrumentationFailure
+        )),
+    );
+    assert!(
+        db.instrumented_code(RUNTIME_ID, code_id).is_none(),
+        "a recorded failure must not be re-instrumented"
+    );
+    assert_eq!(
+        db.code_metadata(code_id)
+            .expect("metadata is still present")
+            .instrumentation_status(),
+        InstrumentationStatus::InstrumentationFailed {
+            version: CODES_INSTRUMENTATION_VERSION,
+        },
+    );
 }
 
 #[tokio::test]

--- a/ethexe/runtime/common/src/lib.rs
+++ b/ethexe/runtime/common/src/lib.rs
@@ -41,7 +41,7 @@
 //!
 //! Protocol limit constants ([`MAX_OUTGOING_MESSAGES_PER_EXECUTION`],
 //! [`MAX_OUTGOING_MESSAGES_PER_RUN`], [`MAX_CALL_REPLIES_PER_RUN`], etc.) and runtime version
-//! constants ([`VERSION`], [`RUNTIME_ID`]) are also exported.
+//! constants ([`RUNTIME_ID`], [`CODES_INSTRUMENTATION_VERSION`]) are also exported.
 //!
 //! ## Invariants
 //!
@@ -105,10 +105,13 @@ mod journal;
 mod schedule;
 mod transitions;
 
-// TODO: consider format.
-/// Version of the runtime.
-pub const VERSION: u32 = 1;
-pub const RUNTIME_ID: u32 = 1;
+/// Runtime ID
+/// MUST BE BUMPED IF:
+/// - any instrumentation logic changes ([`CODES_INSTRUMENTATION_VERSION`] is updated);
+pub const RUNTIME_ID: u32 = 2;
+
+/// Gear program wasm codes instrumentation version.
+pub const CODES_INSTRUMENTATION_VERSION: u32 = 2;
 
 /// Maximum number of outgoing messages per execution of one dispatch.
 pub const MAX_OUTGOING_MESSAGES_PER_EXECUTION: u32 = 4;
@@ -130,11 +133,10 @@ pub struct ProcessQueueContext {
     pub program_id: ActorId,
     pub state_root: H256,
     pub queue_type: MessageType,
-    pub instrumented_code: InstrumentedCode,
-    pub code_metadata: CodeMetadata,
     pub gas_allowance: GasAllowanceCounter,
     pub block_info: BlockInfo,
     pub promise_policy: PromisePolicy,
+    pub code: Option<(InstrumentedCode, CodeMetadata)>,
 }
 
 pub trait RuntimeInterface: Storage {
@@ -413,8 +415,7 @@ where
 
     let &ProcessQueueContext {
         program_id,
-        instrumented_code: ref code,
-        ref code_metadata,
+        ref code,
         ..
     } = ctx;
 
@@ -431,6 +432,8 @@ where
     let dispatch = IncomingDispatch::new(kind, incoming_message, context);
 
     let context = ContextCharged::new(program_id, dispatch, ctx.gas_allowance.left());
+
+    // TODO #5561: change charging logic for ethexe, because we do not need to load all that data for each dispatch
 
     let context = match context.charge_for_program(block_config) {
         Ok(context) => context,
@@ -472,11 +475,18 @@ where
         Err(journal) => return journal,
     };
 
-    let context =
-        match context.charge_for_instrumented_code(block_config, code.bytes().len() as u32) {
-            Ok(context) => context,
-            Err(journal) => return journal,
-        };
+    // NOTE: code bytes are not loaded each dispatch in ethexe. Should be refactored in #5561
+    let context = match context.charge_for_instrumented_code(block_config, 0) {
+        Ok(context) => context,
+        Err(journal) => return journal,
+    };
+
+    let Some((code, code_metadata)) = code else {
+        log::trace!(
+            "Missing instrumented code for program {program_id}, skipping execution of dispatch {dispatch_id} due to reinstrumentation failure"
+        );
+        return core_processor::process_reinstrumentation_error(context);
+    };
 
     let allocations = active_state
         .allocations_hash
@@ -560,20 +570,19 @@ mod tests {
             program_id: ActorId::from(42),
             state_root: storage.write_program_state(ProgramState::zero()),
             queue_type: MessageType::Canonical,
-            instrumented_code: InstrumentedCode::new(
-                Vec::new(),
-                InstantiatedSectionSizes::new(0, 0, 0, 0, 0, 0),
-            ),
-            code_metadata: CodeMetadata::new(
-                0,
-                BTreeSet::new(),
-                0.into(),
-                None,
-                InstrumentationStatus::NotInstrumented,
-            ),
             gas_allowance: GasAllowanceCounter::new(1_000_000),
             block_info: BlockInfo::default(),
             promise_policy: PromisePolicy::Disabled,
+            code: Some((
+                InstrumentedCode::new(Vec::new(), InstantiatedSectionSizes::new(0, 0, 0, 0, 0, 0)),
+                CodeMetadata::new(
+                    0,
+                    BTreeSet::new(),
+                    0.into(),
+                    None,
+                    InstrumentationStatus::NotInstrumented,
+                ),
+            )),
         }
     }
 

--- a/ethexe/runtime/src/wasm/api/instrument.rs
+++ b/ethexe/runtime/src/wasm/api/instrument.rs
@@ -20,8 +20,7 @@ pub fn instrument_code(original_code: Vec<u8>) -> Option<(InstrumentedCode, Code
 
     let code = Code::try_new(
         original_code,
-        // TODO: should we update it on each upgrade (?);
-        ethexe_runtime_common::VERSION,
+        ethexe_runtime_common::CODES_INSTRUMENTATION_VERSION,
         |module| schedule.rules(module),
         schedule.limits.stack_height,
         schedule.limits.data_segments_amount.into(),

--- a/ethexe/service/src/tests/mod.rs
+++ b/ethexe/service/src/tests/mod.rs
@@ -33,7 +33,7 @@ use ethexe_db::{Database, dump::StateDump};
 use ethexe_ethereum::{EthereumBuilder, TryGetReceipt, router::Router};
 use ethexe_processor::Processor;
 use ethexe_rpc::InjectedClient;
-use ethexe_runtime_common::state::Storage;
+use ethexe_runtime_common::{RUNTIME_ID, state::Storage};
 use gear_core::{
     ids::prelude::MessageIdExt,
     message::{ReplyCode, SuccessReplyReason},
@@ -142,7 +142,7 @@ async fn write_memory_to_last_byte() {
 
     let _ = node
         .db
-        .instrumented_code(1, code_id)
+        .instrumented_code(RUNTIME_ID, code_id)
         .expect("After approval, instrumented code is guaranteed to be in the database");
     let res = env
         .create_program(code_id, 500_000_000_000_000)
@@ -199,7 +199,7 @@ async fn ping() {
 
     let _ = node
         .db
-        .instrumented_code(1, code_id)
+        .instrumented_code(RUNTIME_ID, code_id)
         .expect("After approval, instrumented code is guaranteed to be in the database");
     let res = env
         .create_program(code_id, 500_000_000_000_000)
@@ -3084,7 +3084,7 @@ async fn reply_callback() {
 
     let _ = node
         .db
-        .instrumented_code(1, code_id)
+        .instrumented_code(RUNTIME_ID, code_id)
         .expect("After approval, instrumented code is guaranteed to be in the database");
     let res = env
         .create_program(code_id, 500_000_000_000_000)

--- a/sdk/gtest/src/ethexe/api.rs
+++ b/sdk/gtest/src/ethexe/api.rs
@@ -485,7 +485,7 @@ impl ProgramBuilder {
         let schedule = Schedule::default();
         let code = Code::try_new(
             original_code,
-            ethexe_runtime_common::VERSION,
+            ethexe_runtime_common::CODES_INSTRUMENTATION_VERSION,
             |module| schedule.rules(module),
             schedule.limits.stack_height,
             schedule.limits.data_segments_amount.into(),

--- a/sdk/gtest/src/ethexe/run.rs
+++ b/sdk/gtest/src/ethexe/run.rs
@@ -146,8 +146,9 @@ impl EthexeBackend {
                             program_id,
                             state_root: state.hash,
                             queue_type,
-                            instrumented_code,
-                            code_metadata,
+                            // gtest always has instrumented code for the current runtime, so the
+                            // reinstrumentation path (a `None` here) never applies.
+                            code: Some((instrumented_code, code_metadata)),
                             gas_allowance: GasAllowanceCounter::new(chunk_allowance),
                             block_info,
                             // gtest currently models promise syscalls as unavailable in ethexe mode.


### PR DESCRIPTION
Closes #5559.

## What

When a program's instrumented code is missing for the current runtime, the processor lazily (re)instruments the original code during execution. Previously a failed (re)instrumentation returned a hard `MissingInstrumentedCodeForProgram` error that **aborted the whole block**.

This PR makes a failed (re)instrumentation non-fatal and isolated to the program:

- `instrumented_code_and_metadata` returns `Ok(None)` instead of erroring, so the block keeps running;
- the failure is recorded as `InstrumentationStatus::InstrumentationFailed { version }` so it is not retried on later runs;
- the dispatch is routed to `process_reinstrumentation_error`, replying with `UnavailableActor(ReinstrumentationFailure)`.

## Tests

Processor integration tests through `process_queues`:

- (previous-runtime instrumented code: yes / no) × (current (re)instrumentation: succeeds / fails) — 4 cases, asserting code metadata + the error / normal reply;
- `reinstrumentation_not_retried_when_already_failed` — a recorded failure short-circuits without re-instrumenting (proved with a *valid* code that would otherwise instrument successfully).