### PR TITLE
feat(vara.eth): ProcessQueueV3 with auto reply for events

### DIFF
--- a/ethexe/common/src/db.rs
+++ b/ethexe/common/src/db.rs
@@ -267,7 +267,7 @@ mod tests {
     #[test]
     fn ensure_types_unchanged() {
         const EXPECTED_TYPE_INFO_HASH: &str =
-            "e050897a5a15f2324072691a68ef4cce21219f801629fa55ac20e11d7ded779b";
+            "cbf21dc97ec57cc6f653a7808672dc2c086fdfae28d1435e93f0dfe812de21c3";
 
         let types = [
             meta_type::<BlockMeta>(),

--- a/ethexe/common/src/malachite.rs
+++ b/ethexe/common/src/malachite.rs
@@ -59,7 +59,8 @@ pub enum Operation {
     ProcessQueuesV2 { gas_allowance: u64 } = 4,
 
     /// Execute queued messages within `gas_allowance`.
-    /// V3 - auto-replies to Sails and Ethereum event destinations without mailboxing.
+    /// V3 - auto-replies to Sails event destinations without mailboxing and
+    /// emits Ethereum event destinations via transition messages.
     ProcessQueuesV3 { gas_allowance: u64 } = 5,
 }
 

--- a/ethexe/common/src/malachite.rs
+++ b/ethexe/common/src/malachite.rs
@@ -57,6 +57,10 @@ pub enum Operation {
     /// Execute queued messages within `gas_allowance`.
     /// V2 - changes mailbox validity, from one week to 15 minutes
     ProcessQueuesV2 { gas_allowance: u64 } = 4,
+
+    /// Execute queued messages within `gas_allowance`.
+    /// V3 - auto-replies to Sails and Ethereum event destinations without mailboxing.
+    ProcessQueuesV3 { gas_allowance: u64 } = 5,
 }
 
 impl Operation {
@@ -76,6 +80,7 @@ impl Operation {
             Self::ProcessQueues { .. } => 2,
             Self::Injected(_) => 3,
             Self::ProcessQueuesV2 { .. } => 4,
+            Self::ProcessQueuesV3 { .. } => 5,
         }
     }
 }
@@ -103,6 +108,9 @@ impl Decode for Operation {
             4 => Ok(Operation::ProcessQueuesV2 {
                 gas_allowance: u64::decode(input)?,
             }),
+            5 => Ok(Operation::ProcessQueuesV3 {
+                gas_allowance: u64::decode(input)?,
+            }),
             _ => Err(parity_scale_codec::Error::from("invalid operation tag")),
         }
     }
@@ -117,6 +125,7 @@ impl Encode for Operation {
             Operation::ProcessQueues { gas_allowance } => gas_allowance.encode_to(dest),
             Operation::Injected(signed_tx) => signed_tx.encode_to(dest),
             Operation::ProcessQueuesV2 { gas_allowance } => gas_allowance.encode_to(dest),
+            Operation::ProcessQueuesV3 { gas_allowance } => gas_allowance.encode_to(dest),
         }
     }
 }
@@ -146,7 +155,7 @@ mod tests {
     fn empty_txs() -> Operations {
         Operations::new(alloc::vec![
             Operation::ProgressTasks,
-            Operation::ProcessQueuesV2 {
+            Operation::ProcessQueuesV3 {
                 gas_allowance: 1234,
             },
         ])
@@ -175,12 +184,12 @@ mod tests {
             block_hash: H256::zero(),
         };
         let progress = Operation::ProgressTasks;
-        let queues = Operation::ProcessQueuesV2 {
+        let queues = Operation::ProcessQueuesV3 {
             gas_allowance: 1234,
         };
         assert!(advance.is_advance_till_ethereum_block());
         assert!(progress.is_progress_tasks());
-        assert!(queues.is_process_queues_v_2());
+        assert!(queues.is_process_queues_v_3());
     }
 
     #[test]
@@ -200,6 +209,7 @@ mod tests {
         assert_eq!(Operation::ProgressTasks.tag(), 1);
         assert_eq!(Operation::ProcessQueues { gas_allowance: 0 }.tag(), 2);
         assert_eq!(Operation::ProcessQueuesV2 { gas_allowance: 0 }.tag(), 4);
+        assert_eq!(Operation::ProcessQueuesV3 { gas_allowance: 0 }.tag(), 5);
 
         assert_eq!(
             &Operation::AdvanceTillEthereumBlock {
@@ -217,10 +227,14 @@ mod tests {
             &Operation::ProcessQueuesV2 { gas_allowance: 0 }.encode()[..4],
             &[4, 0, 0, 0],
         );
+        assert_eq!(
+            &Operation::ProcessQueuesV3 { gas_allowance: 0 }.encode()[..4],
+            &[5, 0, 0, 0],
+        );
 
         // Unknown tag must be rejected by `Decode`, not interpreted.
         use parity_scale_codec::DecodeAll;
-        assert!(Operation::decode_all(&mut [5u8, 0, 0, 0].as_slice()).is_err());
+        assert!(Operation::decode_all(&mut [6u8, 0, 0, 0].as_slice()).is_err());
     }
 
     #[test]

--- a/ethexe/compute/src/compute.rs
+++ b/ethexe/compute/src/compute.rs
@@ -310,7 +310,7 @@ fn build_executable_data(
             Operation::ProcessQueuesV3 {
                 gas_allowance: op_gas_allowance,
             } => {
-                // Keep V2 mailbox validity and enable V3 event-destination auto-replies.
+                // Keep V2 mailbox validity and enable V3 event-destination handling.
                 event_destinations_autoreply = true;
 
                 gas_allowance = Some(op_gas_allowance);

--- a/ethexe/compute/src/compute.rs
+++ b/ethexe/compute/src/compute.rs
@@ -269,6 +269,7 @@ fn build_executable_data(
     let mut gas_allowance: Option<u64> = None;
     let mut current_anchor = initial_advanced_block;
     let mut mailbox_validity = ethexe_common::MAILBOX_VALIDITY_VERSION_2;
+    let mut event_destinations_autoreply = false;
 
     for op in operations {
         match op {
@@ -294,6 +295,7 @@ fn build_executable_data(
             } => {
                 // Old block - change mailbox validity to the previous default one
                 mailbox_validity = ethexe_common::MAILBOX_VALIDITY_VERSION_1;
+                event_destinations_autoreply = false;
 
                 gas_allowance = Some(op_gas_allowance);
             }
@@ -301,6 +303,15 @@ fn build_executable_data(
                 gas_allowance: op_gas_allowance,
             } => {
                 // Keep the new mailbox validity for this operation, as it is the default one
+                event_destinations_autoreply = false;
+
+                gas_allowance = Some(op_gas_allowance);
+            }
+            Operation::ProcessQueuesV3 {
+                gas_allowance: op_gas_allowance,
+            } => {
+                // Keep V2 mailbox validity and enable V3 event-destination auto-replies.
+                event_destinations_autoreply = true;
 
                 gas_allowance = Some(op_gas_allowance);
             }
@@ -327,6 +338,7 @@ fn build_executable_data(
         gas_allowance,
         events,
         mailbox_validity,
+        event_destinations_autoreply,
     })
 }
 
@@ -495,7 +507,7 @@ mod tests {
                 block_hash: eth_block_hash,
             },
             Operation::ProgressTasks,
-            Operation::ProcessQueuesV2 {
+            Operation::ProcessQueuesV3 {
                 gas_allowance: DEFAULT_BLOCK_GAS_LIMIT,
             },
         ])
@@ -721,7 +733,7 @@ mod tests {
     fn mb_bookend() -> [Operation; 2] {
         [
             Operation::ProgressTasks,
-            Operation::ProcessQueuesV2 {
+            Operation::ProcessQueuesV3 {
                 gas_allowance: DEFAULT_BLOCK_GAS_LIMIT,
             },
         ]

--- a/ethexe/compute/src/lib.rs
+++ b/ethexe/compute/src/lib.rs
@@ -71,7 +71,7 @@
 //! chain via [`ethexe_common::db::CompactMb::parent`] until it reaches
 //! a computed ancestor (or genesis), then runs the executor over the
 //! [`ethexe_common::malachite::Operations`] payload of each. Per-step gas
-//! budget is carried inside each `Operation::ProcessQueuesV2` payload
+//! budget is carried inside each `Operation::ProcessQueuesV3` payload
 //! (its `gas_allowance` field).
 //!
 //! ## Canonical event quarantine

--- a/ethexe/compute/src/service.rs
+++ b/ethexe/compute/src/service.rs
@@ -163,7 +163,7 @@ mod tests {
                 block_hash: eth_block_hash,
             },
             Operation::ProgressTasks,
-            Operation::ProcessQueuesV2 { gas_allowance },
+            Operation::ProcessQueuesV3 { gas_allowance },
         ]));
 
         db.set_mb_compact_block(

--- a/ethexe/consensus/src/validator/batch/tests.rs
+++ b/ethexe/consensus/src/validator/batch/tests.rs
@@ -63,7 +63,7 @@ fn append_mb(db: &Database, parent: H256, height: u64, outcome: Vec<StateTransit
         Operation::AdvanceTillEthereumBlock {
             block_hash: H256::from_low_u64_be(0xEB00 + height),
         },
-        Operation::ProcessQueuesV2 { gas_allowance: 0 },
+        Operation::ProcessQueuesV3 { gas_allowance: 0 },
     ]);
     let operations_hash = db.set_operations(ops);
     // Synthetic mb_hash — uniqueness is what matters here.

--- a/ethexe/consensus/src/validator/batch/utils.rs
+++ b/ethexe/consensus/src/validator/batch/utils.rs
@@ -482,7 +482,7 @@ mod tests {
             Operation::AdvanceTillEthereumBlock {
                 block_hash: H256::from_low_u64_be(0xEB00 + height),
             },
-            Operation::ProcessQueuesV2 { gas_allowance: 0 },
+            Operation::ProcessQueuesV3 { gas_allowance: 0 },
         ])
     }
 

--- a/ethexe/malachite/service/src/externalities.rs
+++ b/ethexe/malachite/service/src/externalities.rs
@@ -350,7 +350,7 @@ impl Externalities for EthexeExternalities {
         //      quarantine-passed EB exists),
         //   2. then injected user txs,
         //   3. finally the service-level ProgressTasks +
-        //      ProcessQueuesV2 bookend.
+        //      ProcessQueuesV3 bookend.
         let mut operations = Vec::with_capacity(capped.len() + 3);
         if let Some(block_hash) = advance {
             operations.push(Operation::AdvanceTillEthereumBlock { block_hash });
@@ -359,7 +359,7 @@ impl Externalities for EthexeExternalities {
             operations.push(Operation::Injected(tx));
         }
         operations.push(Operation::ProgressTasks);
-        operations.push(Operation::ProcessQueuesV2 {
+        operations.push(Operation::ProcessQueuesV3 {
             gas_allowance: self.gas_allowance,
         });
 
@@ -388,7 +388,7 @@ impl Externalities for EthexeExternalities {
             match op {
                 Operation::AdvanceTillEthereumBlock { .. }
                 | Operation::ProgressTasks
-                | Operation::ProcessQueuesV2 { .. }
+                | Operation::ProcessQueuesV3 { .. }
                 | Operation::Injected(_) => {
                     // Known and allowed.
                 }
@@ -401,7 +401,7 @@ impl Externalities for EthexeExternalities {
 
         // (1) Shape + ordering. Every honest MB has exactly the form:
         //
-        //   [AdvanceTillEthereumBlock]?  Injected*  ProgressTasks  ProcessQueuesV2
+        //   [AdvanceTillEthereumBlock]?  Injected*  ProgressTasks  ProcessQueuesV3
         //
         // This single walk catches: missing bookend, extra bookend,
         // out-of-order op, more than one Advance, and the
@@ -432,8 +432,8 @@ impl Externalities for EthexeExternalities {
             return Ok(false);
         };
 
-        let Some(Operation::ProcessQueuesV2 { gas_allowance }) = iter.next() else {
-            warn!("validate: MB shape violation — expected `ProcessQueuesV2` bookend");
+        let Some(Operation::ProcessQueuesV3 { gas_allowance }) = iter.next() else {
+            warn!("validate: MB shape violation — expected `ProcessQueuesV3` bookend");
             return Ok(false);
         };
 
@@ -441,13 +441,13 @@ impl Externalities for EthexeExternalities {
             warn!(
                 allowance = *gas_allowance,
                 cap = crate::MalachiteConfig::DEFAULT_GAS_ALLOWANCE,
-                "validate: ProcessQueuesV2.gas_allowance exceeds protocol cap"
+                "validate: ProcessQueuesV3.gas_allowance exceeds protocol cap"
             );
             return Ok(false);
         }
 
         if iter.next().is_some() {
-            warn!("validate: MB has extra operations after the `ProcessQueuesV2` bookend");
+            warn!("validate: MB has extra operations after the `ProcessQueuesV3` bookend");
             return Ok(false);
         }
 
@@ -827,7 +827,7 @@ mod tests {
         for _ in 0..(salt.max(1)) {
             txs.push(Operation::ProgressTasks);
         }
-        txs.push(Operation::ProcessQueuesV2 { gas_allowance: 0 });
+        txs.push(Operation::ProcessQueuesV3 { gas_allowance: 0 });
         Operations::new(txs)
     }
 
@@ -1026,7 +1026,7 @@ mod tests {
                 block_hash: H256::repeat_byte(0xBB),
             },
             Operation::ProgressTasks,
-            Operation::ProcessQueuesV2 { gas_allowance: 0 },
+            Operation::ProcessQueuesV3 { gas_allowance: 0 },
         ]);
         assert!(
             !ext.validate_operations(H256::zero(), payload)
@@ -1073,7 +1073,7 @@ mod tests {
                 block_hash: H256::repeat_byte(0xCC),
             },
             Operation::ProgressTasks,
-            Operation::ProcessQueuesV2 { gas_allowance: 0 },
+            Operation::ProcessQueuesV3 { gas_allowance: 0 },
         ]);
         assert!(
             !ext.validate_operations(H256::zero(), payload)
@@ -1125,7 +1125,7 @@ mod tests {
                 block_hash: chain_hashes[1].0,
             },
             Operation::ProgressTasks,
-            Operation::ProcessQueuesV2 { gas_allowance: 0 },
+            Operation::ProcessQueuesV3 { gas_allowance: 0 },
         ]);
         assert!(
             ext.validate_operations(H256::zero(), payload)
@@ -1165,7 +1165,7 @@ mod tests {
     /// `process_mb_finalized` must hand exactly the
     /// [`Operation::Injected`] subset of the committed block to
     /// [`Mempool::forget`] (and nothing else — service txs like
-    /// `ProcessQueuesV2` stay out of the mempool round trip).
+    /// `ProcessQueuesV3` stay out of the mempool round trip).
     #[tokio::test]
     async fn finalize_forgets_injected_txs() {
         use ethexe_common::{
@@ -1223,7 +1223,7 @@ mod tests {
             // user tx #1 — must show up
             Operation::Injected(tx_a.clone()),
             // service tx — must NOT
-            Operation::ProcessQueuesV2 { gas_allowance: 0 },
+            Operation::ProcessQueuesV3 { gas_allowance: 0 },
             // user tx #2 — must show up
             Operation::Injected(tx_b.clone()),
         ]);
@@ -1575,7 +1575,7 @@ mod tests {
         }
         // Full shape — the shape walk must not be the reason for rejection.
         operations.push(Operation::ProgressTasks);
-        operations.push(Operation::ProcessQueuesV2 { gas_allowance: 0 });
+        operations.push(Operation::ProcessQueuesV3 { gas_allowance: 0 });
         let payload = Operations::new(operations);
         assert!(
             !ext.validate_operations(parent_mb, payload).await.unwrap(),
@@ -1661,8 +1661,8 @@ mod tests {
     // Shape & ordering checks on `validate_block_above`.
     //
     // Every MB the producer emits has the strict shape
-    //   [AdvanceTillEthereumBlock]?  Injected*  ProgressTasks  ProcessQueuesV2
-    // with `ProcessQueuesV2.gas_allowance <= DEFAULT_GAS_ALLOWANCE`.
+    //   [AdvanceTillEthereumBlock]?  Injected*  ProgressTasks  ProcessQueuesV3
+    // with `ProcessQueuesV3.gas_allowance <= DEFAULT_GAS_ALLOWANCE`.
     // A malicious proposer must not be able to slip in a malformed MB
     // (oversized gas, missing bookend, out-of-order tx).
     // ------------------------------------------------------------------
@@ -1705,7 +1705,7 @@ mod tests {
     }
 
     /// REPRODUCES: a malicious proposer can set `gas_allowance = u64::MAX`
-    /// in `ProcessQueuesV2.gas_allowance` and force every participant to attempt
+    /// in `ProcessQueuesV3.gas_allowance` and force every participant to attempt
     /// an unbounded queue drain. Validator must reject MBs whose
     /// `gas_allowance` exceeds the protocol cap
     /// (`MalachiteConfig::DEFAULT_GAS_ALLOWANCE`).
@@ -1718,7 +1718,7 @@ mod tests {
                 block_hash: advance,
             },
             Operation::ProgressTasks,
-            Operation::ProcessQueuesV2 {
+            Operation::ProcessQueuesV3 {
                 gas_allowance: u64::MAX,
             },
         ]);
@@ -1731,7 +1731,7 @@ mod tests {
     }
 
     /// REPRODUCES: MB without a `ProgressTasks` tx between injected txs
-    /// and `ProcessQueuesV2` violates the protocol shape — scheduled
+    /// and `ProcessQueuesV3` violates the protocol shape — scheduled
     /// tasks would never be advanced.
     #[tokio::test]
     async fn validate_rejects_mb_missing_progress_tasks() {
@@ -1741,8 +1741,8 @@ mod tests {
             Operation::AdvanceTillEthereumBlock {
                 block_hash: advance,
             },
-            // No ProgressTasks here — straight to ProcessQueuesV2.
-            Operation::ProcessQueuesV2 { gas_allowance: 0 },
+            // No ProgressTasks here — straight to ProcessQueuesV3.
+            Operation::ProcessQueuesV3 { gas_allowance: 0 },
         ]);
         assert!(
             !ext.validate_operations(H256::zero(), payload)
@@ -1752,7 +1752,7 @@ mod tests {
         );
     }
 
-    /// REPRODUCES: MB without a final `ProcessQueuesV2` tx never drains
+    /// REPRODUCES: MB without a final `ProcessQueuesV3` tx never drains
     /// the message queues for this MB — compute pipeline would stall
     /// on the next MB.
     #[tokio::test]
@@ -1764,13 +1764,13 @@ mod tests {
                 block_hash: advance,
             },
             Operation::ProgressTasks,
-            // No ProcessQueuesV2 here.
+            // No ProcessQueuesV3 here.
         ]);
         assert!(
             !ext.validate_operations(H256::zero(), payload)
                 .await
                 .unwrap(),
-            "MB missing `ProcessQueuesV2` bookend must be rejected"
+            "MB missing `ProcessQueuesV3` bookend must be rejected"
         );
     }
 
@@ -1814,7 +1814,7 @@ mod tests {
                 block_hash: chain.blocks[2].hash,
             },
             Operation::ProgressTasks,
-            Operation::ProcessQueuesV2 { gas_allowance: 0 },
+            Operation::ProcessQueuesV3 { gas_allowance: 0 },
         ]);
         assert!(
             !ext.validate_operations(parent_mb, payload).await.unwrap(),
@@ -1822,7 +1822,7 @@ mod tests {
         );
     }
 
-    /// REPRODUCES: `ProcessQueuesV2` must be the very last tx in the MB.
+    /// REPRODUCES: `ProcessQueuesV3` must be the very last tx in the MB.
     /// Otherwise later txs run *after* queues drain and the gas budget
     /// is wrong.
     #[tokio::test]
@@ -1833,15 +1833,15 @@ mod tests {
             Operation::AdvanceTillEthereumBlock {
                 block_hash: advance,
             },
-            // Order swapped: ProcessQueuesV2 before ProgressTasks.
-            Operation::ProcessQueuesV2 { gas_allowance: 0 },
+            // Order swapped: ProcessQueuesV3 before ProgressTasks.
+            Operation::ProcessQueuesV3 { gas_allowance: 0 },
             Operation::ProgressTasks,
         ]);
         assert!(
             !ext.validate_operations(H256::zero(), payload)
                 .await
                 .unwrap(),
-            "MB where `ProcessQueuesV2` is not the last tx must be rejected"
+            "MB where `ProcessQueuesV3` is not the last tx must be rejected"
         );
     }
 
@@ -1906,7 +1906,7 @@ mod tests {
                 block_hash: chain[1].0,
             },
             Operation::ProgressTasks,
-            Operation::ProcessQueuesV2 { gas_allowance: 0 },
+            Operation::ProcessQueuesV3 { gas_allowance: 0 },
         ]);
 
         assert!(
@@ -1965,7 +1965,7 @@ mod tests {
                 block_hash: stranger_advance,
             },
             Operation::ProgressTasks,
-            Operation::ProcessQueuesV2 { gas_allowance: 0 },
+            Operation::ProcessQueuesV3 { gas_allowance: 0 },
         ]);
 
         let result = tokio::time::timeout(

--- a/ethexe/processor/src/lib.rs
+++ b/ethexe/processor/src/lib.rs
@@ -317,11 +317,13 @@ impl Processor {
             gas_allowance,
             events,
             mailbox_validity,
+            event_destinations_autoreply,
         } = executable;
 
         let cfg = TransitionsConfig {
             block_height: height,
             mailbox_validity,
+            event_destinations_autoreply,
         };
 
         let mut transitions = InBlockTransitions::new(cfg, program_states, schedule);
@@ -442,6 +444,7 @@ pub struct ExecutableData {
     pub gas_allowance: Option<u64>,
     pub events: Vec<BlockRequestEvent>,
     pub mailbox_validity: NonZero<u32>,
+    pub event_destinations_autoreply: bool,
 }
 
 #[cfg(test)]
@@ -456,6 +459,7 @@ impl Default for ExecutableData {
             gas_allowance: Some(ethexe_common::DEFAULT_BLOCK_GAS_LIMIT),
             events: vec![],
             mailbox_validity: MAILBOX_VALIDITY_VERSION_2,
+            event_destinations_autoreply: false,
         }
     }
 }
@@ -524,6 +528,7 @@ impl OverlaidProcessor {
         let cfg = TransitionsConfig {
             block_height: height,
             mailbox_validity: MAILBOX_VALIDITY_VERSION_2,
+            event_destinations_autoreply: false,
         };
 
         let transitions = InBlockTransitions::new(cfg, program_states, Schedule::default());

--- a/ethexe/processor/src/tests.rs
+++ b/ethexe/processor/src/tests.rs
@@ -2294,6 +2294,7 @@ async fn injected_and_events_then_tasks_then_queues() {
         events: canonical_event,
         gas_allowance: Some(DEFAULT_BLOCK_GAS_LIMIT),
         mailbox_validity: MAILBOX_VALIDITY_VERSION_2,
+        event_destinations_autoreply: false,
     };
     let FinalizedBlockTransitions { transitions, .. } = processor
         .process_programs(executable, Some(promise_sink))

--- a/ethexe/runtime/common/src/journal.rs
+++ b/ethexe/runtime/common/src/journal.rs
@@ -4,8 +4,8 @@
 use crate::{
     TransitionController,
     state::{
-        ActiveProgram, Dispatch, Expiring, MailboxMessage, ModifiableStorage, Program,
-        ProgramState, Storage,
+        ActiveProgram, Dispatch, Expiring, MailboxMessage, ModifiableStorage, PayloadLookup,
+        Program, ProgramState, Storage,
     },
 };
 use alloc::{
@@ -26,13 +26,23 @@ use gear_core::{
     pages::{GearPage, WasmPage, num_traits::Zero as _, numerated::tree::IntervalsTree},
     reservation::GasReserver,
 };
-use gear_core_errors::SignalCode;
+use gear_core_errors::{SignalCode, SuccessReplyReason};
 use gprimitives::{ActorId, CodeId, H256, MessageId, ReservationId};
 use gsys::GasMultiplier;
 
 /// Maximum duration for gr_wait_up_to in blocks,
 /// when not enough gas was provided for the requested duration.
 pub const WAIT_UP_TO_SAFE_DURATION: u32 = 64;
+
+const SAILS_EVENT_DESTINATION: ActorId = ActorId::new([0; 32]);
+const ETHEREUM_EVENT_DESTINATION: ActorId = ActorId::new([u8::MAX; 32]);
+
+fn is_event_destination(destination: ActorId) -> bool {
+    matches!(
+        destination,
+        SAILS_EVENT_DESTINATION | ETHEREUM_EVENT_DESTINATION
+    )
+}
 
 // Handles unprocessed journal notes during chunk processing.
 pub struct NativeJournalHandler<'a, S: Storage + ?Sized> {
@@ -133,10 +143,17 @@ impl<S: Storage + ?Sized> NativeJournalHandler<'_, S> {
 
         let message_type = self.message_type;
         let mailbox_validity = self.controller.transitions.cfg().mailbox_validity;
+        let event_destinations_autoreply = self
+            .controller
+            .transitions
+            .cfg()
+            .event_destinations_autoreply
+            && is_event_destination(dispatch.destination());
 
         self.controller
             .update_state(dispatch.source(), |state, storage, transitions| {
                 let value = dispatch.value();
+                let destination = dispatch.destination();
 
                 if !value.is_zero() {
                     state.balance = state.balance.checked_sub(value).expect(
@@ -149,6 +166,31 @@ impl<S: Storage + ?Sized> NativeJournalHandler<'_, S> {
                             .checked_sub(i128::try_from(value).expect("value fits into i128"))
                             .expect("Insufficient balance: underflow in transition.value_to_receive -= dispatch.value()");
                     });
+                }
+
+                if event_destinations_autoreply {
+                    transitions.modify_transition(dispatch.source(), |transition| {
+                        transition.claims.push(ethexe_common::gear::ValueClaim {
+                            message_id: dispatch.id(),
+                            destination,
+                            value,
+                        });
+                    });
+
+                    let reply = Dispatch::reply(
+                        dispatch.id(),
+                        destination,
+                        PayloadLookup::empty(),
+                        0,
+                        SuccessReplyReason::Auto,
+                        message_type,
+                        false,
+                    );
+
+                    let queue = state.queue_from_msg_type(message_type);
+                    queue.modify_queue(storage, |queue| queue.queue(reply));
+
+                    return;
                 }
 
                 if let Ok(non_zero_delay) = delay.try_into() {
@@ -860,11 +902,15 @@ impl Limiter {
 
 #[cfg(test)]
 mod tests {
-    use gear_core::message::{DispatchKind, Message as CoreMessage, StoredMessage};
+    use ethexe_common::{ProgramStates, StateHashWithQueueSize};
+    use gear_core::{
+        ids::prelude::MessageIdExt,
+        message::{DispatchKind, Message as CoreMessage, ReplyCode, StoredMessage},
+    };
 
     use super::*;
 
-    use crate::state::MemStorage;
+    use crate::{InBlockTransitions, TransitionsConfig, state::MemStorage};
 
     fn init_setup(
         exec_balance: u128,
@@ -899,6 +945,122 @@ mod tests {
             call_reply: false,
             limiter,
         }
+    }
+
+    fn dispatch_to(destination: ActorId, value: u128) -> CoreDispatch {
+        CoreDispatch::new(
+            DispatchKind::Handle,
+            CoreMessage::new(
+                MessageId::from(10),
+                ActorId::from(7),
+                destination,
+                Default::default(),
+                None,
+                value,
+                None,
+            ),
+        )
+    }
+
+    fn handle_user_dispatch(
+        destination: ActorId,
+        event_destinations_autoreply: bool,
+    ) -> (MemStorage, ProgramState) {
+        let storage = MemStorage::default();
+        let source = ActorId::from(7);
+        let mut state = ProgramState::zero();
+        state.balance = 100;
+        let state_hash = storage.write_program_state(state);
+        let states = ProgramStates::from_iter([(
+            source,
+            StateHashWithQueueSize {
+                hash: state_hash,
+                canonical_queue_size: 0,
+                injected_queue_size: 0,
+            },
+        )]);
+        let cfg = TransitionsConfig {
+            event_destinations_autoreply,
+            ..Default::default()
+        };
+        let mut transitions = InBlockTransitions::new(cfg, states, Default::default());
+        let gas_allowance_counter = GasAllowanceCounter::new(1_000_000);
+        let mut out_of_gas = false;
+        let mut outgoing_messages_limiter = 10;
+        let mut outgoing_messages_bytes_limiter = 1024;
+        let mut call_reply_limiter = 10;
+
+        {
+            let mut handler = NativeJournalHandler {
+                program_id: source,
+                message_type: MessageType::Canonical,
+                call_reply: false,
+                controller: TransitionController {
+                    storage: &storage,
+                    transitions: &mut transitions,
+                },
+                gas_allowance_counter: &gas_allowance_counter,
+                chunk_gas_limit: 1_000_000,
+                out_of_gas: &mut out_of_gas,
+                outgoing_messages_limiter: &mut outgoing_messages_limiter,
+                outgoing_messages_bytes_limiter: &mut outgoing_messages_bytes_limiter,
+                call_reply_limiter: &mut call_reply_limiter,
+            };
+
+            handler.send_dispatch(MessageId::from(9), dispatch_to(destination, 11), 0, None);
+        }
+
+        let transition = transitions.modifications_mut().remove(&source).unwrap();
+        let state_hash = transitions.state_of(&source).unwrap().hash;
+        let state = storage.program_state(state_hash).unwrap();
+
+        if event_destinations_autoreply {
+            assert!(transition.messages.is_empty());
+            assert_eq!(transition.claims.len(), 1);
+            assert_eq!(transition.claims[0].message_id, MessageId::from(10));
+            assert_eq!(transition.claims[0].destination, destination);
+            assert_eq!(transition.claims[0].value, 11);
+        } else {
+            assert_eq!(transition.messages.len(), 1);
+            assert!(transition.claims.is_empty());
+        }
+
+        (storage, state)
+    }
+
+    #[test]
+    fn event_destination_messages_are_auto_replied_without_mailbox() {
+        for destination in [SAILS_EVENT_DESTINATION, ETHEREUM_EVENT_DESTINATION] {
+            let (storage, state) = handle_user_dispatch(destination, true);
+
+            assert!(state.mailbox_hash.is_empty());
+            assert_eq!(state.balance, 89);
+
+            let mut queue = state.canonical_queue.query(&storage).unwrap();
+            let reply = queue.dequeue().expect("auto reply must be queued");
+            assert_eq!(reply.id, MessageId::generate_reply(MessageId::from(10)));
+            assert_eq!(reply.kind, DispatchKind::Reply);
+            assert_eq!(reply.source, destination);
+            assert_eq!(reply.value, 0);
+            assert_eq!(reply.message_type, MessageType::Canonical);
+            assert!(!reply.call);
+
+            let details = reply.details.unwrap().to_reply_details().unwrap();
+            assert_eq!(details.to_message_id(), MessageId::from(10));
+            assert_eq!(
+                details.to_reply_code(),
+                ReplyCode::Success(SuccessReplyReason::Auto)
+            );
+            assert!(queue.is_empty());
+        }
+    }
+
+    #[test]
+    fn event_destination_messages_keep_legacy_mailbox_when_disabled() {
+        let (_storage, state) = handle_user_dispatch(SAILS_EVENT_DESTINATION, false);
+
+        assert!(!state.mailbox_hash.is_empty());
+        assert!(state.canonical_queue.is_empty());
     }
 
     #[test]

--- a/ethexe/runtime/common/src/journal.rs
+++ b/ethexe/runtime/common/src/journal.rs
@@ -905,8 +905,11 @@ mod tests {
 
     use super::*;
 
-    use crate::{InBlockTransitions, TransitionsConfig, state::MemStorage};
-    use crate::transitions::{ETHEREUM_EVENT_DESTINATION, SAILS_EVENT_DESTINATION};
+    use crate::{
+        InBlockTransitions, TransitionsConfig,
+        state::MemStorage,
+        transitions::{ETHEREUM_EVENT_DESTINATION, SAILS_EVENT_DESTINATION},
+    };
 
     fn init_setup(
         exec_balance: u128,
@@ -1160,7 +1163,12 @@ mod tests {
         assert_eq!(reply.id, MessageId::generate_reply(message_id));
         assert_eq!(reply.source, destination);
         assert_eq!(
-            reply.details.unwrap().to_reply_details().unwrap().to_reply_code(),
+            reply
+                .details
+                .unwrap()
+                .to_reply_details()
+                .unwrap()
+                .to_reply_code(),
             ReplyCode::Success(SuccessReplyReason::Auto)
         );
         assert!(queue.is_empty());

--- a/ethexe/runtime/common/src/journal.rs
+++ b/ethexe/runtime/common/src/journal.rs
@@ -7,6 +7,7 @@ use crate::{
         ActiveProgram, Dispatch, Expiring, MailboxMessage, ModifiableStorage, PayloadLookup,
         Program, ProgramState, Storage,
     },
+    transitions::is_event_destination,
 };
 use alloc::{
     collections::{BTreeMap, BTreeSet},
@@ -33,16 +34,6 @@ use gsys::GasMultiplier;
 /// Maximum duration for gr_wait_up_to in blocks,
 /// when not enough gas was provided for the requested duration.
 pub const WAIT_UP_TO_SAFE_DURATION: u32 = 64;
-
-const SAILS_EVENT_DESTINATION: ActorId = ActorId::new([0; 32]);
-const ETHEREUM_EVENT_DESTINATION: ActorId = ActorId::new([u8::MAX; 32]);
-
-fn is_event_destination(destination: ActorId) -> bool {
-    matches!(
-        destination,
-        SAILS_EVENT_DESTINATION | ETHEREUM_EVENT_DESTINATION
-    )
-}
 
 // Handles unprocessed journal notes during chunk processing.
 pub struct NativeJournalHandler<'a, S: Storage + ?Sized> {
@@ -143,18 +134,19 @@ impl<S: Storage + ?Sized> NativeJournalHandler<'_, S> {
 
         let message_type = self.message_type;
         let mailbox_validity = self.controller.transitions.cfg().mailbox_validity;
-        let event_destinations_autoreply = self
+        let event_destinations = self
             .controller
             .transitions
             .cfg()
-            .event_destinations_autoreply
-            && is_event_destination(dispatch.destination());
+            .event_destinations_autoreply;
+        let destination = dispatch.destination();
 
         self.controller
             .update_state(dispatch.source(), |state, storage, transitions| {
                 let value = dispatch.value();
-                let destination = dispatch.destination();
 
+                // Charge value before branching: event destinations still settle via
+                // transition claims and must not touch mailbox or scheduled tasks.
                 if !value.is_zero() {
                     state.balance = state.balance.checked_sub(value).expect(
                         "Insufficient balance: underflow in state.balance -= dispatch.value()",
@@ -166,31 +158,6 @@ impl<S: Storage + ?Sized> NativeJournalHandler<'_, S> {
                             .checked_sub(i128::try_from(value).expect("value fits into i128"))
                             .expect("Insufficient balance: underflow in transition.value_to_receive -= dispatch.value()");
                     });
-                }
-
-                if event_destinations_autoreply {
-                    transitions.modify_transition(dispatch.source(), |transition| {
-                        transition.claims.push(ethexe_common::gear::ValueClaim {
-                            message_id: dispatch.id(),
-                            destination,
-                            value,
-                        });
-                    });
-
-                    let reply = Dispatch::reply(
-                        dispatch.id(),
-                        destination,
-                        PayloadLookup::empty(),
-                        0,
-                        SuccessReplyReason::Auto,
-                        message_type,
-                        false,
-                    );
-
-                    let queue = state.queue_from_msg_type(message_type);
-                    queue.modify_queue(storage, |queue| queue.queue(reply));
-
-                    return;
                 }
 
                 if let Ok(non_zero_delay) = delay.try_into() {
@@ -209,6 +176,34 @@ impl<S: Storage + ?Sized> NativeJournalHandler<'_, S> {
                     storage.modify(&mut state.stash_hash, |stash| {
                         stash.add_to_user(dispatch, expiry, user_id);
                     });
+                } else if event_destinations && is_event_destination(destination) {
+                    let message_id = dispatch.id();
+
+                    transitions.modify_transition(dispatch.source(), |transition| {
+                        let stored = dispatch.into_parts().1;
+
+                        transition
+                            .messages
+                            .push(Message::from_stored(stored, false));
+                        transition.claims.push(ethexe_common::gear::ValueClaim {
+                            message_id,
+                            destination,
+                            value,
+                        });
+                    });
+
+                    let reply = Dispatch::reply(
+                        message_id,
+                        destination,
+                        PayloadLookup::empty(),
+                        0,
+                        SuccessReplyReason::Auto,
+                        message_type,
+                        false,
+                    );
+
+                    let queue = state.queue_from_msg_type(message_type);
+                    queue.modify_queue(storage, |queue| queue.queue(reply));
                 } else {
                     let expiry = transitions.schedule_task(
                         mailbox_validity,
@@ -911,6 +906,7 @@ mod tests {
     use super::*;
 
     use crate::{InBlockTransitions, TransitionsConfig, state::MemStorage};
+    use crate::transitions::{ETHEREUM_EVENT_DESTINATION, SAILS_EVENT_DESTINATION};
 
     fn init_setup(
         exec_balance: u128,
@@ -1015,7 +1011,10 @@ mod tests {
         let state = storage.program_state(state_hash).unwrap();
 
         if event_destinations_autoreply {
-            assert!(transition.messages.is_empty());
+            assert_eq!(transition.messages.len(), 1);
+            assert_eq!(transition.messages[0].id, MessageId::from(10));
+            assert_eq!(transition.messages[0].destination, destination);
+            assert_eq!(transition.messages[0].value, 11);
             assert_eq!(transition.claims.len(), 1);
             assert_eq!(transition.claims[0].message_id, MessageId::from(10));
             assert_eq!(transition.claims[0].destination, destination);
@@ -1029,7 +1028,7 @@ mod tests {
     }
 
     #[test]
-    fn event_destination_messages_are_auto_replied_without_mailbox() {
+    fn event_destination_messages_skip_mailbox_and_expire_immediately() {
         for destination in [SAILS_EVENT_DESTINATION, ETHEREUM_EVENT_DESTINATION] {
             let (storage, state) = handle_user_dispatch(destination, true);
 
@@ -1061,6 +1060,110 @@ mod tests {
 
         assert!(!state.mailbox_hash.is_empty());
         assert!(state.canonical_queue.is_empty());
+    }
+
+    #[test]
+    fn delayed_event_destination_stashes_then_matches_immediate_send() {
+        use crate::schedule::Handler;
+        use gear_core::tasks::TaskHandler;
+
+        const DELAY: u32 = 5;
+        let destination = ETHEREUM_EVENT_DESTINATION;
+        let storage = MemStorage::default();
+        let source = ActorId::from(7);
+        let message_id = MessageId::from(10);
+        let mut state = ProgramState::zero();
+        state.balance = 100;
+        let state_hash = storage.write_program_state(state);
+        let states = ProgramStates::from_iter([(
+            source,
+            StateHashWithQueueSize {
+                hash: state_hash,
+                canonical_queue_size: 0,
+                injected_queue_size: 0,
+            },
+        )]);
+        let cfg = TransitionsConfig {
+            event_destinations_autoreply: true,
+            ..Default::default()
+        };
+        let mut transitions = InBlockTransitions::new(cfg, states, Default::default());
+        let gas_allowance_counter = GasAllowanceCounter::new(1_000_000);
+        let mut out_of_gas = false;
+        let mut outgoing_messages_limiter = 10;
+        let mut outgoing_messages_bytes_limiter = 1024;
+        let mut call_reply_limiter = 10;
+
+        {
+            let mut handler = NativeJournalHandler {
+                program_id: source,
+                message_type: MessageType::Canonical,
+                call_reply: false,
+                controller: TransitionController {
+                    storage: &storage,
+                    transitions: &mut transitions,
+                },
+                gas_allowance_counter: &gas_allowance_counter,
+                chunk_gas_limit: 1_000_000,
+                out_of_gas: &mut out_of_gas,
+                outgoing_messages_limiter: &mut outgoing_messages_limiter,
+                outgoing_messages_bytes_limiter: &mut outgoing_messages_bytes_limiter,
+                call_reply_limiter: &mut call_reply_limiter,
+            };
+
+            handler.send_dispatch(
+                MessageId::from(9),
+                dispatch_to(destination, 11),
+                DELAY,
+                None,
+            );
+        }
+
+        let transition = transitions.modifications_mut().get(&source).unwrap();
+        assert!(transition.messages.is_empty());
+        assert!(transition.claims.is_empty());
+
+        let state_hash = transitions.state_of(&source).unwrap().hash;
+        let state = storage.program_state(state_hash).unwrap();
+        assert!(state.mailbox_hash.is_empty());
+        assert!(!state.stash_hash.is_empty());
+        assert_eq!(state.balance, 89);
+        assert!(state.canonical_queue.is_empty());
+
+        {
+            let mut handler = Handler {
+                controller: TransitionController {
+                    storage: &storage,
+                    transitions: &mut transitions,
+                },
+            };
+            handler.send_user_message(message_id, source);
+        }
+
+        let transition = transitions.modifications_mut().get(&source).unwrap();
+        assert_eq!(transition.messages.len(), 1);
+        assert_eq!(transition.messages[0].id, message_id);
+        assert_eq!(transition.messages[0].destination, destination);
+        assert_eq!(transition.messages[0].value, 11);
+        assert_eq!(transition.claims.len(), 1);
+        assert_eq!(transition.claims[0].message_id, message_id);
+        assert_eq!(transition.claims[0].destination, destination);
+        assert_eq!(transition.claims[0].value, 11);
+
+        let state_hash = transitions.state_of(&source).unwrap().hash;
+        let state = storage.program_state(state_hash).unwrap();
+        assert!(state.mailbox_hash.is_empty());
+        assert!(state.stash_hash.is_empty());
+
+        let mut queue = state.canonical_queue.query(&storage).unwrap();
+        let reply = queue.dequeue().expect("auto reply must be queued");
+        assert_eq!(reply.id, MessageId::generate_reply(message_id));
+        assert_eq!(reply.source, destination);
+        assert_eq!(
+            reply.details.unwrap().to_reply_details().unwrap().to_reply_code(),
+            ReplyCode::Success(SuccessReplyReason::Auto)
+        );
+        assert!(queue.is_empty());
     }
 
     #[test]

--- a/ethexe/runtime/common/src/journal.rs
+++ b/ethexe/runtime/common/src/journal.rs
@@ -908,7 +908,7 @@ mod tests {
     use crate::{
         InBlockTransitions, TransitionsConfig,
         state::MemStorage,
-        transitions::{ETHEREUM_EVENT_DESTINATION, SAILS_EVENT_DESTINATION},
+        transitions::{ETH_SAILS_EVENT, GEAR_SAILS_EVENT},
     };
 
     fn init_setup(
@@ -1032,7 +1032,7 @@ mod tests {
 
     #[test]
     fn event_destination_messages_skip_mailbox_and_expire_immediately() {
-        for destination in [SAILS_EVENT_DESTINATION, ETHEREUM_EVENT_DESTINATION] {
+        for destination in [GEAR_SAILS_EVENT, ETH_SAILS_EVENT] {
             let (storage, state) = handle_user_dispatch(destination, true);
 
             assert!(state.mailbox_hash.is_empty());
@@ -1059,7 +1059,7 @@ mod tests {
 
     #[test]
     fn event_destination_messages_keep_legacy_mailbox_when_disabled() {
-        let (_storage, state) = handle_user_dispatch(SAILS_EVENT_DESTINATION, false);
+        let (_storage, state) = handle_user_dispatch(GEAR_SAILS_EVENT, false);
 
         assert!(!state.mailbox_hash.is_empty());
         assert!(state.canonical_queue.is_empty());
@@ -1071,7 +1071,7 @@ mod tests {
         use gear_core::tasks::TaskHandler;
 
         const DELAY: u32 = 5;
-        let destination = ETHEREUM_EVENT_DESTINATION;
+        let destination = ETH_SAILS_EVENT;
         let storage = MemStorage::default();
         let source = ActorId::from(7);
         let message_id = MessageId::from(10);

--- a/ethexe/runtime/common/src/schedule.rs
+++ b/ethexe/runtime/common/src/schedule.rs
@@ -546,8 +546,10 @@ mod tests {
 
     #[test]
     fn send_user_message_to_event_destination_skips_mailbox() {
-        use crate::{InBlockTransitions, TransitionController, TransitionsConfig};
-        use crate::transitions::{ETHEREUM_EVENT_DESTINATION, SAILS_EVENT_DESTINATION};
+        use crate::{
+            InBlockTransitions, TransitionController, TransitionsConfig,
+            transitions::{ETHEREUM_EVENT_DESTINATION, SAILS_EVENT_DESTINATION},
+        };
         use ethexe_common::{ProgramStates, StateHashWithQueueSize};
         use gear_core::{
             ids::prelude::MessageIdExt,
@@ -621,7 +623,12 @@ mod tests {
             assert_eq!(reply.kind, DispatchKind::Reply);
             assert_eq!(reply.source, destination);
             assert_eq!(
-                reply.details.unwrap().to_reply_details().unwrap().to_reply_code(),
+                reply
+                    .details
+                    .unwrap()
+                    .to_reply_details()
+                    .unwrap()
+                    .to_reply_code(),
                 ReplyCode::Success(SuccessReplyReason::Auto)
             );
             assert!(queue.is_empty());

--- a/ethexe/runtime/common/src/schedule.rs
+++ b/ethexe/runtime/common/src/schedule.rs
@@ -548,7 +548,7 @@ mod tests {
     fn send_user_message_to_event_destination_skips_mailbox() {
         use crate::{
             InBlockTransitions, TransitionController, TransitionsConfig,
-            transitions::{ETHEREUM_EVENT_DESTINATION, SAILS_EVENT_DESTINATION},
+            transitions::{ETH_SAILS_EVENT, GEAR_SAILS_EVENT},
         };
         use ethexe_common::{ProgramStates, StateHashWithQueueSize};
         use gear_core::{
@@ -556,7 +556,7 @@ mod tests {
             message::{DispatchKind, ReplyCode},
         };
 
-        for destination in [SAILS_EVENT_DESTINATION, ETHEREUM_EVENT_DESTINATION] {
+        for destination in [GEAR_SAILS_EVENT, ETH_SAILS_EVENT] {
             let storage = MemStorage::default();
             let program_id = ActorId::from(7);
             let message_id = MessageId::from(10);

--- a/ethexe/runtime/common/src/schedule.rs
+++ b/ethexe/runtime/common/src/schedule.rs
@@ -7,6 +7,7 @@ use crate::{
         Dispatch, DispatchStash, Expiring, MailboxMessage, ModifiableStorage, PayloadLookup,
         ProgramState, QueryableStorage, Storage, UserMailbox, Waitlist,
     },
+    transitions::is_event_destination,
 };
 use alloc::collections::{BTreeMap, BTreeSet};
 use anyhow::Context;
@@ -83,13 +84,46 @@ impl<S: Storage> TaskHandler<Rfm, Sd, Sum> for Handler<'_, S> {
     }
 
     fn send_user_message(&mut self, stashed_message_id: MessageId, program_id: ActorId) -> u64 {
-        let mailbox_validity = self.controller.transitions.cfg().mailbox_validity;
+        let cfg = self.controller.transitions.cfg();
+        let mailbox_validity = cfg.mailbox_validity;
+        let event_destinations = cfg.event_destinations_autoreply;
 
         self.controller
             .update_state(program_id, |state, storage, transitions| {
                 let (dispatch, user_id) = storage.modify(&mut state.stash_hash, |stash| {
                     stash.remove_to_user(&stashed_message_id)
                 });
+
+                if event_destinations && is_event_destination(user_id) {
+                    let value = dispatch.value;
+                    let message_type = dispatch.message_type;
+
+                    transitions.modify_transition(program_id, |transition| {
+                        transition
+                            .messages
+                            .push(dispatch.clone().into_message(storage, user_id));
+                        transition.claims.push(ValueClaim {
+                            message_id: stashed_message_id,
+                            destination: user_id,
+                            value,
+                        });
+                    });
+
+                    let reply = Dispatch::reply(
+                        stashed_message_id,
+                        user_id,
+                        PayloadLookup::empty(),
+                        0,
+                        SuccessReplyReason::Auto,
+                        message_type,
+                        false,
+                    );
+
+                    let queue = state.queue_from_msg_type(message_type);
+                    queue.modify_queue(storage, |queue| queue.queue(reply));
+
+                    return;
+                }
 
                 let expiry = transitions.schedule_task(
                     mailbox_validity,
@@ -508,5 +542,155 @@ mod tests {
                 ),
             ]),
         );
+    }
+
+    #[test]
+    fn send_user_message_to_event_destination_skips_mailbox() {
+        use crate::{InBlockTransitions, TransitionController, TransitionsConfig};
+        use crate::transitions::{ETHEREUM_EVENT_DESTINATION, SAILS_EVENT_DESTINATION};
+        use ethexe_common::{ProgramStates, StateHashWithQueueSize};
+        use gear_core::{
+            ids::prelude::MessageIdExt,
+            message::{DispatchKind, ReplyCode},
+        };
+
+        for destination in [SAILS_EVENT_DESTINATION, ETHEREUM_EVENT_DESTINATION] {
+            let storage = MemStorage::default();
+            let program_id = ActorId::from(7);
+            let message_id = MessageId::from(10);
+
+            let dispatch = Dispatch::new(
+                &storage,
+                message_id,
+                program_id,
+                vec![1, 2, 3],
+                11,
+                false,
+                MessageType::Canonical,
+                false,
+            )
+            .expect("dispatch");
+
+            let mut stash = DispatchStash::default();
+            stash.add_to_user(dispatch, 1000, destination);
+
+            let mut state = ProgramState::zero();
+            state.stash_hash = stash.store(&storage);
+            let state_hash = storage.write_program_state(state);
+            let states = ProgramStates::from_iter([(
+                program_id,
+                StateHashWithQueueSize {
+                    hash: state_hash,
+                    canonical_queue_size: 0,
+                    injected_queue_size: 0,
+                },
+            )]);
+
+            let cfg = TransitionsConfig {
+                event_destinations_autoreply: true,
+                ..Default::default()
+            };
+            let mut transitions = InBlockTransitions::new(cfg, states, Default::default());
+
+            {
+                let mut handler = Handler {
+                    controller: TransitionController {
+                        storage: &storage,
+                        transitions: &mut transitions,
+                    },
+                };
+                handler.send_user_message(message_id, program_id);
+            }
+
+            let transition = transitions.modifications_mut().remove(&program_id).unwrap();
+            assert_eq!(transition.messages.len(), 1);
+            assert_eq!(transition.messages[0].destination, destination);
+            assert_eq!(transition.messages[0].value, 11);
+            assert_eq!(transition.claims.len(), 1);
+            assert_eq!(transition.claims[0].message_id, message_id);
+            assert_eq!(transition.claims[0].destination, destination);
+            assert_eq!(transition.claims[0].value, 11);
+
+            let state_hash = transitions.state_of(&program_id).unwrap().hash;
+            let state = storage.program_state(state_hash).unwrap();
+            assert!(state.mailbox_hash.is_empty());
+
+            let mut queue = state.canonical_queue.query(&storage).unwrap();
+            let reply = queue.dequeue().expect("auto reply must be queued");
+            assert_eq!(reply.id, MessageId::generate_reply(message_id));
+            assert_eq!(reply.kind, DispatchKind::Reply);
+            assert_eq!(reply.source, destination);
+            assert_eq!(
+                reply.details.unwrap().to_reply_details().unwrap().to_reply_code(),
+                ReplyCode::Success(SuccessReplyReason::Auto)
+            );
+            assert!(queue.is_empty());
+        }
+    }
+
+    #[test]
+    fn send_user_message_to_regular_user_uses_mailbox() {
+        use crate::{InBlockTransitions, TransitionController, TransitionsConfig};
+        use ethexe_common::{ProgramStates, StateHashWithQueueSize};
+
+        let storage = MemStorage::default();
+        let program_id = ActorId::from(7);
+        let user_id = ActorId::from(2);
+        let message_id = MessageId::from(10);
+
+        let dispatch = Dispatch::new(
+            &storage,
+            message_id,
+            program_id,
+            vec![1, 2, 3],
+            11,
+            false,
+            MessageType::Canonical,
+            false,
+        )
+        .expect("dispatch");
+
+        let mut stash = DispatchStash::default();
+        stash.add_to_user(dispatch, 1000, user_id);
+
+        let mut state = ProgramState::zero();
+        state.stash_hash = stash.store(&storage);
+        let state_hash = storage.write_program_state(state);
+        let states = ProgramStates::from_iter([(
+            program_id,
+            StateHashWithQueueSize {
+                hash: state_hash,
+                canonical_queue_size: 0,
+                injected_queue_size: 0,
+            },
+        )]);
+
+        let cfg = TransitionsConfig {
+            event_destinations_autoreply: true,
+            ..Default::default()
+        };
+        let mut transitions = InBlockTransitions::new(cfg, states, Default::default());
+
+        {
+            let mut handler = Handler {
+                controller: TransitionController {
+                    storage: &storage,
+                    transitions: &mut transitions,
+                },
+            };
+            handler.send_user_message(message_id, program_id);
+        }
+
+        let transition = transitions.modifications_mut().remove(&program_id).unwrap();
+        assert_eq!(transition.messages.len(), 1);
+        assert_eq!(transition.messages[0].destination, user_id);
+        assert_eq!(transition.messages[0].value, 11);
+        assert!(transition.claims.is_empty());
+
+        let state_hash = transitions.state_of(&program_id).unwrap().hash;
+        let state = storage.program_state(state_hash).unwrap();
+        assert!(!state.mailbox_hash.is_empty());
+        assert!(state.stash_hash.is_empty());
+        assert!(state.canonical_queue.is_empty());
     }
 }

--- a/ethexe/runtime/common/src/transitions.rs
+++ b/ethexe/runtime/common/src/transitions.rs
@@ -13,13 +13,20 @@ use ethexe_common::{
 };
 use gprimitives::{ActorId, CodeId, H256};
 
-pub(crate) const SAILS_EVENT_DESTINATION: ActorId = ActorId::new([0; 32]);
-pub(crate) const ETHEREUM_EVENT_DESTINATION: ActorId = ActorId::new([u8::MAX; 32]);
+pub(crate) const GEAR_SAILS_EVENT: ActorId = ActorId::new([0; 32]);
+
+/// Must match `gstd`/`gcore` `ETH_EVENT_ADDR`
+/// (`0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF` on Ethereum).
+pub(crate) const ETH_SAILS_EVENT: ActorId = ActorId::new([
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff,
+]);
 
 pub(crate) fn is_event_destination(destination: ActorId) -> bool {
     matches!(
         destination,
-        SAILS_EVENT_DESTINATION | ETHEREUM_EVENT_DESTINATION
+        GEAR_SAILS_EVENT | ETH_SAILS_EVENT
     )
 }
 
@@ -420,5 +427,18 @@ mod tests {
 
         assert_eq!(t.take_actual_tasks(), vec![wake(1, 1)]);
         assert!(t.schedule.contains_key(&1));
+    }
+
+    #[test]
+    fn ethereum_event_destination_matches_eth_event_addr() {
+        use gprimitives::H160;
+
+        let eth_event_addr = H160::repeat_byte(0xff);
+        assert_eq!(
+            ETH_SAILS_EVENT,
+            ActorId::from(eth_event_addr)
+        );
+        assert_ne!(ETH_SAILS_EVENT, ActorId::new([u8::MAX; 32]));
+        assert!(is_event_destination(ETH_SAILS_EVENT));
     }
 }

--- a/ethexe/runtime/common/src/transitions.rs
+++ b/ethexe/runtime/common/src/transitions.rs
@@ -13,6 +13,16 @@ use ethexe_common::{
 };
 use gprimitives::{ActorId, CodeId, H256};
 
+pub(crate) const SAILS_EVENT_DESTINATION: ActorId = ActorId::new([0; 32]);
+pub(crate) const ETHEREUM_EVENT_DESTINATION: ActorId = ActorId::new([u8::MAX; 32]);
+
+pub(crate) fn is_event_destination(destination: ActorId) -> bool {
+    matches!(
+        destination,
+        SAILS_EVENT_DESTINATION | ETHEREUM_EVENT_DESTINATION
+    )
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TransitionsConfig {
     pub block_height: u32,

--- a/ethexe/runtime/common/src/transitions.rs
+++ b/ethexe/runtime/common/src/transitions.rs
@@ -18,16 +18,12 @@ pub(crate) const GEAR_SAILS_EVENT: ActorId = ActorId::new([0; 32]);
 /// Must match `gstd`/`gcore` `ETH_EVENT_ADDR`
 /// (`0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF` on Ethereum).
 pub(crate) const ETH_SAILS_EVENT: ActorId = ActorId::new([
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 ]);
 
 pub(crate) fn is_event_destination(destination: ActorId) -> bool {
-    matches!(
-        destination,
-        GEAR_SAILS_EVENT | ETH_SAILS_EVENT
-    )
+    matches!(destination, GEAR_SAILS_EVENT | ETH_SAILS_EVENT)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -434,10 +430,7 @@ mod tests {
         use gprimitives::H160;
 
         let eth_event_addr = H160::repeat_byte(0xff);
-        assert_eq!(
-            ETH_SAILS_EVENT,
-            ActorId::from(eth_event_addr)
-        );
+        assert_eq!(ETH_SAILS_EVENT, ActorId::from(eth_event_addr));
         assert_ne!(ETH_SAILS_EVENT, ActorId::new([u8::MAX; 32]));
         assert!(is_event_destination(ETH_SAILS_EVENT));
     }

--- a/ethexe/runtime/common/src/transitions.rs
+++ b/ethexe/runtime/common/src/transitions.rs
@@ -17,6 +17,7 @@ use gprimitives::{ActorId, CodeId, H256};
 pub struct TransitionsConfig {
     pub block_height: u32,
     pub mailbox_validity: NonZero<u32>,
+    pub event_destinations_autoreply: bool,
 }
 
 impl Default for TransitionsConfig {
@@ -24,6 +25,7 @@ impl Default for TransitionsConfig {
         Self {
             block_height: 0,
             mailbox_validity: MAILBOX_VALIDITY_VERSION_2,
+            event_destinations_autoreply: false,
         }
     }
 }


### PR DESCRIPTION

## Summary

Adds ProcessQueueV3 with auto-reply for Ethereum and Sails events.  They now skip mailbox/outbound message emission and immediately enqueue the same auto-reply/value-claim path as mailbox expiry.


## How to test

`cargo nextest` or `cargo test -p ethexe-processor`

## Notes

This adds a new ProcessQueueV3 and makes it default for new blocks. 

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): description`)
- [x] Single logical change
- [x] Tests added or updated (if logic changed)
- [x] Docs updated (if needed)
