### PR TITLE
feat(ethexe-rpc): read wasm custom sections

### DIFF
--- a/ethexe/rpc/src/apis/code.rs
+++ b/ethexe/rpc/src/apis/code.rs
@@ -61,7 +61,7 @@ impl CodeApi {
 
         get_custom_section_data(&original_code, section_name)
             .map(|section| section.map(|section| Bytes(section.to_vec())))
-            .map_err(|err| errors::bad_request(err).into())
+            .map_err(errors::bad_request)
     }
 }
 

--- a/ethexe/rpc/src/apis/code.rs
+++ b/ethexe/rpc/src/apis/code.rs
@@ -98,32 +98,11 @@ impl CodeServer for CodeApi {
 #[cfg(all(test, feature = "server"))]
 mod tests {
     use super::*;
+    use crate::test_utils::{wasm_with_custom_section, wasm_with_custom_sections};
     use ethexe_common::db::CodesStorageRW;
 
     const SECTION_NAME: &str = "sails:idl";
     const SECTION_DATA: &[u8] = b"hello idl";
-
-    fn wasm_with_custom_sections(sections: &[(&str, &[u8])]) -> Vec<u8> {
-        let mut wasm = b"\0asm\x01\0\0\0".to_vec();
-
-        for (name, data) in sections {
-            let section_len = 1 + name.len() + data.len();
-            assert!(name.len() < 0x80);
-            assert!(section_len < 0x80);
-
-            wasm.push(0);
-            wasm.push(section_len as u8);
-            wasm.push(name.len() as u8);
-            wasm.extend_from_slice(name.as_bytes());
-            wasm.extend_from_slice(data);
-        }
-
-        wasm
-    }
-
-    fn wasm_with_custom_section(name: &str, data: &[u8]) -> Vec<u8> {
-        wasm_with_custom_sections(&[(name, data)])
-    }
 
     fn api_with_code(code: &[u8]) -> (CodeApi, H256) {
         let db = Database::memory();

--- a/ethexe/rpc/src/apis/code.rs
+++ b/ethexe/rpc/src/apis/code.rs
@@ -7,6 +7,8 @@ use crate::errors;
 use ethexe_common::db::CodesStorageRO;
 #[cfg(feature = "server")]
 use ethexe_db::Database;
+#[cfg(feature = "server")]
+use gear_core::code::get_custom_section_data;
 use gprimitives::H256;
 #[cfg(feature = "server")]
 use jsonrpsee::core::async_trait;
@@ -28,6 +30,13 @@ pub trait Code {
         runtime_id: u32,
         code_id: H256,
     ) -> jsonrpsee::core::RpcResult<Bytes>;
+
+    #[method(name = "code_readWasmCustomSection")]
+    async fn read_wasm_custom_section(
+        &self,
+        code_id: H256,
+        section_name: String,
+    ) -> jsonrpsee::core::RpcResult<Option<Bytes>>;
 }
 
 #[cfg(feature = "server")]
@@ -39,6 +48,20 @@ pub struct CodeApi {
 impl CodeApi {
     pub fn new(db: Database) -> Self {
         Self { db }
+    }
+
+    fn read_custom_section(
+        &self,
+        code_id: H256,
+        section_name: &str,
+    ) -> jsonrpsee::core::RpcResult<Option<Bytes>> {
+        let Some(original_code) = self.db.original_code(code_id.into()) else {
+            return Ok(None);
+        };
+
+        get_custom_section_data(&original_code, section_name)
+            .map(|section| section.map(|section| Bytes(section.to_vec())))
+            .map_err(|err| errors::bad_request(err).into())
     }
 }
 
@@ -61,5 +84,112 @@ impl CodeServer for CodeApi {
             .instrumented_code(runtime_id, code_id.into())
             .map(|bytes| bytes.encode().into())
             .ok_or_else(|| errors::db("Failed to get code by supplied id"))
+    }
+
+    async fn read_wasm_custom_section(
+        &self,
+        code_id: H256,
+        section_name: String,
+    ) -> jsonrpsee::core::RpcResult<Option<Bytes>> {
+        self.read_custom_section(code_id, &section_name)
+    }
+}
+
+#[cfg(all(test, feature = "server"))]
+mod tests {
+    use super::*;
+    use ethexe_common::db::CodesStorageRW;
+
+    const SECTION_NAME: &str = "sails:idl";
+    const SECTION_DATA: &[u8] = b"hello idl";
+
+    fn wasm_with_custom_sections(sections: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut wasm = b"\0asm\x01\0\0\0".to_vec();
+
+        for (name, data) in sections {
+            let section_len = 1 + name.len() + data.len();
+            assert!(name.len() < 0x80);
+            assert!(section_len < 0x80);
+
+            wasm.push(0);
+            wasm.push(section_len as u8);
+            wasm.push(name.len() as u8);
+            wasm.extend_from_slice(name.as_bytes());
+            wasm.extend_from_slice(data);
+        }
+
+        wasm
+    }
+
+    fn wasm_with_custom_section(name: &str, data: &[u8]) -> Vec<u8> {
+        wasm_with_custom_sections(&[(name, data)])
+    }
+
+    fn api_with_code(code: &[u8]) -> (CodeApi, H256) {
+        let db = Database::memory();
+        let code_id = H256::from(db.set_original_code(code).into_bytes());
+
+        (CodeApi::new(db), code_id)
+    }
+
+    #[tokio::test]
+    async fn read_wasm_custom_section_returns_found_section() {
+        let wasm = wasm_with_custom_section(SECTION_NAME, SECTION_DATA);
+        let (api, code_id) = api_with_code(&wasm);
+
+        let result = api
+            .read_custom_section(code_id, SECTION_NAME)
+            .expect("custom section read must succeed");
+
+        assert_eq!(result, Some(Bytes(SECTION_DATA.to_vec())));
+    }
+
+    #[tokio::test]
+    async fn read_wasm_custom_section_returns_first_matching_section() {
+        let wasm =
+            wasm_with_custom_sections(&[(SECTION_NAME, b"first"), (SECTION_NAME, b"second")]);
+        let (api, code_id) = api_with_code(&wasm);
+
+        let result = api
+            .read_custom_section(code_id, SECTION_NAME)
+            .expect("custom section read must succeed");
+
+        assert_eq!(result, Some(Bytes(b"first".to_vec())));
+    }
+
+    #[tokio::test]
+    async fn read_wasm_custom_section_returns_none_for_missing_section() {
+        let wasm = wasm_with_custom_section("other", b"data");
+        let (api, code_id) = api_with_code(&wasm);
+
+        let result = api
+            .read_custom_section(code_id, SECTION_NAME)
+            .expect("custom section read must succeed");
+
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn read_wasm_custom_section_returns_none_for_unknown_code() {
+        let api = CodeApi::new(Database::memory());
+
+        let result = api
+            .read_custom_section(H256::zero(), SECTION_NAME)
+            .expect("unknown code must not be an error");
+
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn read_wasm_custom_section_errors_for_malformed_stored_wasm() {
+        let mut wasm = wasm_with_custom_section(SECTION_NAME, SECTION_DATA);
+        wasm.extend_from_slice(b"trailing junk");
+        let (api, code_id) = api_with_code(&wasm);
+
+        let err = api
+            .read_custom_section(code_id, SECTION_NAME)
+            .expect_err("malformed stored wasm must be an RPC error");
+
+        assert_eq!(err.code(), 8000);
     }
 }

--- a/ethexe/rpc/src/lib.rs
+++ b/ethexe/rpc/src/lib.rs
@@ -84,6 +84,8 @@ mod metrics;
 #[cfg(feature = "server")]
 mod utils;
 
+#[cfg(test)]
+mod test_utils;
 #[cfg(all(test, feature = "client"))]
 mod tests;
 

--- a/ethexe/rpc/src/test_utils.rs
+++ b/ethexe/rpc/src/test_utils.rs
@@ -1,0 +1,24 @@
+// Copyright (C) Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+pub(crate) fn wasm_with_custom_sections(sections: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut wasm = b"\0asm\x01\0\0\0".to_vec();
+
+    for (name, data) in sections {
+        let section_len = 1 + name.len() + data.len();
+        assert!(name.len() < 0x80);
+        assert!(section_len < 0x80);
+
+        wasm.push(0);
+        wasm.push(section_len as u8);
+        wasm.push(name.len() as u8);
+        wasm.extend_from_slice(name.as_bytes());
+        wasm.extend_from_slice(data);
+    }
+
+    wasm
+}
+
+pub(crate) fn wasm_with_custom_section(name: &str, data: &[u8]) -> Vec<u8> {
+    wasm_with_custom_sections(&[(name, data)])
+}

--- a/ethexe/rpc/src/tests.rs
+++ b/ethexe/rpc/src/tests.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 use crate::{
-    InjectedApi, InjectedClient, InjectedTransactionAcceptance, RpcConfig, RpcEvent, RpcServer,
-    RpcService,
+    CodeClient, InjectedApi, InjectedClient, InjectedTransactionAcceptance, RpcConfig, RpcEvent,
+    RpcServer, RpcService,
 };
 use ethexe_common::{
     SignedMessage, ValidatorsVec,
-    db::OnChainStorageRW,
+    db::{CodesStorageRW, OnChainStorageRW},
     ecdsa::{PrivateKey, PublicKey},
     gear::MAX_BLOCK_GAS_LIMIT,
     injected::{
@@ -18,7 +18,7 @@ use ethexe_common::{
 use ethexe_db::Database;
 use futures::StreamExt;
 use gear_core::message::{ReplyCode, SuccessReplyReason};
-use jsonrpsee::{server::ServerHandle, ws_client::WsClientBuilder};
+use jsonrpsee::{core::ClientError, server::ServerHandle, ws_client::WsClientBuilder};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use tokio::task::{JoinHandle, JoinSet};
 
@@ -124,6 +124,80 @@ async fn wait_for_closed_subscriptions(injected_api: InjectedApi) {
 
 fn mock_signed_transaction() -> SignedInjectedTransaction {
     SignedMessage::create(PrivateKey::random(), InjectedTransaction::mock(())).unwrap()
+}
+
+fn wasm_with_custom_sections(sections: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut wasm = b"\0asm\x01\0\0\0".to_vec();
+
+    for (name, data) in sections {
+        let section_len = 1 + name.len() + data.len();
+        assert!(name.len() < 0x80);
+        assert!(section_len < 0x80);
+
+        wasm.push(0);
+        wasm.push(section_len as u8);
+        wasm.push(name.len() as u8);
+        wasm.extend_from_slice(name.as_bytes());
+        wasm.extend_from_slice(data);
+    }
+
+    wasm
+}
+
+fn wasm_with_custom_section(name: &str, data: &[u8]) -> Vec<u8> {
+    wasm_with_custom_sections(&[(name, data)])
+}
+
+#[tokio::test]
+#[ntest::timeout(60_000)]
+async fn test_code_read_wasm_custom_section_via_rpc() {
+    let listen_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8011);
+    let db = Database::memory();
+    let section_data = b"wire idl";
+    let code_id = gprimitives::H256::from(
+        db.set_original_code(&wasm_with_custom_section("sails:idl", section_data))
+            .into_bytes(),
+    );
+    let mut malformed_wasm = wasm_with_custom_section("sails:idl", b"malformed");
+    malformed_wasm.extend_from_slice(b"trailing junk");
+    let malformed_code_id =
+        gprimitives::H256::from(db.set_original_code(&malformed_wasm).into_bytes());
+
+    let (handle, _rpc) = start_new_server(listen_addr, db).await;
+    let ws_client = WsClientBuilder::new()
+        .build(format!("ws://{}", listen_addr))
+        .await
+        .expect("WS client will be created");
+
+    let result = ws_client
+        .read_wasm_custom_section(code_id, "sails:idl".to_string())
+        .await
+        .expect("custom section read must succeed");
+
+    assert_eq!(result, Some(sp_core::Bytes(section_data.to_vec())));
+
+    let missing_section = ws_client
+        .read_wasm_custom_section(code_id, "missing".to_string())
+        .await
+        .expect("missing section must not be an error");
+    assert_eq!(missing_section, None);
+
+    let unknown_code = ws_client
+        .read_wasm_custom_section(gprimitives::H256::zero(), "sails:idl".to_string())
+        .await
+        .expect("unknown code must not be an error");
+    assert_eq!(unknown_code, None);
+
+    let err = ws_client
+        .read_wasm_custom_section(malformed_code_id, "sails:idl".to_string())
+        .await
+        .expect_err("malformed stored wasm must be an RPC error");
+    let ClientError::Call(err) = err else {
+        panic!("expected RPC call error for malformed Wasm");
+    };
+    assert_eq!(err.code(), 8000);
+
+    handle.stop().expect("RPC server must stop");
 }
 
 #[tokio::test]

--- a/ethexe/rpc/src/tests.rs
+++ b/ethexe/rpc/src/tests.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     CodeClient, InjectedApi, InjectedClient, InjectedTransactionAcceptance, RpcConfig, RpcEvent,
-    RpcServer, RpcService,
+    RpcServer, RpcService, test_utils::wasm_with_custom_section,
 };
 use ethexe_common::{
     SignedMessage, ValidatorsVec,
@@ -126,39 +126,19 @@ fn mock_signed_transaction() -> SignedInjectedTransaction {
     SignedMessage::create(PrivateKey::random(), InjectedTransaction::mock(())).unwrap()
 }
 
-fn wasm_with_custom_sections(sections: &[(&str, &[u8])]) -> Vec<u8> {
-    let mut wasm = b"\0asm\x01\0\0\0".to_vec();
-
-    for (name, data) in sections {
-        let section_len = 1 + name.len() + data.len();
-        assert!(name.len() < 0x80);
-        assert!(section_len < 0x80);
-
-        wasm.push(0);
-        wasm.push(section_len as u8);
-        wasm.push(name.len() as u8);
-        wasm.extend_from_slice(name.as_bytes());
-        wasm.extend_from_slice(data);
-    }
-
-    wasm
-}
-
-fn wasm_with_custom_section(name: &str, data: &[u8]) -> Vec<u8> {
-    wasm_with_custom_sections(&[(name, data)])
-}
-
 #[tokio::test]
 #[ntest::timeout(60_000)]
 async fn test_code_read_wasm_custom_section_via_rpc() {
+    const SECTION_NAME: &str = "sails:idl";
+
     let listen_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8011);
     let db = Database::memory();
     let section_data = b"wire idl";
     let code_id = gprimitives::H256::from(
-        db.set_original_code(&wasm_with_custom_section("sails:idl", section_data))
+        db.set_original_code(&wasm_with_custom_section(SECTION_NAME, section_data))
             .into_bytes(),
     );
-    let mut malformed_wasm = wasm_with_custom_section("sails:idl", b"malformed");
+    let mut malformed_wasm = wasm_with_custom_section(SECTION_NAME, b"malformed");
     malformed_wasm.extend_from_slice(b"trailing junk");
     let malformed_code_id =
         gprimitives::H256::from(db.set_original_code(&malformed_wasm).into_bytes());
@@ -170,7 +150,7 @@ async fn test_code_read_wasm_custom_section_via_rpc() {
         .expect("WS client will be created");
 
     let result = ws_client
-        .read_wasm_custom_section(code_id, "sails:idl".to_string())
+        .read_wasm_custom_section(code_id, SECTION_NAME.to_string())
         .await
         .expect("custom section read must succeed");
 
@@ -183,13 +163,13 @@ async fn test_code_read_wasm_custom_section_via_rpc() {
     assert_eq!(missing_section, None);
 
     let unknown_code = ws_client
-        .read_wasm_custom_section(gprimitives::H256::zero(), "sails:idl".to_string())
+        .read_wasm_custom_section(gprimitives::H256::zero(), SECTION_NAME.to_string())
         .await
         .expect("unknown code must not be an error");
     assert_eq!(unknown_code, None);
 
     let err = ws_client
-        .read_wasm_custom_section(malformed_code_id, "sails:idl".to_string())
+        .read_wasm_custom_section(malformed_code_id, SECTION_NAME.to_string())
         .await
         .expect_err("malformed stored wasm must be an RPC error");
     let ClientError::Call(err) = err else {


### PR DESCRIPTION
## Summary

- Add `code_readWasmCustomSection(code_id, section_name)` to the ethexe code RPC API.
- Read from original code storage and return raw custom-section bytes without involving runtime, compute, processor, or schema changes.
- Return `None` for unknown code IDs or missing sections, and map malformed stored Wasm parser failures to RPC error code `8000`.

## Test Coverage

Coverage gate: PASS (100%).

New code paths: 6. Covered: 6. Gaps: 0.

```text
code_readWasmCustomSection
|-- known code + matching section -> Some(Bytes) [covered]
|-- duplicate matching sections -> first payload [covered]
|-- known code + missing section -> None [covered]
|-- unknown code id -> None [covered]
|-- malformed stored Wasm -> RPC error 8000 [covered]
`-- JSON-RPC client/server method path -> success/missing/unknown/malformed [covered]
```

Test plan artifact: `~/.gstack/projects/gear-tech-gear/test-plans/vsethexe-read-wasm-custom-section-ship-test-plan-20260605.md`

## Review

Pre-landing review: no issues found.

Notes:
- `.agents/skills/gstack/review/checklist.md` is not present in this checkout, so the ship review used the installed `gstack-review` workflow criteria directly.
- No frontend files changed, so design review was skipped.

## Verification Results

- `rtk git fetch origin master`
- `rtk git merge origin/master --no-edit`
- `rtk cargo fmt -p ethexe-rpc --check`
- `rtk git diff --check -- ethexe/rpc/src/apis/code.rs ethexe/rpc/src/tests.rs`
- `rtk cargo nextest run -p ethexe-rpc`
- `rtk cargo check -p ethexe-rpc --no-default-features --features client`

`cargo check` emitted the existing `trie-db v0.29.1` future-incompat warning and no errors.

## Plan Completion

Source plan: `~/.gstack/projects/gear-tech-gear/ukintvs-master-eng-review-test-plan-20260605-231050.md`

- T1: Add wire-level JSON-RPC coverage for `code_readWasmCustomSection` - DONE.

Plan result: 1/1 items completed.

## Version And Changelog

No root `VERSION` or root `CHANGELOG.md` exists on `origin/master`; this PR does not create new repo-level release metadata.

## Documentation

No existing markdown documentation was found for the ethexe code RPC methods, and no docs were updated.
