### PR TITLE
fix(sdk/wasm-optimizer): support specific systems where `rustup` is not available

### DIFF
--- a/sdk/wasm-optimizer/src/cargo_command.rs
+++ b/sdk/wasm-optimizer/src/cargo_command.rs
@@ -14,7 +14,7 @@ pub struct CargoCommand {
     rustc_flags: Vec<&'static str>,
     target_dir: PathBuf,
     features: Vec<String>,
-    toolchain: Toolchain,
+    toolchain: Option<Toolchain>,
     check_recommended_toolchain: bool,
     force_recommended_toolchain: bool,
 }
@@ -22,10 +22,17 @@ pub struct CargoCommand {
 impl CargoCommand {
     /// Initialize new cargo command.
     pub fn new() -> CargoCommand {
-        #[cfg(not(target_os = "android"))]
-        let toolchain = Toolchain::try_from_rustup().expect("Failed to resolve toolchain version");
-        #[cfg(target_os = "android")]
-        let toolchain = Toolchain::stable();
+        let is_rustup_available = Toolchain::is_rustup_available();
+        let toolchain = if is_rustup_available {
+            Some(Toolchain::try_from_rustup().expect("Failed to resolve toolchain version"))
+        } else {
+            None
+        };
+        let path = if is_rustup_available {
+            "rustup".into()
+        } else {
+            "cargo".into()
+        };
         let rustc_version = rustc_version::version().expect("Failed to get rustc version");
         let linker_plugin_lto = rustc_version.major == 1 && rustc_version.minor >= 91;
         let allow_undefined = rustc_version.major == 1 && rustc_version.minor >= 96;
@@ -54,7 +61,7 @@ impl CargoCommand {
         }
 
         CargoCommand {
-            path: "rustup".to_string(),
+            path,
             manifest_path: "Cargo.toml".into(),
             profile: "dev".to_string(),
             rustc_flags,
@@ -108,30 +115,27 @@ impl CargoCommand {
 
     /// Execute the `cargo` command with invoking supplied arguments.
     pub fn run(&self) -> Result<()> {
-        if self.check_recommended_toolchain {
-            self.toolchain.check_recommended_toolchain()?;
-        }
-
-        #[cfg(not(target_os = "android"))]
-        let toolchain = if self.force_recommended_toolchain {
-            Toolchain::recommended_nightly()
-        } else {
-            self.toolchain.clone()
-        };
-
-        #[cfg(not(target_os = "android"))]
         let mut cargo = Command::new(&self.path);
-        #[cfg(not(target_os = "android"))]
-        cargo
-            .arg("run")
-            .arg(toolchain.raw_toolchain_str().as_ref())
-            .arg("cargo");
 
-        #[cfg(target_os = "android")]
-        let mut cargo = Command::new("cargo");
+        if let Some(toolchain) = &self.toolchain {
+            if self.check_recommended_toolchain {
+                toolchain.check_recommended_toolchain()?;
+            }
 
-        if self.force_recommended_toolchain {
-            self.clean_up_environment(&mut cargo);
+            let toolchain = if self.force_recommended_toolchain {
+                Toolchain::recommended_nightly()
+            } else {
+                toolchain.clone()
+            };
+
+            cargo
+                .arg("run")
+                .arg(toolchain.raw_toolchain_str().as_ref())
+                .arg("cargo");
+
+            if self.force_recommended_toolchain {
+                self.clean_up_environment(&mut cargo);
+            }
         }
 
         cargo

--- a/sdk/wasm-optimizer/src/cargo_toolchain.rs
+++ b/sdk/wasm-optimizer/src/cargo_toolchain.rs
@@ -21,15 +21,14 @@ impl Toolchain {
     /// This is a version of nightly toolchain, tested on our CI.
     const PINNED_NIGHTLY_TOOLCHAIN: &'static str = "nightly-2025-10-20";
 
-    /// Returns `Toolchain` representing the stable version.
-    #[cfg(target_os = "android")]
-    pub fn stable() -> Self {
-        Self("stable".into())
-    }
-
     /// Returns `Toolchain` representing the recommended nightly version.
     pub fn recommended_nightly() -> Self {
         Self(Self::PINNED_NIGHTLY_TOOLCHAIN.into())
+    }
+
+    /// Checks if `rustup` is available in the system.
+    pub fn is_rustup_available() -> bool {
+        Command::new("rustup").arg("--version").output().is_ok()
     }
 
     /// Fetches `Toolchain` via rustup.


### PR DESCRIPTION
Closes #5595
