### PR TITLE
feat(vara.eth/rpc): add `program_subscribeBestState` to RPC

### DIFF
--- a/ethexe/rpc/src/apis/mod.rs
+++ b/ethexe/rpc/src/apis/mod.rs
@@ -7,6 +7,8 @@ mod dev;
 mod info;
 mod injected;
 mod program;
+#[cfg(feature = "server")]
+mod program_best_state;
 
 #[cfg(feature = "client")]
 pub use crate::apis::{
@@ -15,7 +17,7 @@ pub use crate::apis::{
     dev::DevClient,
     info::{InfoClient, RPC_VERSION},
     injected::InjectedClient,
-    program::{CalculateReplyForHandleResult, FullProgramState, ProgramClient},
+    program::{CalculateReplyForHandleResult, FullProgramState, ProgramBestState, ProgramClient},
 };
 #[cfg(feature = "server")]
 pub use block::{BlockApi, BlockServer};
@@ -29,3 +31,5 @@ pub use info::{InfoApi, InfoServer};
 pub use injected::{InjectedApi, InjectedServer};
 #[cfg(feature = "server")]
 pub use program::{ProgramApi, ProgramServer};
+#[cfg(feature = "server")]
+pub use program_best_state::BestStateManager;

--- a/ethexe/rpc/src/apis/program.rs
+++ b/ethexe/rpc/src/apis/program.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 #[cfg(feature = "server")]
-use crate::{errors, utils};
+use crate::{
+    apis::program_best_state::{BestStateManager, spawn_best_state_subscriber},
+    errors, utils,
+};
 use ethexe_common::gear::Message;
 #[cfg(feature = "server")]
 use ethexe_common::{
@@ -20,9 +23,12 @@ use ethexe_runtime_common::state::{
 use ethexe_runtime_common::state::{QueryableStorage, Storage};
 use gear_core::rpc::ReplyInfo;
 use gprimitives::{H160, H256};
-#[cfg(feature = "server")]
-use jsonrpsee::core::async_trait;
 use jsonrpsee::proc_macros::rpc;
+#[cfg(feature = "server")]
+use jsonrpsee::{
+    core::{SubscriptionResult, async_trait},
+    server::PendingSubscriptionSink,
+};
 #[cfg(feature = "server")]
 use parity_scale_codec::Encode;
 use serde::{Deserialize, Serialize};
@@ -43,6 +49,13 @@ pub struct FullProgramState {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CalculateReplyForHandleResult {
     pub reply: ReplyInfo,
+    pub messages: Vec<Message>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProgramBestState {
+    pub mb_hash: H256,
+    pub new_state_hash: H256,
     pub messages: Vec<Message>,
 }
 
@@ -90,6 +103,14 @@ pub trait Program {
 
     #[method(name = "program_readPageData")]
     async fn read_page_data(&self, hash: H256) -> jsonrpsee::core::RpcResult<Bytes>;
+
+    /// Subscribes to the program's best state, emitted on every newly computed MB.
+    #[subscription(
+        name = "program_subscribeBestState",
+        unsubscribe = "program_unsubscribeBestState",
+        item = ProgramBestState
+    )]
+    async fn subscribe_best_state(&self, program_id: H160) -> jsonrpsee::core::SubscriptionResult;
 }
 
 #[cfg(feature = "server")]
@@ -97,16 +118,24 @@ pub struct ProgramApi {
     db: Database,
     processor: OverlaidProcessor,
     gas_allowance: u64,
+    best_state: BestStateManager,
 }
 
 #[cfg(feature = "server")]
 impl ProgramApi {
     pub fn new(db: Database, processor: OverlaidProcessor, gas_allowance: u64) -> Self {
+        let best_state = BestStateManager::new(db.clone());
         Self {
             db,
             processor,
             gas_allowance,
+            best_state,
         }
+    }
+
+    /// Cloneable handle used by the service to push computed MBs into subscriptions.
+    pub fn best_state(&self) -> BestStateManager {
+        self.best_state.clone()
     }
 
     fn read_queue(&self, hash: H256) -> Option<MessageQueue> {
@@ -258,5 +287,15 @@ impl ProgramServer for ProgramApi {
             .page_data(unsafe { HashOf::new(hash) })
             .map(|buf| buf.encode().into())
             .ok_or_else(|| errors::db("Failed to read page data by hash"))
+    }
+
+    async fn subscribe_best_state(
+        &self,
+        pending: PendingSubscriptionSink,
+        program_id: H160,
+    ) -> SubscriptionResult {
+        let sink = pending.accept().await?;
+        spawn_best_state_subscriber(sink, self.best_state(), program_id);
+        Ok(())
     }
 }

--- a/ethexe/rpc/src/apis/program_best_state.rs
+++ b/ethexe/rpc/src/apis/program_best_state.rs
@@ -60,7 +60,9 @@ impl BestStateManager {
         // `try_get_with` coalesces concurrent misses for the same `mb_hash`, so
         // many subscribers sharing an MB trigger only a single DB read.
         self.cache
-            .try_get_with(mb_hash, || self.db.mb_outcome(mb_hash).map(Arc::new).ok_or(()))
+            .try_get_with(mb_hash, || {
+                self.db.mb_outcome(mb_hash).map(Arc::new).ok_or(())
+            })
             .ok()
     }
 }

--- a/ethexe/rpc/src/apis/program_best_state.rs
+++ b/ethexe/rpc/src/apis/program_best_state.rs
@@ -57,13 +57,11 @@ impl BestStateManager {
     }
 
     fn outcome(&self, mb_hash: H256) -> Option<Arc<Vec<StateTransition>>> {
-        if let Some(transitions) = self.cache.get(&mb_hash) {
-            return Some(transitions);
-        }
-
-        let transitions = Arc::new(self.db.mb_outcome(mb_hash)?);
-        self.cache.insert(mb_hash, transitions.clone());
-        Some(transitions)
+        // `try_get_with` coalesces concurrent misses for the same `mb_hash`, so
+        // many subscribers sharing an MB trigger only a single DB read.
+        self.cache
+            .try_get_with(mb_hash, || self.db.mb_outcome(mb_hash).map(Arc::new).ok_or(()))
+            .ok()
     }
 }
 

--- a/ethexe/rpc/src/apis/program_best_state.rs
+++ b/ethexe/rpc/src/apis/program_best_state.rs
@@ -1,0 +1,128 @@
+// Copyright (C) Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+//! Best-state fan-out for the `program_subscribeBestState` subscription.
+//!
+//! When the service computes an MB it pushes the `mb_hash` here via
+//! [`BestStateManager::notify`]. Each active subscription owns a
+//! [`broadcast::Receiver`] and, on every `mb_hash`, loads the MB outcome
+//! (cached by hash), picks the transition for its program and forwards a
+//! [`ProgramBestState`] to the JSON-RPC sink. The outcome is already persisted
+//! by the time `MbComputed` is emitted, so the DB is the source of truth and the
+//! cache only avoids repeated reads when many subscribers share an MB.
+
+use super::program::ProgramBestState;
+use ethexe_common::{db::MbStorageRO, gear::StateTransition};
+use ethexe_db::Database;
+use gprimitives::{ActorId, H160, H256};
+use jsonrpsee::{SubscriptionMessage, SubscriptionSink};
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use tracing::{error, trace, warn};
+
+/// Buffered `mb_hash` notifications per subscriber before it starts lagging.
+const BROADCAST_CAPACITY: usize = 1024;
+
+/// Maximum number of cached MB outcomes (DB remains the source of truth).
+const CACHE_CAPACITY: u64 = 128;
+
+type StateTransitionsCache = moka::sync::Cache<H256, Arc<Vec<StateTransition>>>;
+
+/// Cloneable handle shared between [`ProgramApi`](super::ProgramApi) (creates
+/// subscribers) and [`RpcService`](crate::RpcService) (pushes `mb_hash`es).
+#[derive(Clone)]
+pub struct BestStateManager {
+    db: Database,
+    sender: broadcast::Sender<H256>,
+    cache: StateTransitionsCache,
+}
+
+impl BestStateManager {
+    pub fn new(db: Database) -> Self {
+        let (sender, _receiver) = broadcast::channel(BROADCAST_CAPACITY);
+        let cache = moka::sync::Cache::builder()
+            .max_capacity(CACHE_CAPACITY)
+            .build();
+        Self { db, sender, cache }
+    }
+
+    /// Fan a freshly computed MB out to all active subscribers.
+    pub fn notify(&self, mb_hash: H256) {
+        // Err only means there are no subscribers right now — nothing to do.
+        let _ = self.sender.send(mb_hash);
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<H256> {
+        self.sender.subscribe()
+    }
+
+    fn outcome(&self, mb_hash: H256) -> Option<Arc<Vec<StateTransition>>> {
+        if let Some(transitions) = self.cache.get(&mb_hash) {
+            return Some(transitions);
+        }
+
+        let transitions = Arc::new(self.db.mb_outcome(mb_hash)?);
+        self.cache.insert(mb_hash, transitions.clone());
+        Some(transitions)
+    }
+}
+
+/// Spawns the background task driving a single best-state subscription until the
+/// client disconnects or the broadcast channel closes.
+pub fn spawn_best_state_subscriber(
+    sink: SubscriptionSink,
+    manager: BestStateManager,
+    program_id: H160,
+) {
+    let actor_id: ActorId = program_id.into();
+    let mut receiver = manager.subscribe();
+
+    let _handle = tokio::spawn(async move {
+        loop {
+            let mb_hash = tokio::select! {
+                res = receiver.recv() => match res {
+                    Ok(mb_hash) => mb_hash,
+                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                        warn!(skipped, "best state subscriber lagged, skipping missed MBs");
+                        continue;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                },
+                _ = sink.closed() => {
+                    trace!("best state subscription closed by user, stop background task");
+                    break;
+                }
+            };
+
+            let Some(transitions) = manager.outcome(mb_hash) else {
+                trace!(%mb_hash, "mb outcome not found for best state subscription");
+                continue;
+            };
+
+            let Some(transition) = transitions.iter().find(|t| t.actor_id == actor_id) else {
+                continue;
+            };
+
+            let best_state = ProgramBestState {
+                mb_hash,
+                new_state_hash: transition.new_state_hash,
+                messages: transition.messages.clone(),
+            };
+
+            match SubscriptionMessage::from_json(&best_state) {
+                Ok(message) => {
+                    if let Err(err) = sink.send(message).await {
+                        trace!("failed to send best state, client disconnected: err={err}");
+                        break;
+                    }
+                }
+                Err(err) => {
+                    error!(
+                        ?err,
+                        "failed to serialize `ProgramBestState`; this must never happen"
+                    );
+                }
+            }
+        }
+    });
+}

--- a/ethexe/rpc/src/lib.rs
+++ b/ethexe/rpc/src/lib.rs
@@ -37,15 +37,15 @@ pub use crate::apis::RPC_VERSION;
 #[cfg(feature = "client")]
 pub use crate::apis::{
     BlockClient, CalculateReplyForHandleResult, CodeClient, DevClient, FullProgramState,
-    InfoClient, InjectedClient, ProgramClient,
+    InfoClient, InjectedClient, ProgramBestState, ProgramClient,
 };
 
 #[cfg(feature = "server")]
 use anyhow::Result;
 #[cfg(feature = "server")]
 use apis::{
-    BlockApi, BlockServer, CodeApi, CodeServer, DevApi, DevServer, InfoApi, InfoServer,
-    InjectedApi, InjectedServer, ProgramApi, ProgramServer,
+    BestStateManager, BlockApi, BlockServer, CodeApi, CodeServer, DevApi, DevServer, InfoApi,
+    InfoServer, InjectedApi, InjectedServer, ProgramApi, ProgramServer,
 };
 #[cfg(feature = "server")]
 use ethexe_common::injected::{
@@ -57,6 +57,8 @@ use ethexe_db::Database;
 use ethexe_processor::{Processor, ProcessorConfig};
 #[cfg(feature = "server")]
 use futures::{Stream, stream::FusedStream};
+#[cfg(feature = "server")]
+use gprimitives::H256;
 #[cfg(feature = "server")]
 use hyper::header::HeaderValue;
 #[cfg(feature = "server")]
@@ -150,10 +152,13 @@ impl RpcServer {
         )?
         .overlaid();
 
+        let program = ProgramApi::new(self.db.clone(), processor, self.config.gas_allowance);
+        let best_state = program.best_state();
+
         let server_apis = RpcServerApis {
             code: CodeApi::new(self.db.clone()),
             block: BlockApi::new(self.db.clone()),
-            program: ProgramApi::new(self.db.clone(), processor, self.config.gas_allowance),
+            program,
             injected: InjectedApi::new(self.db.clone(), rpc_sender),
             dev: self
                 .config
@@ -173,7 +178,10 @@ impl RpcServer {
             .await?
             .start(server_apis.into_module());
 
-        Ok((server_handle, RpcService::new(rpc_receiver, injected_api)))
+        Ok((
+            server_handle,
+            RpcService::new(rpc_receiver, injected_api, best_state),
+        ))
     }
 
     fn cors_layer(&self) -> Result<CorsLayer> {
@@ -196,14 +204,21 @@ pub struct RpcService {
     receiver: mpsc::UnboundedReceiver<RpcEvent>,
     /// Injected API implementation.
     injected_api: InjectedApi,
+    /// Best-state fan-out shared with the program API subscriptions.
+    best_state: BestStateManager,
 }
 
 #[cfg(feature = "server")]
 impl RpcService {
-    pub fn new(receiver: mpsc::UnboundedReceiver<RpcEvent>, injected_api: InjectedApi) -> Self {
+    pub fn new(
+        receiver: mpsc::UnboundedReceiver<RpcEvent>,
+        injected_api: InjectedApi,
+        best_state: BestStateManager,
+    ) -> Self {
         Self {
             receiver,
             injected_api,
+            best_state,
         }
     }
 
@@ -213,6 +228,10 @@ impl RpcService {
 
     pub fn receive_tx_receipt(&self, receipt: SignedCompactTxReceipt) {
         self.injected_api.on_tx_receipt(receipt);
+    }
+
+    pub fn receive_mb_computed(&self, mb_hash: H256) {
+        self.best_state.notify(mb_hash);
     }
 }
 

--- a/ethexe/sdk/src/mirror.rs
+++ b/ethexe/sdk/src/mirror.rs
@@ -19,10 +19,14 @@ use ethexe_ethereum::{
         MirrorQuery as EthereumMirrorQuery,
     },
 };
-use ethexe_rpc::{CalculateReplyForHandleResult, FullProgramState, InjectedClient, ProgramClient};
+use ethexe_rpc::{
+    CalculateReplyForHandleResult, FullProgramState, InjectedClient, ProgramBestState,
+    ProgramClient,
+};
 use ethexe_runtime_common::state::ProgramState;
 use futures::TryFutureExt;
 use gprimitives::{ActorId, CodeId, H256, MessageId, U256};
+use jsonrpsee::core::client::Subscription;
 use gsigner::secp256k1::Secp256k1SignerExt;
 
 pub struct Mirror<'a> {
@@ -279,6 +283,17 @@ impl<'a> Mirror<'a> {
         };
 
         Ok((message_id, promise))
+    }
+
+    /// Subscribes to this program's best state, yielding a [`ProgramBestState`]
+    /// on every newly computed MB that produces a transition for the program.
+    pub async fn subscribe_best_state(&self) -> Result<Subscription<ProgramBestState>> {
+        let program_id = self.actor_id().to_address_lossy();
+        self.api
+            .vara_eth_client
+            .subscribe_best_state(program_id)
+            .await
+            .with_context(|| "failed to subscribe to program best state")
     }
 
     pub async fn wait_for_reply(&self, message_id: MessageId) -> Result<ReplyInfo> {

--- a/ethexe/sdk/src/mirror.rs
+++ b/ethexe/sdk/src/mirror.rs
@@ -26,8 +26,8 @@ use ethexe_rpc::{
 use ethexe_runtime_common::state::ProgramState;
 use futures::TryFutureExt;
 use gprimitives::{ActorId, CodeId, H256, MessageId, U256};
-use jsonrpsee::core::client::Subscription;
 use gsigner::secp256k1::Secp256k1SignerExt;
+use jsonrpsee::core::client::Subscription;
 
 pub struct Mirror<'a> {
     pub(crate) api: &'a VaraEthApi,

--- a/ethexe/service/src/lib.rs
+++ b/ethexe/service/src/lib.rs
@@ -779,6 +779,10 @@ impl Service {
                                 g.latest_computed_mb_hash = mb_hash;
                             }
                         });
+
+                        if let Some(rpc) = &rpc {
+                            rpc.receive_mb_computed(mb_hash);
+                        }
                     }
                     ComputeEvent::Promise(promise, _mb_hash) => {
                         // The local node always feeds its computed body

--- a/ethexe/service/src/tests/mod.rs
+++ b/ethexe/service/src/tests/mod.rs
@@ -2782,6 +2782,7 @@ async fn program_subscribe_best_state() {
 
     let mut env = TestEnv::default().await;
 
+    let pubkey = env.validators[0].public_key;
     let mut node = env
         .new_node(
             NodeConfig::default()
@@ -2843,6 +2844,54 @@ async fn program_subscribe_best_state() {
         "expected the PONG reply in the best state messages"
     );
     tracing::info!("✅ Best state successfully received from RPC subscription");
+
+    // Now send the same PING as an injected transaction: it must yield a PONG
+    // promise over its own subscription, and our best-state subscription must
+    // also observe the resulting transition.
+    let ping_tx = InjectedTransaction {
+        destination: ping_id,
+        payload: b"PING".to_vec().try_into().unwrap(),
+        value: 0,
+        reference_block: node.db.globals().latest_prepared_eb_hash,
+        salt: vec![1].try_into().unwrap(),
+    };
+    let rpc_tx = env
+        .signer
+        .signed_message(pubkey, ping_tx.clone(), None)
+        .unwrap();
+
+    let mut tx_subscription = rpc_client
+        .send_transaction_and_watch(rpc_tx)
+        .await
+        .expect("successfully subscribe for injected transaction promise");
+
+    let promise = tx_subscription
+        .next()
+        .await
+        .expect("promise from subscription")
+        .expect("transaction promise")
+        .data()
+        .clone()
+        .unwrap_promise();
+    assert_eq!(promise.tx_hash, ping_tx.to_hash());
+    assert_eq!(promise.reply.payload, b"PONG");
+    tracing::info!("✅ Injected PING promise received from RPC subscription");
+
+    let injected_best_state = subscription
+        .next()
+        .await
+        .expect("subscription produces a best state for the injected ping")
+        .expect("no RPC subscription error");
+    assert_ne!(injected_best_state.mb_hash, H256::zero());
+    assert_ne!(injected_best_state.new_state_hash, H256::zero());
+    assert!(
+        injected_best_state
+            .messages
+            .iter()
+            .any(|msg| msg.payload == b"PONG"),
+        "expected the injected PONG reply in the best state messages"
+    );
+    tracing::info!("✅ Best state for injected PING received from RPC subscription");
 
     subscription
         .unsubscribe()

--- a/ethexe/service/src/tests/mod.rs
+++ b/ethexe/service/src/tests/mod.rs
@@ -31,7 +31,7 @@ use ethexe_consensus::BatchCommitter;
 use ethexe_db::{Database, dump::StateDump};
 use ethexe_ethereum::{EthereumBuilder, TryGetReceipt, router::Router};
 use ethexe_processor::Processor;
-use ethexe_rpc::InjectedClient;
+use ethexe_rpc::{InjectedClient, ProgramClient};
 use ethexe_runtime_common::{RUNTIME_ID, state::Storage};
 use gear_core::{
     ids::prelude::MessageIdExt,
@@ -2768,6 +2768,86 @@ async fn injected_tx_fungible_token() {
         .expect("successfully unsubscribe for promise");
 
     tracing::info!("✅ Promise successfully received from RPC subscription");
+
+    stop_nodes([node]).await;
+}
+
+/// Subscribe to a program's best state over RPC and assert that handling a
+/// message produces a `ProgramBestState` carrying the program's new state hash
+/// and its outgoing reply.
+#[tokio::test]
+#[ntest::timeout(60_000)]
+async fn program_subscribe_best_state() {
+    init_logger();
+
+    let mut env = TestEnv::default().await;
+
+    let mut node = env
+        .new_node(
+            NodeConfig::default()
+                .service_rpc(8095)
+                .validator(env.validators[0]),
+        )
+        .await;
+    node.start_service().await;
+    let rpc_client = node
+        .rpc_ws_client()
+        .await
+        .expect("RPC client provide by node");
+
+    // Upload demo_ping and create the program.
+    let uploaded_code = env
+        .upload_code(demo_ping::WASM_BINARY)
+        .await
+        .unwrap()
+        .wait_for()
+        .await
+        .unwrap();
+    assert!(uploaded_code.valid);
+
+    let program = env
+        .create_program(uploaded_code.code_id, 500_000_000_000_000)
+        .await
+        .unwrap()
+        .wait_for()
+        .await
+        .unwrap();
+    let ping_id = program.program_id;
+
+    // Subscribe after creation so the first emitted state is the PING handle.
+    let mut subscription = rpc_client
+        .subscribe_best_state(ping_id.to_address_lossy())
+        .await
+        .expect("successfully subscribe for program best state");
+
+    // Trigger a state transition for the program.
+    let reply = env
+        .send_message(ping_id, b"PING")
+        .await
+        .unwrap()
+        .wait_for()
+        .await
+        .unwrap();
+    assert_eq!(reply.payload, b"PONG");
+
+    let best_state = subscription
+        .next()
+        .await
+        .expect("subscription produces a best state")
+        .expect("no RPC subscription error");
+
+    assert_ne!(best_state.mb_hash, H256::zero());
+    assert_ne!(best_state.new_state_hash, H256::zero());
+    assert!(
+        best_state.messages.iter().any(|msg| msg.payload == b"PONG"),
+        "expected the PONG reply in the best state messages"
+    );
+    tracing::info!("✅ Best state successfully received from RPC subscription");
+
+    subscription
+        .unsubscribe()
+        .await
+        .expect("successfully unsubscribe from best state");
 
     stop_nodes([node]).await;
 }


### PR DESCRIPTION
Closes #5445 

 ## Summary

  Adds a JSON-RPC WebSocket subscription `program_subscribeBestState` to the
  vara.eth (ethexe) RPC server. On every newly computed MB, the subscriber for a
  given program receives its best `StateTransition` as `ProgramBestState { mb_hash,
  new_state_hash, messages }`.

  - `BestStateManager` fans `mb_hash`es out via `tokio::sync::broadcast` and caches
    MB outcomes by hash (`moka::sync::Cache`, cap 128) to avoid repeated DB reads.
  - The service forwards `ComputeEvent::MbComputed` into RPC via
    `RpcService::receive_mb_computed`.
  - Future MBs only; lagging subscribers drop missed MBs; disconnect on send failure.

  ## How to test

  - `cargo nextest run -p ethexe-rpc --no-fail-fast`
  - Manual: `ethexe run --dev`, open `program_subscribeBestState` for a live program
    id over WS, send a message, observe `ProgramBestState` on each computed MB.

  ## Notes

  Intentionally minimal hotfix. No reorg de-dup: during catch-up replay a subscriber
  may briefly receive an older state.

  ## Checklist

  - [x] PR title follows Conventional Commits (`type(scope): description`)
  - [x] Single logical change
  - [x] Tests added or updated (if logic changed)
  - [x] Docs updated (if needed)
