### PR TITLE
feat(vara.eth/ethexe): configurable mailbox validity (V2 = 15 min)

### DIFF
--- a/ethexe/common/src/db.rs
+++ b/ethexe/common/src/db.rs
@@ -267,7 +267,7 @@ mod tests {
     #[test]
     fn ensure_types_unchanged() {
         const EXPECTED_TYPE_INFO_HASH: &str =
-            "600c7b8ccc11ab8c87a94170473bad7cf7c1c87973f5f56f3734ff4ad7473a2a";
+            "e050897a5a15f2324072691a68ef4cce21219f801629fa55ac20e11d7ded779b";
 
         let types = [
             meta_type::<BlockMeta>(),

--- a/ethexe/common/src/lib.rs
+++ b/ethexe/common/src/lib.rs
@@ -117,3 +117,11 @@ pub const OUTGOING_MESSAGES_SOFT_LIMIT: u32 = 128;
 pub const OUTGOING_MESSAGES_BYTES_SOFT_LIMIT: u32 = 32 * 1024;
 pub const CALL_REPLY_SOFT_LIMIT: u32 = 4;
 pub const PROGRAM_MODIFICATIONS_SOFT_LIMIT: u32 = MAX_TOUCHED_PROGRAMS_PER_MB / 2;
+
+/// Old mailbox validity version (in Ethereum blocks).
+pub const MAILBOX_VALIDITY_VERSION_1: core::num::NonZero<u32> =
+    core::num::NonZero::new(54_000).expect("54_000 != 0");
+
+/// New mailbox validity version (in Ethereum blocks). 15 minutes at 12s block time.
+pub const MAILBOX_VALIDITY_VERSION_2: core::num::NonZero<u32> =
+    core::num::NonZero::new(15 * 60 / 12).expect("75 != 0");

--- a/ethexe/common/src/malachite.rs
+++ b/ethexe/common/src/malachite.rs
@@ -48,11 +48,15 @@ pub enum Operation {
     /// Progress scheduled tasks (mailbox/waitlist/reservation cleanup).
     ProgressTasks = 1,
 
-    /// Drain message queues within `gas_allowance`; producer emits last.
+    /// Execute queued message within `gas_allowance`.
     ProcessQueues { gas_allowance: u64 } = 2,
 
     /// User-submitted transaction from the mempool.
     Injected(SignedInjectedTransaction) = 3,
+
+    /// Execute queued messages within `gas_allowance`.
+    /// V2 - changes mailbox validity, from one week to 15 minutes
+    ProcessQueuesV2 { gas_allowance: u64 } = 4,
 }
 
 impl Operation {
@@ -71,6 +75,7 @@ impl Operation {
             Self::ProgressTasks => 1,
             Self::ProcessQueues { .. } => 2,
             Self::Injected(_) => 3,
+            Self::ProcessQueuesV2 { .. } => 4,
         }
     }
 }
@@ -95,6 +100,9 @@ impl Decode for Operation {
             3 => Ok(Operation::Injected(SignedInjectedTransaction::decode(
                 input,
             )?)),
+            4 => Ok(Operation::ProcessQueuesV2 {
+                gas_allowance: u64::decode(input)?,
+            }),
             _ => Err(parity_scale_codec::Error::from("invalid operation tag")),
         }
     }
@@ -108,6 +116,7 @@ impl Encode for Operation {
             Operation::ProgressTasks => {}
             Operation::ProcessQueues { gas_allowance } => gas_allowance.encode_to(dest),
             Operation::Injected(signed_tx) => signed_tx.encode_to(dest),
+            Operation::ProcessQueuesV2 { gas_allowance } => gas_allowance.encode_to(dest),
         }
     }
 }
@@ -137,7 +146,7 @@ mod tests {
     fn empty_txs() -> Operations {
         Operations::new(alloc::vec![
             Operation::ProgressTasks,
-            Operation::ProcessQueues {
+            Operation::ProcessQueuesV2 {
                 gas_allowance: 1234,
             },
         ])
@@ -166,12 +175,12 @@ mod tests {
             block_hash: H256::zero(),
         };
         let progress = Operation::ProgressTasks;
-        let queues = Operation::ProcessQueues {
+        let queues = Operation::ProcessQueuesV2 {
             gas_allowance: 1234,
         };
         assert!(advance.is_advance_till_ethereum_block());
         assert!(progress.is_progress_tasks());
-        assert!(queues.is_process_queues());
+        assert!(queues.is_process_queues_v_2());
     }
 
     #[test]
@@ -190,6 +199,7 @@ mod tests {
         );
         assert_eq!(Operation::ProgressTasks.tag(), 1);
         assert_eq!(Operation::ProcessQueues { gas_allowance: 0 }.tag(), 2);
+        assert_eq!(Operation::ProcessQueuesV2 { gas_allowance: 0 }.tag(), 4);
 
         assert_eq!(
             &Operation::AdvanceTillEthereumBlock {
@@ -203,10 +213,14 @@ mod tests {
             &Operation::ProcessQueues { gas_allowance: 0 }.encode()[..4],
             &[2, 0, 0, 0],
         );
+        assert_eq!(
+            &Operation::ProcessQueuesV2 { gas_allowance: 0 }.encode()[..4],
+            &[4, 0, 0, 0],
+        );
 
         // Unknown tag must be rejected by `Decode`, not interpreted.
         use parity_scale_codec::DecodeAll;
-        assert!(Operation::decode_all(&mut [4u8, 0, 0, 0].as_slice()).is_err());
+        assert!(Operation::decode_all(&mut [5u8, 0, 0, 0].as_slice()).is_err());
     }
 
     #[test]

--- a/ethexe/compute/src/compute.rs
+++ b/ethexe/compute/src/compute.rs
@@ -268,8 +268,9 @@ fn build_executable_data(
     let mut injected_transactions = Vec::new();
     let mut gas_allowance: Option<u64> = None;
     let mut current_anchor = initial_advanced_block;
+    let mut mailbox_validity = ethexe_common::MAILBOX_VALIDITY_VERSION_2;
 
-    for op in operations.0 {
+    for op in operations {
         match op {
             Operation::AdvanceTillEthereumBlock { block_hash } => {
                 let chain = collect_advance_chain(db, block_hash, current_anchor)?;
@@ -291,6 +292,16 @@ fn build_executable_data(
             Operation::ProcessQueues {
                 gas_allowance: op_gas_allowance,
             } => {
+                // Old block - change mailbox validity to the previous default one
+                mailbox_validity = ethexe_common::MAILBOX_VALIDITY_VERSION_1;
+
+                gas_allowance = Some(op_gas_allowance);
+            }
+            Operation::ProcessQueuesV2 {
+                gas_allowance: op_gas_allowance,
+            } => {
+                // Keep the new mailbox validity for this operation, as it is the default one
+
                 gas_allowance = Some(op_gas_allowance);
             }
         }
@@ -315,6 +326,7 @@ fn build_executable_data(
         injected_transactions,
         gas_allowance,
         events,
+        mailbox_validity,
     })
 }
 
@@ -483,7 +495,7 @@ mod tests {
                 block_hash: eth_block_hash,
             },
             Operation::ProgressTasks,
-            Operation::ProcessQueues {
+            Operation::ProcessQueuesV2 {
                 gas_allowance: DEFAULT_BLOCK_GAS_LIMIT,
             },
         ])
@@ -709,7 +721,7 @@ mod tests {
     fn mb_bookend() -> [Operation; 2] {
         [
             Operation::ProgressTasks,
-            Operation::ProcessQueues {
+            Operation::ProcessQueuesV2 {
                 gas_allowance: DEFAULT_BLOCK_GAS_LIMIT,
             },
         ]

--- a/ethexe/compute/src/lib.rs
+++ b/ethexe/compute/src/lib.rs
@@ -71,7 +71,7 @@
 //! chain via [`ethexe_common::db::CompactMb::parent`] until it reaches
 //! a computed ancestor (or genesis), then runs the executor over the
 //! [`ethexe_common::malachite::Operations`] payload of each. Per-step gas
-//! budget is carried inside each `Operation::ProcessQueues` payload
+//! budget is carried inside each `Operation::ProcessQueuesV2` payload
 //! (its `gas_allowance` field).
 //!
 //! ## Canonical event quarantine

--- a/ethexe/compute/src/service.rs
+++ b/ethexe/compute/src/service.rs
@@ -163,7 +163,7 @@ mod tests {
                 block_hash: eth_block_hash,
             },
             Operation::ProgressTasks,
-            Operation::ProcessQueues { gas_allowance },
+            Operation::ProcessQueuesV2 { gas_allowance },
         ]));
 
         db.set_mb_compact_block(

--- a/ethexe/consensus/src/validator/batch/tests.rs
+++ b/ethexe/consensus/src/validator/batch/tests.rs
@@ -63,7 +63,7 @@ fn append_mb(db: &Database, parent: H256, height: u64, outcome: Vec<StateTransit
         Operation::AdvanceTillEthereumBlock {
             block_hash: H256::from_low_u64_be(0xEB00 + height),
         },
-        Operation::ProcessQueues { gas_allowance: 0 },
+        Operation::ProcessQueuesV2 { gas_allowance: 0 },
     ]);
     let operations_hash = db.set_operations(ops);
     // Synthetic mb_hash — uniqueness is what matters here.

--- a/ethexe/consensus/src/validator/batch/utils.rs
+++ b/ethexe/consensus/src/validator/batch/utils.rs
@@ -482,7 +482,7 @@ mod tests {
             Operation::AdvanceTillEthereumBlock {
                 block_hash: H256::from_low_u64_be(0xEB00 + height),
             },
-            Operation::ProcessQueues { gas_allowance: 0 },
+            Operation::ProcessQueuesV2 { gas_allowance: 0 },
         ])
     }
 

--- a/ethexe/malachite/service/src/externalities.rs
+++ b/ethexe/malachite/service/src/externalities.rs
@@ -59,7 +59,7 @@ use std::{
     sync::{Arc, Mutex, RwLock},
 };
 use tokio::sync::{Notify, mpsc};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Inputs the externalities need to satisfy the [`ethexe_malachite_core::Externalities`]
 /// contract. Constructed by [`crate::MalachiteService::new`] and
@@ -350,7 +350,7 @@ impl Externalities for EthexeExternalities {
         //      quarantine-passed EB exists),
         //   2. then injected user txs,
         //   3. finally the service-level ProgressTasks +
-        //      ProcessQueues bookend.
+        //      ProcessQueuesV2 bookend.
         let mut operations = Vec::with_capacity(capped.len() + 3);
         if let Some(block_hash) = advance {
             operations.push(Operation::AdvanceTillEthereumBlock { block_hash });
@@ -359,7 +359,7 @@ impl Externalities for EthexeExternalities {
             operations.push(Operation::Injected(tx));
         }
         operations.push(Operation::ProgressTasks);
-        operations.push(Operation::ProcessQueues {
+        operations.push(Operation::ProcessQueuesV2 {
             gas_allowance: self.gas_allowance,
         });
 
@@ -375,7 +375,7 @@ impl Externalities for EthexeExternalities {
         // path), so it enforces the operations *this* build accepts. Decode
         // rejects any operation whose discriminant this build doesn't know —
         // such a proposal is voted nil rather than crashing the node.
-        let payload = match Operations::decode_all(&mut payload.as_ref()) {
+        let operations = match Operations::decode_all(&mut payload.as_ref()) {
             Ok(payload) => payload,
             Err(e) => {
                 warn!(error = %e, "validate: undecodable block payload — rejecting");
@@ -383,16 +383,32 @@ impl Externalities for EthexeExternalities {
             }
         };
 
+        // Check operations are allowed at this protocol version.
+        for op in operations.iter() {
+            match op {
+                Operation::AdvanceTillEthereumBlock { .. }
+                | Operation::ProgressTasks
+                | Operation::ProcessQueuesV2 { .. }
+                | Operation::Injected(_) => {
+                    // Known and allowed.
+                }
+                op => {
+                    debug!("Found deprecated operation in proposed MB: {op:?}");
+                    return Ok(false);
+                }
+            }
+        }
+
         // (1) Shape + ordering. Every honest MB has exactly the form:
         //
-        //   [AdvanceTillEthereumBlock]?  Injected*  ProgressTasks  ProcessQueues
+        //   [AdvanceTillEthereumBlock]?  Injected*  ProgressTasks  ProcessQueuesV2
         //
         // This single walk catches: missing bookend, extra bookend,
         // out-of-order op, more than one Advance, and the
         // `gas_allowance` cap. Everything else (TxValidity per injected
         // tx, EB quarantine, touched-programs cap) runs below assuming
         // the shape is sound.
-        let mut iter = payload.iter();
+        let mut iter = operations.iter();
         let mut next = iter.next();
 
         let advance: Option<H256> =
@@ -416,8 +432,8 @@ impl Externalities for EthexeExternalities {
             return Ok(false);
         };
 
-        let Some(Operation::ProcessQueues { gas_allowance }) = iter.next() else {
-            warn!("validate: MB shape violation — expected `ProcessQueues` bookend");
+        let Some(Operation::ProcessQueuesV2 { gas_allowance }) = iter.next() else {
+            warn!("validate: MB shape violation — expected `ProcessQueuesV2` bookend");
             return Ok(false);
         };
 
@@ -425,13 +441,13 @@ impl Externalities for EthexeExternalities {
             warn!(
                 allowance = *gas_allowance,
                 cap = crate::MalachiteConfig::DEFAULT_GAS_ALLOWANCE,
-                "validate: ProcessQueues.gas_allowance exceeds protocol cap"
+                "validate: ProcessQueuesV2.gas_allowance exceeds protocol cap"
             );
             return Ok(false);
         }
 
         if iter.next().is_some() {
-            warn!("validate: MB has extra operations after the `ProcessQueues` bookend");
+            warn!("validate: MB has extra operations after the `ProcessQueuesV2` bookend");
             return Ok(false);
         }
 
@@ -521,7 +537,7 @@ impl Externalities for EthexeExternalities {
             // No local chain head yet. If the MB carries no injected
             // txs we can still accept it; otherwise we must abstain
             // since the checker has no anchor to walk from.
-            let has_injected = payload
+            let has_injected = operations
                 .iter()
                 .any(|tx| matches!(tx, Operation::Injected(_)));
             if has_injected {
@@ -539,7 +555,7 @@ impl Externalities for EthexeExternalities {
         // Propagating the error upward is the right call: it indicates
         // local DB corruption, not a peer-side issue.
         let checker = TxValidityChecker::new_for_mb(self.db.clone(), chain_head, parent_hash)?;
-        for tx in payload.iter() {
+        for tx in operations.iter() {
             let Operation::Injected(signed) = tx else {
                 continue;
             };
@@ -594,7 +610,7 @@ impl Externalities for EthexeExternalities {
             None => std::collections::HashSet::new(),
         };
         let limit = touched.len().max(MAX_TOUCHED_PROGRAMS_PER_MB as usize);
-        for tx in payload.iter() {
+        for tx in operations.iter() {
             if let Operation::Injected(signed) = tx {
                 touched.insert(signed.data().destination);
             }
@@ -811,7 +827,7 @@ mod tests {
         for _ in 0..(salt.max(1)) {
             txs.push(Operation::ProgressTasks);
         }
-        txs.push(Operation::ProcessQueues { gas_allowance: 0 });
+        txs.push(Operation::ProcessQueuesV2 { gas_allowance: 0 });
         Operations::new(txs)
     }
 
@@ -1010,7 +1026,7 @@ mod tests {
                 block_hash: H256::repeat_byte(0xBB),
             },
             Operation::ProgressTasks,
-            Operation::ProcessQueues { gas_allowance: 0 },
+            Operation::ProcessQueuesV2 { gas_allowance: 0 },
         ]);
         assert!(
             !ext.validate_operations(H256::zero(), payload)
@@ -1057,7 +1073,7 @@ mod tests {
                 block_hash: H256::repeat_byte(0xCC),
             },
             Operation::ProgressTasks,
-            Operation::ProcessQueues { gas_allowance: 0 },
+            Operation::ProcessQueuesV2 { gas_allowance: 0 },
         ]);
         assert!(
             !ext.validate_operations(H256::zero(), payload)
@@ -1109,7 +1125,7 @@ mod tests {
                 block_hash: chain_hashes[1].0,
             },
             Operation::ProgressTasks,
-            Operation::ProcessQueues { gas_allowance: 0 },
+            Operation::ProcessQueuesV2 { gas_allowance: 0 },
         ]);
         assert!(
             ext.validate_operations(H256::zero(), payload)
@@ -1149,7 +1165,7 @@ mod tests {
     /// `process_mb_finalized` must hand exactly the
     /// [`Operation::Injected`] subset of the committed block to
     /// [`Mempool::forget`] (and nothing else — service txs like
-    /// `ProcessQueues` stay out of the mempool round trip).
+    /// `ProcessQueuesV2` stay out of the mempool round trip).
     #[tokio::test]
     async fn finalize_forgets_injected_txs() {
         use ethexe_common::{
@@ -1207,7 +1223,7 @@ mod tests {
             // user tx #1 — must show up
             Operation::Injected(tx_a.clone()),
             // service tx — must NOT
-            Operation::ProcessQueues { gas_allowance: 0 },
+            Operation::ProcessQueuesV2 { gas_allowance: 0 },
             // user tx #2 — must show up
             Operation::Injected(tx_b.clone()),
         ]);
@@ -1559,7 +1575,7 @@ mod tests {
         }
         // Full shape — the shape walk must not be the reason for rejection.
         operations.push(Operation::ProgressTasks);
-        operations.push(Operation::ProcessQueues { gas_allowance: 0 });
+        operations.push(Operation::ProcessQueuesV2 { gas_allowance: 0 });
         let payload = Operations::new(operations);
         assert!(
             !ext.validate_operations(parent_mb, payload).await.unwrap(),
@@ -1645,8 +1661,8 @@ mod tests {
     // Shape & ordering checks on `validate_block_above`.
     //
     // Every MB the producer emits has the strict shape
-    //   [AdvanceTillEthereumBlock]?  Injected*  ProgressTasks  ProcessQueues
-    // with `ProcessQueues.gas_allowance <= DEFAULT_GAS_ALLOWANCE`.
+    //   [AdvanceTillEthereumBlock]?  Injected*  ProgressTasks  ProcessQueuesV2
+    // with `ProcessQueuesV2.gas_allowance <= DEFAULT_GAS_ALLOWANCE`.
     // A malicious proposer must not be able to slip in a malformed MB
     // (oversized gas, missing bookend, out-of-order tx).
     // ------------------------------------------------------------------
@@ -1689,7 +1705,7 @@ mod tests {
     }
 
     /// REPRODUCES: a malicious proposer can set `gas_allowance = u64::MAX`
-    /// in `ProcessQueues.gas_allowance` and force every participant to attempt
+    /// in `ProcessQueuesV2.gas_allowance` and force every participant to attempt
     /// an unbounded queue drain. Validator must reject MBs whose
     /// `gas_allowance` exceeds the protocol cap
     /// (`MalachiteConfig::DEFAULT_GAS_ALLOWANCE`).
@@ -1702,7 +1718,7 @@ mod tests {
                 block_hash: advance,
             },
             Operation::ProgressTasks,
-            Operation::ProcessQueues {
+            Operation::ProcessQueuesV2 {
                 gas_allowance: u64::MAX,
             },
         ]);
@@ -1715,7 +1731,7 @@ mod tests {
     }
 
     /// REPRODUCES: MB without a `ProgressTasks` tx between injected txs
-    /// and `ProcessQueues` violates the protocol shape — scheduled
+    /// and `ProcessQueuesV2` violates the protocol shape — scheduled
     /// tasks would never be advanced.
     #[tokio::test]
     async fn validate_rejects_mb_missing_progress_tasks() {
@@ -1725,8 +1741,8 @@ mod tests {
             Operation::AdvanceTillEthereumBlock {
                 block_hash: advance,
             },
-            // No ProgressTasks here — straight to ProcessQueues.
-            Operation::ProcessQueues { gas_allowance: 0 },
+            // No ProgressTasks here — straight to ProcessQueuesV2.
+            Operation::ProcessQueuesV2 { gas_allowance: 0 },
         ]);
         assert!(
             !ext.validate_operations(H256::zero(), payload)
@@ -1736,7 +1752,7 @@ mod tests {
         );
     }
 
-    /// REPRODUCES: MB without a final `ProcessQueues` tx never drains
+    /// REPRODUCES: MB without a final `ProcessQueuesV2` tx never drains
     /// the message queues for this MB — compute pipeline would stall
     /// on the next MB.
     #[tokio::test]
@@ -1748,13 +1764,13 @@ mod tests {
                 block_hash: advance,
             },
             Operation::ProgressTasks,
-            // No ProcessQueues here.
+            // No ProcessQueuesV2 here.
         ]);
         assert!(
             !ext.validate_operations(H256::zero(), payload)
                 .await
                 .unwrap(),
-            "MB missing `ProcessQueues` bookend must be rejected"
+            "MB missing `ProcessQueuesV2` bookend must be rejected"
         );
     }
 
@@ -1798,7 +1814,7 @@ mod tests {
                 block_hash: chain.blocks[2].hash,
             },
             Operation::ProgressTasks,
-            Operation::ProcessQueues { gas_allowance: 0 },
+            Operation::ProcessQueuesV2 { gas_allowance: 0 },
         ]);
         assert!(
             !ext.validate_operations(parent_mb, payload).await.unwrap(),
@@ -1806,7 +1822,7 @@ mod tests {
         );
     }
 
-    /// REPRODUCES: `ProcessQueues` must be the very last tx in the MB.
+    /// REPRODUCES: `ProcessQueuesV2` must be the very last tx in the MB.
     /// Otherwise later txs run *after* queues drain and the gas budget
     /// is wrong.
     #[tokio::test]
@@ -1817,15 +1833,15 @@ mod tests {
             Operation::AdvanceTillEthereumBlock {
                 block_hash: advance,
             },
-            // Order swapped: ProcessQueues before ProgressTasks.
-            Operation::ProcessQueues { gas_allowance: 0 },
+            // Order swapped: ProcessQueuesV2 before ProgressTasks.
+            Operation::ProcessQueuesV2 { gas_allowance: 0 },
             Operation::ProgressTasks,
         ]);
         assert!(
             !ext.validate_operations(H256::zero(), payload)
                 .await
                 .unwrap(),
-            "MB where `ProcessQueues` is not the last tx must be rejected"
+            "MB where `ProcessQueuesV2` is not the last tx must be rejected"
         );
     }
 
@@ -1890,7 +1906,7 @@ mod tests {
                 block_hash: chain[1].0,
             },
             Operation::ProgressTasks,
-            Operation::ProcessQueues { gas_allowance: 0 },
+            Operation::ProcessQueuesV2 { gas_allowance: 0 },
         ]);
 
         assert!(
@@ -1949,7 +1965,7 @@ mod tests {
                 block_hash: stranger_advance,
             },
             Operation::ProgressTasks,
-            Operation::ProcessQueues { gas_allowance: 0 },
+            Operation::ProcessQueuesV2 { gas_allowance: 0 },
         ]);
 
         let result = tokio::time::timeout(

--- a/ethexe/processor/src/handling/run/mod.rs
+++ b/ethexe/processor/src/handling/run/mod.rs
@@ -552,8 +552,11 @@ mod tests {
     use super::*;
     use crate::{handling::overlaid::OverlaidRunContext, host};
     use ethexe_common::{MaybeHashOf, StateHashWithQueueSize, gear::MessageType};
-    use ethexe_runtime_common::state::{
-        ActiveProgram, Dispatch, MessageQueueHashWithSize, Program, ProgramState, Storage,
+    use ethexe_runtime_common::{
+        TransitionsConfig,
+        state::{
+            ActiveProgram, Dispatch, MessageQueueHashWithSize, Program, ProgramState, Storage,
+        },
     };
     use gprimitives::{ActorId, MessageId};
     use std::collections::{BTreeMap, HashMap};
@@ -585,7 +588,11 @@ mod tests {
         .take(STATE_SIZE)
         .collect();
 
-        let transitions = InBlockTransitions::new(0, states, Default::default());
+        let cfg = TransitionsConfig {
+            block_height: 0,
+            ..Default::default()
+        };
+        let transitions = InBlockTransitions::new(cfg, states, Default::default());
         let db = Database::memory();
         let mut ctx = CommonRunContext::new(
             db.clone(),
@@ -721,7 +728,11 @@ mod tests {
             (pid2, pid2_state_hash_with_queue_size),
         ]);
 
-        let mut in_block_transitions = InBlockTransitions::new(3, states, Default::default());
+        let cfg = TransitionsConfig {
+            block_height: 3,
+            ..Default::default()
+        };
+        let mut in_block_transitions = InBlockTransitions::new(cfg, states, Default::default());
 
         let base_program = pid2;
 

--- a/ethexe/processor/src/lib.rs
+++ b/ethexe/processor/src/lib.rs
@@ -145,7 +145,7 @@ pub use promise::BoundPromiseSink;
 
 use core::num::NonZero;
 use ethexe_common::{
-    CodeAndIdUnchecked, ProgramStates, Schedule,
+    CodeAndIdUnchecked, MAILBOX_VALIDITY_VERSION_2, ProgramStates, Schedule,
     ecdsa::VerifiedData,
     events::{BlockRequestEvent, MirrorRequestEvent, mirror::MessageQueueingRequestedEvent},
     gear::Message,
@@ -154,7 +154,7 @@ use ethexe_common::{
 use ethexe_db::Database;
 use ethexe_runtime_common::{
     FinalizedBlockTransitions, InBlockTransitions, ScheduleHandler, TransitionController,
-    state::Storage,
+    TransitionsConfig, state::Storage,
 };
 use gear_core::{
     code::{CodeMetadata, InstrumentedCode},
@@ -316,9 +316,15 @@ impl Processor {
             injected_transactions,
             gas_allowance,
             events,
+            mailbox_validity,
         } = executable;
 
-        let mut transitions = InBlockTransitions::new(height, program_states, schedule);
+        let cfg = TransitionsConfig {
+            block_height: height,
+            mailbox_validity,
+        };
+
+        let mut transitions = InBlockTransitions::new(cfg, program_states, schedule);
 
         // First step: push injected to queues and handle block events.
         transitions =
@@ -389,7 +395,7 @@ impl Processor {
 
     fn process_tasks(&mut self, mut transitions: InBlockTransitions) -> InBlockTransitions {
         let tasks = transitions.take_actual_tasks();
-        let block_height = transitions.block_height();
+        let block_height = transitions.cfg().block_height;
 
         log::trace!("Running schedule for #{block_height}: tasks are {tasks:?}");
 
@@ -435,6 +441,7 @@ pub struct ExecutableData {
     pub injected_transactions: Vec<VerifiedData<InjectedTransaction>>,
     pub gas_allowance: Option<u64>,
     pub events: Vec<BlockRequestEvent>,
+    pub mailbox_validity: NonZero<u32>,
 }
 
 #[cfg(test)]
@@ -448,6 +455,7 @@ impl Default for ExecutableData {
             injected_transactions: vec![],
             gas_allowance: Some(ethexe_common::DEFAULT_BLOCK_GAS_LIMIT),
             events: vec![],
+            mailbox_validity: MAILBOX_VALIDITY_VERSION_2,
         }
     }
 }
@@ -513,7 +521,12 @@ impl OverlaidProcessor {
             return Err(ExecuteForReplyError::ProgramNotInitialized(program_id));
         }
 
-        let transitions = InBlockTransitions::new(height, program_states, Schedule::default());
+        let cfg = TransitionsConfig {
+            block_height: height,
+            mailbox_validity: MAILBOX_VALIDITY_VERSION_2,
+        };
+
+        let transitions = InBlockTransitions::new(cfg, program_states, Schedule::default());
 
         let transitions = self.0.handle_injected_and_events(
             transitions,

--- a/ethexe/processor/src/tests.rs
+++ b/ethexe/processor/src/tests.rs
@@ -4,8 +4,8 @@
 use crate::*;
 use anyhow::{Result, anyhow};
 use ethexe_common::{
-    DEFAULT_BLOCK_GAS_LIMIT, OUTGOING_MESSAGES_SOFT_LIMIT, PROGRAM_MODIFICATIONS_SOFT_LIMIT,
-    PrivateKey, ScheduledTask, SignedMessage,
+    DEFAULT_BLOCK_GAS_LIMIT, MAILBOX_VALIDITY_VERSION_2, OUTGOING_MESSAGES_SOFT_LIMIT,
+    PROGRAM_MODIFICATIONS_SOFT_LIMIT, PrivateKey, ScheduledTask, SignedMessage,
     db::*,
     events::{
         BlockRequestEvent, MirrorRequestEvent, RouterRequestEvent,
@@ -16,7 +16,8 @@ use ethexe_common::{
     mock::*,
 };
 use ethexe_runtime_common::{
-    CODES_INSTRUMENTATION_VERSION, RUNTIME_ID, WAIT_UP_TO_SAFE_DURATION, state::MessageQueue,
+    CODES_INSTRUMENTATION_VERSION, RUNTIME_ID, TransitionsConfig, WAIT_UP_TO_SAFE_DURATION,
+    state::MessageQueue,
 };
 use gear_core::{
     code::{CodeMetadata, InstantiatedSectionSizes, InstrumentationStatus, InstrumentedCode},
@@ -104,7 +105,11 @@ mod utils {
     }
 
     pub fn setup_handler(db: Database, height: u32) -> ProcessingHandler {
-        let transitions = InBlockTransitions::new(height, Default::default(), Default::default());
+        let cfg = TransitionsConfig {
+            block_height: height,
+            ..Default::default()
+        };
+        let transitions = InBlockTransitions::new(cfg, Default::default(), Default::default());
 
         ProcessingHandler::new(db, transitions)
     }
@@ -1000,7 +1005,7 @@ async fn many_waits() {
     // Hack: change block height to wake up tasks.
     let transitions = handler
         .transitions
-        .tap_mut(|ts| *ts.block_height_mut() = wake_block.header.height);
+        .tap_mut(|ts| ts.cfg_mut().block_height = wake_block.header.height);
     let mut transitions = processor.process_tasks(transitions);
     // Hack: nullify modifications to avoid modifications limit.
     transitions.modifications_mut().clear();
@@ -1153,7 +1158,7 @@ async fn cross_height_wake_drain() {
     // `process_tasks` must still drain the wakes despite the height gap.
     let transitions = handler
         .transitions
-        .tap_mut(|ts| *ts.block_height_mut() = wake_block.header.height);
+        .tap_mut(|ts| ts.cfg_mut().block_height = wake_block.header.height);
     let mut transitions = processor.process_tasks(transitions);
     transitions.modifications_mut().clear();
     let transitions = processor
@@ -1298,9 +1303,13 @@ async fn overlay_execution() {
     // programs already have some state.
 
     let block2 = chain.blocks[2].to_simple();
+    let cfg = TransitionsConfig {
+        block_height: block2.header.height,
+        ..Default::default()
+    };
     let mut handler = ProcessingHandler::new(
         processor.db.clone(),
-        InBlockTransitions::new(block2.header.height, states, schedule),
+        InBlockTransitions::new(cfg, states, schedule),
     );
 
     // Manually add messages to programs queues
@@ -2284,6 +2293,7 @@ async fn injected_and_events_then_tasks_then_queues() {
         injected_transactions: vec![verified_injected],
         events: canonical_event,
         gas_allowance: Some(DEFAULT_BLOCK_GAS_LIMIT),
+        mailbox_validity: MAILBOX_VALIDITY_VERSION_2,
     };
     let FinalizedBlockTransitions { transitions, .. } = processor
         .process_programs(executable, Some(promise_sink))
@@ -2397,7 +2407,7 @@ async fn call_wait_up_to_with_huge_duration() {
     // Huge duration
     let wat = get_wat(0xFFFFFFFF);
     let transitions = simple_init_test(wat_to_wasm(&wat).1).await;
-    let block_height = transitions.block_height();
+    let block_height = transitions.cfg().block_height;
     let FinalizedBlockTransitions { schedule, .. } = transitions.finalize();
     let (block, tasks) = schedule.into_iter().next().unwrap();
     assert_eq!(
@@ -2412,7 +2422,7 @@ async fn call_wait_up_to_with_huge_duration() {
     let duration = WAIT_UP_TO_SAFE_DURATION + 20;
     let wat = get_wat(duration);
     let transitions = simple_init_test(wat_to_wasm(&wat).1).await;
-    let block_height = transitions.block_height();
+    let block_height = transitions.cfg().block_height;
     let FinalizedBlockTransitions { schedule, .. } = transitions.finalize();
     let (block, tasks) = schedule.into_iter().next().unwrap();
     assert_eq!(

--- a/ethexe/runtime/common/src/journal.rs
+++ b/ethexe/runtime/common/src/journal.rs
@@ -4,8 +4,8 @@
 use crate::{
     TransitionController,
     state::{
-        ActiveProgram, Dispatch, Expiring, MAILBOX_VALIDITY, MailboxMessage, ModifiableStorage,
-        Program, ProgramState, Storage,
+        ActiveProgram, Dispatch, Expiring, MailboxMessage, ModifiableStorage, Program,
+        ProgramState, Storage,
     },
 };
 use alloc::{
@@ -132,6 +132,7 @@ impl<S: Storage + ?Sized> NativeJournalHandler<'_, S> {
         }
 
         let message_type = self.message_type;
+        let mailbox_validity = self.controller.transitions.cfg().mailbox_validity;
 
         self.controller
             .update_state(dispatch.source(), |state, storage, transitions| {
@@ -168,7 +169,7 @@ impl<S: Storage + ?Sized> NativeJournalHandler<'_, S> {
                     });
                 } else {
                     let expiry = transitions.schedule_task(
-                        MAILBOX_VALIDITY.try_into().expect("infallible"),
+                        mailbox_validity,
                         ScheduledTask::RemoveFromMailbox(
                             (dispatch.source(), dispatch.destination()),
                             dispatch.id(),

--- a/ethexe/runtime/common/src/lib.rs
+++ b/ethexe/runtime/common/src/lib.rs
@@ -94,7 +94,9 @@ pub use journal::{
     RuntimeQueueReport, WAIT_UP_TO_SAFE_DURATION,
 };
 pub use schedule::{Handler as ScheduleHandler, Restorer as ScheduleRestorer};
-pub use transitions::{FinalizedBlockTransitions, InBlockTransitions, NonFinalTransition};
+pub use transitions::{
+    FinalizedBlockTransitions, InBlockTransitions, NonFinalTransition, TransitionsConfig,
+};
 
 #[cfg(any(test, feature = "mock"))]
 pub mod proptest;

--- a/ethexe/runtime/common/src/proptest.rs
+++ b/ethexe/runtime/common/src/proptest.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 use crate::{
-    FinalizedBlockTransitions, InBlockTransitions, NonFinalTransition,
+    FinalizedBlockTransitions, InBlockTransitions, NonFinalTransition, TransitionsConfig,
     state::{
         ActiveProgram, Allocations, Dispatch, DispatchStash, Expiring, Mailbox, MailboxMessage,
         MemStorage, MemoryPages, MemoryPagesRegion, MessageQueue, MessageQueueHashWithSize,
@@ -379,8 +379,12 @@ fn in_block_transitions_strategy() -> BoxedStrategy<InBlockTransitions> {
                     }
                 }
 
-                InBlockTransitions::from_parts(
+                let cfg = TransitionsConfig {
                     block_height,
+                    ..Default::default()
+                };
+                InBlockTransitions::from_parts(
+                    cfg,
                     states,
                     schedule,
                     modifications,
@@ -481,8 +485,12 @@ fn in_block_transitions_with_model_strategy()
                             schedule: schedule.clone(),
                             program_creations: program_creations.clone(),
                         };
-                        let transitions = InBlockTransitions::from_parts(
+                        let cfg = TransitionsConfig {
                             block_height,
+                            ..Default::default()
+                        };
+                        let transitions = InBlockTransitions::from_parts(
+                            cfg,
                             states,
                             schedule,
                             modifications,

--- a/ethexe/runtime/common/src/schedule.rs
+++ b/ethexe/runtime/common/src/schedule.rs
@@ -4,8 +4,8 @@
 use crate::{
     TransitionController,
     state::{
-        Dispatch, DispatchStash, Expiring, MAILBOX_VALIDITY, MailboxMessage, ModifiableStorage,
-        PayloadLookup, ProgramState, QueryableStorage, Storage, UserMailbox, Waitlist,
+        Dispatch, DispatchStash, Expiring, MailboxMessage, ModifiableStorage, PayloadLookup,
+        ProgramState, QueryableStorage, Storage, UserMailbox, Waitlist,
     },
 };
 use alloc::collections::{BTreeMap, BTreeSet};
@@ -83,6 +83,8 @@ impl<S: Storage> TaskHandler<Rfm, Sd, Sum> for Handler<'_, S> {
     }
 
     fn send_user_message(&mut self, stashed_message_id: MessageId, program_id: ActorId) -> u64 {
+        let mailbox_validity = self.controller.transitions.cfg().mailbox_validity;
+
         self.controller
             .update_state(program_id, |state, storage, transitions| {
                 let (dispatch, user_id) = storage.modify(&mut state.stash_hash, |stash| {
@@ -90,7 +92,7 @@ impl<S: Storage> TaskHandler<Rfm, Sd, Sum> for Handler<'_, S> {
                 });
 
                 let expiry = transitions.schedule_task(
-                    MAILBOX_VALIDITY.try_into().expect("infallible"),
+                    mailbox_validity,
                     ScheduledTask::RemoveFromMailbox((program_id, user_id), stashed_message_id),
                 );
 

--- a/ethexe/runtime/common/src/state.rs
+++ b/ethexe/runtime/common/src/state.rs
@@ -34,10 +34,6 @@ use gear_core_errors::{ReplyCode, SuccessReplyReason};
 use gprimitives::{ActorId, H256, MessageId};
 use parity_scale_codec::{Decode, Encode};
 
-/// 3h validity in mailbox for 12s blocks.
-// TODO (breathx): WITHIN THE PR
-pub const MAILBOX_VALIDITY: u32 = 54_000;
-
 #[allow(unused)]
 fn shortname<S: Any>() -> &'static str {
     core::any::type_name::<S>()

--- a/ethexe/runtime/common/src/transitions.rs
+++ b/ethexe/runtime/common/src/transitions.rs
@@ -8,10 +8,25 @@ use alloc::{
 use anyhow::{Result, anyhow};
 use core::num::NonZero;
 use ethexe_common::{
-    ProgramStates, Schedule, ScheduledTask, StateHashWithQueueSize,
+    MAILBOX_VALIDITY_VERSION_2, ProgramStates, Schedule, ScheduledTask, StateHashWithQueueSize,
     gear::{Message, StateTransition, ValueClaim},
 };
 use gprimitives::{ActorId, CodeId, H256};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransitionsConfig {
+    pub block_height: u32,
+    pub mailbox_validity: NonZero<u32>,
+}
+
+impl Default for TransitionsConfig {
+    fn default() -> Self {
+        Self {
+            block_height: 0,
+            mailbox_validity: MAILBOX_VALIDITY_VERSION_2,
+        }
+    }
+}
 
 /// In-memory store for the state transitions
 /// that are going to be applied in the current block.
@@ -24,7 +39,7 @@ use gprimitives::{ActorId, CodeId, H256};
 /// applied in the current block.
 #[derive(Debug, Default)]
 pub struct InBlockTransitions {
-    block_height: u32,
+    cfg: TransitionsConfig,
     states: ProgramStates,
     schedule: Schedule,
     modifications: BTreeMap<ActorId, NonFinalTransition>,
@@ -40,9 +55,9 @@ pub struct FinalizedBlockTransitions {
 }
 
 impl InBlockTransitions {
-    pub fn new(block_height: u32, states: ProgramStates, schedule: Schedule) -> Self {
+    pub fn new(cfg: TransitionsConfig, states: ProgramStates, schedule: Schedule) -> Self {
         Self {
-            block_height,
+            cfg,
             states,
             schedule,
             ..Default::default()
@@ -84,14 +99,14 @@ impl InBlockTransitions {
     /// `block_height` and return them in chronological order
     /// (oldest height first; within a height, BTreeSet `Ord`).
     pub fn take_actual_tasks(&mut self) -> Vec<ScheduledTask> {
-        let cutoff = self.block_height.saturating_add(1);
+        let cutoff = self.cfg.block_height.saturating_add(1);
         let kept = self.schedule.split_off(&cutoff);
         let due = core::mem::replace(&mut self.schedule, kept);
         due.into_values().flatten().collect()
     }
 
     pub fn schedule_task(&mut self, in_blocks: NonZero<u32>, task: ScheduledTask) -> u32 {
-        let scheduled_block = self.block_height + u32::from(in_blocks);
+        let scheduled_block = self.cfg.block_height + u32::from(in_blocks);
 
         self.schedule
             .entry(scheduled_block)
@@ -224,20 +239,20 @@ impl InBlockTransitions {
         }
     }
 
-    pub fn block_height(&self) -> u32 {
-        self.block_height
+    pub fn cfg(&self) -> &TransitionsConfig {
+        &self.cfg
     }
 
     #[cfg(any(test, feature = "mock"))]
     pub fn from_parts(
-        block_height: u32,
+        cfg: TransitionsConfig,
         states: ProgramStates,
         schedule: Schedule,
         modifications: BTreeMap<ActorId, NonFinalTransition>,
         program_creations: BTreeMap<ActorId, CodeId>,
     ) -> Self {
         Self {
-            block_height,
+            cfg,
             states,
             schedule,
             modifications,
@@ -251,8 +266,8 @@ impl InBlockTransitions {
     }
 
     #[cfg(any(test, feature = "mock"))]
-    pub fn block_height_mut(&mut self) -> &mut u32 {
-        &mut self.block_height
+    pub fn cfg_mut(&mut self) -> &mut TransitionsConfig {
+        &mut self.cfg
     }
 }
 
@@ -310,7 +325,11 @@ mod tests {
     }
 
     fn transitions_with_schedule(block_height: u32, schedule: Schedule) -> InBlockTransitions {
-        InBlockTransitions::new(block_height, ProgramStates::default(), schedule)
+        let cfg = TransitionsConfig {
+            block_height,
+            ..Default::default()
+        };
+        InBlockTransitions::new(cfg, ProgramStates::default(), schedule)
     }
 
     #[test]

--- a/ethexe/service/src/tests/mod.rs
+++ b/ethexe/service/src/tests/mod.rs
@@ -555,7 +555,7 @@ async fn mailbox() {
     // adds one block of distance). Schedule expiries are computed against
     // that synthetic height.
     let wake_expiry = block.header.height - 2 + 100;
-    let expiry = block.header.height - 2 + ethexe_runtime_common::state::MAILBOX_VALIDITY;
+    let expiry = block.header.height - 2 + ethexe_common::MAILBOX_VALIDITY_VERSION_2.get();
 
     let expected_schedule = std::collections::BTreeMap::from_iter([
         (

--- a/sdk/gtest/src/ethexe/run.rs
+++ b/sdk/gtest/src/ethexe/run.rs
@@ -14,8 +14,8 @@ use ethexe_common::{
 use ethexe_runtime_common::{
     BlockInfo, InBlockTransitions, JournalHandler, MAX_CALL_REPLIES_PER_RUN,
     MAX_OUTGOING_MESSAGES_BYTES_PER_RUN, MAX_OUTGOING_MESSAGES_PER_RUN, ProcessQueueContext,
-    RuntimeQueueReport, ScheduleHandler, TransitionController, process_queue_with_report,
-    state::Storage,
+    RuntimeQueueReport, ScheduleHandler, TransitionController, TransitionsConfig,
+    process_queue_with_report, state::Storage,
 };
 use gear_core::{gas::GasAllowanceCounter, ids::ActorId};
 
@@ -30,8 +30,12 @@ impl EthexeBackend {
         allowance: Gas,
     ) -> BlockRunResult {
         let block_info = BlockInfo { height, timestamp };
+        let cfg = TransitionsConfig {
+            block_height: height,
+            ..Default::default()
+        };
         let mut transitions =
-            InBlockTransitions::new(height, self.states.clone(), self.schedule.clone());
+            InBlockTransitions::new(cfg, self.states.clone(), self.schedule.clone());
         let mut gas_allowance = GasAllowanceCounter::new(allowance);
         let mut result = BlockRunResult {
             block_info,
@@ -74,8 +78,12 @@ impl EthexeBackend {
 
     pub(crate) fn run_scheduled_block(&mut self, height: u32, timestamp: u64) -> BlockRunResult {
         let block_info = BlockInfo { height, timestamp };
+        let cfg = TransitionsConfig {
+            block_height: height,
+            ..Default::default()
+        };
         let mut transitions =
-            InBlockTransitions::new(height, self.states.clone(), self.schedule.clone());
+            InBlockTransitions::new(cfg, self.states.clone(), self.schedule.clone());
         let mut result = BlockRunResult {
             block_info,
             ..Default::default()


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `MAILBOX_VALIDITY` with a per-block `TransitionsConfig.mailbox_validity`, plumbed through `InBlockTransitions` and `ExecutableData`.
- Adds a versioned malachite operation: `ProcessQueuesV1` (tag 2, old 54000-block validity) is kept for historical replay; new `ProcessQueues` (tag 4) uses the 15-minute validity (`MAILBOX_VALIDITY_VERSION_2 = 75` blocks). Validator `validate` rejects proposals carrying the deprecated V1 op.
- `compute` picks the validity version from the operation present in the MB.

Stacked on #5586 (db cleanup hot fix).

## Test plan

- [x] `cargo nextest run -p ethexe-runtime-common -p ethexe-processor -p ethexe-db -p ethexe-compute -p ethexe-common`
- [x] `cargo nextest run -p ethexe-malachite -p ethexe-consensus`
- [x] frozen op-encoding test + DB type-info hash guard updated for the new operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)