### PR TITLE
fix(vara.eth): restore all tasks in ScheduleRestorer

### DIFF
--- a/ethexe/db/src/migrations/init.rs
+++ b/ethexe/db/src/migrations/init.rs
@@ -278,9 +278,7 @@ async fn genesis_data_initialization(
         );
     }
 
-    let schedule =
-        ScheduleRestorer::from_storage(&db.cas, &program_states, genesis_eb.header.height)?
-            .restore();
+    let schedule = ScheduleRestorer::from_storage(&db.cas, &program_states)?.restore();
     log::info!(
         "Genesis schedule restored, tasks amount {}",
         schedule.iter().flat_map(|(_, tasks)| tasks.iter()).count()

--- a/ethexe/runtime/common/src/proptest.rs
+++ b/ethexe/runtime/common/src/proptest.rs
@@ -1141,13 +1141,12 @@ mod tests {
         #[test]
         fn restorer_waitlist_restores_all(program_id in actor_id_strategy(), waitlist in any::<Waitlist>()) {
             let expected: Schedule = waitlist
-                .clone()
-                .into_inner()
-                .into_iter()
+                .as_ref()
+                .iter()
                 .map(|(message_id, expiring)| {
                     (
                         expiring.expiry,
-                        BTreeSet::from([ScheduledTask::WakeMessage(program_id, message_id)]),
+                        BTreeSet::from([ScheduledTask::WakeMessage(program_id, *message_id)]),
                     )
                 })
                 .fold(BTreeMap::new(), |mut acc, (expiry, tasks)| {

--- a/ethexe/runtime/common/src/proptest.rs
+++ b/ethexe/runtime/common/src/proptest.rs
@@ -1139,31 +1139,30 @@ mod tests {
         }
 
         #[test]
-        fn restorer_waitlist_respects_expiry(current_block in any::<u32>(), program_id in actor_id_strategy(), waitlist in any::<Waitlist>()) {
+        fn restorer_waitlist_restores_all(program_id in actor_id_strategy(), waitlist in any::<Waitlist>()) {
             let expected: Schedule = waitlist
                 .clone()
                 .into_inner()
                 .into_iter()
-                .filter_map(|(message_id, expiring)| {
-                    (expiring.expiry > current_block).then_some((
+                .map(|(message_id, expiring)| {
+                    (
                         expiring.expiry,
                         BTreeSet::from([ScheduledTask::WakeMessage(program_id, message_id)]),
-                    ))
+                    )
                 })
                 .fold(BTreeMap::new(), |mut acc, (expiry, tasks)| {
                     acc.entry(expiry).or_default().extend(tasks);
                     acc
                 });
 
-            let mut restorer = ScheduleRestorer::new(current_block);
+            let mut restorer = ScheduleRestorer::new();
             restorer.waitlist(program_id, &waitlist);
 
             prop_assert_eq!(restorer.restore(), expected);
         }
 
         #[test]
-        fn restorer_user_mailbox_respects_expiry(
-            current_block in any::<u32>(),
+        fn restorer_user_mailbox_restores_all(
             program_id in actor_id_strategy(),
             user_id in actor_id_strategy(),
             user_mailbox in any::<UserMailbox>(),
@@ -1171,21 +1170,21 @@ mod tests {
             let expected: Schedule = user_mailbox
                 .as_ref()
                 .iter()
-                .filter_map(|(&message_id, expiring)| {
-                    (expiring.expiry > current_block).then_some((
+                .map(|(&message_id, expiring)| {
+                    (
                         expiring.expiry,
                         BTreeSet::from([ScheduledTask::RemoveFromMailbox(
                             (program_id, user_id),
                             message_id,
                         )]),
-                    ))
+                    )
                 })
                 .fold(BTreeMap::new(), |mut acc, (expiry, tasks)| {
                     acc.entry(expiry).or_default().extend(tasks);
                     acc
                 });
 
-            let mut restorer = ScheduleRestorer::new(current_block);
+            let mut restorer = ScheduleRestorer::new();
             restorer.user_mailbox(program_id, user_id, &user_mailbox);
 
             prop_assert_eq!(restorer.restore(), expected);
@@ -1193,7 +1192,6 @@ mod tests {
 
         #[test]
         fn restorer_stash_restores_correct_task_kind(
-            current_block in any::<u32>(),
             program_id in actor_id_strategy(),
             entries in dispatch_stash_entries_strategy(),
         ) {
@@ -1206,27 +1204,23 @@ mod tests {
                 let expiry = *expiry;
                 if let Some(user_id) = *user_id {
                     stash.add_to_user(dispatch.clone(), expiry, user_id);
-                    if expiry > current_block {
-                        expected
-                            .entry(expiry)
-                            .or_default()
-                            .insert(ScheduledTask::SendUserMessage {
-                                message_id,
-                                to_mailbox: program_id,
-                            });
-                    }
+                    expected
+                        .entry(expiry)
+                        .or_default()
+                        .insert(ScheduledTask::SendUserMessage {
+                            message_id,
+                            to_mailbox: program_id,
+                        });
                 } else {
                     stash.add_to_program(dispatch.clone(), expiry);
-                    if expiry > current_block {
-                        expected
-                            .entry(expiry)
-                            .or_default()
-                            .insert(ScheduledTask::SendDispatch((program_id, message_id)));
-                    }
+                    expected
+                        .entry(expiry)
+                        .or_default()
+                        .insert(ScheduledTask::SendDispatch((program_id, message_id)));
                 }
             }
 
-            let mut restorer = ScheduleRestorer::new(current_block);
+            let mut restorer = ScheduleRestorer::new();
             restorer.stash(program_id, &stash);
 
             prop_assert_eq!(restorer.restore(), expected);

--- a/ethexe/runtime/common/src/schedule.rs
+++ b/ethexe/runtime/common/src/schedule.rs
@@ -148,21 +148,22 @@ impl<S: Storage> TaskHandler<Rfm, Sd, Sum> for Handler<'_, S> {
 
 /// A [`Schedule`] restorer.
 ///
-/// Used primary for fast sync and tests
+/// Used primary for fast sync and tests.
+///
+/// No expiry filtering is applied: every scheduled task found in the dumped
+/// states is restored. Committed states never hold a task already expired at
+/// the dumped block, and the executor drains the full backlog with no lower
+/// bound, so any restored task fires at the first computed block regardless of
+/// its expiry.
+#[derive(Default)]
 pub struct Restorer {
-    current_block: u32,
     schedule: Schedule,
 }
 
 impl Restorer {
-    /// Creates restorer.
-    ///
-    /// A current block is required to detect whether a value expired or not
-    pub fn new(current_block: u32) -> Self {
-        Self {
-            current_block,
-            schedule: Default::default(),
-        }
+    /// Creates an empty restorer.
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Creates a restorer from storage.
@@ -171,7 +172,6 @@ impl Restorer {
     pub fn from_storage<T: Storage>(
         storage: &T,
         program_states: &ProgramStates,
-        current_block: u32,
     ) -> anyhow::Result<Self> {
         let program_states: BTreeMap<H256, BTreeSet<ActorId>> =
             program_states
@@ -181,7 +181,7 @@ impl Restorer {
                     acc
                 });
 
-        let mut restorer = Self::new(current_block);
+        let mut restorer = Self::new();
 
         for (hash, program_ids) in program_states {
             let program_state = storage
@@ -231,10 +231,6 @@ impl Restorer {
             },
         ) in waitlist.as_ref()
         {
-            if expiry <= self.current_block {
-                continue;
-            }
-
             debug_assert_eq!(message_id, dispatch.id);
 
             self.schedule
@@ -251,10 +247,6 @@ impl Restorer {
         user_mailbox: &UserMailbox,
     ) {
         for (&message_id, &Expiring { value: _, expiry }) in user_mailbox.as_ref() {
-            if expiry <= self.current_block {
-                continue;
-            }
-
             self.schedule
                 .entry(expiry)
                 .or_default()
@@ -275,10 +267,6 @@ impl Restorer {
         ) in stash.as_ref()
         {
             debug_assert_eq!(message_id, dispatch.id);
-
-            if expiry <= self.current_block {
-                continue;
-            }
 
             let task = if user_id.is_some() {
                 ScheduledTask::SendUserMessage {
@@ -323,7 +311,7 @@ mod tests {
         let mut waitlist = Waitlist::default();
         waitlist.wait(dispatch.clone(), 1000);
 
-        let mut restorer = Restorer::new(999);
+        let mut restorer = Restorer::new();
         restorer.waitlist(program_id, &waitlist);
         assert_eq!(
             restorer.restore(),
@@ -332,10 +320,6 @@ mod tests {
                 BTreeSet::from([ScheduledTask::WakeMessage(program_id, dispatch.id)])
             )])
         );
-
-        let mut restorer = Restorer::new(1000);
-        restorer.waitlist(program_id, &waitlist);
-        assert_eq!(restorer.restore(), BTreeMap::new());
     }
 
     #[test]
@@ -363,7 +347,7 @@ mod tests {
             })
             .unwrap();
 
-        let mut restorer = Restorer::new(999);
+        let mut restorer = Restorer::new();
         restorer.user_mailbox(program_id, user_id, &user_mailbox);
         assert_eq!(
             restorer.restore(),
@@ -375,10 +359,6 @@ mod tests {
                 )])
             )]),
         );
-
-        let mut restorer = Restorer::new(1000);
-        restorer.user_mailbox(program_id, user_id, &user_mailbox);
-        assert_eq!(restorer.restore(), BTreeMap::new());
     }
 
     #[test]
@@ -409,7 +389,7 @@ mod tests {
         stash.add_to_program(program_dispatch.clone(), 1000);
         stash.add_to_user(user_dispatch.clone(), 1000, user_id);
 
-        let mut restorer = Restorer::new(999);
+        let mut restorer = Restorer::new();
         restorer.stash(program_id, &stash);
         assert_eq!(
             restorer.restore(),
@@ -424,9 +404,5 @@ mod tests {
                 ])
             )]),
         );
-
-        let mut restorer = Restorer::new(1000);
-        restorer.stash(program_id, &stash);
-        assert_eq!(restorer.restore(), BTreeMap::new());
     }
 }

--- a/ethexe/runtime/common/src/schedule.rs
+++ b/ethexe/runtime/common/src/schedule.rs
@@ -405,4 +405,106 @@ mod tests {
             )]),
         );
     }
+
+    // Regression for #5574: the genesis `from_storage` path must restore every
+    // scheduled task in the dumped states regardless of its expiry. The restorer
+    // used to drop tasks with `expiry <= genesis_block_height`; during re-genesis
+    // that height can sit far above a task's expiry, so still-pending tasks were
+    // silently lost. Here all expiries are tiny (1..=4) — exactly the entries the
+    // old cutoff would have discarded — and all four must survive restoration.
+    #[test]
+    fn from_storage_restores_tasks_below_genesis_height() {
+        use ethexe_common::StateHashWithQueueSize;
+
+        let storage = MemStorage::default();
+        let program_id = ActorId::from(1);
+        let user_id = ActorId::from(2);
+
+        let reply = |id: u64, fill: u8| {
+            Dispatch::reply(
+                MessageId::from(id),
+                ActorId::from(id + 1000),
+                PayloadLookup::Direct(Payload::repeat(fill)),
+                0xffffff,
+                SuccessReplyReason::Auto,
+                MessageType::Canonical,
+                false,
+            )
+        };
+
+        let waitlisted = reply(10, 0x11);
+        let stashed_to_program = reply(11, 0x22);
+        let stashed_to_user = reply(12, 0x33);
+        let mailbox_message_id = MessageId::from(13);
+
+        let mut waitlist = Waitlist::default();
+        waitlist.wait(waitlisted.clone(), 1);
+
+        let mut stash = DispatchStash::default();
+        stash.add_to_program(stashed_to_program.clone(), 2);
+        stash.add_to_user(stashed_to_user.clone(), 3, user_id);
+
+        let mut mailbox = Mailbox::default();
+        mailbox.add_and_store_user_mailbox(
+            &storage,
+            user_id,
+            mailbox_message_id,
+            MailboxMessage::new(
+                PayloadLookup::Direct(Payload::repeat(0x44)),
+                0xffffff,
+                MessageType::Canonical,
+            ),
+            4,
+        );
+
+        let mut state = ProgramState::zero();
+        state.waitlist_hash = waitlist.store(&storage).expect("waitlist changed");
+        state.stash_hash = stash.store(&storage);
+        state.mailbox_hash = mailbox.store(&storage).expect("mailbox changed");
+        let state_hash = storage.write_program_state(state);
+
+        let program_states = ProgramStates::from([(
+            program_id,
+            StateHashWithQueueSize {
+                hash: state_hash,
+                canonical_queue_size: 0,
+                injected_queue_size: 0,
+            },
+        )]);
+
+        let schedule = Restorer::from_storage(&storage, &program_states)
+            .expect("restore must succeed")
+            .restore();
+
+        assert_eq!(
+            schedule,
+            BTreeMap::from([
+                (
+                    1,
+                    BTreeSet::from([ScheduledTask::WakeMessage(program_id, waitlisted.id)])
+                ),
+                (
+                    2,
+                    BTreeSet::from([ScheduledTask::SendDispatch((
+                        program_id,
+                        stashed_to_program.id
+                    ))])
+                ),
+                (
+                    3,
+                    BTreeSet::from([ScheduledTask::SendUserMessage {
+                        message_id: stashed_to_user.id,
+                        to_mailbox: program_id,
+                    }])
+                ),
+                (
+                    4,
+                    BTreeSet::from([ScheduledTask::RemoveFromMailbox(
+                        (program_id, user_id),
+                        mailbox_message_id
+                    )])
+                ),
+            ]),
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #5574 — re-genesis silently drops scheduled tasks when the genesis block is above the dumped block.

`ScheduleRestorer` was given the Router genesis height (`N_gen`) as an expiry cutoff and dropped every task whose `expiry <= N_gen`. Re-genesis allows `N_gen >= H_dump` (the dumped execution block), so any still-pending task with `H_dump < expiry <= N_gen` — delayed dispatches, stash sends, waitlist wakes, mailbox-expiry removals — was silently discarded and never fired.

This PR removes `current_block` from `ScheduleRestorer` entirely and stops filtering at genesis restoration:

- `ScheduleRestorer::new()` / `from_storage(..)` no longer take a `current_block`.
- The three `if expiry <= current_block { continue }` filters (waitlist, user mailbox, stash) are gone.
- The `init.rs` genesis call site no longer passes `genesis_eb.header.height`.

The cutoff was never correct at genesis: committed states never contain a task with `expiry <= H_dump` (firing a task removes its `Expiring` entry at commit), and the executor drains the full backlog with no lower bound (`take_actual_tasks` → `split_off(block_height + 1)`), so any restored task fires at the first computed block regardless of expiry. The cutoff could therefore only do nothing or wrongly drop valid tasks.

## Changes

- `ethexe/runtime/common/src/schedule.rs` — drop `current_block` field/param and the expiry filters; add `#[derive(Default)]`; update inline unit tests.
- `ethexe/runtime/common/src/proptest.rs` — update the three restorer proptests to assert full restoration (no expiry filtering).
- `ethexe/db/src/migrations/init.rs` — drop the `genesis_eb.header.height` argument at the genesis restore call site.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p ethexe-runtime-common -p ethexe-db --all-targets` (clean)
- [x] `cargo nextest run -p ethexe-runtime-common -p ethexe-db -E 'test(restorer)'` (6 passed)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)