### PR TITLE
fix(vara.eth/ethexe-network): drop stale state when request future is ready

### DIFF
--- a/ethexe/network/src/db_sync/requests.rs
+++ b/ethexe/network/src/db_sync/requests.rs
@@ -173,7 +173,8 @@ impl OngoingRequests {
                 // it means `HandleFuture` is dropped,
                 // so we just remove the request and don't make any further work
                 if channel.as_ref().expect("always Some").is_closed() {
-                    self.pending_events.push_back(Event::RequestCancelled { request_id });
+                    self.pending_events
+                        .push_back(Event::RequestCancelled { request_id });
                     return false;
                 }
 
@@ -188,16 +189,17 @@ impl OngoingRequests {
 
                 if let Poll::Ready(res) = poll {
                     let (event, res) = match res {
-                        Ok(response) => {
-                            (Event::RequestSucceed { request_id }, Ok(response))
-                        }
-                        Err((error, request)) => {
-                            (Event::RequestFailed { request_id, error }, Err((error, RetriableRequest {
-                                request_id,
-                                request,
-                            },
-                            )))
-                        }
+                        Ok(response) => (Event::RequestSucceed { request_id }, Ok(response)),
+                        Err((error, request)) => (
+                            Event::RequestFailed { request_id, error },
+                            Err((
+                                error,
+                                RetriableRequest {
+                                    request_id,
+                                    request,
+                                },
+                            )),
+                        ),
                     };
 
                     self.pending_events.push_back(event);
@@ -205,7 +207,8 @@ impl OngoingRequests {
                     // channel can be dropped after `is_closed()` check during future polling
                     let res = channel.take().expect("always Some").send(res);
                     if res.is_err() {
-                        self.pending_events.push_back(Event::RequestCancelled { request_id });
+                        self.pending_events
+                            .push_back(Event::RequestCancelled { request_id });
                     }
 
                     return false;
@@ -214,10 +217,9 @@ impl OngoingRequests {
                 if let Some(state) = state {
                     match state {
                         OngoingRequestState::NoPeers => {
-
                             self.pending_events.push_back(Event::NoPeers { request_id });
-                        },
-                        OngoingRequestState::SendRequest(peer, request, ) => {
+                        }
+                        OngoingRequestState::SendRequest(peer, request) => {
                             let outbound_request_id = behaviour.send_request(&peer, request);
                             self.active_requests.insert(outbound_request_id, request_id);
                         }

--- a/ethexe/network/src/db_sync/requests.rs
+++ b/ethexe/network/src/db_sync/requests.rs
@@ -185,24 +185,8 @@ impl OngoingRequests {
 
                 let (ctx, poll) = CONTEXT.scope(ctx, || fut.poll_unpin(cx));
                 let state = ctx.into_state();
-                if state.is_some() && poll.is_ready() {
-                    unreachable!(
-                        "state machine invariant violated: unexpected ready poll with existing state"
-                    );
-                }
 
-                if let Some(state) = state {
-                    match state {
-                        OngoingRequestState::NoPeers => {
-
-                            self.pending_events.push_back(Event::NoPeers { request_id });
-                        },
-                        OngoingRequestState::SendRequest(peer, request, ) => {
-                            let outbound_request_id = behaviour.send_request(&peer, request);
-                            self.active_requests.insert(outbound_request_id, request_id);
-                        }
-                    };
-                } else if let Poll::Ready(res) = poll {
+                if let Poll::Ready(res) = poll {
                     let (event, res) = match res {
                         Ok(response) => {
                             (Event::RequestSucceed { request_id }, Ok(response))
@@ -225,6 +209,19 @@ impl OngoingRequests {
                     }
 
                     return false;
+                }
+
+                if let Some(state) = state {
+                    match state {
+                        OngoingRequestState::NoPeers => {
+
+                            self.pending_events.push_back(Event::NoPeers { request_id });
+                        },
+                        OngoingRequestState::SendRequest(peer, request, ) => {
+                            let outbound_request_id = behaviour.send_request(&peer, request);
+                            self.active_requests.insert(outbound_request_id, request_id);
+                        }
+                    };
                 }
 
                 true


### PR DESCRIPTION
`OngoingRequests::poll` panicked when the request future returned `Poll::Ready` on the same poll cycle that set `OngoingRequestState::SendRequest`. This happens when `tokio::time::timeout` fires immediately after `send_request` synchronously stages its next-round state but before the outer scheduler returns Pending — e.g. in `db_sync::tests::request_response_type_mismatch`, where `request_timeout = Duration::ZERO`.

Fix: when `poll` is Ready, emit the terminal event and drop the request; ignore the stale state that the future will never act on.

Repro before: https://github.com/gear-tech/gear/actions/runs/27063530426/job/79881153988