### PR TITLE
fix(vara): prevent staking builtin from bypassing bond blacklist

### DIFF
--- a/vara/pallets/gear-builtin/src/lib.rs
+++ b/vara/pallets/gear-builtin/src/lib.rs
@@ -158,6 +158,7 @@ pub mod pallet {
     use frame_support::{
         dispatch::{GetDispatchInfo, PostDispatchInfo},
         pallet_prelude::*,
+        traits::Contains,
     };
     use frame_system::pallet_prelude::*;
     use sp_runtime::traits::Dispatchable;
@@ -176,6 +177,9 @@ pub mod pallet {
 
         /// Block limits.
         type BlockLimiter: BlockLimiter<Balance = u64>;
+
+        /// Filter that determines whether staking bond should be disallowed for an account.
+        type NonStakingAccountsFilter: Contains<Self::AccountId>;
 
         /// Weight cost incurred by builtin actors calls.
         type WeightInfo: WeightInfo;

--- a/vara/pallets/gear-builtin/src/mock.rs
+++ b/vara/pallets/gear-builtin/src/mock.rs
@@ -27,7 +27,9 @@ use frame_support::{
     PalletId, construct_runtime,
     pallet_prelude::{DispatchClass, Weight},
     parameter_types,
-    traits::{ConstU32, ConstU64, FindAuthor, Get, InstanceFilter, OnFinalize, OnInitialize},
+    traits::{
+        ConstU32, ConstU64, FindAuthor, Get, InstanceFilter, Nothing, OnFinalize, OnInitialize,
+    },
 };
 use frame_support_test::TestRandomness;
 use frame_system::{self as system, limits::BlockWeights, pallet_prelude::BlockNumberFor};
@@ -335,6 +337,7 @@ impl pallet_gear_builtin::Config for Test {
         ActorWithId<4, proxy::Actor<Self>>,
     );
     type BlockLimiter = GearGas;
+    type NonStakingAccountsFilter = Nothing;
     type WeightInfo = ();
 }
 

--- a/vara/pallets/gear-builtin/src/staking.rs
+++ b/vara/pallets/gear-builtin/src/staking.rs
@@ -21,6 +21,7 @@
 use super::*;
 use common::Origin;
 use core::marker::PhantomData;
+use frame_support::traits::Contains;
 use gbuiltin_staking::*;
 use gear_core::limited::LimitedStr;
 use pallet_staking::{Config as StakingConfig, NominationsQuota, RewardDestination};
@@ -133,6 +134,14 @@ where
         // Decode the message payload to derive the desired action
         let request =
             Request::decode(&mut payload).map_err(|_| BuiltinActorError::DecodingError)?;
+
+        if matches!(request, Request::Bond { .. })
+            && T::NonStakingAccountsFilter::contains(&origin.cast())
+        {
+            return Err(BuiltinActorError::Custom(LimitedStr::from_small_str(
+                "Staking bond is disabled for account",
+            )));
+        }
 
         // Handle special cases that return custom response instead of just dispatching calls
         if let Request::ActiveEra = request {

--- a/vara/pallets/gear-builtin/src/tests/bad_builtin_ids.rs
+++ b/vara/pallets/gear-builtin/src/tests/bad_builtin_ids.rs
@@ -20,7 +20,7 @@ use crate::{self as pallet_gear_builtin, ActorWithId, BuiltinActor, BuiltinReply
 use builtins_common::{BuiltinActorError, BuiltinContext};
 use frame_support::{
     PalletId, construct_runtime, parameter_types,
-    traits::{ConstU32, ConstU64, FindAuthor, OnFinalize, OnInitialize},
+    traits::{ConstU32, ConstU64, FindAuthor, Nothing, OnFinalize, OnInitialize},
 };
 use frame_support_test::TestRandomness;
 use frame_system::{self as system, pallet_prelude::BlockNumberFor};
@@ -122,6 +122,7 @@ impl pallet_gear_builtin::Config for Test {
         ActorWithId<2, SomeBuiltinActor>, // 2 already exists
     );
     type BlockLimiter = GearGas;
+    type NonStakingAccountsFilter = Nothing;
     type WeightInfo = ();
 }
 

--- a/vara/pallets/gear-builtin/src/tests/staking.rs
+++ b/vara/pallets/gear-builtin/src/tests/staking.rs
@@ -919,6 +919,7 @@ mod util {
         type RuntimeCall = RuntimeCall;
         type Builtins = (ActorWithId<2, StakingBuiltin<Self>>,);
         type BlockLimiter = GearGas;
+        type NonStakingAccountsFilter = NonStakingAccountsFilter;
         type WeightInfo = ();
     }
 

--- a/vara/pallets/gear-eth-bridge/src/mock.rs
+++ b/vara/pallets/gear-eth-bridge/src/mock.rs
@@ -20,7 +20,7 @@ use crate::{self as pallet_gear_eth_bridge};
 use common::Origin as _;
 use frame_support::{
     PalletId, construct_runtime, parameter_types,
-    traits::{ConstU32, ConstU64, FindAuthor, Hooks, SortedMembers},
+    traits::{ConstU32, ConstU64, FindAuthor, Hooks, Nothing, SortedMembers},
 };
 use frame_support_test::TestRandomness;
 use frame_system::{self as system, EnsureSignedBy, pallet_prelude::BlockNumberFor};
@@ -186,6 +186,7 @@ impl pallet_gear_builtin::Config for Test {
     type RuntimeCall = RuntimeCall;
     type Builtins = (ActorWithId<BUILTIN_ID, crate::builtin::Actor<Test>>,);
     type BlockLimiter = GearGas;
+    type NonStakingAccountsFilter = Nothing;
     type WeightInfo = ();
 }
 

--- a/vara/runtime/vara/src/lib.rs
+++ b/vara/runtime/vara/src/lib.rs
@@ -1189,6 +1189,7 @@ impl pallet_gear_builtin::Config for Runtime {
     type RuntimeCall = RuntimeCall;
     type Builtins = BuiltinActors;
     type BlockLimiter = GearGas;
+    type NonStakingAccountsFilter = NonStakingAccountsFilter;
     type WeightInfo = pallet_gear_builtin::weights::SubstrateWeight<Runtime>;
 }
 


### PR DESCRIPTION
### Motivation

- Close an authorization bypass where a `Gear::send_message` to the staking builtin could execute `pallet_staking::bond` internally and avoid `StakingBlackList` signed-extension checks applied to normal extrinsics.

### Description

- Add a new associated type `NonStakingAccountsFilter: Contains<Self::AccountId>` to `pallet_gear_builtin::Config` so builtins can consult the runtime’s non-staking account policy via `Contains`.
- Enforce the filter in the staking builtin by rejecting `Request::Bond` when `T::NonStakingAccountsFilter::contains(&origin.cast())` returns true, returning a `BuiltinActorError::Custom` rather than dispatching the internal `bond` call.
- Wire the new config type into the Vara runtime (`type NonStakingAccountsFilter = NonStakingAccountsFilter;`) and update mock/test runtimes to provide the associated type (use `Nothing` for generic mocks and `NonStakingAccountsFilter` in the staking tests).
- Add required `Contains`/`Nothing` imports in affected files; keep the change minimal and restrict the check to `Request::Bond` to preserve other builtin staking operations.

### Testing

- Ran `cargo check -p pallet-gear-builtin`, which started and progressed through dependency compilation but did not complete within the run window (no failure observed while it was compiling dependencies). 
- No automated test suites were completed in this session; updated mock runtimes were adjusted so existing tests can compile once dependency compilation finishes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b09f50e0c832788b78753ac0d6b57)