### PR TITLE
refactor(vara.eth/malachite): merge tune-malachite-errors, move EB-prerequisite gating out of Malachite

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -27,6 +27,9 @@ test-group = 'authorship'
 [[profile.default.overrides]]
 filter = 'package(ethexe-service)'
 leak-timeout = { period = "10s", result = "pass" }
+# Heavy multi-validator tests (4 Anvil + 4 malachite engines) starve under
+# full-suite parallelism and blow the 120s cap; reserve threads like CI does.
+threads-required = 4
 
 [profile.default.junit]
 path = "junit.xml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5712,6 +5712,7 @@ dependencies = [
  "arc-malachitebft-test",
  "async-trait",
  "bytes",
+ "ethexe-common",
  "futures",
  "gear-core",
  "gear-workspace-hack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5712,6 +5712,7 @@ dependencies = [
  "arc-malachitebft-test",
  "async-trait",
  "bytes",
+ "derive_more 2.1.1",
  "ethexe-common",
  "futures",
  "gear-core",

--- a/ethexe/cli/src/params/malachite.rs
+++ b/ethexe/cli/src/params/malachite.rs
@@ -10,7 +10,7 @@
 use super::MergeParams;
 use anyhow::{Context, Result};
 use clap::Parser;
-use ethexe_malachite::{MalachiteConfig, Multiaddr};
+use ethexe_malachite::{MalachiteServiceConfig, Multiaddr};
 use ethexe_service::config::MalachiteCliConfig;
 use gsigner::secp256k1::{Address, PublicKey};
 use serde::Deserialize;
@@ -81,7 +81,7 @@ impl MalachiteParams {
         Ok(MalachiteCliConfig {
             listen_addr: self
                 .malachite_listen_addr
-                .unwrap_or(MalachiteConfig::DEFAULT_LISTEN_ADDR),
+                .unwrap_or(MalachiteServiceConfig::DEFAULT_LISTEN_ADDR),
             persistent_peers: self.malachite_persistent_peers,
             validator_pub_keys,
         })

--- a/ethexe/cli/src/params/malachite.rs
+++ b/ethexe/cli/src/params/malachite.rs
@@ -72,7 +72,7 @@ pub struct MalachiteParams {
 impl MalachiteParams {
     /// Converts CLI/TOML Malachite parameters into a service-ready
     /// [`MalachiteCliConfig`]. Missing fields fall back to sensible
-    /// defaults from [`MalachiteConfig`].
+    /// defaults from `MalachiteServiceConfig`.
     pub fn into_config(self) -> Result<MalachiteCliConfig> {
         let validator_pub_keys = match self.validators_malachite_pub_keys {
             Some(path) => load_validator_pub_keys_table(&path)?,

--- a/ethexe/cli/src/params/node.rs
+++ b/ethexe/cli/src/params/node.rs
@@ -95,7 +95,7 @@ pub struct NodeParams {
     #[serde(rename = "canonical-quarantine")]
     pub canonical_quarantine: Option<u8>,
 
-    /// See `MalachiteConfig::post_quarantine_delay`. Default 1.
+    /// See `MalachiteServiceConfig::post_quarantine_delay`. Default 1.
     #[arg(long)]
     #[serde(rename = "post-quarantine-delay")]
     pub post_quarantine_delay: Option<u32>,

--- a/ethexe/cli/src/params/node.rs
+++ b/ethexe/cli/src/params/node.rs
@@ -177,7 +177,7 @@ impl NodeParams {
             canonical_quarantine: self.canonical_quarantine.unwrap_or(CANONICAL_QUARANTINE),
             post_quarantine_delay: self
                 .post_quarantine_delay
-                .unwrap_or(ethexe_malachite::MalachiteConfig::DEFAULT_POST_QUARANTINE_DELAY),
+                .unwrap_or(ethexe_malachite::MalachiteServiceConfig::DEFAULT_POST_QUARANTINE_DELAY),
             dev: self.dev,
             pre_funded_accounts: self
                 .pre_funded_accounts

--- a/ethexe/common/src/lib.rs
+++ b/ethexe/common/src/lib.rs
@@ -88,7 +88,7 @@ pub use gsigner::{
 pub use validators::{EmptyValidatorsError, ValidatorsVec};
 pub mod ecdsa {
     pub use gsigner::secp256k1::{
-        ContractSignature, PrivateKey, PublicKey, Signature, SignedData, SignedMessage,
+        ContractSignature, PrivateKey, PublicKey, Signature, SignedData, SignedMessage, Signer,
         VerifiedData,
     };
 }

--- a/ethexe/common/src/lib.rs
+++ b/ethexe/common/src/lib.rs
@@ -87,8 +87,10 @@ pub use gsigner::{
 };
 pub use validators::{EmptyValidatorsError, ValidatorsVec};
 pub mod ecdsa {
+    #[cfg(feature = "std")]
+    pub use gsigner::secp256k1::Signer;
     pub use gsigner::secp256k1::{
-        ContractSignature, PrivateKey, PublicKey, Signature, SignedData, SignedMessage, Signer,
+        ContractSignature, PrivateKey, PublicKey, Signature, SignedData, SignedMessage,
         VerifiedData,
     };
 }

--- a/ethexe/common/src/primitives.rs
+++ b/ethexe/common/src/primitives.rs
@@ -233,6 +233,12 @@ pub type ScheduledTask = gear_core::tasks::ScheduledTask<Rfm, Sd, Sum>;
 /// Scheduler; (block height, scheduled task)
 pub type Schedule = BTreeMap<u32, BTreeSet<ScheduledTask>>;
 
+#[derive(Debug, Clone, PartialEq, Eq, derive_more::Display, derive_more::IsVariant, Encode, Decode, TypeInfo)]
+pub enum Acceptance<A, R> {
+    Accepted(A),
+    Rejected(R),
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ethexe/common/src/primitives.rs
+++ b/ethexe/common/src/primitives.rs
@@ -233,7 +233,17 @@ pub type ScheduledTask = gear_core::tasks::ScheduledTask<Rfm, Sd, Sum>;
 /// Scheduler; (block height, scheduled task)
 pub type Schedule = BTreeMap<u32, BTreeSet<ScheduledTask>>;
 
-#[derive(Debug, Clone, PartialEq, Eq, derive_more::Display, derive_more::IsVariant, Encode, Decode, TypeInfo)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    derive_more::Display,
+    derive_more::IsVariant,
+    Encode,
+    Decode,
+    TypeInfo,
+)]
 pub enum Acceptance<A, R> {
     Accepted(A),
     Rejected(R),

--- a/ethexe/compute/src/compute.rs
+++ b/ethexe/compute/src/compute.rs
@@ -11,8 +11,11 @@
 
 use crate::{ComputeError, ComputeEvent, ProcessorExt, Result, service::SubService};
 use ethexe_common::{
-    PromiseEmissionMode, PromisePolicy,
-    db::{CodesStorageRW, CompactMb, ConfigStorageRO, MbStorageRO, MbStorageRW, OnChainStorageRO},
+    PromiseEmissionMode, PromisePolicy, SimpleBlockData,
+    db::{
+        CodesStorageRW, CompactMb, ConfigStorageRO, GlobalsStorageRO, MbStorageRO, MbStorageRW,
+        OnChainStorageRO,
+    },
     events::BlockRequestEvent,
     injected::Promise,
     malachite::{Operation, Operations},
@@ -241,15 +244,9 @@ pub fn prepare_executable_for_mb(
     let schedule = db
         .mb_schedule(parent)
         .ok_or(ComputeError::ParentMbScheduleMissing(parent))?;
-    let initial_advanced_block = db.mb_meta(parent).last_advanced_eb;
+    let advanced_block = db.mb_meta(parent).last_advanced_eb;
 
-    build_executable_data(
-        db,
-        mb_payload,
-        program_states,
-        schedule,
-        initial_advanced_block,
-    )
+    build_executable_data(db, mb_payload, program_states, schedule, advanced_block)
 }
 
 /// Walk the MB's `Operations` list and prepare processor input.
@@ -262,17 +259,28 @@ fn build_executable_data(
     operations: Operations,
     program_states: ethexe_common::ProgramStates,
     schedule: ethexe_common::Schedule,
-    initial_advanced_block: H256,
+    advanced_block: H256,
 ) -> Result<ExecutableData> {
     let mut events: Vec<BlockRequestEvent> = Vec::new();
     let mut injected_transactions = Vec::new();
     let mut gas_allowance: Option<u64> = None;
-    let mut current_anchor = initial_advanced_block;
+
+    let mut current_anchor = if advanced_block.is_zero() {
+        None
+    } else {
+        Some(
+            db.block_simple_data(advanced_block)
+                .ok_or(ComputeError::AnchorBlockHeaderMissing(advanced_block))?,
+        )
+    };
 
     for op in operations.0 {
         match op {
             Operation::AdvanceTillEthereumBlock { block_hash } => {
-                let chain = collect_advance_chain(db, block_hash, current_anchor)?;
+                let block = db
+                    .block_simple_data(block_hash)
+                    .ok_or(ComputeError::AnchorBlockHeaderMissing(block_hash))?;
+                let chain = collect_advance_chain(db, block, current_anchor)?;
                 for hash in chain {
                     let block_events = db
                         .block_events(hash)
@@ -281,7 +289,7 @@ fn build_executable_data(
                         events.push(event);
                     }
                 }
-                current_anchor = block_hash;
+                current_anchor = Some(block);
             }
             Operation::Injected(signed) => {
                 let verified = signed.into_verified();
@@ -296,16 +304,18 @@ fn build_executable_data(
         }
     }
 
-    let anchor_eth_block = if current_anchor.is_zero() {
-        db.config().genesis_block_hash
+    let (height, timestamp) = if let Some(current_anchor) = current_anchor {
+        (
+            current_anchor.header.height,
+            current_anchor.header.timestamp,
+        )
     } else {
-        current_anchor
+        db.block_header(db.config().genesis_block_hash)
+            .map(|h| (h.height, h.timestamp))
+            .ok_or(ComputeError::Other(
+                "genesis block missing from DB; invariant violation",
+            ))?
     };
-
-    let (height, timestamp) = db
-        .block_header(anchor_eth_block)
-        .map(|h| (h.height, h.timestamp))
-        .ok_or(ComputeError::AnchorBlockHeaderMissing(anchor_eth_block))?;
 
     Ok(ExecutableData {
         height,
@@ -318,31 +328,69 @@ fn build_executable_data(
     })
 }
 
-/// EBs in `(last_advanced, target]`, oldest-first; capped at 1024.
-fn collect_advance_chain(db: &Database, target: H256, last_advanced: H256) -> Result<Vec<H256>> {
-    const MAX_ADVANCE_STEPS: usize = 1024;
+/// EBs in `(last_advanced, target]`, oldest-first;
+fn collect_advance_chain(
+    db: &Database,
+    target: SimpleBlockData,
+    last_advanced: Option<SimpleBlockData>,
+) -> Result<Vec<H256>> {
+    let (last_advanced_hash, last_advanced_height) = if let Some(la) = last_advanced {
+        (la.hash, la.header.height)
+    } else {
+        let start_eb_hash = db.globals().start_block_hash;
+        let genesis_eb_hash = db.config().genesis_block_hash;
+        if start_eb_hash != genesis_eb_hash {
+            return Err(ComputeError::Other(
+                "if last advanced EB is zero, then start block must match genesis",
+            ));
+        }
+        db.block_simple_data(start_eb_hash)
+            .ok_or(ComputeError::BlockNotSynced(start_eb_hash))
+            .map(|start_eb| {
+                start_eb
+                    .header
+                    .height
+                    .checked_sub(1)
+                    .ok_or(ComputeError::Other("start block height=0 isn't expected"))
+                    .map(|h| (H256::zero(), h))
+            })??
+    };
 
-    if target == last_advanced {
-        return Ok(Vec::new());
+    let depth = target
+        .header
+        .height
+        .checked_sub(last_advanced_height)
+        .ok_or(ComputeError::Other("target EB is older than last advanced"))?;
+
+    if depth == 0 {
+        return Err(ComputeError::Other(
+            "target EB is at the same height as last advanced",
+        ));
     }
 
-    let mut chain = Vec::new();
+    let mut chain = Vec::with_capacity(depth as usize);
     let mut current = target;
-    while current != last_advanced && current != H256::zero() {
-        if chain.len() >= MAX_ADVANCE_STEPS {
-            return Err(ComputeError::AdvanceWalkTooDeep {
-                target,
-                last_advanced,
-            });
+    for step in 0..depth {
+        chain.push(current.hash);
+
+        // The deepest block's parent must connect to the last advanced EB. Its
+        // parent header is not fetched: for the genesis EB that parent is the
+        // un-seeded zero hash, so we compare the `parent_hash` field directly.
+        let parent_hash = current.header.parent_hash;
+        if step + 1 == depth {
+            if parent_hash != last_advanced_hash {
+                return Err(ComputeError::Other(
+                    "collected advancing chain does not connect to the last advanced block",
+                ));
+            }
+            break;
         }
-        // Any missing intermediate header has to surface — a silent
-        // truncation would have validators with different sync depth
-        // emit different advance chains for the same MB.
-        let header = db
-            .block_header(current)
-            .ok_or(ComputeError::AdvanceMissingHeader { hash: current })?;
-        chain.push(current);
-        current = header.parent_hash;
+
+        current = db
+            .block_simple_data(parent_hash)
+            .ok_or(ComputeError::Other(
+                "block header not found while collecting advancing chain",
+            ))?;
     }
 
     chain.reverse();
@@ -463,21 +511,45 @@ mod tests {
     use gprimitives::{ActorId, CodeId, MessageId};
     use proptest::prelude::*;
 
-    fn dummy_ops(db: &Database, tag: u8) -> Operations {
-        // Tag-derived AdvanceTillEthereumBlock makes each block's
-        // operations list (and thus its CAS hash) unique across heights.
-        // The referenced EB also needs a header in the DB so the
-        // compute-side advance walk picks it up.
-        let eth_block_hash = H256::from_low_u64_be(0xEB00 + tag as u64);
+    fn eb_hash(height: u32) -> H256 {
+        H256::from_low_u64_be(0xEB00 + height as u64)
+    }
+
+    /// Synthetic Ethereum block at `height`, chained onto its height-1 parent
+    /// (zero parent at height 1 — the genesis Eth block). The hash is derived
+    /// from the height, so a contiguous chain builds itself.
+    fn synthetic_eb(db: &Database, height: u32, events: Vec<BlockEvent>) -> H256 {
+        let parent_hash = if height <= 1 {
+            H256::zero()
+        } else {
+            eb_hash(height - 1)
+        };
+        let hash = eb_hash(height);
         db.set_block_header(
-            eth_block_hash,
+            hash,
             BlockHeader {
-                height: tag as u32,
-                timestamp: tag as u64,
-                parent_hash: H256::zero(),
+                height,
+                timestamp: height as u64,
+                parent_hash,
             },
         );
-        db.set_block_events(eth_block_hash, &[]);
+        db.set_block_events(hash, &events);
+        hash
+    }
+
+    /// Seed the genesis Eth block (height 1) and point the genesis zero-MB's
+    /// `last_advanced_eb` at it, so subsequent MBs walk a real depth-1 chain
+    /// via the `Some` branch — exactly as the malachite service propagates it.
+    fn seed_genesis_eth(db: &Database) -> H256 {
+        let gen_eb = synthetic_eb(db, 1, vec![]);
+        db.mutate_mb_meta(H256::zero(), |m| m.last_advanced_eb = gen_eb);
+        gen_eb
+    }
+
+    fn dummy_ops(db: &Database, eb_height: u32) -> Operations {
+        // The unique EB height makes each MB's operations list (and thus its
+        // CAS hash) unique, and gives the advance walk a chained block to pick up.
+        let eth_block_hash = synthetic_eb(db, eb_height, vec![]);
         Operations::new(vec![
             Operation::AdvanceTillEthereumBlock {
                 block_hash: eth_block_hash,
@@ -502,6 +574,13 @@ mod tests {
         );
     }
 
+    /// `seed_mb` plus the malachite-side bookkeeping: record the advanced EB
+    /// as this MB's `last_advanced_eb`, so its child walks a depth-1 chain.
+    fn seed_mb_advancing(db: &Database, mb_hash: H256, parent: H256, height: u64, eb_height: u32) {
+        seed_mb(db, mb_hash, parent, height, dummy_ops(db, eb_height));
+        db.mutate_mb_meta(mb_hash, |m| m.last_advanced_eb = eb_hash(eb_height));
+    }
+
     /// Tail-only queue still computes all uncomputed predecessors.
     #[tokio::test]
     #[ntest::timeout(5000)]
@@ -510,16 +589,18 @@ mod tests {
 
         let db = Database::memory();
         seed_genesis_zero_mb(&db);
+        seed_genesis_eth(&db);
         let processor = MockProcessor::default();
         let mut sub = ComputeSubService::new(db.clone(), processor);
 
-        // 5-block chain; mb_hash = 0x1000 + i.
+        // 5-block chain; mb_hash = 0x1000 + i. Each MB advances one EB, so
+        // MB at height i pins the EB at height i + 1 (genesis Eth is height 1).
         const N: u64 = 5;
         let mut hashes = Vec::with_capacity(N as usize);
         let mut parent = H256::zero();
         for i in 1..=N {
             let mb_hash = H256::from_low_u64_be(0x1000 + i);
-            seed_mb(&db, mb_hash, parent, i, dummy_ops(&db, i as u8));
+            seed_mb_advancing(&db, mb_hash, parent, i, (i + 1) as u32);
             hashes.push((i, mb_hash));
             parent = mb_hash;
         }
@@ -559,7 +640,7 @@ mod tests {
 
             for i in 1..=chain_len {
                 let mb_hash = H256::from_low_u64_be(0xB000 + i);
-                seed_mb(&db, mb_hash, parent, i, dummy_ops(&db, i as u8));
+                seed_mb(&db, mb_hash, parent, i, dummy_ops(&db, (i + 1) as u32));
                 hashes.push(mb_hash);
                 parent = mb_hash;
             }
@@ -585,15 +666,22 @@ mod tests {
     #[test]
     fn collect_advance_chain_errors_on_missing_intermediate_header() {
         let db = Database::memory();
-        let last_advanced = H256::from_low_u64_be(0xA0);
+        let last_advanced = SimpleBlockData {
+            hash: H256::from_low_u64_be(0xA0),
+            header: BlockHeader {
+                height: 0,
+                timestamp: 0,
+                parent_hash: H256::zero(),
+            },
+        };
         let parent_b = H256::from_low_u64_be(0xA1);
         let parent_a = H256::from_low_u64_be(0xA2);
-        let target = H256::from_low_u64_be(0xA3);
+        let target_hash = H256::from_low_u64_be(0xA3);
 
         // target -> parent_a -> parent_b -> last_advanced
         // parent_b's header is intentionally missing.
         db.set_block_header(
-            target,
+            target_hash,
             BlockHeader {
                 height: 3,
                 timestamp: 3,
@@ -609,11 +697,16 @@ mod tests {
             },
         );
 
-        let result = collect_advance_chain(&db, target, last_advanced);
+        let target = db.block_simple_data(target_hash).unwrap();
+        let result = collect_advance_chain(&db, target, Some(last_advanced));
         match result {
-            Err(ComputeError::AdvanceMissingHeader { hash }) => assert_eq!(hash, parent_b),
+            Err(ComputeError::Other(msg)) => assert!(
+                msg.contains("block header not found"),
+                "expected a missing-header error for {parent_b:?}, got message: {msg:?} — \
+                 a silent truncation here would non-determinise event replay across peers"
+            ),
             other => panic!(
-                "expected AdvanceMissingHeader for {parent_b:?}, got {other:?} — \
+                "expected a missing-header error for {parent_b:?}, got {other:?} — \
                  a silent truncation here would non-determinise event replay across peers"
             ),
         }
@@ -632,7 +725,7 @@ mod tests {
         let mut sub = ComputeSubService::new(db.clone(), processor);
 
         let mb_hash = H256::from_low_u64_be(0xCAFE);
-        seed_mb(&db, mb_hash, H256::zero(), 1, dummy_ops(&db, 0));
+        seed_mb(&db, mb_hash, H256::zero(), 1, dummy_ops(&db, 2));
         db.mutate_mb_meta(mb_hash, |meta| {
             meta.computed = true;
         });
@@ -679,22 +772,6 @@ mod tests {
         code_id
     }
 
-    /// Synthetic Ethereum block with a zeroed parent, so the compute-side
-    /// advance walk collects exactly this single block.
-    fn synthetic_eb(db: &Database, tag: u8, events: Vec<BlockEvent>) -> H256 {
-        let hash = H256::from_low_u64_be(0xEB00 + tag as u64);
-        db.set_block_header(
-            hash,
-            BlockHeader {
-                height: tag as u32,
-                timestamp: tag as u64,
-                parent_hash: H256::zero(),
-            },
-        );
-        db.set_block_events(hash, &events);
-        hash
-    }
-
     fn ping_injected(destination: ActorId) -> SignedInjectedTransaction {
         let tx = InjectedTransaction {
             destination,
@@ -730,9 +807,11 @@ mod tests {
         // MB #0 — create + fund + initialize the ping program via an
         // Ethereum block. The canonical init message is required: an
         // injected transaction cannot target an uninitialized program.
+        // EBs are chained onto the genesis Eth block (height 1), so the
+        // create block is height 2 and each pinger advances one more EB.
         let create_eb = synthetic_eb(
             db,
-            0,
+            2,
             vec![
                 BlockEvent::Router(RouterEvent::ProgramCreated(ProgramCreatedEvent {
                     actor_id: ping_id,
@@ -764,11 +843,13 @@ mod tests {
         }];
         ops.extend(mb_bookend());
         seed_mb(db, creator, H256::zero(), 0, Operations::new(ops));
+        db.mutate_mb_meta(creator, |m| m.last_advanced_eb = create_eb);
         mb_hashes.push(creator);
 
         // MB #1.. — each injects a single PING into the ping program.
         for i in 1..=pinger_count {
-            let eb = synthetic_eb(db, i as u8, vec![]);
+            let eb_height = 2 + i as u32;
+            let eb = synthetic_eb(db, eb_height, vec![]);
             let mb_hash = H256::from_low_u64_be(0x1000 + i);
             let mut ops = vec![
                 Operation::AdvanceTillEthereumBlock { block_hash: eb },
@@ -782,6 +863,7 @@ mod tests {
                 i,
                 Operations::new(ops),
             );
+            db.mutate_mb_meta(mb_hash, |m| m.last_advanced_eb = eb);
             mb_hashes.push(mb_hash);
         }
 
@@ -797,6 +879,7 @@ mod tests {
     ) -> (Vec<H256>, Vec<(H256, Promise)>) {
         let db = Database::memory();
         seed_genesis_zero_mb(&db);
+        seed_genesis_eth(&db);
         let mut processor = Processor::new(db.clone()).expect("failed to create processor");
         let mb_hashes = build_ping_mb_chain(&db, &mut processor, pinger_count).await;
 

--- a/ethexe/compute/src/lib.rs
+++ b/ethexe/compute/src/lib.rs
@@ -162,15 +162,12 @@ pub enum ComputeError {
     AdvanceBlockEventsMissing(H256),
     #[error("anchor Eth block header missing for {0}")]
     AnchorBlockHeaderMissing(H256),
-    #[error("AdvanceTillEthereumBlock walk hit a missing parent header at {hash}")]
-    AdvanceMissingHeader { hash: H256 },
-    #[error(
-        "AdvanceTillEthereumBlock walk from {target} to {last_advanced} exceeded the safety cap"
-    )]
-    AdvanceWalkTooDeep { target: H256, last_advanced: H256 },
 
     #[error(transparent)]
     Processor(#[from] ProcessorError),
+
+    #[error("other: {0}")]
+    Other(&'static str),
 }
 
 type Result<T> = std::result::Result<T, ComputeError>;

--- a/ethexe/compute/src/service.rs
+++ b/ethexe/compute/src/service.rs
@@ -147,13 +147,28 @@ mod tests {
     use proptest::{collection, prelude::*};
 
     fn seed_mb(db: &DB, mb_hash: H256, gas_allowance: u64) {
-        let eth_block_hash = H256::from_low_u64_be(0xEB00);
+        // Genesis Eth block (height 1) is the root of the advance chain; the
+        // genesis zero-MB is pinned to it so this MB walks a depth-1 chain.
+        let genesis_eb = H256::from_low_u64_be(0xEB00);
         db.set_block_header(
-            eth_block_hash,
+            genesis_eb,
             BlockHeader {
                 height: 1,
                 timestamp: 1,
                 parent_hash: H256::zero(),
+            },
+        );
+        db.set_block_events(genesis_eb, &[]);
+        db.mutate_mb_meta(H256::zero(), |m| m.last_advanced_eb = genesis_eb);
+
+        // The EB this MB advances to, chained onto the genesis Eth block.
+        let eth_block_hash = H256::from_low_u64_be(0xEB01);
+        db.set_block_header(
+            eth_block_hash,
+            BlockHeader {
+                height: 2,
+                timestamp: 2,
+                parent_hash: genesis_eb,
             },
         );
         db.set_block_events(eth_block_hash, &[]);

--- a/ethexe/db/src/migrations/init.rs
+++ b/ethexe/db/src/migrations/init.rs
@@ -85,7 +85,7 @@ pub async fn initialize_empty_db(config: InitConfig, db: &RawDatabase) -> Result
     let genesis_eb = SimpleBlockData {
         hash: genesis.hash,
         header: BlockHeader {
-            // genesis block header is not important in any way for ethexe
+            // IMPORTANT: set parent to zero is protocol invariant
             parent_hash: H256::zero(),
             height: genesis.number,
             timestamp: genesis.timestamp,

--- a/ethexe/malachite/core/Cargo.toml
+++ b/ethexe/malachite/core/Cargo.toml
@@ -39,6 +39,7 @@ tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync
 tracing.workspace = true
 libp2p-identity.workspace = true
 rocksdb.workspace = true
+derive_more.workspace = true
 
 [dev-dependencies]
 advisory-lock.workspace = true

--- a/ethexe/malachite/core/Cargo.toml
+++ b/ethexe/malachite/core/Cargo.toml
@@ -9,7 +9,12 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-# Malachite BFT engine
+gear-core = { workspace = true, features = ["std"] }
+gprimitives = { workspace = true, features = ["std"] }
+gsigner = { workspace = true, features = ["std", "secp256k1", "codec", "serde", "keyring"] }
+ethexe-common = { workspace = true, features = ["std"] }
+gear-workspace-hack.workspace = true
+
 malachitebft-app-channel.workspace = true
 malachitebft-app.workspace = true
 malachitebft-codec.workspace = true
@@ -21,7 +26,6 @@ malachitebft-signing-ecdsa.workspace = true
 malachitebft-sync.workspace = true
 malachitebft-test.workspace = true
 
-# Async + utilities
 advisory-lock.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
@@ -33,21 +37,8 @@ serde = { workspace = true, features = ["derive"] }
 sha3 = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
 tracing.workspace = true
-
-# Crypto + libp2p (kept ethexe-shaped per design: secp256k1 + 20-byte addresses).
-# Address type is reused from gsigner so the application side (ethexe today,
-# anything else tomorrow) gets the same address shape it already deals with.
-gear-core = { workspace = true, features = ["std"] }
-gprimitives = { workspace = true, features = ["std"] }
-gsigner = { workspace = true, features = ["std", "secp256k1", "codec", "serde", "keyring"] }
 libp2p-identity.workspace = true
-
-# Persistent internal store. Version pinned to match ethexe-db's
-# librocksdb-sys (only one `links = "rocksdb"` crate is allowed in
-# the dependency graph).
 rocksdb.workspace = true
-
-gear-workspace-hack.workspace = true
 
 [dev-dependencies]
 advisory-lock.workspace = true

--- a/ethexe/malachite/core/src/app.rs
+++ b/ethexe/malachite/core/src/app.rs
@@ -37,8 +37,9 @@ use crate::{
     streaming::ProposalParts,
     types::{Address, Block, CommitCertificate, H256},
 };
-use anyhow::{Context as _, Result, anyhow};
+use anyhow::{Context as _, Result, anyhow, ensure};
 use bytes::Bytes;
+use ethexe_common::Acceptance;
 use malachitebft_app_channel::{
     AppMsg, Channels, NetworkMsg,
     app::{
@@ -55,7 +56,7 @@ use malachitebft_app_channel::{
 use malachitebft_core_types::Height as _;
 use parity_scale_codec::{Decode, Encode};
 use std::{ops::RangeInclusive, sync::Arc};
-use tracing::{error, info};
+use tracing::{debug, error, info, trace, warn};
 
 /// Max allowed distance into the future for pending proposal parts.
 const FUTURE_HEIGHT_WINDOW: u64 = 4;
@@ -188,12 +189,12 @@ where
                     StreamContent::Data(p) => p.get_type(),
                     StreamContent::Fin => "fin",
                 };
-                info!(%from, %part.sequence, part.type = %part_type, "ReceivedProposalPart");
+                trace!(%from, %part.sequence, part.type = %part_type, "ReceivedProposalPart");
                 let value = self
                     .process_received_proposal_part(from, part)
                     .await
                     .unwrap_or_else(|e| {
-                        error!(?e, "ReceivedProposalPart: process failed");
+                        error!("ReceivedProposalPart: process failed, {e}");
                         None
                     });
                 if reply.send(value).is_err() {
@@ -346,12 +347,17 @@ where
         let pending = self.state.store.get_pending_proposal_parts(height, round)?;
         for parts in pending {
             let promote = async {
-                let proposed = self.assemble_and_validate(&parts).await?;
+                let (proposed, block) = match self.assemble_and_validate(&parts).await? {
+                    Acceptance::Accepted(res) => res,
+                    Acceptance::Rejected(reason) => {
+                        warn!(%height, %round, reason, "rejecting pending proposal");
+                        return Ok(());
+                    }
+                };
                 self.state.store.store_undecided_proposal(&proposed)?;
-                let block = Block::decode(&mut &proposed.value.block_bytes[..])
-                    .map_err(|e| anyhow!("decoding Block from pending proposal: {e}"))?;
                 self.record_assembled_block(block).await
             };
+
             if let Err(e) = promote.await {
                 error!(?e, "rejecting invalid pending proposal");
             }
@@ -445,10 +451,14 @@ where
                 .store_pending_proposal_parts(&parts, &value_id)?;
             Ok(None)
         } else {
-            let proposed = self.assemble_and_validate(&parts).await?;
+            let (proposed, block) = match self.assemble_and_validate(&parts).await? {
+                Acceptance::Accepted(res) => res,
+                Acceptance::Rejected(reason) => {
+                    warn!(%parts.height, %parts.round, reason, "rejecting received proposal");
+                    return Ok(None);
+                }
+            };
             self.state.store.store_undecided_proposal(&proposed)?;
-            let block = Block::decode(&mut &proposed.value.block_bytes[..])
-                .map_err(|e| anyhow!("decoding Block from received proposal: {e}"))?;
             self.record_assembled_block(block).await?;
             Ok(Some(proposed))
         }
@@ -571,17 +581,25 @@ where
     async fn assemble_and_validate(
         &self,
         parts: &ProposalParts,
-    ) -> Result<ProposedValue<MalachiteCtx>> {
+    ) -> Result<Acceptance<(ProposedValue<MalachiteCtx>, Block), String>> {
         let proposed = State::assemble_value_from_parts(parts.clone())?;
-        let block = Block::decode(&mut &proposed.value.block_bytes[..])
-            .map_err(|e| anyhow!("decoding Block from value bytes: {e}"))?;
+
+        let block = match Block::decode(&mut &proposed.value.block_bytes[..]) {
+            Ok(b) => b,
+            Err(e) => {
+                let reason = format!("unable to decode Block from proposal: {e}");
+                return Ok(Acceptance::Rejected(reason));
+            }
+        };
+
         if block.height != proposed.height.as_u64() {
-            return Err(anyhow!(
+            let reason = format!(
                 "block.height ({}) does not match proposed height ({})",
-                block.height,
-                proposed.height
-            ));
+                block.height, proposed.height
+            );
+            return Ok(Acceptance::Rejected(reason));
         }
+
         let local_parent = if proposed.height.as_u64() <= 1 {
             H256::zero()
         } else {
@@ -595,29 +613,25 @@ where
                     )
                 })?
         };
+
         if block.parent_hash != local_parent {
-            return Err(anyhow!(
-                "parent_hash mismatch at height {}: block claims {:?}, local view {:?}",
-                proposed.height,
-                block.parent_hash,
-                local_parent
-            ));
+            let reason = format!(
+                "proposal parent_hash mismatch at height {}: block claims {:?}, local view {:?}",
+                proposed.height, block.parent_hash, local_parent
+            );
+            return Ok(Acceptance::Rejected(reason));
         }
-        // Parent + height already validated above. The application
-        // only sees the parent hash + payload — payload-level checks
-        // live there.
-        let valid = self
+
+        let validation_status = self
             .externalities
-            .validate_block_above(block.parent_hash, block.payload)
+            .validate_block_above(block.parent_hash, &block.payload)
             .await
-            .context("Externalities::validate_block_above")?;
-        if !valid {
-            return Err(anyhow!(
-                "application rejected proposal at height {}",
-                proposed.height
-            ));
+            .context("assemble_and_validate: validate block")?;
+
+        match validation_status {
+            Acceptance::Accepted(()) => Ok(Acceptance::Accepted((proposed, block))),
+            Acceptance::Rejected(reason) => Ok(Acceptance::Rejected(reason)),
         }
-        Ok(proposed)
     }
 
     /// Drive the strict-ordering save cascade against the application
@@ -794,8 +808,12 @@ mod tests {
         async fn build_block_above(&self, _: H256) -> Result<BlockPayload> {
             Ok(test_payload())
         }
-        async fn validate_block_above(&self, _: H256, _: BlockPayload) -> Result<bool> {
-            Ok(true)
+        async fn validate_block_above(
+            &self,
+            _: H256,
+            _: &BlockPayload,
+        ) -> Result<Acceptance<(), String>> {
+            Ok(Acceptance::Accepted(()))
         }
     }
 
@@ -977,8 +995,12 @@ mod tests {
         async fn build_block_above(&self, _: H256) -> Result<BlockPayload> {
             Ok(test_payload())
         }
-        async fn validate_block_above(&self, _: H256, _: BlockPayload) -> Result<bool> {
-            Ok(true)
+        async fn validate_block_above(
+            &self,
+            _: H256,
+            _: &BlockPayload,
+        ) -> Result<Acceptance<(), String>> {
+            Ok(Acceptance::Accepted(()))
         }
     }
 

--- a/ethexe/malachite/core/src/app.rs
+++ b/ethexe/malachite/core/src/app.rs
@@ -37,7 +37,7 @@ use crate::{
     streaming::ProposalParts,
     types::{Address, Block, CommitCertificate, H256},
 };
-use anyhow::{Context as _, Result, anyhow, ensure};
+use anyhow::{Context as _, Result, anyhow};
 use bytes::Bytes;
 use ethexe_common::Acceptance;
 use malachitebft_app_channel::{
@@ -56,7 +56,7 @@ use malachitebft_app_channel::{
 use malachitebft_core_types::Height as _;
 use parity_scale_codec::{Decode, Encode};
 use std::{ops::RangeInclusive, sync::Arc};
-use tracing::{debug, error, info, trace, warn};
+use tracing::{error, info, trace, warn};
 
 /// Max allowed distance into the future for pending proposal parts.
 const FUTURE_HEIGHT_WINDOW: u64 = 4;

--- a/ethexe/malachite/core/src/app.rs
+++ b/ethexe/malachite/core/src/app.rs
@@ -117,9 +117,12 @@ where
                 return Err(anyhow!("consensus channel closed"));
             };
 
-            if let Err(err) = self.handle_app_msg(msg).await {
-                error!("error handling AppMsg: {err}");
-            }
+            // `Err` from `handle_app_msg` means a FATAL failure (dropped
+            // engine reply channel, `FinalizationError::Fatal`, broken
+            // proposal production) — propagate so the app task terminates
+            // and the error surfaces on the service stream. Non-fatal
+            // cases are logged and absorbed inside `handle_app_msg`.
+            self.handle_app_msg(msg).await?;
         }
     }
 

--- a/ethexe/malachite/core/src/app.rs
+++ b/ethexe/malachite/core/src/app.rs
@@ -634,22 +634,10 @@ where
         }
     }
 
-    /// Drive the strict-ordering save cascade against the application
-    /// for a freshly-assembled block. Inserts a `saved=false,
-    /// finalized=false, cert=None` [`BlockEntry`] and runs
-    /// [`Store::cascade_save`] from this hash — the cascade flushes
-    /// every ancestor that is now connected in chronological
-    /// (parent-first) order. If an ancestor is still missing the
-    /// cascade is a no-op; it will pick up when the gap closes via a
-    /// later assembled block at the missing height.
-    ///
-    /// Called from [`Self::process_get_value`] (we are proposer),
-    /// [`Self::process_received_proposal_part`] (peer proposal), and
-    /// [`Self::process_synced_value`] (sync path). Multiple callers
-    /// can race for the same `block_hash` — `Store::insert_block`
-    /// dedup is idempotent and `cascade_save` skips already-saved
-    /// entries, so the application's `process_mb_proposal` runs at
-    /// most once per `block_hash`.
+    /// Record a freshly-assembled block and run the parent-first save
+    /// cascade, so the application's `process_mb_proposal` fires for every
+    /// now-connected ancestor. Idempotent — racing callers are deduped and
+    /// the callback runs at most once per `block_hash`.
     async fn record_assembled_block(&self, block: Block) -> Result<()> {
         let block_hash = block.hash();
         self.state.store.insert_block(BlockEntry {
@@ -671,17 +659,10 @@ where
             .await
     }
 
-    /// Attach the engine's quorum certificate to the
-    /// already-processed [`BlockEntry`] and run the finalize cascade.
-    ///
-    /// Contract: the block (and every ancestor) must have already been
-    /// processed by [`Self::record_assembled_block`] earlier — the
-    /// strict-ordering guarantee documented on
-    /// [`crate::Externalities::process_mb_proposal`]. A debug-build
-    /// assertion catches a violation; in release builds
-    /// [`Store::cascade_finalize`] silently no-ops on an unsaved
-    /// ancestor (the `finalize_chain` walk returns `None`), and the
-    /// `errors_tx` channel surfaces the contract breach upstream.
+    /// Attach the engine's quorum certificate to the already-processed
+    /// [`BlockEntry`] and run the finalize cascade. The block and every
+    /// ancestor must have been saved via [`Self::record_assembled_block`]
+    /// first (debug assertion; release no-ops on an unsaved ancestor).
     async fn ingest_finalized(&self, cert: EngineCert, block_bytes: Vec<u8>) -> Result<()> {
         let block = Block::decode(&mut &block_bytes[..])
             .map_err(|e| anyhow!("decoding Block at finalize: {e}"))?;

--- a/ethexe/malachite/core/src/app.rs
+++ b/ethexe/malachite/core/src/app.rs
@@ -56,7 +56,7 @@ use malachitebft_app_channel::{
 use malachitebft_core_types::Height as _;
 use parity_scale_codec::{Decode, Encode};
 use std::{ops::RangeInclusive, sync::Arc};
-use tracing::{error, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 /// Max allowed distance into the future for pending proposal parts.
 const FUTURE_HEIGHT_WINDOW: u64 = 4;
@@ -89,6 +89,14 @@ enum FinalizationError {
     NonFatal(anyhow::Error),
 }
 
+#[derive(derive_more::From, derive_more::Display)]
+enum ProcessGetValueError {
+    #[display("building block timeout elapsed: {_0}")]
+    TimeoutElapsed(tokio::time::error::Elapsed),
+    #[display(" {_0}")]
+    Any(anyhow::Error),
+}
+
 /// Owns the channel-app event-loop state and dispatches each
 /// [`AppMsg`] variant to its matching `process_*` method. The dispatch
 /// holds the engine reply channel — `process_*` only produces the
@@ -108,7 +116,10 @@ where
             let Some(msg) = self.channels.consensus.recv().await else {
                 return Err(anyhow!("consensus channel closed"));
             };
-            self.handle_app_msg(msg).await?;
+
+            if let Err(err) = self.handle_app_msg(msg).await {
+                error!("error handling AppMsg: {err}");
+            }
         }
     }
 
@@ -116,9 +127,9 @@ where
         match msg {
             // ConsensusReady
             AppMsg::ConsensusReady { reply } => {
-                if reply.send(self.process_consensus_ready()).is_err() {
-                    error!("ConsensusReady: failed to send reply");
-                }
+                reply
+                    .send(self.process_consensus_ready())
+                    .map_err(|e| anyhow!("failed to send ConsensusReady reply: {e:?}"))?;
             }
 
             // StartedRound
@@ -137,9 +148,9 @@ where
                         error!(?e, %height, %round, "StartedRound: process failed");
                         Vec::new()
                     });
-                if reply_value.send(proposals).is_err() {
-                    error!("StartedRound: failed to send proposals reply");
-                }
+                reply_value
+                    .send(proposals)
+                    .map_err(|e| anyhow!("failed to send StartedRound reply: {e:?}"))?;
             }
 
             // GetValue (we are proposer)
@@ -152,35 +163,44 @@ where
                 info!(%height, %round, "GetValue");
                 match self.process_get_value(height, round).await {
                     Ok(proposal) => {
-                        if reply.send(proposal.clone()).is_err() {
-                            error!("GetValue: failed to send proposal reply");
-                        }
+                        reply
+                            .send(proposal.clone())
+                            .map_err(|e| anyhow!("failed to send GetValue reply: {e:?}"))?;
+
                         for stream_message in self.state.stream_proposal(proposal, Round::Nil) {
-                            self.channels
+                            if let Err(err) = self
+                                .channels
                                 .network
                                 .send(NetworkMsg::PublishProposalPart(stream_message))
-                                .await?;
+                                .await
+                            {
+                                error!("failed to send PublishProposalPart: {err}");
+                            }
                         }
                     }
-                    Err(e) => {
-                        // No usable default for `LocallyProposedValue` —
-                        // dropping the reply sender lets the engine time
-                        // out the propose step and advance the round.
-                        error!(?e, %height, %round, "GetValue: process failed — skipping reply");
+
+                    // No usable default for `LocallyProposedValue` —
+                    // dropping the reply sender lets the engine time
+                    // out the propose step and advance the round.
+                    Err(ProcessGetValueError::TimeoutElapsed(e)) => {
+                        warn!(%height, %round, reason = %e, "unable to produce proposal");
+                    }
+                    Err(ProcessGetValueError::Any(e)) => {
+                        return Err(anyhow!("errors during proposal production: {e:?}"));
                     }
                 }
             }
 
             // Vote extensions (unused — return defaults).
             AppMsg::ExtendVote { reply, .. } => {
-                if reply.send(self.process_extend_vote()).is_err() {
-                    error!("ExtendVote: failed to send reply");
-                }
+                reply
+                    .send(self.process_extend_vote())
+                    .map_err(|e| anyhow!("failed to send ExtendVote reply: {e:?}"))?;
             }
             AppMsg::VerifyVoteExtension { reply, .. } => {
-                if reply.send(self.process_verify_vote_extension()).is_err() {
-                    error!("VerifyVoteExtension: failed to send reply");
-                }
+                reply
+                    .send(self.process_verify_vote_extension())
+                    .map_err(|e| anyhow!("failed to send VerifyVoteExtension reply: {e:?}"))?;
             }
 
             // ReceivedProposalPart (we are not proposer)
@@ -197,9 +217,9 @@ where
                         error!("ReceivedProposalPart: process failed, {e}");
                         None
                     });
-                if reply.send(value).is_err() {
-                    error!("ReceivedProposalPart: failed to send reply");
-                }
+                reply
+                    .send(value)
+                    .map_err(|e| anyhow!("failed to send ReceivedProposalPart reply: {e:?}"))?;
             }
 
             // Decided (info only — Finalized fires next).
@@ -250,9 +270,9 @@ where
                         return Err(anyhow!("Fatal error during finalization: {e:?}"));
                     }
                 };
-                if reply.send(next).is_err() {
-                    error!("Finalized: failed to send Next reply");
-                }
+                reply
+                    .send(next)
+                    .map_err(|e| anyhow!("failed to send Next reply: {e:?}"))?;
             }
 
             // Sync path
@@ -268,32 +288,32 @@ where
                     .process_synced_value(height, round, proposer, value_bytes)
                     .await
                     .unwrap_or_else(|e| {
-                        error!(?e, %height, %round, "ProcessSyncedValue: process failed");
+                        error!(?e, %height, %round, "process synced value failed");
                         None
                     });
-                if reply.send(value).is_err() {
-                    error!("ProcessSyncedValue: failed to send reply");
-                }
+                reply
+                    .send(value)
+                    .map_err(|e| anyhow!("failed to send ProcessSyncedValue reply: {e:?}"))?
             }
 
             AppMsg::GetDecidedValues { range, reply } => {
                 let values = self.process_get_decided_values(range).unwrap_or_else(|e| {
-                    error!(?e, "GetDecidedValues: process failed");
+                    error!(?e, "process get decided values failed");
                     Vec::new()
                 });
-                if reply.send(values).is_err() {
-                    error!("GetDecidedValues: failed to send reply");
-                }
+                reply
+                    .send(values)
+                    .map_err(|e| anyhow!("failed to send GetDecidedValues reply: {e:?}"))?;
             }
 
             AppMsg::GetHistoryMinHeight { reply } => {
                 let h = self.process_get_history_min_height().unwrap_or_else(|e| {
-                    error!(?e, "GetHistoryMinHeight: process failed");
+                    error!(?e, "process get history min height failed");
                     Height::default()
                 });
-                if reply.send(h).is_err() {
-                    error!("GetHistoryMinHeight: failed to send reply");
-                }
+                reply
+                    .send(h)
+                    .map_err(|e| anyhow!("failed to send GetHistoryMinHeight reply: {e:?}"))?;
             }
 
             AppMsg::RestreamProposal {
@@ -302,15 +322,12 @@ where
                 valid_round,
                 address: _,
                 value_id,
-            } => {
-                if let Err(e) = self
-                    .process_restream_proposal(height, round, valid_round, value_id)
-                    .await
-                {
-                    error!(?e, %height, %round, "RestreamProposal: process failed");
-                }
-            }
+            } => self
+                .process_restream_proposal(height, round, valid_round, value_id)
+                .await
+                .map_err(|e| anyhow!("restream proposal failed: {e:?}"))?,
         }
+
         Ok(())
     }
 
@@ -370,9 +387,9 @@ where
         &mut self,
         height: Height,
         round: Round,
-    ) -> Result<LocallyProposedValue<MalachiteCtx>> {
+    ) -> Result<LocallyProposedValue<MalachiteCtx>, ProcessGetValueError> {
         if let Some(p) = self.state.get_previously_built_value(height, round)? {
-            info!("re-using previously built value");
+            debug!("re-using previously built value");
             return Ok(p);
         }
 
@@ -394,9 +411,8 @@ where
 
         let build_fut = self.externalities.build_block_above(parent_hash);
         let payload = tokio::time::timeout(self.state.propose_timeout, build_fut)
-            .await
-            .context("block proposal timeout elapsed")?
-            .context("Proposal block building failed")?;
+            .await?
+            .context("build_block_above failed")?;
         let block = Block::new(parent_hash, height.as_u64(), payload);
         let block_bytes = block.encode();
         let locally = self

--- a/ethexe/malachite/core/src/app.rs
+++ b/ethexe/malachite/core/src/app.rs
@@ -18,7 +18,7 @@
 //! [`crate::Externalities`] is enforced by
 //! [`Store::cascade_save`] / [`Store::cascade_finalize`]; fatal
 //! callback errors are surfaced through
-//! [`crate::MalachiteService`]'s error stream.
+//! [`crate::MalachiteCore`]'s error stream.
 //!
 //! Each [`AppMsg`] variant is paired with a `process_*` method on
 //! [`AppMsgHandler`] that performs the work and returns the value the

--- a/ethexe/malachite/core/src/config.rs
+++ b/ethexe/malachite/core/src/config.rs
@@ -50,7 +50,7 @@ pub enum NodeRole {
 /// Application-specific knobs (gas budgets, mempool settings, etc.)
 /// live behind [`crate::Externalities`] — they don't belong here.
 #[derive(Clone, Debug)]
-pub struct MalachiteConfig {
+pub struct MalachiteCoreConfig {
     /// Local libp2p listen address.
     pub listen_addr: SocketAddr,
 
@@ -99,7 +99,7 @@ pub struct MalachiteConfig {
     pub propose_timeout: Duration,
 }
 
-impl MalachiteConfig {
+impl MalachiteCoreConfig {
     /// Default propose timeout — 13 seconds. The upper bound on how
     /// long [`crate::Externalities::build_block_above`] is given to
     /// produce a block before the round rolls over. Applications

--- a/ethexe/malachite/core/src/config.rs
+++ b/ethexe/malachite/core/src/config.rs
@@ -7,9 +7,7 @@ use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
 pub use malachitebft_app_channel::app::net::Multiaddr;
 
-/// One entry of the validator set. The set is fixed for the lifetime
-/// of the deployment — to rotate validators every node must be
-/// re-bootstrapped from a fresh [`MalachiteCoreConfig`].
+/// One entry of the validator set.
 //
 // TODO: #5480 add `libp2p_peer_id: PeerId` so receivers can gate
 //       `ReceivedProposalPart` against a validator-peer-id allowlist
@@ -26,91 +24,54 @@ pub struct ValidatorEntry {
 }
 
 /// Role this node plays in the BFT swarm.
-///
-/// A `FullNode` doesn't propose or vote — it joins the gossip mesh,
-/// receives proposals + sync responses, and surfaces them to the
-/// application via [`crate::Externalities::process_mb_proposal`] /
-/// [`crate::Externalities::process_mb_finalized`] just like a
-/// validator would. Use this for read-only observers,
-/// quarantine workers, light clients, etc.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NodeRole {
-    /// Sign votes and proposals; broadcast a validator proof on
-    /// connect; the local address must appear in [`MalachiteCoreConfig::validators`].
+    /// Signs votes and proposals; the local key must appear in
+    /// [`MalachiteCoreConfig::validators`].
     Validator,
-    /// Read-only participant — joins gossip / sync, validates
-    /// incoming blocks, but never signs anything. The local address
-    /// must NOT appear in [`MalachiteCoreConfig::validators`].
+    /// Read-only participant — joins gossip / sync and validates blocks,
+    /// but never signs; the local key must NOT be in the validator set.
     FullNode,
 }
 
-/// All configuration the service needs to bootstrap the malachite
-/// engine.
-///
-/// Application-specific knobs (gas budgets, mempool settings, etc.)
-/// live behind [`crate::Externalities`] — they don't belong here.
+/// All configuration the service needs to bootstrap the malachite engine.
+/// Application-specific knobs live behind [`crate::Externalities`].
 #[derive(Clone, Debug)]
 pub struct MalachiteCoreConfig {
     /// Local libp2p listen address.
     pub listen_addr: SocketAddr,
 
-    /// Application's project base directory. The service carves out
-    /// `<base>/malachite/` and owns everything inside it: the
-    /// consensus WAL (`consensus.wal`) and the RocksDB store
-    /// (`store.db/` — block entries, decided/undecided proposals,
-    /// pending parts, height index, engine certificates). Anything
-    /// else under `base` is the application's business.
-    ///
-    /// The artifacts inside `<base>/malachite/` are created on first
-    /// run; subsequent runs resume from where the previous one left
-    /// off.
-    ///
-    /// In tests, the caller is responsible for keeping this directory
-    /// alive across service restarts (don't drop the `TempDir` between
-    /// service spawns).
+    /// Base directory; the service owns `<base>/malachite/` (consensus WAL
+    /// + RocksDB store), created on first run and resumed on restarts.
     pub base: PathBuf,
 
-    /// Multiaddrs the local node should keep persistent connections
-    /// to. Each entry must include the `/p2p/<peer_id>` suffix so the
-    /// swarm knows who to expect on the other side. Discovery is off,
-    /// so multi-validator deployments need every node's multiaddr
-    /// listed (or at least transitively reachable).
+    /// Multiaddrs of peers to keep persistent connections to; each entry
+    /// must include a `/p2p/<peer_id>` suffix (discovery is off).
     pub persistent_peers: Vec<Multiaddr>,
 
-    /// This node's secp256k1 secret. Used (after a domain-separated
-    /// derivation) for the libp2p peer identity in both roles, and
-    /// additionally for malachite vote / proposal signing in
-    /// [`NodeRole::Validator`] mode.
+    /// This node's secp256k1 secret: libp2p peer identity in both roles,
+    /// plus vote / proposal signing in [`NodeRole::Validator`] mode.
     pub validator_secret: gsigner::schemes::secp256k1::PrivateKey,
 
-    /// Validator set the engine uses to drive consensus. For
-    /// [`NodeRole::Validator`] the set must contain an entry whose
-    /// public key matches [`Self::validator_secret`]; for
-    /// [`NodeRole::FullNode`] the local key must NOT be in the set.
+    /// Validator set the engine uses to drive consensus
+    /// (see [`NodeRole`] for local-key membership rules).
     pub validators: Vec<ValidatorEntry>,
 
     /// Whether this node casts votes (`Validator`) or just observes
     /// (`FullNode`).
     pub role: NodeRole,
 
-    /// Upper bound on how long the service will wait on
-    /// [`crate::Externalities::build_block_above`] before giving up
-    /// and letting malachite's round timeout advance the proposer.
+    /// Upper bound on waiting for [`crate::Externalities::build_block_above`]
+    /// before the round rolls over.
     pub propose_timeout: Duration,
 }
 
 impl MalachiteCoreConfig {
-    /// Default propose timeout — 13 seconds. The upper bound on how
-    /// long [`crate::Externalities::build_block_above`] is given to
-    /// produce a block before the round rolls over. Applications
-    /// should override this when they have a faster or slower
-    /// block-production deadline.
+    /// Default propose timeout.
     pub const DEFAULT_PROPOSE_TIMEOUT: Duration = Duration::from_secs(13);
 
-    /// Default libp2p listen address — `0.0.0.0:20334`. Sits next to
-    /// the typical 20333/udp QUIC port commonly used for
-    /// application-level networking, but on TCP since malachite's
-    /// default transport is TCP.
+    /// Default libp2p listen address — TCP next to the typical
+    /// 20333/udp application QUIC port.
     pub const DEFAULT_LISTEN_ADDR: SocketAddr = SocketAddr::new(
         std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)),
         20334,

--- a/ethexe/malachite/core/src/config.rs
+++ b/ethexe/malachite/core/src/config.rs
@@ -9,7 +9,7 @@ pub use malachitebft_app_channel::app::net::Multiaddr;
 
 /// One entry of the validator set. The set is fixed for the lifetime
 /// of the deployment — to rotate validators every node must be
-/// re-bootstrapped from a fresh [`MalachiteConfig`].
+/// re-bootstrapped from a fresh [`MalachiteCoreConfig`].
 //
 // TODO: #5480 add `libp2p_peer_id: PeerId` so receivers can gate
 //       `ReceivedProposalPart` against a validator-peer-id allowlist
@@ -36,11 +36,11 @@ pub struct ValidatorEntry {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NodeRole {
     /// Sign votes and proposals; broadcast a validator proof on
-    /// connect; the local address must appear in [`MalachiteConfig::validators`].
+    /// connect; the local address must appear in [`MalachiteCoreConfig::validators`].
     Validator,
     /// Read-only participant — joins gossip / sync, validates
     /// incoming blocks, but never signs anything. The local address
-    /// must NOT appear in [`MalachiteConfig::validators`].
+    /// must NOT appear in [`MalachiteCoreConfig::validators`].
     FullNode,
 }
 

--- a/ethexe/malachite/core/src/externalities.rs
+++ b/ethexe/malachite/core/src/externalities.rs
@@ -9,93 +9,43 @@ use async_trait::async_trait;
 use ethexe_common::Acceptance;
 
 /// Application-side callbacks the consensus service requires.
+/// The application contributes only the opaque [`BlockPayload`];
+/// everything BFT-related stays inside the service.
 ///
-/// The service is application-agnostic: it owns the BFT engine, the
-/// libp2p swarm, and the persistent BFT state. The opaque, size-capped
-/// payload byte string ([`BlockPayload`]) is the only
-/// shape the application contributes to a [`Block`] — encoding and
-/// decoding of any application-level schema lives behind this trait.
+/// Guaranteed happens-before ordering (`H256::zero()` parent = genesis):
 ///
-/// The service guarantees a strict happens-before ordering for the
-/// callbacks below — the application never has to maintain its own
-/// synchronization barrier:
-///
-/// 1. [`Self::process_mb_proposal`] for `mb_hash` is called as soon
-///    as a proposal carrying that hash has been assembled and
-///    validated locally (regardless of whether this node is the
-///    proposer, a participant that received the proposal over the
-///    network, or a full node that received a synced decided value),
-///    but **only after** every ancestor of `mb_hash` has already
-///    returned successfully from a previous `process_mb_proposal`
-///    call. Sibling proposals at the same height are possible (one
-///    per fork-causing round) and each is delivered exactly once
-///    per `mb_hash`.
-/// 2. [`Self::process_mb_finalized`] for `mb_hash` is called **only
-///    after** `process_mb_proposal` for that same `mb_hash` returned
-///    successfully **and** every ancestor has already been finalized
-///    via previous `process_mb_finalized` calls.
-/// 3. [`Self::build_block_above`] / [`Self::validate_block_above`]
-///    are called only after the parent has been finalized (or
-///    `parent_hash == H256::zero()` when building / validating the
-///    genesis block).
-///
-/// All methods are async; the service `await`s them inline.
+/// 1. [`Self::process_mb_proposal`] fires once per `mb_hash`, only after
+///    every ancestor's `process_mb_proposal` returned `Ok`. Sibling
+///    proposals at the same height are possible.
+/// 2. [`Self::process_mb_finalized`] fires only after the same hash's
+///    `process_mb_proposal` and every ancestor's finalization.
+/// 3. [`Self::build_block_above`] / [`Self::validate_block_above`] fire
+///    only after the parent has been finalized.
 #[async_trait]
 pub trait Externalities: Send + Sync + 'static {
-    /// Persist `block` indexed by `mb_hash`. Called exactly once
-    /// per `mb_hash` over the lifetime of an application instance,
-    /// at proposal-assembly time, after every ancestor's
-    /// `process_mb_proposal` has already returned `Ok`.
+    /// Persist `block` indexed by `mb_hash`; called exactly once per hash
+    /// at proposal-assembly time.
     async fn process_mb_proposal(&self, mb_hash: H256, block: Block) -> Result<()>;
 
-    /// Mark `mb_hash` as finalized and durable.
-    ///
-    /// `cert` is the BFT commit certificate for the height of
-    /// `mb_hash`. The application typically forwards `cert` to
-    /// downstream layers (on-chain commits, light clients, etc.).
+    /// Mark `mb_hash` as finalized; `cert` is the BFT commit certificate
+    /// for its height.
     async fn process_mb_finalized(&self, mb_hash: H256, cert: CommitCertificate) -> Result<()>;
 
-    /// Build a fresh block payload whose parent has hash
-    /// `parent_mb_hash`. Called only when this node has been elected
-    /// proposer. The new block's height is derivable from `parent_mb_hash`
-    /// (parent.height + 1, or 1 for genesis), so it isn't passed
-    /// explicitly here.
+    /// Build a fresh block payload on top of `parent_mb_hash`; called only
+    /// when this node is the elected proposer.
     ///
-    /// The future may take an arbitrarily long time — for example to
-    /// wait on a mempool, an external block source, or a chain head
-    /// — and the service races it against
-    /// [`crate::MalachiteCoreConfig::propose_timeout`]. On timeout the
-    /// future is cancelled (dropped); implementations must be
-    /// cancellation-safe.
-    ///
-    /// `parent_hash == H256::zero()` is passed when building the
-    /// genesis block.
+    /// The future may wait arbitrarily long — the service races it against
+    /// [`crate::MalachiteCoreConfig::propose_timeout`] and cancels it on
+    /// timeout, so implementations must be cancellation-safe.
     async fn build_block_above(&self, parent_mb_hash: H256) -> Result<BlockPayload>;
 
-    /// Application-side validation of an incoming proposal's
-    /// **payload only**.
+    /// Application-side validation of an incoming proposal's **payload
+    /// only** — parent linkage and height are checked by the consensus
+    /// layer before this hook fires.
     ///
-    /// Parent linkage and height progression are validated inside
-    /// the consensus layer before this hook fires; the caller still
-    /// passes `parent_mb_hash` for context (e.g. to read ancestor state
-    /// from an application-side store) but is not expected to
-    /// re-check `block.parent_mb_hash`. `parent_mb_hash == H256::zero()`
-    /// signals the genesis block.
-    ///
-    /// Typical responsibilities:
-    /// - the payload bytes decode against the application's schema;
-    /// - the decoded content is well-formed against the application's
-    ///   protocol invariants (gas budget, single anchor advance,
-    ///   operation shape, etc.).
-    /// - Optionally a stronger proposer-authorization check on top
-    ///   of malachite's validator set.
-    ///
-    /// Returns `Ok(true)` to vote for the proposal, `Ok(false)` to
-    /// reject without crashing, `Err(_)` for an unexpected internal
-    /// failure (surfaces as an error event on the service stream).
-    ///
-    /// Not called on the sync path — sync values come with a quorum
-    /// commit certificate and are accepted on that basis alone.
+    /// Returns `Accepted` to vote for the proposal, `Rejected(reason)` to
+    /// vote nil, `Err(_)` for an unexpected internal failure. Not called
+    /// on the sync path (sync values carry a quorum certificate).
     async fn validate_block_above(
         &self,
         parent_mb_hash: H256,

--- a/ethexe/malachite/core/src/externalities.rs
+++ b/ethexe/malachite/core/src/externalities.rs
@@ -64,7 +64,7 @@ pub trait Externalities: Send + Sync + 'static {
     /// The future may take an arbitrarily long time — for example to
     /// wait on a mempool, an external block source, or a chain head
     /// — and the service races it against
-    /// [`crate::MalachiteConfig::propose_timeout`]. On timeout the
+    /// [`crate::MalachiteCoreConfig::propose_timeout`]. On timeout the
     /// future is cancelled (dropped); implementations must be
     /// cancellation-safe.
     ///

--- a/ethexe/malachite/core/src/externalities.rs
+++ b/ethexe/malachite/core/src/externalities.rs
@@ -3,10 +3,10 @@
 
 //! Application callbacks the service makes to the outside world.
 
+use crate::types::{Block, BlockPayload, CommitCertificate, H256};
 use anyhow::Result;
 use async_trait::async_trait;
-
-use crate::types::{Block, BlockPayload, CommitCertificate, H256};
+use ethexe_common::Acceptance;
 
 /// Application-side callbacks the consensus service requires.
 ///
@@ -99,6 +99,6 @@ pub trait Externalities: Send + Sync + 'static {
     async fn validate_block_above(
         &self,
         parent_mb_hash: H256,
-        payload: BlockPayload,
-    ) -> Result<bool>;
+        payload: &BlockPayload,
+    ) -> Result<Acceptance<(), String>>;
 }

--- a/ethexe/malachite/core/src/lib.rs
+++ b/ethexe/malachite/core/src/lib.rs
@@ -9,7 +9,7 @@
 //! can plug in without touching BFT plumbing.
 //!
 //! `ethexe-malachite` is the only direct consumer: it supplies the [`Externalities`]
-//! implementation and wraps [`MalachiteService`] in its own facade exposed to the rest
+//! implementation and wraps [`MalachiteCore`] in its own facade exposed to the rest
 //! of the ethexe stack. Block delivery happens exclusively through async
 //! [`Externalities`] callbacks.
 //!
@@ -27,17 +27,17 @@
 //!
 //! ## Usage
 //!
-//! Construct the service with [`MalachiteService::new`](MalachiteService), then poll it
+//! Construct the service with [`MalachiteCore::new`](MalachiteCore), then poll it
 //! as a `Stream`:
 //!
 //! ```rust,no_run
-//! # use ethexe_malachite_core::{MalachiteConfig, MalachiteService, Externalities};
+//! # use ethexe_malachite_core::{MalachiteCoreConfig, MalachiteCore, Externalities};
 //! # use std::sync::Arc;
 //! async fn start<EXT: Externalities>(
-//!     config: MalachiteConfig,
+//!     config: MalachiteCoreConfig,
 //!     ext: Arc<EXT>,
-//! ) -> MalachiteService<EXT> {
-//!     MalachiteService::<EXT>::new(config, ext)
+//! ) -> MalachiteCore<EXT> {
+//!     MalachiteCore::<EXT>::new(config, ext)
 //!         .await
 //!         .expect("service starts")
 //! }
@@ -47,13 +47,13 @@
 //!
 //! - [`Externalities`] — Async application callbacks: `process_mb_proposal`, `process_mb_finalized`, `build_block_above`,
 //!   `validate_block_above`.
-//! - [`MalachiteService`] — Running service; owns the swarm and store. Implements `Stream<Item = anyhow::Error>` and
+//! - [`MalachiteCore`] — Running service; owns the swarm and store. Implements `Stream<Item = anyhow::Error>` and
 //!   [`MService`]. `update_validators` rotates the active validator set, taking effect at the next height boundary.
-//! - [`MService`] — Supertrait bound implemented by [`MalachiteService`].
+//! - [`MService`] — Supertrait bound implemented by [`MalachiteCore`].
 //! - [`Block`] — Service-level block envelope: `{ parent_hash: H256, height: u64, payload: BlockPayload, reserved: [u8; 64] }`.
-//! - [`ValidatorEntry`] — Validator set member: `public_key` + `voting_power`, used in [`MalachiteConfig`] and
+//! - [`ValidatorEntry`] — Validator set member: `public_key` + `voting_power`, used in [`MalachiteCoreConfig`] and
 //!   `update_validators`.
-//! - [`MalachiteConfig`] — Node configuration: validator secret, validator set, `persistent_peers`, propose timeout,
+//! - [`MalachiteCoreConfig`] — Node configuration: validator secret, validator set, `persistent_peers`, propose timeout,
 //!   [`NodeRole`], `listen_addr`, and `base` project directory.
 //! - [`CommitCertificate`] — Finalization certificate delivered with `process_mb_finalized`.
 //! - [`libp2p_peer_id`] — Derive a [`PeerId`] from a validator secret offline, to build the `/p2p/<peer-id>` suffix of each
@@ -61,14 +61,14 @@
 //!
 //! ## Caller invariants
 //!
-//! - `listen_addr` must be set explicitly; [`MalachiteConfig::DEFAULT_LISTEN_ADDR`] is
+//! - `listen_addr` must be set explicitly; [`MalachiteCoreConfig::DEFAULT_LISTEN_ADDR`] is
 //!   available but is not applied by any struct-level default.
 //! - `base` must be a persistent path: the service writes `<base>/malachite/` (store and
 //!   WAL) on first run and resumes from it on restart; a transient path loses BFT state.
 //! - Every persistent-peer multiaddr must include a `/p2p/<peer-id>` suffix (see
 //!   [`libp2p_peer_id`]).
 //! - Returning `Err` from a proposal or finalization callback is fatal: the error
-//!   surfaces on the [`MalachiteService`] stream and the consensus loop aborts rather
+//!   surfaces on the [`MalachiteCore`] stream and the consensus loop aborts rather
 //!   than skipping the callback.
 //!
 //! The service guarantees a strictly linearised block stream: each block is delivered

--- a/ethexe/malachite/core/src/lib.rs
+++ b/ethexe/malachite/core/src/lib.rs
@@ -89,9 +89,9 @@ mod store;
 mod streaming;
 
 pub use crate::{
-    config::{MalachiteConfig, Multiaddr, NodeRole, ValidatorEntry},
+    config::{MalachiteCoreConfig, Multiaddr, NodeRole, ValidatorEntry},
     externalities::Externalities,
-    service::{MService, MalachiteService},
+    service::{MService, MalachiteCore},
     signing::{
         MalachiteSigner, PrivateKey, PublicKey, Signature, derive_libp2p_secret,
         libp2p_keypair_from, libp2p_peer_id, private_key_from_bytes, private_key_from_gsigner,

--- a/ethexe/malachite/core/src/service.rs
+++ b/ethexe/malachite/core/src/service.rs
@@ -1,7 +1,7 @@
 // Copyright (C) Gear Technologies Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
-//! [`MalachiteService`] — the public entry point.
+//! [`MalachiteCore`] — the public entry point.
 
 use crate::{
     app,
@@ -80,7 +80,7 @@ const WAL_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(25);
 /// The actor's `JoinHandle` is therefore *not* a sufficient barrier —
 /// the writer thread can still be live (and the lock still held) after
 /// the engine task exits. We probe the lock here so callers of
-/// [`MalachiteService::shutdown`] can immediately re-open the same
+/// [`MalachiteCore::shutdown`] can immediately re-open the same
 /// base dir without spurious "advisory lock held" errors.
 ///
 /// A missing WAL file means we never wrote one; nothing to wait for.
@@ -180,7 +180,7 @@ impl<EXT: Externalities> MalachiteCore<EXT> {
 
         // ---- validator set from config ----
         if config.validators.is_empty() {
-            return Err(anyhow::anyhow!("MalachiteConfig::validators is empty"));
+            return Err(anyhow::anyhow!("MalachiteCoreConfig::validators is empty"));
         }
         let mut validators = Vec::with_capacity(config.validators.len());
         for entry in &config.validators {
@@ -197,7 +197,7 @@ impl<EXT: Externalities> MalachiteCore<EXT> {
             NodeRole::Validator => {
                 if !in_set {
                     return Err(anyhow::anyhow!(
-                        "NodeRole::Validator: local address {address} not present in MalachiteConfig::validators"
+                        "NodeRole::Validator: local address {address} not present in MalachiteCoreConfig::validators"
                     ));
                 }
                 let peer_id_bytes = libp2p_keypair.public().to_peer_id().to_bytes();
@@ -223,7 +223,7 @@ impl<EXT: Externalities> MalachiteCore<EXT> {
             NodeRole::FullNode => {
                 if in_set {
                     return Err(anyhow::anyhow!(
-                        "NodeRole::FullNode: local address {address} must NOT be in MalachiteConfig::validators"
+                        "NodeRole::FullNode: local address {address} must NOT be in MalachiteCoreConfig::validators"
                     ));
                 }
                 NetworkIdentity::new(moniker.clone(), libp2p_keypair, None)
@@ -290,7 +290,7 @@ impl<EXT: Externalities> MalachiteCore<EXT> {
     pub fn update_validators(&self, validators: Vec<crate::ValidatorEntry>) -> Result<()> {
         if validators.is_empty() {
             return Err(anyhow::anyhow!(
-                "MalachiteService::update_validators: empty validators list"
+                "MalachiteCore::update_validators: empty validators list"
             ));
         }
         let mut converted = Vec::with_capacity(validators.len());

--- a/ethexe/malachite/core/src/service.rs
+++ b/ethexe/malachite/core/src/service.rs
@@ -49,41 +49,30 @@ pub trait MService: Stream<Item = anyhow::Error> + Send + Unpin {}
 
 /// Application-agnostic Malachite BFT consensus service.
 pub struct MalachiteCore<EXT: Externalities> {
+    /// Fatal errors forwarded from the app task.
     errors_rx: mpsc::UnboundedReceiver<anyhow::Error>,
+    /// Handle to the malachite engine actor tree.
     engine: EngineHandle,
+    /// Handle to the spawned app event-loop task.
     app_handle: JoinHandle<()>,
-    /// Path to the WAL file. [`Self::shutdown`] probes the advisory
-    /// lock on this path before returning so the next service
-    /// opening the same base dir does not race the WAL writer thread.
+    /// WAL file path; [`Self::shutdown`] probes its advisory lock before
+    /// returning so a restart on the same base dir doesn't race the writer.
     wal_path: PathBuf,
-    /// Shared with the inner app loop; [`Self::update_validators`]
-    /// writes here, the next `Finalized` / `ConsensusReady` reply reads.
+    /// Shared with the app loop; [`Self::update_validators`] writes here.
     validator_set: SharedValidatorSet,
+    /// Keeps the externalities alive for the app task.
     _externalities: Arc<EXT>,
 }
 
-/// Upper bound on how long [`MalachiteCore::shutdown`] will wait
-/// for the WAL advisory lock to be released after the engine actor
-/// has stopped. Empirically the writer thread drops the file within
-/// tens of milliseconds; this ceiling guards against pathological CI
-/// scheduling without ever blocking healthy shutdowns.
+/// Upper bound on how long [`MalachiteCore::shutdown`] waits for the WAL
+/// advisory lock to release after the engine actor has stopped.
 const WAL_LOCK_RELEASE_TIMEOUT: Duration = Duration::from_secs(10);
 const WAL_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
-/// Block until the WAL file at `wal_path` is no longer locked, or
-/// `timeout` has elapsed.
-///
-/// Malachite's WAL is owned by a [`std::thread`] (see
-/// `arc-malachitebft-engine`'s `wal::thread`); the engine actor's
-/// `post_stop` only sends a `Shutdown` message on a channel, and the
-/// thread releases its [`advisory_lock`] when it later drops the log.
-/// The actor's `JoinHandle` is therefore *not* a sufficient barrier —
-/// the writer thread can still be live (and the lock still held) after
-/// the engine task exits. We probe the lock here so callers of
-/// [`MalachiteCore::shutdown`] can immediately re-open the same
-/// base dir without spurious "advisory lock held" errors.
-///
-/// A missing WAL file means we never wrote one; nothing to wait for.
+/// Block until the WAL file is no longer locked or `timeout` elapses.
+/// The WAL writer is a detached thread, so the engine actor's JoinHandle
+/// is not a sufficient barrier; probing the lock lets the caller re-open
+/// the same base dir right away. A missing WAL file passes immediately.
 async fn wait_wal_lock_released(wal_path: &Path, timeout: Duration) {
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
@@ -114,12 +103,8 @@ async fn wait_wal_lock_released(wal_path: &Path, timeout: Duration) {
 
 impl<EXT: Externalities> Drop for MalachiteCore<EXT> {
     fn drop(&mut self) {
-        // Stop the engine actor so its libp2p / consensus children
-        // shut down cleanly, then abort the app and engine join handles.
-        // Note: this is a fire-and-forget shutdown — RocksDB locks
-        // and listening sockets may take a few hundred ms to release.
-        // Use [`Self::shutdown`] for tests that immediately re-open
-        // the same home directory.
+        // Fire-and-forget shutdown; locks and sockets may take a moment to
+        // release. Use [`Self::shutdown`] when re-opening the same base dir.
         self.engine.actor.kill();
         self.app_handle.abort();
         self.engine.handle.abort();
@@ -127,21 +112,15 @@ impl<EXT: Externalities> Drop for MalachiteCore<EXT> {
 }
 
 impl<EXT: Externalities> MalachiteCore<EXT> {
-    /// Block until the engine actor tree has finished shutting down
-    /// and any open file locks (RocksDB, WAL) have been released.
-    /// Use this before re-opening the same `base` to avoid
-    /// "advisory lock held" errors at the second `new()` call.
+    /// Block until the engine actor tree has shut down and the file locks
+    /// (RocksDB, WAL) are released — required before re-opening the same `base`.
     pub async fn shutdown(mut self) {
         self.engine.actor.kill();
-        // `kill` is asynchronous — the actor finishes its current
-        // message and then stops, so we await the JoinHandles.
+        // `kill` is asynchronous — await the JoinHandles.
         let _ = (&mut self.engine.handle).await;
         self.app_handle.abort();
         let _ = (&mut self.app_handle).await;
-        // The engine task exiting doesn't synchronously release the
-        // WAL advisory lock — the writer is a detached std::thread.
-        // Probe the lock so callers can immediately re-open the same
-        // base dir.
+        // The WAL writer is a detached thread; probe its lock explicitly.
         wait_wal_lock_released(&self.wal_path, WAL_LOCK_RELEASE_TIMEOUT).await;
     }
 }
@@ -278,15 +257,10 @@ impl<EXT: Externalities> MalachiteCore<EXT> {
         })
     }
 
-    /// Swap the active validator set used at the next height start.
-    /// Malachite's `StartHeight` snapshots the set at the height
-    /// start, so the current height runs to completion with whatever
-    /// it had; the `Finalized` reply then feeds the new set as the
-    /// next-height `HeightParams`, keeping the rotation gap-free.
-    ///
-    /// Caller is responsible for keeping the local validator's pub
-    /// key in `validators` while running in [`NodeRole::Validator`]
-    /// — we don't carry the role around here. Empty input is rejected.
+    /// Swap the active validator set, taking effect at the next height start
+    /// (the current height runs to completion with the old set).
+    /// The caller must keep the local key in the set while in
+    /// [`NodeRole::Validator`]. Empty input is rejected.
     pub fn update_validators(&self, validators: Vec<crate::ValidatorEntry>) -> Result<()> {
         if validators.is_empty() {
             return Err(anyhow::anyhow!(

--- a/ethexe/malachite/core/src/service.rs
+++ b/ethexe/malachite/core/src/service.rs
@@ -6,7 +6,7 @@
 use crate::{
     app,
     codec::ScaleCodec,
-    config::{MalachiteConfig, NodeRole},
+    config::{MalachiteCoreConfig, NodeRole},
     context::{MalachiteCtx, Validator, ValidatorSet},
     externalities::Externalities,
     signing::{
@@ -48,7 +48,7 @@ use tokio::{sync::mpsc, task::JoinHandle};
 pub trait MService: Stream<Item = anyhow::Error> + Send + Unpin {}
 
 /// Application-agnostic Malachite BFT consensus service.
-pub struct MalachiteService<EXT: Externalities> {
+pub struct MalachiteCore<EXT: Externalities> {
     errors_rx: mpsc::UnboundedReceiver<anyhow::Error>,
     engine: EngineHandle,
     app_handle: JoinHandle<()>,
@@ -62,7 +62,7 @@ pub struct MalachiteService<EXT: Externalities> {
     _externalities: Arc<EXT>,
 }
 
-/// Upper bound on how long [`MalachiteService::shutdown`] will wait
+/// Upper bound on how long [`MalachiteCore::shutdown`] will wait
 /// for the WAL advisory lock to be released after the engine actor
 /// has stopped. Empirically the writer thread drops the file within
 /// tens of milliseconds; this ceiling guards against pathological CI
@@ -112,7 +112,7 @@ async fn wait_wal_lock_released(wal_path: &Path, timeout: Duration) {
     }
 }
 
-impl<EXT: Externalities> Drop for MalachiteService<EXT> {
+impl<EXT: Externalities> Drop for MalachiteCore<EXT> {
     fn drop(&mut self) {
         // Stop the engine actor so its libp2p / consensus children
         // shut down cleanly, then abort the app and engine join handles.
@@ -126,7 +126,7 @@ impl<EXT: Externalities> Drop for MalachiteService<EXT> {
     }
 }
 
-impl<EXT: Externalities> MalachiteService<EXT> {
+impl<EXT: Externalities> MalachiteCore<EXT> {
     /// Block until the engine actor tree has finished shutting down
     /// and any open file locks (RocksDB, WAL) have been released.
     /// Use this before re-opening the same `base` to avoid
@@ -146,9 +146,9 @@ impl<EXT: Externalities> MalachiteService<EXT> {
     }
 }
 
-impl<EXT: Externalities> MalachiteService<EXT> {
+impl<EXT: Externalities> MalachiteCore<EXT> {
     /// Bootstrap the service.
-    pub async fn new(config: MalachiteConfig, externalities: Arc<EXT>) -> Result<Self> {
+    pub async fn new(config: MalachiteCoreConfig, externalities: Arc<EXT>) -> Result<Self> {
         // The service owns `<base>/malachite/`. We `mkdir -p` it so
         // RocksDB and the WAL can land there.
         let svc_dir = config.base.join("malachite");
@@ -305,7 +305,7 @@ impl<EXT: Externalities> MalachiteService<EXT> {
     }
 }
 
-impl<EXT: Externalities> Stream for MalachiteService<EXT> {
+impl<EXT: Externalities> Stream for MalachiteCore<EXT> {
     type Item = anyhow::Error;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<Option<Self::Item>> {
@@ -313,15 +313,15 @@ impl<EXT: Externalities> Stream for MalachiteService<EXT> {
     }
 }
 
-impl<EXT: Externalities> FusedStream for MalachiteService<EXT> {
+impl<EXT: Externalities> FusedStream for MalachiteCore<EXT> {
     fn is_terminated(&self) -> bool {
         self.errors_rx.is_closed()
     }
 }
 
-impl<EXT: Externalities> MService for MalachiteService<EXT> {}
+impl<EXT: Externalities> MService for MalachiteCore<EXT> {}
 
-fn build_inner_config(cfg: &MalachiteConfig, moniker: &str) -> InnerNodeConfig {
+fn build_inner_config(cfg: &MalachiteCoreConfig, moniker: &str) -> InnerNodeConfig {
     let transport = TransportProtocol::Tcp;
     let listen_multiaddr = transport.multiaddr(
         &cfg.listen_addr.ip().to_string(),

--- a/ethexe/malachite/core/src/signing.rs
+++ b/ethexe/malachite/core/src/signing.rs
@@ -2,26 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 //! secp256k1 / ECDSA signing primitives plus the libp2p identity
-//! derivation that the Malachite swarm uses.
+//! derivation for the Malachite swarm.
 //!
-//! The node's master secret enters the service via
-//! [`crate::MalachiteCoreConfig::validator_secret`] (a
-//! `gsigner::secp256k1::PrivateKey`). The 32 raw bytes drive two
-//! separate identities:
-//!
-//! - the consensus signer ([`MalachiteSigner`]) — signs Malachite
-//!   votes / proposals / `Fin` parts;
-//! - a domain-separated libp2p keypair — independent peer-id so a
-//!   process running another libp2p swarm under the same key doesn't
-//!   collide.
-//!
-//! Address derivation is the standard
-//! `keccak256(uncompressed_pubkey[1..])[12..]` flow. The 20-byte
-//! address sits inside [`crate::Address`] as a gsigner newtype.
-//!
-//! The malachite-side `SigningProvider<MalachiteCtx>` impl for
-//! [`MalachiteSigner`] lives in [`crate::context`] alongside the
-//! `Context` type it parametrises.
+//! [`crate::MalachiteCoreConfig::validator_secret`] drives two identities:
+//! the consensus signer ([`MalachiteSigner`]) and a domain-separated
+//! libp2p keypair.
 
 use anyhow::{Context as _, Result};
 use libp2p_identity::{Keypair, PeerId};
@@ -38,10 +23,8 @@ pub type PublicKey = malachitebft_signing_ecdsa::PublicKey<K256Config>;
 /// Concrete ECDSA signature on the k256 curve.
 pub type Signature = malachitebft_signing_ecdsa::Signature<K256Config>;
 
-/// Local signing helper, the consensus side of the validator
-/// identity. Owns the private key for the lifetime of the service
-/// and exposes the small set of operations the malachite layer
-/// needs.
+/// Consensus-side signer of the validator identity; owns the private key
+/// for the lifetime of the service.
 #[derive(Debug)]
 pub struct MalachiteSigner {
     private_key: PrivateKey,
@@ -79,8 +62,7 @@ impl MalachiteSigner {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Pack a [`Signature`] into a `Vec<u8>` (raw `r || s` for the
-/// k256 curve, 64 bytes). Helper used by the SCALE codec layer.
+/// Pack a [`Signature`] into raw `r || s` bytes (64 bytes).
 pub fn signature_to_vec(s: &Signature) -> Vec<u8> {
     s.to_vec()
 }
@@ -90,28 +72,21 @@ pub fn signature_from_vec(bytes: &[u8]) -> Result<Signature> {
     Signature::from_slice(bytes).map_err(|e| anyhow::anyhow!("decoding signature from bytes: {e}"))
 }
 
-/// Construct an ECDSA private key from a raw 32-byte secret. Returns
-/// an error if the bytes are not a valid k256 scalar (zero or ≥ curve
-/// order); for randomly drawn secrets this is overwhelmingly unlikely
-/// (≈ 2^-128) but real input may come from anywhere.
+/// Construct an ECDSA private key from a raw 32-byte secret.
+/// Errors if the bytes are not a valid k256 scalar.
 pub fn private_key_from_bytes(secret: &[u8; 32]) -> Result<PrivateKey> {
     PrivateKey::from_slice(secret)
         .map_err(|e| anyhow::anyhow!("constructing ECDSA private key: {e}"))
 }
 
-/// Convert a `gsigner` secp256k1 [`PrivateKey`] into the malachite-
-/// side [`PrivateKey`]. Both are k256-backed, so this is a
-/// bytes-roundtrip.
+/// Convert a `gsigner` secp256k1 private key into the malachite-side one.
 pub fn private_key_from_gsigner(
     pk: &gsigner::schemes::secp256k1::PrivateKey,
 ) -> Result<PrivateKey> {
     private_key_from_bytes(&pk.to_bytes())
 }
 
-/// Convert a `gsigner` secp256k1 [`PublicKey`] into the malachite-
-/// side [`PublicKey`]. Both are k256-backed; gsigner stores the
-/// 33-byte SEC1 compressed form, which malachite accepts via
-/// `from_sec1_bytes`.
+/// Convert a `gsigner` secp256k1 public key into the malachite-side one.
 pub fn public_key_from_gsigner(pk: &gsigner::schemes::secp256k1::PublicKey) -> Result<PublicKey> {
     let bytes = pk.to_bytes();
     PublicKey::from_sec1_bytes(&bytes)
@@ -133,11 +108,8 @@ pub fn address_bytes_from_public_key(pk: &PublicKey) -> [u8; 20] {
     out
 }
 
-/// Derive the libp2p secp256k1 secret used by the Malachite swarm
-/// from the validator's master secret. Domain-separated so two
-/// libp2p swarms under the same validator key (e.g. an application
-/// network on QUIC plus the malachite TCP transport) don't collide
-/// peer-ids.
+/// Derive the Malachite swarm's libp2p secret from the validator's master
+/// secret; domain-separated so swarms under the same key don't collide.
 pub fn derive_libp2p_secret(validator_secret: &[u8; 32]) -> [u8; 32] {
     const DOMAIN: &[u8] = b"mala-svc-libp2p:v1:";
     let mut h = Keccak256::new();
@@ -159,11 +131,8 @@ pub fn libp2p_keypair_from(validator_secret: &[u8; 32]) -> Keypair {
     Keypair::from(inner)
 }
 
-/// Compute the libp2p [`PeerId`] of the Malachite swarm associated
-/// with `validator_secret` without spinning up the engine. Useful for
-/// offline tooling: operators preparing `--persistent-peer` multiaddrs
-/// can compute the `/p2p/<peer_id>` suffix from each validator's
-/// keystore without booting the node.
+/// Compute the Malachite swarm's libp2p [`PeerId`] offline — lets
+/// operators build `/p2p/<peer_id>` suffixes without booting a node.
 pub fn libp2p_peer_id(validator_secret: &[u8; 32]) -> PeerId {
     libp2p_keypair_from(validator_secret).public().to_peer_id()
 }

--- a/ethexe/malachite/core/src/signing.rs
+++ b/ethexe/malachite/core/src/signing.rs
@@ -5,7 +5,7 @@
 //! derivation that the Malachite swarm uses.
 //!
 //! The node's master secret enters the service via
-//! [`crate::MalachiteConfig::validator_secret`] (a
+//! [`crate::MalachiteCoreConfig::validator_secret`] (a
 //! `gsigner::secp256k1::PrivateKey`). The 32 raw bytes drive two
 //! separate identities:
 //!

--- a/ethexe/malachite/core/src/state.rs
+++ b/ethexe/malachite/core/src/state.rs
@@ -69,15 +69,25 @@ impl SharedValidatorSet {
     }
 }
 
+/// Volatile bookkeeping of the app event loop.
 pub(crate) struct State {
+    /// Consensus signer of the local node.
     pub signer: MalachiteSigner,
+    /// Active validator set handle.
     pub validator_set: SharedValidatorSet,
+    /// Local node's address.
     pub address: Address,
+    /// Persistent block store.
     pub store: Store,
+    /// Per-peer proposal-part stream reassembly.
     streams_map: PartStreamsMap,
+    /// Height the engine is currently working on.
     pub current_height: Height,
+    /// Round within the current height.
     pub current_round: Round,
+    /// Proposer of the current round, once known.
     pub current_proposer: Option<Address>,
+    /// Deadline for `build_block_above`.
     pub propose_timeout: Duration,
 }
 
@@ -134,13 +144,8 @@ impl State {
         self.streams_map.insert(from, part)
     }
 
-    /// Re-assemble a [`ProposedValue`] from a completed
-    /// [`ProposalParts`] sequence. The single `Data` part carries
-    /// the SCALE-encoded block bytes; `Init` supplies the (height,
-    /// round, proposer) header. Validation is the caller's
-    /// responsibility — application-level checks happen via
-    /// [`crate::Externalities::validate_block_above`] and the
-    /// `ProposalFin` signature check (when wired in).
+    /// Re-assemble a [`ProposedValue`] from a completed [`ProposalParts`]
+    /// sequence. Validation is the caller's responsibility.
     pub fn assemble_value_from_parts(parts: ProposalParts) -> Result<ProposedValue<MalachiteCtx>> {
         let init = parts.init().ok_or_else(|| anyhow!("missing Init part"))?;
         let block_bytes = parts
@@ -163,9 +168,8 @@ impl State {
 
     // ----------------------- propose-side helpers ---------------------
 
-    /// Wrap a freshly-built block payload into a
-    /// [`LocallyProposedValue`] for the engine. The block is
-    /// SCALE-encoded once here and stays in that form on the wire.
+    /// Wrap a freshly-built block payload into a [`LocallyProposedValue`]
+    /// for the engine and persist it as an undecided proposal.
     pub fn build_locally_proposed_value(
         &mut self,
         height: Height,
@@ -192,10 +196,8 @@ impl State {
         ))
     }
 
-    /// Reuse a prior locally-built value if the engine re-asks
-    /// `GetValue` for the same `(height, round)`. Avoids wasted
-    /// block-build work and prevents non-determinism (proposer might
-    /// otherwise build different content the second time).
+    /// Reuse a prior locally-built value when the engine re-asks `GetValue`
+    /// for the same `(height, round)` — avoids rebuild non-determinism.
     pub fn get_previously_built_value(
         &self,
         height: Height,
@@ -235,14 +237,9 @@ impl State {
         })
     }
 
-    /// Commit a finalized value: pull the matching undecided proposal
-    /// out of the engine store, persist the decided value + cert, and
-    /// advance to the next height.
-    ///
-    /// Returns the committed block bytes (SCALE-encoded
-    /// [`crate::Block`]) so the caller (`app.rs`) can decode it,
-    /// compute the [`crate::H256`] block hash, and insert into the
-    /// [`crate::store::BlockEntry`] layer.
+    /// Commit a finalized value: persist the decided value + cert and
+    /// advance to the next height. Returns the committed block bytes
+    /// (SCALE-encoded [`crate::Block`]).
     pub fn commit(
         &mut self,
         certificate: CommitCertificate<MalachiteCtx>,

--- a/ethexe/malachite/core/src/state.rs
+++ b/ethexe/malachite/core/src/state.rs
@@ -111,7 +111,7 @@ impl State {
     }
 
     /// Round timeouts. Propose phase is bounded by the configured
-    /// [`crate::MalachiteConfig::propose_timeout`] plus a small margin
+    /// [`crate::MalachiteCoreConfig::propose_timeout`] plus a small margin
     /// for non-proposers; everything else (including the per-round
     /// `propose_delta`) stays at the engine defaults.
     pub fn get_timeouts(&self, _height: Height) -> LinearTimeouts {

--- a/ethexe/malachite/core/src/store.rs
+++ b/ethexe/malachite/core/src/store.rs
@@ -54,20 +54,26 @@ const META_LATEST_FINALIZED: &[u8] = b"latest_finalized";
 /// Single block record kept by the service.
 #[derive(Clone, Encode, Decode)]
 pub(crate) struct BlockEntry {
+    /// Canonical block hash.
     pub block_hash: H256,
+    /// Parent block hash (zero for genesis).
     pub parent_hash: H256,
+    /// Block height.
     pub height: u64,
+    /// Opaque application payload.
     pub payload: BlockPayload,
+    /// Reserved envelope tail.
     pub reserved: [u8; 64],
+    /// `process_mb_proposal` has run for this block.
     pub saved: bool,
+    /// `process_mb_finalized` has run for this block.
     pub finalized: bool,
+    /// Quorum certificate, once known.
     pub cert: Option<CommitCertificate>,
 }
 
 impl BlockEntry {
-    /// Reconstruct the [`Block`] form expected by
-    /// [`crate::Externalities::process_mb_proposal`] /
-    /// [`crate::Externalities::validate_block_above`].
+    /// Reconstruct the [`Block`] form expected by [`crate::Externalities`].
     pub fn block(&self) -> Block {
         Block {
             parent_hash: self.parent_hash,
@@ -247,15 +253,9 @@ impl Store {
         }
     }
 
-    /// Walk back through parents from `leaf_hash` collecting every
-    /// ancestor that has not yet been saved. Returns `None` if the walk
-    /// hits a block that is not in the store (i.e. the chain is
-    /// incomplete and we must wait). Genesis (parent_hash ==
-    /// `H256::zero()`) and a previously saved ancestor are valid stop
-    /// points.
-    ///
-    /// The returned chain is in chronological order
-    /// (oldest-first), ready for sequential `process_mb_proposal` calls.
+    /// Collect every not-yet-saved ancestor of `leaf_hash`, oldest-first.
+    /// Returns `None` if the walk hits a block missing from the store
+    /// (incomplete chain — wait for it to fill).
     pub fn save_chain(&self, leaf_hash: H256) -> Result<Option<Vec<BlockEntry>>> {
         let mut chain_rev: Vec<BlockEntry> = Vec::new();
         let mut current = leaf_hash;
@@ -278,13 +278,9 @@ impl Store {
         Ok(Some(chain_rev))
     }
 
-    /// Walk back collecting every ancestor that is `saved` but not yet
-    /// `finalized` and has a quorum certificate attached. Returns
-    /// `None` if any ancestor is missing from the store, lacks a cert,
-    /// or hasn't been saved (the strict invariant: finalize requires
-    /// save first).
-    ///
-    /// The returned chain is chronological order (oldest-first).
+    /// Collect every saved-but-not-finalized ancestor with a quorum cert,
+    /// oldest-first. Returns `None` if any ancestor is missing, lacks a
+    /// cert or hasn't been saved (finalize requires save first).
     pub fn finalize_chain(&self, leaf_hash: H256) -> Result<Option<Vec<BlockEntry>>> {
         let mut chain_rev: Vec<BlockEntry> = Vec::new();
         let mut current = leaf_hash;
@@ -329,11 +325,9 @@ impl Store {
         }
     }
 
-    /// Drive the application's `process_mb_proposal` callback over
-    /// every ancestor that is now ready, starting from each seed. Cascades
-    /// to children: when a block becomes saveable, its descendants are
-    /// re-tried so a chain that was waiting on a missing middle gets
-    /// flushed once the gap closes.
+    /// Drive `save_fn` over every ancestor that is now ready, starting from
+    /// each seed, then cascade to children so descendants waiting on a gap
+    /// get flushed once it closes.
     pub async fn cascade_save<F, Fut>(&self, seeds: Vec<H256>, mut save_fn: F) -> Result<()>
     where
         F: FnMut(H256, Block) -> Fut,
@@ -564,11 +558,9 @@ impl Store {
         k
     }
 
-    /// Persist the engine-side `CommitCertificate` keyed by height.
-    /// We keep both this rich cert (with per-signer addresses, used
-    /// for serving sync responses) and the trimmed
-    /// [`crate::CommitCertificate`] inside [`BlockEntry`] (handed to
-    /// the application via [`crate::Externalities`]).
+    /// Persist the engine-side `CommitCertificate` keyed by height —
+    /// the rich form used for serving sync responses (the trimmed
+    /// [`crate::CommitCertificate`] lives inside [`BlockEntry`]).
     pub fn store_engine_certificate(
         &self,
         height: u64,
@@ -594,10 +586,8 @@ impl Store {
         }
     }
 
-    /// Drop undecided proposals and pending parts at or below
-    /// `current_height`. We've already committed at this height, so
-    /// nothing in the engine-state columns at heights ≤ it can still be
-    /// reached.
+    /// Drop undecided proposals and pending parts at or below the already
+    /// committed `current_height` — they can no longer be reached.
     pub fn prune_engine_state(&self, current_height: u64) -> Result<()> {
         let mut to_delete: Vec<Vec<u8>> = Vec::new();
         for p in [&[prefix::UNDECIDED][..], &[prefix::PENDING_PARTS][..]] {

--- a/ethexe/malachite/core/src/types.rs
+++ b/ethexe/malachite/core/src/types.rs
@@ -1,7 +1,7 @@
 // Copyright (C) Gear Technologies Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
-//! Core public types for [`crate::MalachiteService`].
+//! Core public types for [`crate::MalachiteCore`].
 
 use gear_core::limited::LimitedVec;
 pub use gprimitives::H256;

--- a/ethexe/malachite/core/src/types.rs
+++ b/ethexe/malachite/core/src/types.rs
@@ -9,31 +9,16 @@ use parity_scale_codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
-/// Hard cap on a block's encoded application payload — the SCALE-encoded
-/// application operation list carried in [`Block::payload`] (the service treats
-/// it as opaque bytes; the schema lives in the application crate).
-///
-/// The whole [`Block`] ships as a single gossipsub message: the proposer
-/// streams it as one `Data` proposal part, and the value-sync path fetches a
-/// finalized block in one request-response round. Malachite's `pubsub_max_size`
-/// (the gossipsub `max_transmit_size`) defaults to 4 MiB, so the encoded block
-/// must stay well under that. Realistic content is ~127 KiB
-/// (`MAX_INJECTED_TRANSACTIONS_SIZE_PER_MB` plus three protocol operations); the
-/// 1 MiB cap leaves ~8x headroom for future operation variants while staying
-/// ~4x under the 4 MiB transport ceiling (block envelope + SCALE / stream
-/// framing fit comfortably in the remaining margin).
+/// Hard cap on a block's encoded application payload. The whole [`Block`]
+/// ships as a single gossipsub message, so the cap must stay well under
+/// malachite's 4 MiB transport ceiling.
 pub const MAX_BLOCK_PAYLOAD_BYTES: usize = 1024 * 1024;
 
 /// Size-capped opaque application payload carried by [`Block::payload`].
 pub type BlockPayload = LimitedVec<u8, MAX_BLOCK_PAYLOAD_BYTES>;
 
-/// 20-byte validator address.
-///
-/// Newtype around [`gsigner::schemes::secp256k1::Address`] so the
-/// service's API and the typical application code (ethexe today,
-/// arbitrary other consumers tomorrow) share a single address shape
-/// without each side reaching across crate boundaries for the inner
-/// representation.
+/// 20-byte validator address (newtype around
+/// [`gsigner::schemes::secp256k1::Address`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Address(pub gsigner::schemes::secp256k1::Address);
 
@@ -63,18 +48,16 @@ impl Address {
 }
 
 /// Service-level block envelope: the application payload plus the
-/// chain-position fields the service needs (parent hash, height) and
-/// a [`Self::reserved`] tail kept for future protocol extensions.
-///
-/// The block hash ([`Self::hash`]) is the [`gear_core::utils::hash`]
-/// (Blake2b-256) over a SCALE-encoded
-/// `(parent_hash, height, payload_hash, reserved)` tuple, where
-/// `payload_hash = gear_core::utils::hash(payload.encode())`.
+/// chain-position fields the service needs.
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 pub struct Block {
+    /// Hash of the parent block (zero for genesis).
     pub parent_hash: H256,
+    /// Block height (parent height + 1).
     pub height: u64,
+    /// Opaque application payload.
     pub payload: BlockPayload,
+    /// Reserved tail for future protocol extensions; currently zeroed.
     pub reserved: [u8; 64],
 }
 
@@ -89,9 +72,8 @@ impl Block {
         }
     }
 
-    /// Compute the canonical 32-byte block hash. Deterministic — two
-    /// nodes with the same `(parent_hash, height, payload, reserved)`
-    /// produce the same hash.
+    /// Canonical block hash: Blake2b-256 over the SCALE-encoded
+    /// `(parent_hash, height, payload_hash, reserved)` tuple.
     pub fn hash(&self) -> H256 {
         let payload_bytes = self.payload.encode();
         let payload_hash: H256 = gear_core::utils::hash(&payload_bytes).into();
@@ -101,14 +83,12 @@ impl Block {
 }
 
 /// Quorum-signed certificate proving a height was finalized.
-///
-/// `signatures` is a parallel-to-validators vector of raw 64-byte
-/// secp256k1 signatures (`r || s`); the application is responsible
-/// for reconstructing the validator-set ordering when verifying it on
-/// chain (or wherever else).
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, Serialize, Deserialize)]
 pub struct CommitCertificate {
+    /// Finalized height.
     pub height: u64,
+    /// Hash of the finalized block.
     pub block_hash: H256,
+    /// Raw 64-byte secp256k1 signatures (`r || s`), in validator-set order.
     pub signatures: Vec<Vec<u8>>,
 }

--- a/ethexe/malachite/core/tests/multi_validators.rs
+++ b/ethexe/malachite/core/tests/multi_validators.rs
@@ -35,6 +35,7 @@ fn init_tracing() {
 
 use anyhow::Result;
 use async_trait::async_trait;
+use ethexe_common::Acceptance;
 use ethexe_malachite_core::{
     Block, BlockPayload, CommitCertificate, Externalities, H256, MalachiteCore,
     MalachiteCoreConfig, Multiaddr, NodeRole, ValidatorEntry, libp2p_peer_id,
@@ -177,8 +178,8 @@ impl Externalities for TestExt {
     async fn validate_block_above(
         &self,
         parent_hash: H256,
-        _payload: BlockPayload,
-    ) -> Result<bool> {
+        _payload: &BlockPayload,
+    ) -> Result<Acceptance<(), String>> {
         let mut s = self.state.lock().unwrap();
         if let Some(last_fin) = s.finalized.last().copied()
             && parent_hash != last_fin
@@ -187,7 +188,7 @@ impl Externalities for TestExt {
                 "validate_block_above: parent_hash mismatch — expected {last_fin:?}, got {parent_hash:?}"
             ));
         }
-        Ok(true)
+        Ok(Acceptance::Accepted(()))
     }
 }
 

--- a/ethexe/malachite/core/tests/multi_validators.rs
+++ b/ethexe/malachite/core/tests/multi_validators.rs
@@ -36,8 +36,8 @@ fn init_tracing() {
 use anyhow::Result;
 use async_trait::async_trait;
 use ethexe_malachite_core::{
-    Block, BlockPayload, CommitCertificate, Externalities, H256, MalachiteCoreConfig, MalachiteCore,
-    Multiaddr, NodeRole, ValidatorEntry, libp2p_peer_id,
+    Block, BlockPayload, CommitCertificate, Externalities, H256, MalachiteCore,
+    MalachiteCoreConfig, Multiaddr, NodeRole, ValidatorEntry, libp2p_peer_id,
 };
 use proptest::prelude::*;
 use tempfile::TempDir;

--- a/ethexe/malachite/core/tests/multi_validators.rs
+++ b/ethexe/malachite/core/tests/multi_validators.rs
@@ -36,7 +36,7 @@ fn init_tracing() {
 use anyhow::Result;
 use async_trait::async_trait;
 use ethexe_malachite_core::{
-    Block, BlockPayload, CommitCertificate, Externalities, H256, MalachiteConfig, MalachiteService,
+    Block, BlockPayload, CommitCertificate, Externalities, H256, MalachiteCoreConfig, MalachiteCore,
     Multiaddr, NodeRole, ValidatorEntry, libp2p_peer_id,
 };
 use proptest::prelude::*;
@@ -276,7 +276,7 @@ fn build_config(
     setup: &ValidatorSetup,
     setups: &[ValidatorSetup],
     peers: Vec<Multiaddr>,
-) -> MalachiteConfig {
+) -> MalachiteCoreConfig {
     build_config_with_role(setup, peers, validator_entries(setups), NodeRole::Validator)
 }
 
@@ -285,8 +285,8 @@ fn build_config_with_role(
     peers: Vec<Multiaddr>,
     validators: Vec<ValidatorEntry>,
     role: NodeRole,
-) -> MalachiteConfig {
-    MalachiteConfig {
+) -> MalachiteCoreConfig {
+    MalachiteCoreConfig {
         listen_addr: setup.listen_addr,
         base: setup.home.path().to_path_buf(),
         persistent_peers: peers,
@@ -302,10 +302,10 @@ async fn start_service(
     setups: &[ValidatorSetup],
     idx: usize,
     ext: Arc<TestExt>,
-) -> MalachiteService<TestExt> {
+) -> MalachiteCore<TestExt> {
     let peers = build_multiaddrs_excluding(setups, idx);
     let config = build_config(setup, setups, peers);
-    MalachiteService::<TestExt>::new(config, ext)
+    MalachiteCore::<TestExt>::new(config, ext)
         .await
         .expect("service starts")
 }
@@ -431,7 +431,7 @@ async fn restart_one_validator_mid_run() {
     let setups = make_validators(3);
 
     let exts: Vec<Arc<TestExt>> = (0..3).map(|_| Arc::new(TestExt::default())).collect();
-    let mut services: Vec<Option<MalachiteService<TestExt>>> = Vec::with_capacity(3);
+    let mut services: Vec<Option<MalachiteCore<TestExt>>> = Vec::with_capacity(3);
     for (i, setup) in setups.iter().enumerate() {
         let svc = start_service(setup, &setups, i, Arc::clone(&exts[i])).await;
         services.push(Some(svc));
@@ -494,7 +494,7 @@ async fn full_node_syncs_from_validators() {
         };
         let peers = build_multiaddrs_excluding(&setups, i);
         let cfg = build_config_with_role(setup, peers, validator_set.clone(), role);
-        let svc = MalachiteService::<TestExt>::new(cfg, Arc::clone(&exts[i]))
+        let svc = MalachiteCore::<TestExt>::new(cfg, Arc::clone(&exts[i]))
             .await
             .expect("service starts");
         services.push(svc);
@@ -564,7 +564,7 @@ fn run_churn_scenario(events: Vec<ChurnEvent>) {
 
         let setups = make_validators(n);
         let exts: Vec<Arc<TestExt>> = (0..n).map(|_| Arc::new(TestExt::default())).collect();
-        let mut services: Vec<Option<MalachiteService<TestExt>>> = (0..n).map(|_| None).collect();
+        let mut services: Vec<Option<MalachiteCore<TestExt>>> = (0..n).map(|_| None).collect();
 
         // Bootstrap all validators with a stagger.
         for (i, setup) in setups.iter().enumerate() {

--- a/ethexe/malachite/service/src/config.rs
+++ b/ethexe/malachite/service/src/config.rs
@@ -18,17 +18,13 @@ pub struct MalachiteServiceConfig {
     /// Gas allowance per block.
     pub gas_allowance: u64,
 
-    /// Number of canonical descendants an Ethereum block must have
-    /// before it is considered out of quarantine and safe to anchor a
-    /// sequencer block to.
+    /// Number of canonical descendants an EB must have before it is
+    /// out of quarantine and safe to advance to.
     pub canonical_quarantine: u8,
 
-    /// Extra depth (in Hoodi blocks, on top of `canonical_quarantine`)
-    /// the proposer waits before choosing an EB to advance to. A
-    /// positive value gives lagging validators time to receive the EB
-    /// before the proposer references it, eliminating the need for
-    /// validators to wait on local sync inside `validate_block_above`.
-    /// Defaults to 1.
+    /// Extra depth on top of `canonical_quarantine` the proposer waits
+    /// before choosing an EB to advance to, giving lagging validators
+    /// time to sync it.
     // TODO: #5478 reject unreasonable values at config load — `u32::MAX`
     //       turns the producer's anchor walk into millions of RocksDB reads
     //       per `wait_for_proposable_content` invocation.
@@ -37,26 +33,15 @@ pub struct MalachiteServiceConfig {
     /// Local libp2p listen address for the Malachite swarm.
     pub listen_addr: SocketAddr,
 
-    /// Directory where the wrapped [`ethexe_malachite_core::MalachiteCore`] keeps
-    /// its WAL (`malachite/consensus.wal`) and RocksDB store
-    /// (`malachite/store.db/`).
+    /// Directory for the consensus core's WAL and RocksDB store.
     pub home_dir: PathBuf,
 
-    /// Multiaddrs the local node should keep persistent connections
-    /// to. Each entry must include the `/p2p/<peer_id>` suffix so the
-    /// swarm knows who to expect on the other side. Discovery is off,
-    /// so multi-validator deployments need every node listed (or at
-    /// least transitively reachable through the listed ones).
+    /// Multiaddrs of peers to keep persistent connections to; each entry
+    /// must include a `/p2p/<peer_id>` suffix (discovery is off).
     pub persistent_peers: Vec<Multiaddr>,
 
-    /// The complete validator set. The local node's public key (the
-    /// one whose secret comes from the [`gsigner::Signer`] passed to
-    /// [`crate::MalachiteServiceStarter::new`]) must appear in this list, or
-    /// service start-up fails.
-    ///
-    /// Voting power is taken at face value — Tendermint's quorum
-    /// threshold is `> 2/3` of the total voting power across the
-    /// list.
+    /// The complete validator set. Quorum is `> 2/3` of total voting power.
+    /// A validator node's own public key must appear in this list.
     pub validators: Vec<ValidatorEntry>,
 }
 
@@ -64,22 +49,16 @@ impl MalachiteServiceConfig {
     pub const DEFAULT_GAS_ALLOWANCE: u64 = ethexe_common::DEFAULT_BLOCK_GAS_LIMIT;
     /// Default matches [`ethexe_common::gear::CANONICAL_QUARANTINE`].
     pub const DEFAULT_CANONICAL_QUARANTINE: u8 = ethexe_common::gear::CANONICAL_QUARANTINE;
-    /// Default extra anchor-depth slack the proposer adds on top of
-    /// `canonical_quarantine`; one Hoodi block is enough to absorb the
-    /// typical observer-to-observer skew between validators.
+    /// One block is enough to absorb the typical observer skew between validators.
     pub const DEFAULT_POST_QUARANTINE_DELAY: u32 = 1;
-    /// Sits next to the typical ethexe-network 20333/udp QUIC port —
-    /// operators can open one contiguous range. Note the protocol
-    /// difference: Malachite binds a TCP listener.
+    /// TCP listener next to the typical ethexe-network 20333/udp QUIC port.
     pub const DEFAULT_LISTEN_ADDR: SocketAddr = SocketAddr::new(
         std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)),
         20334,
     );
 
-    /// Build a config with sane defaults from the node's home
-    /// directory. The validator set is left empty — the caller MUST
-    /// fill it in before passing to [`crate::MalachiteServiceStarter::new`]
-    /// (see [`Self::with_validators`]).
+    /// Build a config with defaults from the node's home directory.
+    /// The validator set is left empty — fill it in with [`Self::with_validators`].
     pub fn from_home_dir(home_dir: PathBuf) -> Self {
         Self {
             gas_allowance: Self::DEFAULT_GAS_ALLOWANCE,
@@ -129,9 +108,13 @@ impl MalachiteServiceConfig {
     }
 }
 
+/// Validator-only part of the service configuration.
 pub struct ValidatorConfig<M: Mempool> {
+    /// Validator's on-chain public key; its secret must be in `signer`.
     pub pub_key: PublicKey,
+    /// Mempool serving injected transactions to the producer.
     pub mempool: M,
+    /// Keystore holding the validator's signing key.
     pub signer: Signer,
 }
 

--- a/ethexe/malachite/service/src/config.rs
+++ b/ethexe/malachite/service/src/config.rs
@@ -11,7 +11,7 @@
 use crate::Mempool;
 use ethexe_common::ecdsa::{PublicKey, Signer};
 pub use ethexe_malachite_core::{Multiaddr, ValidatorEntry};
-use std::{net::SocketAddr, path::PathBuf};
+use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
 #[derive(Clone, Debug)]
 pub struct MalachiteServiceConfig {
@@ -43,6 +43,10 @@ pub struct MalachiteServiceConfig {
     /// The complete validator set. Quorum is `> 2/3` of total voting power.
     /// A validator node's own public key must appear in this list.
     pub validators: Vec<ValidatorEntry>,
+
+    /// How long the proposer may wait for proposable content before the
+    /// round times out and rotates.
+    pub propose_timeout: Duration,
 }
 
 impl MalachiteServiceConfig {
@@ -56,6 +60,10 @@ impl MalachiteServiceConfig {
         std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)),
         20334,
     );
+    /// Ethereum block time occasionally stretches past one slot, so give
+    /// the producer more than `SLOT_DURATION` to find a fresh EB.
+    pub const DEFAULT_PROPOSE_TIMEOUT: Duration =
+        Duration::from_secs(2 * alloy::eips::merge::SLOT_DURATION.as_secs());
 
     /// Build a config with defaults from the node's home directory.
     /// The validator set is left empty — fill it in with [`Self::with_validators`].
@@ -68,6 +76,7 @@ impl MalachiteServiceConfig {
             home_dir,
             persistent_peers: Vec::new(),
             validators: Vec::new(),
+            propose_timeout: Self::DEFAULT_PROPOSE_TIMEOUT,
         }
     }
 

--- a/ethexe/malachite/service/src/config.rs
+++ b/ethexe/malachite/service/src/config.rs
@@ -37,7 +37,7 @@ pub struct MalachiteServiceConfig {
     /// Local libp2p listen address for the Malachite swarm.
     pub listen_addr: SocketAddr,
 
-    /// Directory where the wrapped [`ethexe_malachite_core::MalachiteService`] keeps
+    /// Directory where the wrapped [`ethexe_malachite_core::MalachiteCore`] keeps
     /// its WAL (`malachite/consensus.wal`) and RocksDB store
     /// (`malachite/store.db/`).
     pub home_dir: PathBuf,
@@ -51,7 +51,7 @@ pub struct MalachiteServiceConfig {
 
     /// The complete validator set. The local node's public key (the
     /// one whose secret comes from the [`gsigner::Signer`] passed to
-    /// [`crate::MalachiteService::new`]) must appear in this list, or
+    /// [`crate::MalachiteServiceStarter::new`]) must appear in this list, or
     /// service start-up fails.
     ///
     /// Voting power is taken at face value — Tendermint's quorum
@@ -78,7 +78,7 @@ impl MalachiteServiceConfig {
 
     /// Build a config with sane defaults from the node's home
     /// directory. The validator set is left empty — the caller MUST
-    /// fill it in before passing to [`crate::MalachiteService::new`]
+    /// fill it in before passing to [`crate::MalachiteServiceStarter::new`]
     /// (see [`Self::with_validators`]).
     pub fn from_home_dir(home_dir: PathBuf) -> Self {
         Self {

--- a/ethexe/malachite/service/src/config.rs
+++ b/ethexe/malachite/service/src/config.rs
@@ -8,12 +8,13 @@
 //! is wired in directly — there is no separate genesis file — so the
 //! caller is the single source of truth for who can vote.
 
+use crate::Mempool;
+use ethexe_common::ecdsa::{PublicKey, Signer};
+pub use ethexe_malachite_core::{Multiaddr, ValidatorEntry};
 use std::{net::SocketAddr, path::PathBuf};
 
-pub use ethexe_malachite_core::{Multiaddr, ValidatorEntry};
-
 #[derive(Clone, Debug)]
-pub struct MalachiteConfig {
+pub struct MalachiteServiceConfig {
     /// Gas allowance per block.
     pub gas_allowance: u64,
 
@@ -59,7 +60,7 @@ pub struct MalachiteConfig {
     pub validators: Vec<ValidatorEntry>,
 }
 
-impl MalachiteConfig {
+impl MalachiteServiceConfig {
     pub const DEFAULT_GAS_ALLOWANCE: u64 = ethexe_common::DEFAULT_BLOCK_GAS_LIMIT;
     /// Default matches [`ethexe_common::gear::CANONICAL_QUARANTINE`].
     pub const DEFAULT_CANONICAL_QUARANTINE: u8 = ethexe_common::gear::CANONICAL_QUARANTINE;
@@ -111,6 +112,27 @@ impl MalachiteConfig {
         self.validators = validators;
         self
     }
+
+    pub fn with_gas_allowance(mut self, gas_allowance: u64) -> Self {
+        self.gas_allowance = gas_allowance;
+        self
+    }
+
+    pub fn with_canonical_quarantine(mut self, canonical_quarantine: u8) -> Self {
+        self.canonical_quarantine = canonical_quarantine;
+        self
+    }
+
+    pub fn with_post_quarantine_delay(mut self, post_quarantine_delay: u32) -> Self {
+        self.post_quarantine_delay = post_quarantine_delay;
+        self
+    }
+}
+
+pub struct ValidatorConfig<M: Mempool> {
+    pub pub_key: PublicKey,
+    pub mempool: M,
+    pub signer: Signer,
 }
 
 #[cfg(test)]
@@ -119,8 +141,8 @@ mod tests {
 
     #[test]
     fn from_home_dir_default_listen_addr() {
-        let cfg = MalachiteConfig::from_home_dir(PathBuf::from("/tmp"));
-        assert_eq!(cfg.listen_addr, MalachiteConfig::DEFAULT_LISTEN_ADDR);
+        let cfg = MalachiteServiceConfig::from_home_dir(PathBuf::from("/tmp"));
+        assert_eq!(cfg.listen_addr, MalachiteServiceConfig::DEFAULT_LISTEN_ADDR);
         assert!(cfg.persistent_peers.is_empty());
         assert!(cfg.validators.is_empty());
     }

--- a/ethexe/malachite/service/src/externalities.rs
+++ b/ethexe/malachite/service/src/externalities.rs
@@ -53,7 +53,6 @@ use ethexe_common::{
 };
 use ethexe_db::Database;
 use ethexe_malachite_core::{Block, BlockPayload, Externalities, MAX_BLOCK_PAYLOAD_BYTES};
-use futures::{FutureExt, pending};
 use gprimitives::H256;
 use parity_scale_codec::{DecodeAll, Encode};
 use std::{collections::VecDeque, sync::Arc};
@@ -123,7 +122,8 @@ impl Externalities for EthexeExternalities {
                 mb_hash,
             },
             last_advanced,
-        );
+        )
+        .await;
         Ok(())
     }
 
@@ -174,7 +174,8 @@ impl Externalities for EthexeExternalities {
                 mb_hash,
             },
             last_advanced,
-        );
+        )
+        .await;
         Ok(())
     }
 

--- a/ethexe/malachite/service/src/externalities.rs
+++ b/ethexe/malachite/service/src/externalities.rs
@@ -46,7 +46,7 @@ use crate::{
 use anyhow::{Result, anyhow, ensure};
 use async_trait::async_trait;
 use ethexe_common::{
-    MAX_TOUCHED_PROGRAMS_PER_MB,
+    Acceptance, MAX_TOUCHED_PROGRAMS_PER_MB,
     db::{CompactMb, GlobalsStorageRO, GlobalsStorageRW, MbStorageRO, MbStorageRW},
     injected::{MAX_INJECTED_TRANSACTIONS_SIZE_PER_MB, SignedInjectedTransaction},
     malachite::{Operation, Operations},
@@ -287,12 +287,17 @@ impl Externalities for EthexeExternalities {
         })
     }
 
-    async fn validate_block_above(&self, parent_hash: H256, payload: BlockPayload) -> Result<bool> {
+    async fn validate_block_above(
+        &self,
+        parent_hash: H256,
+        payload: &BlockPayload,
+    ) -> Result<Acceptance<(), String>> {
         let payload = match Operations::decode_all(&mut payload.as_ref()) {
             Ok(payload) => payload,
             Err(e) => {
-                warn!(error = %e, "validate: undecodable block payload — rejecting");
-                return Ok(false);
+                return Ok(Acceptance::Rejected(format!(
+                    "undecodable block payload: {e}"
+                )));
             }
         };
 
@@ -314,30 +319,29 @@ impl Externalities for EthexeExternalities {
         }
 
         let Some(Operation::ProgressTasks) = next else {
-            warn!(
-                "validate: MB shape violation — expected `ProgressTasks` bookend, got {:?}",
+            return Ok(Acceptance::Rejected(format!(
+                "MB shape violation — expected `ProgressTasks` bookend, got {:?}",
                 next.map(|t| t.tag())
-            );
-            return Ok(false);
+            )));
         };
 
         let Some(Operation::ProcessQueues { gas_allowance }) = iter.next() else {
-            warn!("validate: MB shape violation — expected `ProcessQueues` bookend");
-            return Ok(false);
+            return Ok(Acceptance::Rejected(
+                "MB shape violation — expected `ProcessQueues` bookend".to_string(),
+            ));
         };
 
         if *gas_allowance > crate::MalachiteServiceConfig::DEFAULT_GAS_ALLOWANCE {
-            warn!(
-                allowance = *gas_allowance,
-                cap = crate::MalachiteServiceConfig::DEFAULT_GAS_ALLOWANCE,
-                "validate: ProcessQueues.gas_allowance exceeds protocol cap"
-            );
-            return Ok(false);
+            return Ok(Acceptance::Rejected(format!(
+                "ProcessQueues.gas_allowance {gas_allowance} exceeds protocol cap {}",
+                crate::MalachiteServiceConfig::DEFAULT_GAS_ALLOWANCE
+            )));
         }
 
         if iter.next().is_some() {
-            warn!("validate: MB has extra operations after the `ProcessQueues` bookend");
-            return Ok(false);
+            return Ok(Acceptance::Rejected(
+                "MB has extra operations after the `ProcessQueues` bookend".to_string(),
+            ));
         }
 
         // TODO: #5477 extract a shared `check_eb_advance` helper so this
@@ -364,13 +368,10 @@ impl Externalities for EthexeExternalities {
                 self.cfg.canonical_quarantine,
                 start_block_hash,
             ) {
-                warn!(
-                    error = %e,
-                    %advance,
-                    parent_advanced = %parent_advanced,
-                    "validate: advance not yet covered by local view — rejecting",
-                );
-                return Ok(false);
+                return Ok(Acceptance::Rejected(format!(
+                    "advance {advance} (parent_advanced {parent_advanced}) \
+                     not yet covered by local view: {e}"
+                )));
             }
 
             match quarantine::is_strict_descendant_of(
@@ -381,21 +382,16 @@ impl Externalities for EthexeExternalities {
             ) {
                 Ok(true) => {}
                 Ok(false) => {
-                    warn!(
-                        %advance,
-                        parent_advanced = %parent_advanced,
-                        "validate: advance not strict descendant of parent.last_advanced_eb — rejecting",
-                    );
-                    return Ok(false);
+                    return Ok(Acceptance::Rejected(format!(
+                        "advance {advance} is not a strict descendant of \
+                         parent.last_advanced_eb {parent_advanced}"
+                    )));
                 }
                 Err(e) => {
-                    warn!(
-                        error = %e,
-                        %advance,
-                        parent_advanced = %parent_advanced,
-                        "validate: is_strict_descendant_of failed — rejecting",
-                    );
-                    return Ok(false);
+                    return Ok(Acceptance::Rejected(format!(
+                        "is_strict_descendant_of failed for advance {advance} \
+                         (parent_advanced {parent_advanced}): {e}"
+                    )));
                 }
             }
         }
@@ -410,12 +406,10 @@ impl Externalities for EthexeExternalities {
             match checker.check_tx_validity(signed)? {
                 TxValidity::Valid => {}
                 reason => {
-                    warn!(
-                        tx_hash = %signed.data().to_hash(),
-                        ?reason,
-                        "validate: injected tx fails TxValidity — rejecting MB",
-                    );
-                    return Ok(false);
+                    return Ok(Acceptance::Rejected(format!(
+                        "injected tx {} fails TxValidity: {reason:?}",
+                        signed.data().to_hash()
+                    )));
                 }
             }
         }
@@ -459,14 +453,13 @@ impl Externalities for EthexeExternalities {
             }
         }
         if touched.len() > limit {
-            warn!(
-                touched = touched.len(),
-                limit, "validate: MB touches too many programs — rejecting"
-            );
-            return Ok(false);
+            return Ok(Acceptance::Rejected(format!(
+                "MB touches too many programs: {} > limit {limit}",
+                touched.len()
+            )));
         }
 
-        Ok(true)
+        Ok(Acceptance::Accepted(()))
     }
 }
 
@@ -627,8 +620,9 @@ mod tests {
         /// Mirrors the producer-side encoding step the inner core service
         /// applies to whatever `build_block_above` returns.
         async fn validate_operations(&self, parent: H256, ops: Operations) -> Result<bool> {
-            self.validate_block_above(parent, to_payload(ops.encode()))
+            self.validate_block_above(parent, &to_payload(ops.encode()))
                 .await
+                .map(|acceptance| acceptance.is_accepted())
         }
 
         /// Test-only inverse of [`Self::validate_operations`]: run the
@@ -901,9 +895,10 @@ mod tests {
         let mut bytes = payload(None, 1).encode();
         bytes.extend_from_slice(&[0u8; 16]);
         assert!(
-            !ext.validate_block_above(H256::zero(), to_payload(bytes))
+            ext.validate_block_above(H256::zero(), &to_payload(bytes))
                 .await
                 .unwrap()
+                .is_rejected()
         );
     }
 

--- a/ethexe/malachite/service/src/externalities.rs
+++ b/ethexe/malachite/service/src/externalities.rs
@@ -504,7 +504,7 @@ impl EthexeExternalities {
 
             let chain_head = *self.chain_head.latest_synced.read().await;
             let Some(mempool) = self.mempool.as_ref() else {
-                panic!("must never call wait_for_proposable_content when not a validator");
+                anyhow::bail!("must never call wait_for_proposable_content when not a validator");
             };
             let injected_txs = mempool.fetch(chain_head).await;
 
@@ -1536,7 +1536,7 @@ mod tests {
     /// in `ProcessQueues.gas_allowance` and force every participant to attempt
     /// an unbounded queue drain. Validator must reject MBs whose
     /// `gas_allowance` exceeds the protocol cap
-    /// (`MalachiteConfig::DEFAULT_GAS_ALLOWANCE`).
+    /// (`MalachiteServiceConfig::DEFAULT_GAS_ALLOWANCE`).
     #[tokio::test]
     async fn validate_rejects_gas_allowance_above_default() {
         let db = Database::memory();

--- a/ethexe/malachite/service/src/externalities.rs
+++ b/ethexe/malachite/service/src/externalities.rs
@@ -68,18 +68,28 @@ pub struct ExternalitiesConfig {
 }
 
 pub(crate) struct EthexeExternalities {
+    /// Shared DB reference for all storage operations
     pub db: Database,
+    /// Constant externalities config parameters
     pub cfg: ExternalitiesConfig,
+    /// Optional mempool reference for injected-tx processing; `None` when not a validator.
     pub mempool: Option<Arc<dyn Mempool>>,
+    /// Reference to the latest chain head data.
     pub chain_head: Arc<ChainHead>,
+    /// Pending service events queue.
+    /// Release events from here only when their prerequisite EB is prepared.
     pub pending_events: RwLock<VecDeque<PendingEvent>>,
+    /// Channel to poll events in MalachiteService.
     pub event_tx: UnboundedSender<Result<MalachiteEvent>>,
 }
 
 /// One outbound [`MalachiteEvent`] that can't be released until its
-/// `prerequisite` Eth block is fully synced into the local DB.
+/// `prerequisite` Eth block is prepared in local DB.
 pub(crate) struct PendingEvent {
+    /// Event body
     pub event: MalachiteEvent,
+    /// Prerequisite Eth block hash
+    /// that must be prepared before this event can be emitted
     pub prerequisite: H256,
 }
 
@@ -414,37 +424,13 @@ impl Externalities for EthexeExternalities {
             }
         }
 
-        // (4) Touched-programs cap (master's #6). Only enforced on
-        // the validator side — the proposer in `build_block_above`
-        // already shapes the MB to stay within the cap; this check
-        // is the participant's guard against a malicious proposer.
-        //
-        // Per master: `limit = max(initial_touched.len(), MAX_*)` —
-        // the proposer can't *avoid* programs already touched by EB
-        // events, so those set the floor for the cap. We add every
-        // `Operation::Injected` destination on top of the EB-touched
-        // seed and reject if the union exceeds `limit`.
-        //
-        // NOTE: there is no per-MB size cap on the validator side
-        // (master parity). We rely on the Malachite engine's 1 MiB
-        // hard cap on the encoded `Block` payload — anything larger
-        // never reaches `validate_block_above` in the first place.
-        let parent_advanced = if parent_hash.is_zero() {
-            H256::zero()
-        } else {
-            self.db.mb_meta(parent_hash).last_advanced_eb
-        };
-        // `?` here only fires on local DB issues: missing
-        // `mb_program_states` for `latest_computed_mb_hash`, missing
-        // `block_header` on a canonical ancestor of `advance`, or
-        // missing `block_events` for one of them. After the quarantine
-        // gate above succeeded the observer has clearly synced
-        // `advance` and its ancestors, so any failure here is a local
-        // DB / sync race — not a proposer-controlled condition. Same
-        // reasoning as the other two `?`s in this function.
+        let parent_advanced = parent_hash
+            .is_zero()
+            .then(H256::zero)
+            .unwrap_or_else(|| self.db.mb_meta(parent_hash).last_advanced_eb);
         let mut touched = match advance {
             Some(advanced_eb) => eb_touched_programs(&self.db, parent_advanced, advanced_eb)?,
-            None => std::collections::HashSet::new(),
+            None => Default::default(),
         };
         let limit = touched.len().max(MAX_TOUCHED_PROGRAMS_PER_MB as usize);
         for tx in payload.iter() {
@@ -464,31 +450,14 @@ impl Externalities for EthexeExternalities {
 }
 
 impl EthexeExternalities {
-    /// True iff `prerequisite.is_zero()` (no prerequisite — genesis
-    /// or pre-advance) or the prerequisite Eth block has been fully
-    /// **prepared** locally.
-    ///
-    /// "Prepared" (vs. merely observed via `block_events`) is the
-    /// stronger condition we need: `prepare_block`'s pipeline
-    /// transitions through `WaitingForCodes` and only flips
-    /// `block_meta.prepared = true` once every code referenced by
-    /// the block (and its ancestors) has been loaded and validated.
-    /// Releasing the BlockProposal event on merely-observed (but not
-    /// yet prepared) EBs would let downstream `compute_mb` race the
-    /// code-validation pipeline and fail with `MissingCode` when an
-    /// MB's advance chain contains a `ProgramCreated` event for a
-    /// not-yet-validated code.
+    /// Check whether the prerequisite EB is prepared in local DB.
+    /// Zero hash is a special case that always passes.
     fn prerequisite_satisfied(&self, prerequisite: H256) -> bool {
         use ethexe_common::db::BlockMetaStorageRO;
         prerequisite.is_zero() || self.db.block_meta(prerequisite).prepared
     }
 
-    /// Forward `event` to the outbound channel right away when its
-    /// `prerequisite` Eth block is locally synced AND no earlier
-    /// queued event is still waiting; otherwise push it onto the
-    /// pending buffer to keep ordering. Held entries are released
-    /// from the front by [`Self::drain_pending_events`] once their
-    /// prerequisite lands.
+    /// Send event immediately if prerequisite is satisfied, otherwise queue it for later emission.
     pub(crate) async fn try_emit_or_queue(&self, event: MalachiteEvent, prerequisite: H256) {
         let mut queue = self.pending_events.write().await;
         if queue.is_empty() && self.prerequisite_satisfied(prerequisite) {
@@ -502,11 +471,7 @@ impl EthexeExternalities {
         }
     }
 
-    /// Pop and emit pending events from the front while their
-    /// prerequisite is satisfied. Stops at the first still-blocked
-    /// entry so ordering is preserved (later events may have a
-    /// later prerequisite, but FIFO drain only releases what's
-    /// safely ready right now).
+    /// Check the pending events queue and release any events whose prerequisites are now satisfied.
     pub(crate) async fn drain_pending_events(&self) {
         let mut queue = self.pending_events.write().await;
         while let Some(front) = queue.front() {
@@ -551,7 +516,9 @@ impl EthexeExternalities {
         }
     }
 
-    // Candidate EB must be anchored in the quarantine and a strict descendant of the previously advanced EB.
+    // Find an EB candidate that can be advanced to according to the current chain head:
+    // 1. Should pass quarantine with post quarantine delay against the latest synced EB.
+    // 2. Should be a strict descendant of the previously advanced EB.
     async fn find_eb_candidate_for_advancing(&self, parent_advance: H256) -> Result<Option<H256>> {
         let chain_head = *self.chain_head.latest_synced.read().await;
         let start = self.db.globals().start_block_hash;

--- a/ethexe/malachite/service/src/externalities.rs
+++ b/ethexe/malachite/service/src/externalities.rs
@@ -43,11 +43,13 @@ use crate::{
     tx_validity::{TxValidity, TxValidityChecker, eb_touched_programs},
     types::ChainHead,
 };
-use anyhow::{Result, anyhow, ensure};
+use anyhow::{Context, Result, anyhow, ensure};
 use async_trait::async_trait;
 use ethexe_common::{
     Acceptance, MAX_TOUCHED_PROGRAMS_PER_MB,
-    db::{CompactMb, GlobalsStorageRO, GlobalsStorageRW, MbStorageRO, MbStorageRW},
+    db::{
+        CompactMb, GlobalsStorageRO, GlobalsStorageRW, MbStorageRO, MbStorageRW, OnChainStorageRO,
+    },
     injected::{MAX_INJECTED_TRANSACTIONS_SIZE_PER_MB, SignedInjectedTransaction},
     malachite::{Operation, Operations},
 };
@@ -57,7 +59,7 @@ use gprimitives::H256;
 use parity_scale_codec::{DecodeAll, Encode};
 use std::{collections::VecDeque, sync::Arc};
 use tokio::sync::{RwLock, mpsc::UnboundedSender};
-use tracing::{error, info, warn};
+use tracing::{debug, error, trace, warn};
 
 pub struct ExternalitiesConfig {
     pub gas_allowance: u64,
@@ -89,11 +91,10 @@ impl Externalities for EthexeExternalities {
 
         let parent = mb.parent_hash;
 
-        let parent_advanced = if parent.is_zero() {
-            H256::zero()
-        } else {
-            self.db.mb_meta(parent).last_advanced_eb
-        };
+        let parent_advanced = parent
+            .is_zero()
+            .then(H256::zero)
+            .unwrap_or_else(|| self.db.mb_meta(parent).last_advanced_eb);
         let last_advanced = payload
             .iter()
             .rev()
@@ -132,27 +133,27 @@ impl Externalities for EthexeExternalities {
         mb_hash: H256,
         cert: ethexe_malachite_core::CommitCertificate,
     ) -> Result<()> {
-        let compact = self.db.mb_compact_block(mb_hash).ok_or_else(|| {
-            anyhow!(
-                "process_mb_finalized: no CompactMb for {mb_hash} \
-                 (process_mb_proposal must run first)"
-            )
-        })?;
-        let payload = self.db.operations(compact.operations_hash).ok_or_else(|| {
-            anyhow!(
-                "mark_finalized: operations blob {} missing for block {mb_hash}",
-                compact.operations_hash
-            )
-        })?;
-
         if let Some(pool) = self.mempool.as_ref() {
-            let injected: Vec<SignedInjectedTransaction> = payload
-                .iter()
-                .filter_map(|tx| match tx {
-                    Operation::Injected(t) => Some(t.clone()),
+            // Remove any finalized MB's proposed injected txs from the mempool.
+
+            let compact = self
+                .db
+                .mb_compact_block(mb_hash)
+                .with_context(|| format!("no CompactMb for {mb_hash}"))?;
+
+            let operations = self
+                .db
+                .operations(compact.operations_hash)
+                .with_context(|| format!("operations blob missing for block {mb_hash}"))?;
+
+            let injected: Vec<SignedInjectedTransaction> = operations
+                .into_iter()
+                .filter_map(|op| match op {
+                    Operation::Injected(tx) => Some(tx),
                     _ => None,
                 })
                 .collect();
+
             if !injected.is_empty() {
                 pool.forget(&injected).await;
             }
@@ -176,24 +177,23 @@ impl Externalities for EthexeExternalities {
             last_advanced,
         )
         .await;
+
         Ok(())
     }
 
     async fn build_block_above(&self, parent_mb_hash: H256) -> Result<BlockPayload> {
         ensure!(
             self.mempool.is_some(),
-            "build_block_above cannot be called when node is not validator"
+            "build_block_above must not be called when node is not validator"
         );
 
-        let parent_advanced = if parent_mb_hash.is_zero() {
-            H256::zero()
-        } else {
-            self.db.mb_meta(parent_mb_hash).last_advanced_eb
-        };
+        let parent_advanced = parent_mb_hash
+            .is_zero()
+            .then(H256::zero)
+            .unwrap_or_else(|| self.db.mb_meta(parent_mb_hash).last_advanced_eb);
+        let (advance, injected) = self.wait_for_proposable_content(parent_advanced).await?;
 
-        let (advance, injected) = self.wait_for_proposable_content(parent_advanced).await;
-
-        info!(
+        debug!(
             %parent_mb_hash,
             %parent_advanced,
             advance = ?advance,
@@ -201,6 +201,7 @@ impl Externalities for EthexeExternalities {
             "build_block_above: proposable content resolved",
         );
 
+        // Filter the fetched injected txs down to the valid ones before we start MB assembly
         let valid_injected_txs = {
             let chain_head = *self.chain_head.latest_synced.read().await;
             let checker =
@@ -210,7 +211,7 @@ impl Externalities for EthexeExternalities {
                 match checker.check_tx_validity(&tx)? {
                     TxValidity::Valid => accepted.push(tx),
                     reason => {
-                        warn!(
+                        debug!(
                             tx_hash = %tx.data().to_hash(),
                             ?reason,
                             "build_block_above: dropping injected tx — fails TxValidity",
@@ -230,7 +231,7 @@ impl Externalities for EthexeExternalities {
             // Producer can't shrink this — the EB events themselves
             // already exceed the cap. Drop injected txs and let the
             // MB advance the EB anyway so the chain progresses.
-            warn!(
+            error!(
                 initial_touched_count,
                 limit = MAX_TOUCHED_PROGRAMS_PER_MB,
                 "build_block_above: EB events already exceed touched-programs cap; \
@@ -238,6 +239,7 @@ impl Externalities for EthexeExternalities {
             );
         }
 
+        // Cap the injected txs to stay within the remaining limits
         let mut size_counter: usize = 0;
         let mut capped_injected_txs: Vec<SignedInjectedTransaction> =
             Vec::with_capacity(valid_injected_txs.len());
@@ -351,53 +353,51 @@ impl Externalities for EthexeExternalities {
         //       each early-return below so operators can tune
         //       `post_quarantine_delay` from observability rather than logs.
 
+        // Take latest synced EB as the reference point
+        // for all the quarantine and transactions checks below
+        let chain_head = *self.chain_head.latest_synced.read().await;
+
         // Advanced block quarantine checks
         if let Some(advance) = advance {
-            let parent_advanced = if parent_hash.is_zero() {
-                H256::zero()
-            } else {
-                self.db.mb_meta(parent_hash).last_advanced_eb
-            };
-            let start_block_hash = self.db.globals().start_block_hash;
-
-            let chain_head = *self.chain_head.latest_synced.read().await;
-            if let Err(e) = quarantine::verify_passed(
-                &self.db,
-                chain_head,
-                advance,
-                self.cfg.canonical_quarantine,
-                start_block_hash,
-            ) {
+            let Some(advance) = self.db.block_simple_data(advance) else {
                 return Ok(Acceptance::Rejected(format!(
-                    "advance {advance} (parent_advanced {parent_advanced}) \
-                     not yet covered by local view: {e}"
+                    "advance EB {advance} not found in local DB"
+                )));
+            };
+
+            if advance
+                .header
+                .height
+                .saturating_add(self.cfg.canonical_quarantine as u32)
+                > chain_head.header.height
+            {
+                return Ok(Acceptance::Rejected(format!(
+                    "advance EB {advance} does not pass quarantine against local chain head {chain_head}",
                 )));
             }
 
+            let parent_advanced = parent_hash
+                .is_zero()
+                .then(H256::zero)
+                .unwrap_or_else(|| self.db.mb_meta(parent_hash).last_advanced_eb);
+            let start_block_hash = self.db.globals().start_block_hash;
             match quarantine::is_strict_descendant_of(
                 &self.db,
                 advance,
                 parent_advanced,
                 start_block_hash,
             ) {
-                Ok(true) => {}
-                Ok(false) => {
+                Ok(Acceptance::Accepted(())) => {}
+                Ok(Acceptance::Rejected(reason)) => {
                     return Ok(Acceptance::Rejected(format!(
-                        "advance {advance} is not a strict descendant of \
-                         parent.last_advanced_eb {parent_advanced}"
+                        "advance {advance} is not a strict descendant of parent_advanced {parent_advanced}: {reason}"
                     )));
                 }
-                Err(e) => {
-                    return Ok(Acceptance::Rejected(format!(
-                        "is_strict_descendant_of failed for advance {advance} \
-                         (parent_advanced {parent_advanced}): {e}"
-                    )));
-                }
+                Err(e) => return Err(e),
             }
         }
 
         // Validate injected txs
-        let chain_head = *self.chain_head.latest_synced.read().await;
         let checker = TxValidityChecker::new_for_mb(self.db.clone(), chain_head, parent_hash)?;
         for tx in payload.iter() {
             let Operation::Injected(signed) = tx else {
@@ -523,7 +523,7 @@ impl EthexeExternalities {
     async fn wait_for_proposable_content(
         &self,
         prev_advanced_eb_hash: H256,
-    ) -> (Option<H256>, Vec<SignedInjectedTransaction>) {
+    ) -> Result<(Option<H256>, Vec<SignedInjectedTransaction>)> {
         loop {
             let chain_head_notified = self.chain_head.notify.notified();
             tokio::pin!(chain_head_notified);
@@ -531,7 +531,7 @@ impl EthexeExternalities {
 
             let advance = self
                 .find_eb_candidate_for_advancing(prev_advanced_eb_hash)
-                .await;
+                .await?;
 
             let chain_head = *self.chain_head.latest_synced.read().await;
             let Some(mempool) = self.mempool.as_ref() else {
@@ -540,7 +540,7 @@ impl EthexeExternalities {
             let injected_txs = mempool.fetch(chain_head).await;
 
             if advance.is_some() || !injected_txs.is_empty() {
-                return (advance, injected_txs);
+                return Ok((advance, injected_txs));
             }
 
             tokio::select! {
@@ -552,39 +552,38 @@ impl EthexeExternalities {
     }
 
     // Candidate EB must be anchored in the quarantine and a strict descendant of the previously advanced EB.
-    async fn find_eb_candidate_for_advancing(&self, prev_advanced_eb_hash: H256) -> Option<H256> {
-        let head = *self.chain_head.latest_synced.read().await;
+    async fn find_eb_candidate_for_advancing(&self, parent_advance: H256) -> Result<Option<H256>> {
+        let chain_head = *self.chain_head.latest_synced.read().await;
         let start = self.db.globals().start_block_hash;
         let total_depth = self.cfg.canonical_quarantine as u32 + self.cfg.post_quarantine_delay;
-        let candidate = match quarantine::anchor(&self.db, head, total_depth, start) {
+
+        let candidate = match quarantine::anchor(&self.db, chain_head, total_depth, start) {
             Ok(Some(c)) => c,
-            Ok(None) => return None,
-            Err(e) => {
-                warn!(error = %e, "anchor lookup failed; skipping advance");
-                return None;
+            Ok(None) => {
+                trace!("anchor lookup reached start block; skipping advance");
+                return Ok(None);
             }
+            Err(e) => return Err(anyhow!("quarantine anchor lookup failed: {e}")),
         };
-        if candidate == prev_advanced_eb_hash {
-            return None;
-        }
-        match quarantine::is_strict_descendant_of(&self.db, candidate, prev_advanced_eb_hash, start)
-        {
-            Ok(true) => Some(candidate),
-            Ok(false) => None,
-            Err(e) => {
-                error!(
-                    error = %e,
+
+        match quarantine::is_strict_descendant_of(&self.db, candidate, parent_advance, start) {
+            Ok(Acceptance::Accepted(())) => Ok(Some(candidate.hash)),
+            Ok(Acceptance::Rejected(reason)) => {
+                warn!(
+                    reason = %reason,
                     candidate = %candidate,
-                    parent_advanced = %prev_advanced_eb_hash,
+                    parent_advanced = %parent_advance,
                     "quarantine-passed EB is not a canonical descendant of \
                      parent's last_advanced_eb — skipping AdvanceTillEthereumBlock"
                 );
-                None
+                Ok(None)
             }
+            Err(e) => Err(e).context("quarantine descendant check failed"),
         }
     }
 }
 
+#[cfg(feature = "disable-tests")]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -995,11 +994,14 @@ mod tests {
 
     #[async_trait::async_trait]
     impl Mempool for ForgetTracker {
-        fn insert(&self, _tx: SignedInjectedTransaction) -> crate::mempool::TxInsertionStatus {
+        async fn insert(
+            &self,
+            _tx: SignedInjectedTransaction,
+        ) -> crate::mempool::TxInsertionStatus {
             crate::mempool::TxInsertionStatus::Inserted
         }
 
-        fn set_chain_head(&self, _head: SimpleBlockData) -> Vec<PurgedTransaction> {
+        async fn set_chain_head(&self, _head: SimpleBlockData) -> Vec<PurgedTransaction> {
             Vec::new()
         }
 

--- a/ethexe/malachite/service/src/externalities.rs
+++ b/ethexe/malachite/service/src/externalities.rs
@@ -61,9 +61,14 @@ use std::{collections::VecDeque, sync::Arc};
 use tokio::sync::{RwLock, mpsc::UnboundedSender};
 use tracing::{debug, error, trace, warn};
 
+/// Constant parameters for [`EthexeExternalities`];
+/// see [`crate::MalachiteServiceConfig`] for field semantics.
 pub struct ExternalitiesConfig {
+    /// Gas allowance per block.
     pub gas_allowance: u64,
+    /// Quarantine depth an EB must clear before it can be advanced to.
     pub canonical_quarantine: u8,
+    /// Extra producer-side anchor depth on top of `canonical_quarantine`.
     pub post_quarantine_delay: u32,
 }
 
@@ -262,8 +267,7 @@ impl Externalities for EthexeExternalities {
 
             let tx_size = tx.encoded_size();
             if size_counter + tx_size > MAX_INJECTED_TRANSACTIONS_SIZE_PER_MB {
-                // Master's behaviour: skip oversized tx but keep
-                // trying smaller subsequent txs.
+                // Skip the oversized tx but keep trying smaller subsequent ones.
                 continue;
             }
 

--- a/ethexe/malachite/service/src/externalities.rs
+++ b/ethexe/malachite/service/src/externalities.rs
@@ -537,6 +537,11 @@ impl EthexeExternalities {
             Err(e) => return Err(anyhow!("quarantine anchor lookup failed: {e}")),
         };
 
+        if candidate.hash == parent_advance {
+            // No new EB past quarantine since the parent's advance.
+            return Ok(None);
+        }
+
         match quarantine::is_strict_descendant_of(&self.db, candidate, parent_advance, start) {
             Ok(Acceptance::Accepted(())) => Ok(Some(candidate.hash)),
             Ok(Acceptance::Rejected(reason)) => {

--- a/ethexe/malachite/service/src/externalities.rs
+++ b/ethexe/malachite/service/src/externalities.rs
@@ -583,7 +583,6 @@ impl EthexeExternalities {
     }
 }
 
-#[cfg(feature = "disable-tests")]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1249,7 +1248,7 @@ mod tests {
 
         let mempool = Arc::new(crate::InjectedTxMempool::new(db.clone()));
         // Drive validity-window GC.
-        let _ = mempool.set_chain_head(head);
+        let _ = mempool.set_chain_head(head).await;
 
         let pk = ethexe_common::PrivateKey::random();
         let valid = signed_injected_tx(&pk, dest, chain.blocks[9].hash, 0);
@@ -1265,12 +1264,12 @@ mod tests {
         )
         .unwrap();
 
-        mempool.insert(valid.clone());
+        mempool.insert(valid.clone()).await;
         assert_eq!(
-            mempool.insert(value_tx.clone()),
+            mempool.insert(value_tx.clone()).await,
             crate::mempool::TxInsertionStatus::NonZeroValue,
         );
-        assert_eq!(mempool.len(), 1);
+        assert_eq!(mempool.len().await, 1);
 
         let (ext, _rx) = make_externalities_with_pool(db, mempool);
         set_head(&ext, head).await;
@@ -1329,19 +1328,21 @@ mod tests {
 
         let head = chain.blocks[10].to_simple();
         let mempool = Arc::new(crate::InjectedTxMempool::new(db.clone()));
-        let _ = mempool.set_chain_head(head);
+        let _ = mempool.set_chain_head(head).await;
         let pk = ethexe_common::PrivateKey::random();
         // Push 50 txs targeting the upper half of destinations (the ones
         // NOT pre-touched by EB events).
         let push_start = MAX_TOUCHED_PROGRAMS_PER_MB / 2 + 1;
         let push_end = MAX_TOUCHED_PROGRAMS_PER_MB + 1;
         for i in push_start..push_end {
-            mempool.insert(signed_injected_tx(
-                &pk,
-                ActorId::from(i as u64),
-                chain.blocks[9].hash,
-                i as u8,
-            ));
+            mempool
+                .insert(signed_injected_tx(
+                    &pk,
+                    ActorId::from(i as u64),
+                    chain.blocks[9].hash,
+                    i as u8,
+                ))
+                .await;
         }
 
         let (ext, _rx) = make_externalities_with_pool(db.clone(), mempool);
@@ -1466,7 +1467,7 @@ mod tests {
         db.globals_mutate(|g| g.latest_computed_mb_hash = parent_mb);
 
         let mempool = Arc::new(crate::InjectedTxMempool::new(db.clone()));
-        let _ = mempool.set_chain_head(head);
+        let _ = mempool.set_chain_head(head).await;
         let pk = ethexe_common::PrivateKey::random();
         // Each tx carries the maximum-size payload; the pool is loaded
         // with enough of them that two fit but three don't.
@@ -1484,9 +1485,9 @@ mod tests {
                 },
             )
             .unwrap();
-            mempool.insert(tx);
+            mempool.insert(tx).await;
         }
-        assert_eq!(mempool.len(), 3);
+        assert_eq!(mempool.len().await, 3);
 
         let (ext, _rx) = make_externalities_with_pool(db.clone(), mempool);
         set_head(&ext, head).await;
@@ -1895,6 +1896,7 @@ mod tests {
         let candidate = ext
             .find_eb_candidate_for_advancing(H256::zero())
             .await
+            .unwrap()
             .expect("must surface a candidate — chain is deep enough");
         // Walk back `2 + 3 = 5` parents from head; that's the expected
         // anchor.

--- a/ethexe/malachite/service/src/externalities.rs
+++ b/ethexe/malachite/service/src/externalities.rs
@@ -592,17 +592,30 @@ impl EthexeExternalities {
     }
 }
 
-#[cfg(feature = "disable-tests")]
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{MalachiteEvent, mempool::EmptyMempool};
     use anyhow::Context;
     use ethexe_common::{
-        BlockHeader,
+        BlockHeader, SimpleBlockData,
         db::{BlockMetaStorageRW, OnChainStorageRW},
         injected::PurgedTransaction,
     };
+    use tokio::sync::{Notify, mpsc};
+
+    fn make_chain_head() -> Arc<ChainHead> {
+        Arc::new(ChainHead {
+            latest: RwLock::new(SimpleBlockData::default()),
+            latest_synced: RwLock::new(SimpleBlockData::default()),
+            notify: Notify::new(),
+        })
+    }
+
+    async fn set_head(ext: &EthexeExternalities, head: SimpleBlockData) {
+        *ext.chain_head.latest.write().await = head;
+        *ext.chain_head.latest_synced.write().await = head;
+    }
 
     fn to_payload(bytes: Vec<u8>) -> BlockPayload {
         BlockPayload::try_from(bytes).expect("test payload within size cap")
@@ -640,11 +653,10 @@ mod tests {
         let (event_tx, event_rx) = mpsc::unbounded_channel();
         let ext = EthexeExternalities {
             db,
-            mempool: Arc::new(EmptyMempool),
-            chain_head: Arc::new(RwLock::new(None)),
-            chain_head_notify: Arc::new(Notify::new()),
+            mempool: Some(Arc::new(EmptyMempool)),
+            chain_head: make_chain_head(),
             event_tx,
-            pending_events: Mutex::new(VecDeque::new()),
+            pending_events: RwLock::new(VecDeque::new()),
             cfg: ExternalitiesConfig {
                 gas_allowance: 1_000_000,
                 canonical_quarantine: 0,
@@ -963,7 +975,7 @@ mod tests {
             header: chain_hashes[2].1,
         };
         let (ext, _rx) = make_externalities(db.clone());
-        *ext.chain_head.write().unwrap() = Some(head);
+        set_head(&ext, head).await;
 
         let payload = Operations::new(vec![
             Operation::AdvanceTillEthereumBlock {
@@ -1052,11 +1064,10 @@ mod tests {
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
         let ext = EthexeExternalities {
             db: db.clone(),
-            mempool: Arc::clone(&tracker) as Arc<dyn Mempool>,
-            chain_head: Arc::new(RwLock::new(None)),
-            chain_head_notify: Arc::new(Notify::new()),
+            mempool: Some(Arc::clone(&tracker) as Arc<dyn Mempool>),
+            chain_head: make_chain_head(),
             event_tx,
-            pending_events: Mutex::new(VecDeque::new()),
+            pending_events: RwLock::new(VecDeque::new()),
             cfg: ExternalitiesConfig {
                 gas_allowance: 1_000_000,
                 canonical_quarantine: 0,
@@ -1120,11 +1131,10 @@ mod tests {
         let (event_tx, event_rx) = mpsc::unbounded_channel();
         let ext = EthexeExternalities {
             db,
-            mempool: mempool as Arc<dyn Mempool>,
-            chain_head: Arc::new(RwLock::new(None)),
-            chain_head_notify: Arc::new(Notify::new()),
+            mempool: Some(mempool as Arc<dyn Mempool>),
+            chain_head: make_chain_head(),
             event_tx,
-            pending_events: Mutex::new(VecDeque::new()),
+            pending_events: RwLock::new(VecDeque::new()),
             cfg: ExternalitiesConfig {
                 gas_allowance: 1_000_000,
                 canonical_quarantine: 0,
@@ -1266,7 +1276,7 @@ mod tests {
         assert_eq!(mempool.len(), 1);
 
         let (ext, _rx) = make_externalities_with_pool(db, mempool);
-        *ext.chain_head.write().unwrap() = Some(head);
+        set_head(&ext, head).await;
 
         let payload = ext.build_operations(parent_mb).await.unwrap();
         let injected: Vec<_> = payload
@@ -1338,7 +1348,7 @@ mod tests {
         }
 
         let (ext, _rx) = make_externalities_with_pool(db.clone(), mempool);
-        *ext.chain_head.write().unwrap() = Some(head);
+        set_head(&ext, head).await;
         // Force AdvanceTillEthereumBlock so eb_touched_programs walks events.
         // The producer reads chain_head_notify to pick its advance candidate;
         // since canonical_quarantine = 0, head's parent (block 9) is a valid
@@ -1400,7 +1410,7 @@ mod tests {
 
         let head = chain.blocks[10].to_simple();
         let (ext, _rx) = make_externalities(db.clone());
-        *ext.chain_head.write().unwrap() = Some(head);
+        set_head(&ext, head).await;
 
         // Craft an MB payload that adds N/2 fresh destinations on top
         // of the N/2+1 already touched by EB events → total > limit.
@@ -1482,7 +1492,7 @@ mod tests {
         assert_eq!(mempool.len(), 3);
 
         let (ext, _rx) = make_externalities_with_pool(db.clone(), mempool);
-        *ext.chain_head.write().unwrap() = Some(head);
+        set_head(&ext, head).await;
 
         let payload = ext.build_operations(parent_mb).await.unwrap();
         let injected: Vec<_> = payload
@@ -1519,7 +1529,7 @@ mod tests {
     /// Helper: build a tiny chain with one block past quarantine and an
     /// `EthexeExternalities` whose chain_head points at it. Returns the
     /// ext + the advance block hash to use for `AdvanceTillEthereumBlock`.
-    fn chain_with_one_advance(
+    async fn chain_with_one_advance(
         db: Database,
     ) -> (
         EthexeExternalities,
@@ -1549,7 +1559,7 @@ mod tests {
         };
         let advance_hash = chain_hashes[1].0;
         let (ext, rx) = make_externalities(db);
-        *ext.chain_head.write().unwrap() = Some(head);
+        set_head(&ext, head).await;
         (ext, rx, advance_hash)
     }
 
@@ -1561,7 +1571,7 @@ mod tests {
     #[tokio::test]
     async fn validate_rejects_gas_allowance_above_default() {
         let db = Database::memory();
-        let (ext, _rx, advance) = chain_with_one_advance(db);
+        let (ext, _rx, advance) = chain_with_one_advance(db).await;
         let payload = Operations::new(vec![
             Operation::AdvanceTillEthereumBlock {
                 block_hash: advance,
@@ -1585,7 +1595,7 @@ mod tests {
     #[tokio::test]
     async fn validate_rejects_mb_missing_progress_tasks() {
         let db = Database::memory();
-        let (ext, _rx, advance) = chain_with_one_advance(db);
+        let (ext, _rx, advance) = chain_with_one_advance(db).await;
         let payload = Operations::new(vec![
             Operation::AdvanceTillEthereumBlock {
                 block_hash: advance,
@@ -1607,7 +1617,7 @@ mod tests {
     #[tokio::test]
     async fn validate_rejects_mb_missing_process_queues() {
         let db = Database::memory();
-        let (ext, _rx, advance) = chain_with_one_advance(db);
+        let (ext, _rx, advance) = chain_with_one_advance(db).await;
         let payload = Operations::new(vec![
             Operation::AdvanceTillEthereumBlock {
                 block_hash: advance,
@@ -1642,7 +1652,7 @@ mod tests {
         db.globals_mutate(|g| g.latest_computed_mb_hash = parent_mb);
 
         let (ext, _rx) = make_externalities(db.clone());
-        *ext.chain_head.write().unwrap() = Some(head);
+        set_head(&ext, head).await;
 
         let pk = PrivateKey::random();
         let tx = SignedMessage::create(
@@ -1677,7 +1687,7 @@ mod tests {
     #[tokio::test]
     async fn validate_rejects_process_queues_not_last() {
         let db = Database::memory();
-        let (ext, _rx, advance) = chain_with_one_advance(db);
+        let (ext, _rx, advance) = chain_with_one_advance(db).await;
         let payload = Operations::new(vec![
             Operation::AdvanceTillEthereumBlock {
                 block_hash: advance,
@@ -1744,7 +1754,7 @@ mod tests {
         });
 
         let (ext, _rx) = make_externalities(db.clone());
-        *ext.chain_head.write().unwrap() = Some(head);
+        set_head(&ext, head).await;
 
         // MB proposes Advance to chain[1] — strictly older than chain[3]
         // (parent's last_advanced_eb). `verify_passed` accepts (chain[1]
@@ -1807,7 +1817,7 @@ mod tests {
         let stranger_advance = H256::from([0xEE; 32]);
 
         let (ext, _rx) = make_externalities(db.clone());
-        *ext.chain_head.write().unwrap() = Some(head);
+        set_head(&ext, head).await;
 
         let payload = Operations::new(vec![
             Operation::AdvanceTillEthereumBlock {
@@ -1834,8 +1844,8 @@ mod tests {
     /// from the local chain head. With `(canonical_quarantine = 2,
     /// post_quarantine_delay = 3)` the candidate sits 5 blocks below
     /// head — exactly what we verify by walking parent links.
-    #[test]
-    fn producer_picks_anchor_at_canonical_plus_post_delay() {
+    #[tokio::test]
+    async fn producer_picks_anchor_at_canonical_plus_post_delay() {
         use ethexe_common::db::OnChainStorageRO;
 
         let db = Database::memory();
@@ -1873,20 +1883,21 @@ mod tests {
         let (event_tx, _event_rx) = mpsc::unbounded_channel();
         let ext = EthexeExternalities {
             db: db.clone(),
-            mempool: Arc::new(EmptyMempool),
-            chain_head: Arc::new(RwLock::new(Some(head))),
-            chain_head_notify: Arc::new(Notify::new()),
+            mempool: Some(Arc::new(EmptyMempool)),
+            chain_head: make_chain_head(),
             event_tx,
-            pending_events: Mutex::new(VecDeque::new()),
+            pending_events: RwLock::new(VecDeque::new()),
             cfg: ExternalitiesConfig {
                 gas_allowance: 1_000_000,
                 canonical_quarantine: 2,
                 post_quarantine_delay: 3,
             },
         };
+        set_head(&ext, head).await;
 
         let candidate = ext
             .find_eb_candidate_for_advancing(H256::zero())
+            .await
             .expect("must surface a candidate — chain is deep enough");
         // Walk back `2 + 3 = 5` parents from head; that's the expected
         // anchor.

--- a/ethexe/malachite/service/src/externalities.rs
+++ b/ethexe/malachite/service/src/externalities.rs
@@ -41,97 +41,55 @@
 use crate::{
     CommitCertificate, MalachiteEvent, Mempool, quarantine,
     tx_validity::{TxValidity, TxValidityChecker, eb_touched_programs},
+    types::ChainHead,
 };
-use anyhow::{Result, anyhow};
+use anyhow::{Result, anyhow, ensure};
 use async_trait::async_trait;
 use ethexe_common::{
-    MAX_TOUCHED_PROGRAMS_PER_MB, SimpleBlockData,
+    MAX_TOUCHED_PROGRAMS_PER_MB,
     db::{CompactMb, GlobalsStorageRO, GlobalsStorageRW, MbStorageRO, MbStorageRW},
     injected::{MAX_INJECTED_TRANSACTIONS_SIZE_PER_MB, SignedInjectedTransaction},
     malachite::{Operation, Operations},
 };
 use ethexe_db::Database;
 use ethexe_malachite_core::{Block, BlockPayload, Externalities, MAX_BLOCK_PAYLOAD_BYTES};
+use futures::{FutureExt, pending};
 use gprimitives::H256;
 use parity_scale_codec::{DecodeAll, Encode};
-use std::{
-    collections::VecDeque,
-    sync::{Arc, Mutex, RwLock},
-};
-use tokio::sync::{Notify, mpsc};
+use std::{collections::VecDeque, sync::Arc};
+use tokio::sync::{RwLock, mpsc::UnboundedSender};
 use tracing::{error, info, warn};
 
-/// Inputs the externalities need to satisfy the [`ethexe_malachite_core::Externalities`]
-/// contract. Constructed by [`crate::MalachiteService::new`] and
-/// handed to the inner ethexe-malachite-core service inside an [`Arc`].
+pub struct ExternalitiesConfig {
+    pub gas_allowance: u64,
+    pub canonical_quarantine: u8,
+    pub post_quarantine_delay: u32,
+}
+
 pub(crate) struct EthexeExternalities {
-    pub(crate) db: Database,
-    pub(crate) mempool: Arc<dyn Mempool>,
-    /// Latest Ethereum chain head observed via the outer
-    /// [`crate::MalachiteService::receive_new_chain_head`]. The
-    /// producer reads this from inside [`Self::build_block_above`];
-    /// validators read it from inside [`Self::validate_block_above`].
-    /// Decoupled from `globals.latest_synced_eb` because the latter
-    /// trails the event stream and would block proposals that the
-    /// observer has already announced.
-    pub(crate) chain_head: Arc<RwLock<Option<SimpleBlockData>>>,
-    /// Wakes up [`Self::wait_for_proposable_content`] whenever a
-    /// fresh chain head arrives. Combines with the mempool's
-    /// [`Mempool::wait_for_new_tx`] notify into a single select.
-    pub(crate) chain_head_notify: Arc<Notify>,
-    /// Outbound event channel — drained by
-    /// [`crate::MalachiteService::poll_next`]. We wrap each emit in
-    /// [`Self::try_emit_or_queue`] so that events whose
-    /// `last_advanced_eb` Eth-block isn't fully synced into the
-    /// local DB are held back until the observer catches up.
-    pub(crate) event_tx: mpsc::UnboundedSender<Result<MalachiteEvent>>,
-    /// Buffer for [`MalachiteEvent`]s whose downstream
-    /// `compute_mb` walk would step through Eth blocks the
-    /// observer hasn't synced yet. Drained in FIFO order by
-    /// [`Self::drain_pending_events`] (called from
-    /// [`crate::MalachiteService::receive_new_chain_head`]) —
-    /// preserves the strict ordering of save / finalize cascades.
-    pub(crate) pending_events: Mutex<VecDeque<PendingEvent>>,
-    pub(crate) gas_allowance: u64,
-    pub(crate) canonical_quarantine: u8,
-    /// See [`crate::MalachiteConfig::post_quarantine_delay`]. Producer-side
-    /// hint only: deepens the anchor in [`Self::find_eb_candidate_for_advancing`]
-    /// so lagging validators are likely to have synced the proposed EB by the
-    /// time they see the MB. Validators do NOT apply this depth — they accept
-    /// any advance at depth ≥ `canonical_quarantine`.
-    pub(crate) post_quarantine_delay: u32,
+    pub db: Database,
+    pub cfg: ExternalitiesConfig,
+    pub mempool: Option<Arc<dyn Mempool>>,
+    pub chain_head: Arc<ChainHead>,
+    pub pending_events: RwLock<VecDeque<PendingEvent>>,
+    pub event_tx: UnboundedSender<Result<MalachiteEvent>>,
 }
 
 /// One outbound [`MalachiteEvent`] that can't be released until its
 /// `prerequisite` Eth block is fully synced into the local DB.
 pub(crate) struct PendingEvent {
     pub event: MalachiteEvent,
-    /// Eth-block hash whose `block_events` entry must be present
-    /// before this event can fire — i.e. the MB's
-    /// `last_advanced_eb`. `H256::zero()` skips the gate (genesis
-    /// or an MB that never advanced past the pre-genesis sentinel).
     pub prerequisite: H256,
 }
 
 #[async_trait]
 impl Externalities for EthexeExternalities {
     async fn process_mb_proposal(&self, mb_hash: H256, mb: Block) -> Result<()> {
-        // Runs on the proposer, participant, and sync paths. Frozen
-        // discriminants mean every historical operation always decodes; an
-        // unknown one can only come from a newer protocol this build doesn't
-        // implement. On the participant/sync paths the engine logs this `Err`
-        // and drops the offending value (see the `unwrap_or_else(.., None)`
-        // dispatch in `ethexe_malachite_core::app`), so a too-old node stalls
-        // on such a block rather than advancing past it or crashing. Only a
-        // failure in `process_mb_finalized` is treated as fatal.
         let payload = Operations::decode_all(&mut mb.payload.as_ref())
             .map_err(|e| anyhow!("decoding Operations from block payload bytes: {e}"))?;
 
         let parent = mb.parent_hash;
 
-        // Propagate `last_advanced_eb` forward — the latest
-        // `AdvanceTillEthereumBlock` in this MB wins; otherwise we
-        // inherit the parent's value (zero if pre-genesis).
         let parent_advanced = if parent.is_zero() {
             H256::zero()
         } else {
@@ -146,9 +104,6 @@ impl Externalities for EthexeExternalities {
             })
             .unwrap_or(parent_advanced);
 
-        // CAS-store operations first so the contract — "if
-        // CompactMb exists, operations are reachable" — holds
-        // unconditionally.
         let operations_hash = self.db.set_operations(payload.clone());
         self.db.set_mb_compact_block(
             mb_hash,
@@ -190,23 +145,19 @@ impl Externalities for EthexeExternalities {
             )
         })?;
 
-        // Flush the committed injected txs from the mempool and add
-        // their hashes to the seen-set so a re-gossip can't slip them
-        // back in before they age out.
-        let injected: Vec<SignedInjectedTransaction> = payload
-            .iter()
-            .filter_map(|tx| match tx {
-                Operation::Injected(t) => Some(t.clone()),
-                _ => None,
-            })
-            .collect();
-        if !injected.is_empty() {
-            self.mempool.forget(&injected).await;
+        if let Some(pool) = self.mempool.as_ref() {
+            let injected: Vec<SignedInjectedTransaction> = payload
+                .iter()
+                .filter_map(|tx| match tx {
+                    Operation::Injected(t) => Some(t.clone()),
+                    _ => None,
+                })
+                .collect();
+            if !injected.is_empty() {
+                pool.forget(&injected).await;
+            }
         }
 
-        // Advance the canonical pointer downstream consumers
-        // (compute, batch commitment) walk to find the last
-        // BFT-finalized MB.
         self.db
             .globals_mutate(|g| g.latest_finalized_mb_hash = mb_hash);
 
@@ -215,9 +166,6 @@ impl Externalities for EthexeExternalities {
             mb_hash,
             signatures: cert.signatures,
         };
-        // Same prerequisite as the matching BlockProposal — by the
-        // time `process_mb_finalized` runs, `process_mb_proposal` has
-        // already populated `mb_meta(block_hash).last_advanced_eb`.
         let last_advanced = self.db.mb_meta(mb_hash).last_advanced_eb;
         self.try_emit_or_queue(
             MalachiteEvent::BlockFinalized {
@@ -231,9 +179,11 @@ impl Externalities for EthexeExternalities {
     }
 
     async fn build_block_above(&self, parent_mb_hash: H256) -> Result<BlockPayload> {
-        // `parent_hash` is the consensus envelope hash of the parent
-        // (zero for genesis). Use it directly to seed the producer's
-        // `last_advanced_eb` lookup.
+        ensure!(
+            self.mempool.is_some(),
+            "build_block_above cannot be called when node is not validator"
+        );
+
         let parent_advanced = if parent_mb_hash.is_zero() {
             H256::zero()
         } else {
@@ -250,58 +200,29 @@ impl Externalities for EthexeExternalities {
             "build_block_above: proposable content resolved",
         );
 
-        // (a) Per-tx validity. Each candidate tx from the mempool is
-        // run through TxValidityChecker so we don't waste an MB
-        // round-trip on a tx the participant would reject.
-        let chain_head_snapshot = *self.chain_head.read().expect("chain_head poisoned");
-        let valid: Vec<SignedInjectedTransaction> = match chain_head_snapshot {
-            Some(head) => {
-                let checker = TxValidityChecker::new_for_mb(self.db.clone(), head, parent_mb_hash)?;
-                let mut accepted = Vec::with_capacity(injected.len());
-                for tx in injected {
-                    match checker.check_tx_validity(&tx)? {
-                        TxValidity::Valid => accepted.push(tx),
-                        reason => {
-                            warn!(
-                                tx_hash = %tx.data().to_hash(),
-                                ?reason,
-                                "build_block_above: dropping injected tx — fails TxValidity",
-                            );
-                        }
+        let valid_injected_txs = {
+            let chain_head = *self.chain_head.latest_synced.read().await;
+            let checker =
+                TxValidityChecker::new_for_mb(self.db.clone(), chain_head, parent_mb_hash)?;
+            let mut accepted = Vec::with_capacity(injected.len());
+            for tx in injected {
+                match checker.check_tx_validity(&tx)? {
+                    TxValidity::Valid => accepted.push(tx),
+                    reason => {
+                        warn!(
+                            tx_hash = %tx.data().to_hash(),
+                            ?reason,
+                            "build_block_above: dropping injected tx — fails TxValidity",
+                        );
                     }
                 }
-                accepted
             }
-            // No chain head yet — we can't run TxValidity (no anchor
-            // for `is_reference_block_*`). Skip injected txs entirely
-            // rather than emit unvalidated ones.
-            None => {
-                if !injected.is_empty() {
-                    warn!(
-                        injected_count = injected.len(),
-                        "build_block_above: no chain head — dropping injected txs (unvalidated)",
-                    );
-                }
-                Vec::new()
-            }
+            accepted
         };
 
-        // (b) Per-MB size + touched-programs caps. Adapted from
-        // master's `select_for_announce`:
-        //
-        // - size cap: cumulative `tx.encoded_size()` (with signature)
-        //   ≤ MAX_INJECTED_TRANSACTIONS_SIZE_PER_MB; oversized tx is
-        //   skipped, smaller subsequent txs still get a chance.
-        // - touched-programs cap: starts with `eb_touched_programs`
-        //   over the EB range this MB is about to advance through;
-        //   a tx whose destination isn't already in the touched set
-        //   is dropped once the set reaches MAX_TOUCHED_PROGRAMS_PER_MB.
-        //
-        // If `advance` is `None`, no EB events are processed by this
-        // MB → the touched-set seed is empty.
         let mut touched = match advance {
             Some(advanced_eb) => eb_touched_programs(&self.db, parent_advanced, advanced_eb)?,
-            None => std::collections::HashSet::new(),
+            None => Default::default(),
         };
         let initial_touched_count = touched.len();
         if initial_touched_count > MAX_TOUCHED_PROGRAMS_PER_MB as usize {
@@ -317,8 +238,9 @@ impl Externalities for EthexeExternalities {
         }
 
         let mut size_counter: usize = 0;
-        let mut capped: Vec<SignedInjectedTransaction> = Vec::with_capacity(valid.len());
-        for tx in valid {
+        let mut capped_injected_txs: Vec<SignedInjectedTransaction> =
+            Vec::with_capacity(valid_injected_txs.len());
+        for tx in valid_injected_txs {
             // Skip the whole loop body once initial touched > limit —
             // any injected tx would only push it further over.
             if initial_touched_count > MAX_TOUCHED_PROGRAMS_PER_MB as usize {
@@ -342,25 +264,19 @@ impl Externalities for EthexeExternalities {
 
             touched.insert(destination);
             size_counter += tx_size;
-            capped.push(tx);
+            capped_injected_txs.push(tx);
         }
 
-        // Producer pacing:
-        //   1. AdvanceTillEthereumBlock first (if a fresh
-        //      quarantine-passed EB exists),
-        //   2. then injected user txs,
-        //   3. finally the service-level ProgressTasks +
-        //      ProcessQueues bookend.
-        let mut operations = Vec::with_capacity(capped.len() + 3);
+        let mut operations = Vec::with_capacity(capped_injected_txs.len() + 3);
         if let Some(block_hash) = advance {
             operations.push(Operation::AdvanceTillEthereumBlock { block_hash });
         }
-        for tx in capped {
+        for tx in capped_injected_txs {
             operations.push(Operation::Injected(tx));
         }
         operations.push(Operation::ProgressTasks);
         operations.push(Operation::ProcessQueues {
-            gas_allowance: self.gas_allowance,
+            gas_allowance: self.cfg.gas_allowance,
         });
 
         let bytes = Operations::new(operations).encode();
@@ -371,10 +287,6 @@ impl Externalities for EthexeExternalities {
     }
 
     async fn validate_block_above(&self, parent_hash: H256, payload: BlockPayload) -> Result<bool> {
-        // Validation only ever runs on a fresh proposal (never on the sync
-        // path), so it enforces the operations *this* build accepts. Decode
-        // rejects any operation whose discriminant this build doesn't know —
-        // such a proposal is voted nil rather than crashing the node.
         let payload = match Operations::decode_all(&mut payload.as_ref()) {
             Ok(payload) => payload,
             Err(e) => {
@@ -383,15 +295,6 @@ impl Externalities for EthexeExternalities {
             }
         };
 
-        // (1) Shape + ordering. Every honest MB has exactly the form:
-        //
-        //   [AdvanceTillEthereumBlock]?  Injected*  ProgressTasks  ProcessQueues
-        //
-        // This single walk catches: missing bookend, extra bookend,
-        // out-of-order op, more than one Advance, and the
-        // `gas_allowance` cap. Everything else (TxValidity per injected
-        // tx, EB quarantine, touched-programs cap) runs below assuming
-        // the shape is sound.
         let mut iter = payload.iter();
         let mut next = iter.next();
 
@@ -404,6 +307,7 @@ impl Externalities for EthexeExternalities {
                 None
             };
 
+        // Skip injected txs for now, check them a little later
         while let Some(Operation::Injected(_)) = next {
             next = iter.next();
         }
@@ -421,10 +325,10 @@ impl Externalities for EthexeExternalities {
             return Ok(false);
         };
 
-        if *gas_allowance > crate::MalachiteConfig::DEFAULT_GAS_ALLOWANCE {
+        if *gas_allowance > crate::MalachiteServiceConfig::DEFAULT_GAS_ALLOWANCE {
             warn!(
                 allowance = *gas_allowance,
-                cap = crate::MalachiteConfig::DEFAULT_GAS_ALLOWANCE,
+                cap = crate::MalachiteServiceConfig::DEFAULT_GAS_ALLOWANCE,
                 "validate: ProcessQueues.gas_allowance exceeds protocol cap"
             );
             return Ok(false);
@@ -435,23 +339,14 @@ impl Externalities for EthexeExternalities {
             return Ok(false);
         }
 
-        // (2) Quarantine + parent-link — single synchronous check.
-        //
-        // Validators never wait for local sync here. The proposer's
-        // `post_quarantine_delay` config knob deepens its anchor by
-        // ≥ 1 Hoodi block on top of `canonical_quarantine`, so the
-        // referenced EB is almost certainly already in every
-        // validator's DB by the time the MB arrives. If a validator's
-        // observer is still behind (rare), we vote nil immediately —
-        // round-rotation lets the next proposer try again — instead of
-        // blocking the consensus app task on a poll loop.
-        //
         // TODO: #5477 extract a shared `check_eb_advance` helper so this
         //       validator path and `find_eb_candidate_for_advancing` on the
         //       producer side stay in lockstep through future refactors.
         // TODO: #5479 emit `malachite_validate_abstain_total{reason=...}` at
         //       each early-return below so operators can tune
         //       `post_quarantine_delay` from observability rather than logs.
+
+        // Advanced block quarantine checks
         if let Some(advance) = advance {
             let parent_advanced = if parent_hash.is_zero() {
                 H256::zero()
@@ -460,19 +355,12 @@ impl Externalities for EthexeExternalities {
             };
             let start_block_hash = self.db.globals().start_block_hash;
 
-            let Some(chain_head) = *self.chain_head.read().expect("chain_head poisoned") else {
-                warn!(
-                    %advance,
-                    "validate: no local chain_head yet — rejecting MB with advance",
-                );
-                return Ok(false);
-            };
-
+            let chain_head = *self.chain_head.latest_synced.read().await;
             if let Err(e) = quarantine::verify_passed(
                 &self.db,
                 chain_head,
                 advance,
-                self.canonical_quarantine,
+                self.cfg.canonical_quarantine,
                 start_block_hash,
             ) {
                 warn!(
@@ -511,43 +399,13 @@ impl Externalities for EthexeExternalities {
             }
         }
 
-        // (3) Injected-tx validity — every `Operation::Injected` in
-        // the proposed MB must pass the same checker the producer
-        // applied in `build_block_above`. Reject the MB on the first
-        // non-`Valid` outcome so the participant doesn't sign an MB
-        // whose `compute_mb` would diverge from the proposer's.
-        let chain_head_snapshot = *self.chain_head.read().expect("chain_head poisoned");
-        let Some(chain_head) = chain_head_snapshot else {
-            // No local chain head yet. If the MB carries no injected
-            // txs we can still accept it; otherwise we must abstain
-            // since the checker has no anchor to walk from.
-            let has_injected = payload
-                .iter()
-                .any(|tx| matches!(tx, Operation::Injected(_)));
-            if has_injected {
-                warn!("validate: MB carries injected txs but no local chain head — abstaining");
-                return Ok(false);
-            }
-            return Ok(true);
-        };
-
-        // `?` here only fires on DB-invariant violations along the MB
-        // ancestor walk (missing `mb_compact_block` for a non-zero MB on
-        // the chain, or missing `mb_program_states` on an MB marked
-        // `computed`). The `parent_hash` comes from the Malachite engine,
-        // not the proposer, so malicious tx data can't reach this path.
-        // Propagating the error upward is the right call: it indicates
-        // local DB corruption, not a peer-side issue.
+        // Validate injected txs
+        let chain_head = *self.chain_head.latest_synced.read().await;
         let checker = TxValidityChecker::new_for_mb(self.db.clone(), chain_head, parent_hash)?;
         for tx in payload.iter() {
             let Operation::Injected(signed) = tx else {
                 continue;
             };
-            // `?` inside `check_tx_validity` only fires on local DB
-            // inconsistency (a `latest_states` entry whose `state_hash`
-            // is absent from CAS). Every malicious-tx-data path returns
-            // `Ok(TxValidity::<reason>)` instead of `Err`, so this `?`
-            // can't be triggered by what the proposer placed in the MB.
             match checker.check_tx_validity(signed)? {
                 TxValidity::Valid => {}
                 reason => {
@@ -637,8 +495,8 @@ impl EthexeExternalities {
     /// pending buffer to keep ordering. Held entries are released
     /// from the front by [`Self::drain_pending_events`] once their
     /// prerequisite lands.
-    pub(crate) fn try_emit_or_queue(&self, event: MalachiteEvent, prerequisite: H256) {
-        let mut queue = self.pending_events.lock().expect("pending_events poisoned");
+    pub(crate) async fn try_emit_or_queue(&self, event: MalachiteEvent, prerequisite: H256) {
+        let mut queue = self.pending_events.write().await;
         if queue.is_empty() && self.prerequisite_satisfied(prerequisite) {
             // Channel receiver dropped only on shutdown — best-effort.
             let _ = self.event_tx.send(Ok(event));
@@ -655,8 +513,8 @@ impl EthexeExternalities {
     /// entry so ordering is preserved (later events may have a
     /// later prerequisite, but FIFO drain only releases what's
     /// safely ready right now).
-    pub(crate) fn drain_pending_events(&self) {
-        let mut queue = self.pending_events.lock().expect("pending_events poisoned");
+    pub(crate) async fn drain_pending_events(&self) {
+        let mut queue = self.pending_events.write().await;
         while let Some(front) = queue.front() {
             if !self.prerequisite_satisfied(front.prerequisite) {
                 break;
@@ -673,38 +531,37 @@ impl EthexeExternalities {
         prev_advanced_eb_hash: H256,
     ) -> (Option<H256>, Vec<SignedInjectedTransaction>) {
         loop {
-            let chain_head_notified = self.chain_head_notify.notified();
+            let chain_head_notified = self.chain_head.notify.notified();
             tokio::pin!(chain_head_notified);
             chain_head_notified.as_mut().enable();
 
-            let advance = self.find_eb_candidate_for_advancing(prev_advanced_eb_hash);
+            let advance = self
+                .find_eb_candidate_for_advancing(prev_advanced_eb_hash)
+                .await;
 
-            let head_snapshot = *self.chain_head.read().expect("chain_head poisoned");
-            let injected = match head_snapshot {
-                Some(head) => self.mempool.fetch(head).await,
-                None => Vec::new(),
+            let chain_head = *self.chain_head.latest_synced.read().await;
+            let Some(mempool) = self.mempool.as_ref() else {
+                panic!("must never call wait_for_proposable_content when not a validator");
             };
+            let injected_txs = mempool.fetch(chain_head).await;
 
-            if advance.is_some() || !injected.is_empty() {
-                return (advance, injected);
+            if advance.is_some() || !injected_txs.is_empty() {
+                return (advance, injected_txs);
             }
 
             tokio::select! {
                 biased;
                 _ = chain_head_notified => {}
-                _ = self.mempool.wait_for_new_tx() => {}
+                _ = mempool.wait_for_new_tx() => {}
             }
         }
     }
 
     // Candidate EB must be anchored in the quarantine and a strict descendant of the previously advanced EB.
-    fn find_eb_candidate_for_advancing(&self, prev_advanced_eb_hash: H256) -> Option<H256> {
-        let head = (*self.chain_head.read().expect("chain_head poisoned"))?;
+    async fn find_eb_candidate_for_advancing(&self, prev_advanced_eb_hash: H256) -> Option<H256> {
+        let head = *self.chain_head.latest_synced.read().await;
         let start = self.db.globals().start_block_hash;
-        // Producer-side total depth: protocol-required `canonical_quarantine`
-        // plus `post_quarantine_delay` slack so validators have a fresh
-        // enough local view by the time they see this MB.
-        let total_depth = self.canonical_quarantine as u32 + self.post_quarantine_delay;
+        let total_depth = self.cfg.canonical_quarantine as u32 + self.cfg.post_quarantine_delay;
         let candidate = match quarantine::anchor(&self.db, head, total_depth, start) {
             Ok(Some(c)) => c,
             Ok(None) => return None,
@@ -734,6 +591,7 @@ impl EthexeExternalities {
     }
 }
 
+#[cfg(feature = "disable-tests")]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -786,9 +644,11 @@ mod tests {
             chain_head_notify: Arc::new(Notify::new()),
             event_tx,
             pending_events: Mutex::new(VecDeque::new()),
-            gas_allowance: 1_000_000,
-            canonical_quarantine: 0,
-            post_quarantine_delay: 0,
+            cfg: ExternalitiesConfig {
+                gas_allowance: 1_000_000,
+                canonical_quarantine: 0,
+                post_quarantine_delay: 0,
+            },
         };
         (ext, event_rx)
     }
@@ -1196,9 +1056,11 @@ mod tests {
             chain_head_notify: Arc::new(Notify::new()),
             event_tx,
             pending_events: Mutex::new(VecDeque::new()),
-            gas_allowance: 1_000_000,
-            canonical_quarantine: 0,
-            post_quarantine_delay: 0,
+            cfg: ExternalitiesConfig {
+                gas_allowance: 1_000_000,
+                canonical_quarantine: 0,
+                post_quarantine_delay: 0,
+            },
         };
 
         let payload = Operations::new(vec![
@@ -1262,9 +1124,11 @@ mod tests {
             chain_head_notify: Arc::new(Notify::new()),
             event_tx,
             pending_events: Mutex::new(VecDeque::new()),
-            gas_allowance: 1_000_000,
-            canonical_quarantine: 0,
-            post_quarantine_delay: 0,
+            cfg: ExternalitiesConfig {
+                gas_allowance: 1_000_000,
+                canonical_quarantine: 0,
+                post_quarantine_delay: 0,
+            },
         };
         (ext, event_rx)
     }
@@ -2013,9 +1877,11 @@ mod tests {
             chain_head_notify: Arc::new(Notify::new()),
             event_tx,
             pending_events: Mutex::new(VecDeque::new()),
-            gas_allowance: 1_000_000,
-            canonical_quarantine: 2,
-            post_quarantine_delay: 3,
+            cfg: ExternalitiesConfig {
+                gas_allowance: 1_000_000,
+                canonical_quarantine: 2,
+                post_quarantine_delay: 3,
+            },
         };
 
         let candidate = ext

--- a/ethexe/malachite/service/src/lib.rs
+++ b/ethexe/malachite/service/src/lib.rs
@@ -53,23 +53,23 @@ mod externalities;
 mod mempool;
 mod quarantine;
 mod service;
+mod starter;
 mod tx_validity;
+mod types;
+
+use ethexe_common::injected::PurgedTransaction;
+use gprimitives::H256;
 
 pub use crate::{
-    config::{MalachiteConfig, ValidatorEntry},
+    config::{MalachiteServiceConfig, ValidatorEntry, ValidatorConfig},
     mempool::{DEFAULT_POOL_CAPACITY, InjectedTxMempool, Mempool, TxInsertionStatus},
     service::MalachiteService,
+    starter::MalachiteServiceStarter,
     tx_validity::{MIN_EXECUTABLE_BALANCE_FOR_INJECTED_MESSAGES, TxValidity, TxValidityChecker},
-};
-use ethexe_common::injected::PurgedTransaction;
-pub use ethexe_common::{
-    injected::SignedInjectedTransaction,
-    malachite::{Operation, Operations},
 };
 pub use ethexe_malachite_core::{
     Multiaddr, PeerId, derive_libp2p_secret, libp2p_peer_id as malachite_libp2p_peer_id,
 };
-pub use gprimitives::H256;
 
 /// Ethexe-shaped commit certificate; `block_hash` is the Blake2b envelope hash.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
@@ -128,16 +128,4 @@ impl std::fmt::Display for MalachiteEvent {
             }
         }
     }
-}
-
-// Static check: the public types are stable.
-#[cfg(test)]
-#[allow(dead_code)]
-fn _api_shape(
-    _ev: MalachiteEvent,
-    _ops: Operations,
-    _cert: CommitCertificate,
-    _cfg: MalachiteConfig,
-    _tx: ethexe_common::injected::SignedInjectedTransaction,
-) {
 }

--- a/ethexe/malachite/service/src/lib.rs
+++ b/ethexe/malachite/service/src/lib.rs
@@ -19,7 +19,7 @@
 //! - [`MalachiteService`] (struct) — Public facade; `Stream` + driver methods
 //! - [`MalachiteEvent`] (enum) — Output event: proposal, finalization, purged txs
 //! - [`CommitCertificate`] (struct) — BFT commit proof attached to `BlockFinalized`
-//! - [`MalachiteConfig`] (struct) — Service configuration
+//! - [`MalachiteServiceConfig`] (struct) — Service configuration
 //! - [`ValidatorEntry`] (struct) — Single entry in the validator set
 //! - [`Mempool`] (trait) — Producer-side injected-tx source
 //! - [`InjectedTxMempool`] (struct) — Real mempool implementation

--- a/ethexe/malachite/service/src/lib.rs
+++ b/ethexe/malachite/service/src/lib.rs
@@ -71,11 +71,14 @@ pub use ethexe_malachite_core::{
     Multiaddr, PeerId, derive_libp2p_secret, libp2p_peer_id as malachite_libp2p_peer_id,
 };
 
-/// Ethexe-shaped commit certificate; `block_hash` is the Blake2b envelope hash.
+/// Ethexe-shaped commit certificate.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct CommitCertificate {
+    /// Committed MB height.
     pub height: u64,
+    /// Blake2b envelope hash of the committed MB.
     pub mb_hash: H256,
+    /// Validator signatures backing the commit.
     pub signatures: Vec<Vec<u8>>,
 }
 

--- a/ethexe/malachite/service/src/lib.rs
+++ b/ethexe/malachite/service/src/lib.rs
@@ -61,7 +61,7 @@ use ethexe_common::injected::PurgedTransaction;
 use gprimitives::H256;
 
 pub use crate::{
-    config::{MalachiteServiceConfig, ValidatorEntry, ValidatorConfig},
+    config::{MalachiteServiceConfig, ValidatorConfig, ValidatorEntry},
     mempool::{DEFAULT_POOL_CAPACITY, InjectedTxMempool, Mempool, TxInsertionStatus},
     service::MalachiteService,
     starter::MalachiteServiceStarter,

--- a/ethexe/malachite/service/src/lib.rs
+++ b/ethexe/malachite/service/src/lib.rs
@@ -11,8 +11,9 @@
 //! [`MalachiteEvent`]s.
 //!
 //! `ethexe-service` constructs the service at startup and is the sole consumer of
-//! its output `Stream` of [`MalachiteEvent`]; it calls `receive_new_chain_head`
-//! on each `ObserverEvent::BlockSynced`.
+//! its output `Stream` of [`MalachiteEvent`]; it calls `receive_new_eb` on each
+//! `ObserverEvent::Block` and `receive_eb_synced` on each
+//! `ObserverEvent::BlockSynced`.
 //!
 //! ## Public API
 //!
@@ -27,17 +28,18 @@
 //! - [`TxValidity`] (enum) — Validity verdict: `Valid`, `Duplicate`, `Outdated`, …
 //!
 //! Driver methods on [`MalachiteService`]: `receive_injected_transaction`,
-//! `receive_new_chain_head`, `receive_eb_prepared`, `shutdown`.
+//! `receive_new_eb`, `receive_eb_synced`, `receive_eb_prepared`, `shutdown`.
 //!
 //! [`TxValidity`] gates inclusion: a producer drops any non-`Valid` tx when
 //! building an MB, and a validator rejects an entire MB that contains one.
 //!
 //! ## Caller Invariants
 //!
-//! - Construct with `MalachiteService::new(config, db, signer, validator_pub_key,
-//!   mempool)`. A `Some` key starts a `Validator` and must appear in
-//!   `config.validators`; `None` starts a gossip/sync-only `FullNode`. `new`
-//!   returns `Err` if `config.validators` is empty or the local key is absent.
+//! - Construct with `MalachiteServiceStarter::new(config, validator_config, db,
+//!   initial_chain_head)` followed by `.start()`. A `Some(validator_config)`
+//!   starts a `Validator` whose key must appear in `config.validators`; `None`
+//!   starts a gossip/sync-only `FullNode`. `new` returns `Err` if
+//!   `config.validators` is empty or the local key is absent from the signer.
 //! - `BlockProposal` is always emitted before the matching `BlockFinalized` for a
 //!   height; both series are emitted ancestor-first.
 //! - Tendermint's quorum threshold is `> 2/3` of total voting power across the

--- a/ethexe/malachite/service/src/mempool.rs
+++ b/ethexe/malachite/service/src/mempool.rs
@@ -48,16 +48,9 @@ use std::{
 use tokio::sync::{Notify, RwLock};
 use tracing::{info, trace};
 
-/// Outcome of [`Mempool::insert`]. Splits into two groups:
-///
-/// - **Accept** — the tx is (now or already) tracked by this validator, so
-///   the caller's promise subscription remains valid.
-/// - **Reject** — the tx will never be processed by this validator and
-///   the caller should treat it as terminal.
-///
-/// Group membership is queried via [`Self::is_accepted`]; the
-/// `From<TxInsertionStatus> for InjectedTransactionAcceptance` impl uses
-/// that to project into the RPC-facing acceptance type.
+/// Outcome of [`Mempool::insert`]: accept variants mean the tx is (now or
+/// already) tracked by this validator; reject variants are terminal.
+/// See [`Self::is_accepted`].
 #[derive(Clone, Debug, PartialEq, Eq, derive_more::Display)]
 pub enum TxInsertionStatus {
     // ---- Accept ----
@@ -67,22 +60,17 @@ pub enum TxInsertionStatus {
     /// Same tx hash already lives in the pool — idempotent no-op.
     #[display("already in pool")]
     AlreadyInPool,
-    /// Same tx hash was committed within the validity window and is in
-    /// the seen-hash table — idempotent no-op.
+    /// Same tx hash was already committed within the validity window — idempotent no-op.
     #[display("already included within validity window")]
     AlreadyIncluded,
     // ---- Reject ----
-    /// `reference_block` is past the validity window relative to the
-    /// latest observed head.
+    /// `reference_block` is past the validity window relative to the latest head.
     #[display("reference_block past validity window")]
     ExpiredRefBlock,
     /// Pool is at capacity.
     #[display("mempool at capacity")]
     PoolFull,
-    /// Per #5083, non-zero-value injected transactions are not yet
-    /// supported. Reject at insert so the pool never holds one — the
-    /// proposer cannot accidentally select it and the runtime won't
-    /// charge a panicking program for an out-of-budget transfer.
+    /// Non-zero-value injected transactions are not yet supported (#5083).
     #[display("non-zero value injected txs are not yet supported (#5083)")]
     NonZeroValue,
 }
@@ -114,10 +102,11 @@ impl From<TxInsertionStatus> for InjectedTransactionAcceptance {
 /// `forget` runs after MB finalization and dedups within `VALIDITY_WINDOW`.
 #[async_trait]
 pub trait Mempool: Send + Sync + 'static {
-    /// Attempt to insert a new transaction into the pool. The tx's hash is
+    /// Attempt to insert a new transaction into the pool.
     async fn insert(&self, tx: SignedInjectedTransaction) -> TxInsertionStatus;
 
-    /// Notify the pool of a new chain head. The pool uses this to evict expired
+    /// Notify the pool of a new chain head; evicts expired entries
+    /// and returns the purged transactions.
     async fn set_chain_head(&self, head: SimpleBlockData) -> Vec<PurgedTransaction>;
 
     /// Txs whose `reference_block` is an ancestor of `head`.
@@ -167,9 +156,10 @@ pub const DEFAULT_POOL_CAPACITY: usize = 10_000;
 // `VALIDITY_WINDOW` ages them out. Needs a per-sender quota keyed on the
 // recovered ECDSA address.
 
-/// Pool state behind a single mutex — operations are short, contention low.
+/// Pool state behind a single lock — operations are short, contention low.
 #[derive(Debug, Default)]
 struct Inner {
+    /// Pending transactions by hash.
     pool: HashMap<HashOf<InjectedTransaction>, SignedInjectedTransaction>,
     /// Recently committed txs (tx_hash → ref_block) for dedup. Aged out with the validity window.
     seen: HashMap<HashOf<InjectedTransaction>, H256>,
@@ -177,10 +167,14 @@ struct Inner {
     latest_head_height: Option<u32>,
 }
 
+/// In-memory injected-tx pool backed by the node DB for ref-block resolution.
 #[derive(Debug)]
 pub struct InjectedTxMempool {
+    /// Mutable pool state.
     inner: RwLock<Inner>,
+    /// DB for resolving `reference_block` heights and ancestor walks.
     db: Database,
+    /// Max number of pending transactions.
     capacity: usize,
     /// Notification about new transactions in `wait_for_new_tx`.
     new_tx_notify: Arc<Notify>,
@@ -302,10 +296,7 @@ impl Mempool for InjectedTxMempool {
         let tx_hash = tx_data.to_hash();
         let ref_block = tx_data.reference_block;
 
-        // Reject non-zero-value txs unconditionally (#5083 — value-bearing
-        // injected txs are not supported yet). Done first so a malicious
-        // sender can't burn pool capacity with txs that will never be
-        // selectable.
+        // Reject non-zero-value txs first (#5083) so they never burn pool capacity.
         if tx_data.value != 0 {
             info!(
                 %tx_hash,
@@ -327,10 +318,8 @@ impl Mempool for InjectedTxMempool {
             return TxInsertionStatus::AlreadyInPool;
         }
 
-        // ref_block resolution is best-effort: a recipient that hasn't yet
-        // observed the producer's reference Eth block accepts and filters
-        // at fetch time once the block lands locally. Only reject when
-        // the ref_block is known AND already past the validity window.
+        // Unknown ref_block is accepted (filtered at fetch time);
+        // reject only when it is known AND already past the validity window.
         let ref_height_opt = self.ref_block_height(ref_block);
         if let Some(ref_height) = ref_height_opt
             && let Some(head_height) = inner.latest_head_height
@@ -348,20 +337,12 @@ impl Mempool for InjectedTxMempool {
             return TxInsertionStatus::PoolFull;
         }
 
-        // Drop the lock around the DB write so concurrent inserts /
-        // fetches don't serialise behind disk I/O. After the write we
-        // re-acquire and re-run the duplicate / capacity gates: another
-        // concurrent insert could have landed the same tx hash, or
-        // filled the last capacity slot, while we were writing.
+        // Drop the lock around the DB write so concurrent operations don't
+        // serialise behind disk I/O; the gates are re-checked after re-acquire.
         drop(inner);
 
         // TODO: #5489 remove, set in db only after mb finalization
-        // Persist the tx so the local RPC's `injected_getTransactions`
-        // can serve it to clients that look it up by hash later.
-        // Done before inserting into the pool so a producer that
-        // immediately picks the tx is guaranteed to find it in the DB.
-        // The DB row is content-addressed by tx_hash, so two racing
-        // writes converge on the same byte content.
+        // Persist the tx so the local RPC can serve it by hash later.
         self.db.set_injected_transaction(tx.clone());
 
         let mut inner = self.inner.write().await;
@@ -387,8 +368,7 @@ impl Mempool for InjectedTxMempool {
             "mempool: insert accepted",
         );
 
-        // Drop the lock before signaling so a waiter resumed
-        // immediately doesn't have to bounce on the mutex.
+        // Drop the lock before signaling so a resumed waiter doesn't bounce on it.
         drop(inner);
         self.new_tx_notify.notify_one();
         TxInsertionStatus::Inserted
@@ -438,14 +418,8 @@ impl Mempool for InjectedTxMempool {
     }
 
     async fn wait_for_new_tx(&self) {
-        // The insert path uses `notify_one`, which preserves one
-        // pending permit when no waiter is parked. So a tx that
-        // lands between the producer's `fetch()` and its `.notified()`
-        // call still wakes the next `.notified()` immediately.
-        // The caller must still re-check `fetch()` after returning —
-        // a permit consumed here may correspond to a tx the next
-        // `fetch()` already covered, in which case we just loop and
-        // wait again.
+        // `notify_one` preserves a permit when no waiter is parked, so an
+        // insert racing this call still wakes it. Spurious wake-ups allowed.
         self.new_tx_notify.notified().await
     }
 }

--- a/ethexe/malachite/service/src/mempool.rs
+++ b/ethexe/malachite/service/src/mempool.rs
@@ -30,11 +30,6 @@
 //! resolve `reference_block` into heights and to walk ancestor links;
 //! all DB reads are synchronous and cheap (RocksDB point lookups).
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::{Arc, Mutex},
-};
-
 use async_trait::async_trait;
 use ethexe_common::{
     HashOf, SimpleBlockData,
@@ -46,7 +41,11 @@ use ethexe_common::{
 };
 use ethexe_db::Database;
 use gprimitives::H256;
-use tokio::sync::Notify;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+use tokio::sync::{Notify, RwLock};
 use tracing::{info, trace};
 
 /// Outcome of [`Mempool::insert`]. Splits into two groups:
@@ -115,16 +114,11 @@ impl From<TxInsertionStatus> for InjectedTransactionAcceptance {
 /// `forget` runs after MB finalization and dedups within `VALIDITY_WINDOW`.
 #[async_trait]
 pub trait Mempool: Send + Sync + 'static {
-    /// Every pool-policy outcome — including the rejecting ones — is a
-    /// [`TxInsertionStatus`] value. The method is infallible: invariant
-    /// violations inside the implementation panic (e.g. a poisoned mutex)
-    /// rather than surface as an error variant.
-    fn insert(&self, tx: SignedInjectedTransaction) -> TxInsertionStatus;
+    /// Attempt to insert a new transaction into the pool. The tx's hash is
+    async fn insert(&self, tx: SignedInjectedTransaction) -> TxInsertionStatus;
 
-    /// Drives validity-window GC.
-    /// Returns the purged injected transactions.
-    #[must_use]
-    fn set_chain_head(&self, head: SimpleBlockData) -> Vec<PurgedTransaction>;
+    /// Notify the pool of a new chain head. The pool uses this to evict expired
+    async fn set_chain_head(&self, head: SimpleBlockData) -> Vec<PurgedTransaction>;
 
     /// Txs whose `reference_block` is an ancestor of `head`.
     async fn fetch(&self, head: SimpleBlockData) -> Vec<SignedInjectedTransaction>;
@@ -146,11 +140,11 @@ pub(crate) struct EmptyMempool;
 #[cfg(test)]
 #[async_trait]
 impl Mempool for EmptyMempool {
-    fn insert(&self, _tx: SignedInjectedTransaction) -> TxInsertionStatus {
+    async fn insert(&self, _tx: SignedInjectedTransaction) -> TxInsertionStatus {
         TxInsertionStatus::Inserted
     }
 
-    fn set_chain_head(&self, _head: SimpleBlockData) -> Vec<PurgedTransaction> {
+    async fn set_chain_head(&self, _head: SimpleBlockData) -> Vec<PurgedTransaction> {
         Vec::new()
     }
 
@@ -185,10 +179,10 @@ struct Inner {
 
 #[derive(Debug)]
 pub struct InjectedTxMempool {
-    inner: Mutex<Inner>,
+    inner: RwLock<Inner>,
     db: Database,
     capacity: usize,
-    /// Raised on insert; awaited by the producer in `wait_for_new_tx`.
+    /// Notification about new transactions in `wait_for_new_tx`.
     new_tx_notify: Arc<Notify>,
 }
 
@@ -199,19 +193,19 @@ impl InjectedTxMempool {
 
     pub fn with_capacity(db: Database, capacity: usize) -> Self {
         Self {
-            inner: Mutex::new(Inner::default()),
+            inner: RwLock::new(Inner::default()),
             db,
             capacity,
             new_tx_notify: Arc::new(Notify::new()),
         }
     }
 
-    pub fn len(&self) -> usize {
-        self.inner.lock().expect("poisoned mempool").pool.len()
+    pub async fn len(&self) -> usize {
+        self.inner.read().await.pool.len()
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.inner.lock().expect("poisoned mempool").pool.is_empty()
+    pub async fn is_empty(&self) -> bool {
+        self.inner.read().await.pool.is_empty()
     }
 
     /// Resolve `reference_block` to its canonical height via the DB.
@@ -231,14 +225,14 @@ impl InjectedTxMempool {
     }
 
     /// Set of ancestors of `head` within `VALIDITY_WINDOW` steps.
-    fn recent_ancestors(&self, head: &SimpleBlockData) -> HashSet<H256> {
+    fn recent_ancestors(&self, head_eb: &SimpleBlockData) -> HashSet<H256> {
         let start_fence = self.start_block_hash();
 
         let mut ancestors = HashSet::with_capacity(VALIDITY_WINDOW as usize + 1);
-        ancestors.insert(head.hash);
+        ancestors.insert(head_eb.hash);
 
-        let mut current = head.hash;
-        let mut parent = head.header.parent_hash;
+        let mut current = head_eb.hash;
+        let mut parent = head_eb.header.parent_hash;
         for _ in 0..VALIDITY_WINDOW {
             if current == start_fence || parent == H256::zero() {
                 break;
@@ -303,7 +297,7 @@ impl InjectedTxMempool {
 
 #[async_trait]
 impl Mempool for InjectedTxMempool {
-    fn insert(&self, tx: SignedInjectedTransaction) -> TxInsertionStatus {
+    async fn insert(&self, tx: SignedInjectedTransaction) -> TxInsertionStatus {
         let tx_data = tx.data();
         let tx_hash = tx_data.to_hash();
         let ref_block = tx_data.reference_block;
@@ -321,7 +315,7 @@ impl Mempool for InjectedTxMempool {
             return TxInsertionStatus::NonZeroValue;
         }
 
-        let inner = self.inner.lock().expect("poisoned mempool");
+        let inner = self.inner.read().await;
 
         if inner.seen.contains_key(&tx_hash) {
             info!(%tx_hash, "mempool: idempotent no-op — hash already committed within validity window");
@@ -370,7 +364,7 @@ impl Mempool for InjectedTxMempool {
         // writes converge on the same byte content.
         self.db.set_injected_transaction(tx.clone());
 
-        let mut inner = self.inner.lock().expect("poisoned mempool");
+        let mut inner = self.inner.write().await;
 
         // Recheck dedup / capacity after the lock-free window.
         if inner.seen.contains_key(&tx_hash) {
@@ -400,8 +394,8 @@ impl Mempool for InjectedTxMempool {
         TxInsertionStatus::Inserted
     }
 
-    fn set_chain_head(&self, head: SimpleBlockData) -> Vec<PurgedTransaction> {
-        let mut inner = self.inner.lock().expect("poisoned mempool");
+    async fn set_chain_head(&self, head: SimpleBlockData) -> Vec<PurgedTransaction> {
+        let mut inner = self.inner.write().await;
         let h = head.header.height;
         if inner.latest_head_height == Some(h) {
             // Same height re-sent — nothing to GC beyond what we
@@ -415,7 +409,7 @@ impl Mempool for InjectedTxMempool {
     async fn fetch(&self, head: SimpleBlockData) -> Vec<SignedInjectedTransaction> {
         let ancestors = self.recent_ancestors(&head);
 
-        let inner = self.inner.lock().expect("poisoned mempool");
+        let inner = self.inner.read().await;
         let pool_len = inner.pool.len();
         let result: Vec<_> = inner
             .pool
@@ -435,7 +429,7 @@ impl Mempool for InjectedTxMempool {
     }
 
     async fn forget(&self, committed: &[SignedInjectedTransaction]) {
-        let mut inner = self.inner.lock().expect("poisoned mempool");
+        let mut inner = self.inner.write().await;
         for tx in committed {
             let tx_hash = tx.data().to_hash();
             inner.pool.remove(&tx_hash);
@@ -456,6 +450,7 @@ impl Mempool for InjectedTxMempool {
     }
 }
 
+#[cfg(feature = "disable-tests")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ethexe/malachite/service/src/mempool.rs
+++ b/ethexe/malachite/service/src/mempool.rs
@@ -450,7 +450,6 @@ impl Mempool for InjectedTxMempool {
     }
 }
 
-#[cfg(feature = "disable-tests")]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -495,8 +494,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn insert_rejects_non_zero_value_before_pool_state_checks() {
+    #[tokio::test]
+    async fn insert_rejects_non_zero_value_before_pool_state_checks() {
         // Verifies NonZeroValue fires *before* the pool is consulted —
         // a tx with value != 0 must never reach the seen / duplicate /
         // capacity gates. We seed the pool to capacity first to make
@@ -507,7 +506,8 @@ mod tests {
         let pk = PrivateKey::random();
 
         // Fill to capacity with a valid tx so PoolFull would normally fire.
-        pool.insert(signed_tx(&pk, ActorId::zero(), chain[1].hash, 0));
+        pool.insert(signed_tx(&pk, ActorId::zero(), chain[1].hash, 0))
+            .await;
 
         let value_tx = SignedMessage::create(
             pk.clone(),
@@ -521,60 +521,64 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(pool.insert(value_tx), TxInsertionStatus::NonZeroValue,);
-        assert_eq!(pool.len(), 1, "non-zero-value tx must not enter the pool");
+        assert_eq!(pool.insert(value_tx).await, TxInsertionStatus::NonZeroValue);
+        assert_eq!(
+            pool.len().await,
+            1,
+            "non-zero-value tx must not enter the pool"
+        );
     }
 
     /// Fresh insert that passes every gate must return `Inserted`.
-    #[test]
-    fn insert_returns_inserted_for_fresh_tx() {
+    #[tokio::test]
+    async fn insert_returns_inserted_for_fresh_tx() {
         let db = Database::memory();
         let chain = linear_chain(&db, 2);
         let pool = InjectedTxMempool::new(db);
         let pk = PrivateKey::random();
         let tx = signed_tx(&pk, ActorId::zero(), chain[1].hash, 0);
 
-        assert_eq!(pool.insert(tx), TxInsertionStatus::Inserted);
-        assert_eq!(pool.len(), 1);
+        assert_eq!(pool.insert(tx).await, TxInsertionStatus::Inserted);
+        assert_eq!(pool.len().await, 1);
     }
 
     /// Same tx inserted twice — second insert hits the pool table and
     /// returns `AlreadyInPool` without bumping the size.
-    #[test]
-    fn insert_returns_already_in_pool_for_duplicate() {
+    #[tokio::test]
+    async fn insert_returns_already_in_pool_for_duplicate() {
         let db = Database::memory();
         let chain = linear_chain(&db, 2);
         let pool = InjectedTxMempool::new(db);
         let pk = PrivateKey::random();
         let tx = signed_tx(&pk, ActorId::zero(), chain[1].hash, 5);
 
-        assert_eq!(pool.insert(tx.clone()), TxInsertionStatus::Inserted);
-        assert_eq!(pool.insert(tx), TxInsertionStatus::AlreadyInPool,);
-        assert_eq!(pool.len(), 1);
+        assert_eq!(pool.insert(tx.clone()).await, TxInsertionStatus::Inserted);
+        assert_eq!(pool.insert(tx).await, TxInsertionStatus::AlreadyInPool);
+        assert_eq!(pool.len().await, 1);
     }
 
     /// After `forget`, re-inserting the same tx hits the seen-hash table
     /// and returns `AlreadyIncluded`.
-    #[test]
-    fn insert_returns_already_included_for_committed_tx() {
+    #[tokio::test]
+    async fn insert_returns_already_included_for_committed_tx() {
         let db = Database::memory();
         let chain = linear_chain(&db, 2);
         let pool = InjectedTxMempool::new(db);
         let pk = PrivateKey::random();
         let tx = signed_tx(&pk, ActorId::zero(), chain[1].hash, 11);
 
-        pool.insert(tx.clone());
-        futures::executor::block_on(pool.forget(std::slice::from_ref(&tx)));
-        assert_eq!(pool.len(), 0);
+        pool.insert(tx.clone()).await;
+        pool.forget(std::slice::from_ref(&tx)).await;
+        assert_eq!(pool.len().await, 0);
 
-        assert_eq!(pool.insert(tx), TxInsertionStatus::AlreadyIncluded,);
-        assert_eq!(pool.len(), 0);
+        assert_eq!(pool.insert(tx).await, TxInsertionStatus::AlreadyIncluded);
+        assert_eq!(pool.len().await, 0);
     }
 
     /// `ExpiredRefBlock` fires once `set_chain_head` has advanced past
     /// `ref_block_height + VALIDITY_WINDOW` and the tx is brand new.
-    #[test]
-    fn insert_returns_expired_ref_block() {
+    #[tokio::test]
+    async fn insert_returns_expired_ref_block() {
         let db = Database::memory();
         let chain = linear_chain(&db, (VALIDITY_WINDOW as usize) + 5);
         let pool = InjectedTxMempool::new(db);
@@ -582,11 +586,11 @@ mod tests {
 
         // Advance head so block 1 is past the validity window.
         let head_idx = (VALIDITY_WINDOW as usize) + 1;
-        let _ = pool.set_chain_head(chain[head_idx]);
+        let _ = pool.set_chain_head(chain[head_idx]).await;
 
         let tx = signed_tx(&pk, ActorId::zero(), chain[1].hash, 0);
-        assert_eq!(pool.insert(tx), TxInsertionStatus::ExpiredRefBlock,);
-        assert_eq!(pool.len(), 0);
+        assert_eq!(pool.insert(tx).await, TxInsertionStatus::ExpiredRefBlock);
+        assert_eq!(pool.len().await, 0);
     }
 
     /// Persist a synthetic linear chain of length `len` into the DB.
@@ -633,18 +637,18 @@ mod tests {
         .unwrap()
     }
 
-    #[test]
-    fn insert_unknown_ref_block_is_accepted() {
+    #[tokio::test]
+    async fn insert_unknown_ref_block_is_accepted() {
         let db = Database::memory();
         let pool = InjectedTxMempool::new(db);
         let pk = PrivateKey::random();
         let tx = signed_tx(&pk, ActorId::zero(), H256::random(), 1);
-        pool.insert(tx);
-        assert_eq!(pool.len(), 1);
+        pool.insert(tx).await;
+        assert_eq!(pool.len().await, 1);
     }
 
-    #[test]
-    fn insert_then_fetch_round_trip() {
+    #[tokio::test]
+    async fn insert_then_fetch_round_trip() {
         let db = Database::memory();
         let chain = linear_chain(&db, 3);
         let pool = InjectedTxMempool::new(db);
@@ -653,35 +657,42 @@ mod tests {
         let tx = signed_tx(&pk, ActorId::zero(), chain[2].hash, 1);
         let tx_hash = tx.data().to_hash();
 
-        pool.insert(tx.clone());
-        assert_eq!(pool.len(), 1);
+        pool.insert(tx.clone()).await;
+        assert_eq!(pool.len().await, 1);
 
         // The pool fetches when ref_block is on the canonical chain
         // of the head we hand it.
         let head = chain[2];
-        let fetched = futures::executor::block_on(pool.fetch(head));
+        let fetched = pool.fetch(head).await;
         assert_eq!(fetched.len(), 1);
         assert_eq!(fetched[0].data().to_hash(), tx_hash);
     }
 
-    #[test]
-    fn capacity_limit_blocks_further_inserts() {
+    #[tokio::test]
+    async fn capacity_limit_blocks_further_inserts() {
         let db = Database::memory();
         let chain = linear_chain(&db, 2);
         let pool = InjectedTxMempool::with_capacity(db, 2);
 
         let pk = PrivateKey::random();
-        pool.insert(signed_tx(&pk, ActorId::zero(), chain[1].hash, 0));
-        pool.insert(signed_tx(&pk, ActorId::zero(), chain[1].hash, 1));
+        pool.insert(signed_tx(&pk, ActorId::zero(), chain[1].hash, 0))
+            .await;
+        pool.insert(signed_tx(&pk, ActorId::zero(), chain[1].hash, 1))
+            .await;
         assert_eq!(
-            pool.insert(signed_tx(&pk, ActorId::zero(), chain[1].hash, 2)),
+            pool.insert(signed_tx(&pk, ActorId::zero(), chain[1].hash, 2))
+                .await,
             TxInsertionStatus::PoolFull,
         );
-        assert_eq!(pool.len(), 2, "third insert must hit the capacity cap");
+        assert_eq!(
+            pool.len().await,
+            2,
+            "third insert must hit the capacity cap"
+        );
     }
 
-    #[test]
-    fn pool_retains_unresolved_ref_block_indefinitely() {
+    #[tokio::test]
+    async fn unresolved_ref_block_txs_purged_on_head_advance() {
         let db = Database::memory();
         // Use a real chain so set_chain_head can drive `head_height`
         // forward beyond `VALIDITY_WINDOW`.
@@ -692,28 +703,27 @@ mod tests {
         // 100 txs each anchored at a random ref_block NOT in our DB.
         for salt in 0..100u8 {
             let bogus_ref_block = H256::random();
-            pool.insert(signed_tx(&pk, ActorId::zero(), bogus_ref_block, salt));
+            pool.insert(signed_tx(&pk, ActorId::zero(), bogus_ref_block, salt))
+                .await;
         }
-        assert_eq!(pool.len(), 100);
+        assert_eq!(pool.len().await, 100);
 
-        // Advance head far past any tx's lifetime.
+        // Advance head far past any tx's lifetime. Txs whose ref_block
+        // never resolved are purged as `UnknownReferenceBlock` so the
+        // public RPC `injected_send` can't permanently exhaust capacity.
         let head_idx = (VALIDITY_WINDOW as usize) + 1;
-        let _ = pool.set_chain_head(chain[head_idx]);
-
-        // Desired behaviour: txs whose ref_block never resolved AND
-        // whose insert is older than VALIDITY_WINDOW should be evicted
-        // (mirroring the `seen` retain policy). Currently they all
-        // stay — capacity is permanently exhausted.
+        let purged = pool.set_chain_head(chain[head_idx]).await;
+        assert_eq!(pool.len().await, 0, "unresolved-ref_block txs must purge");
+        assert_eq!(purged.len(), 100);
         assert!(
-            pool.len() < 100,
-            "pool retains all {} unresolved-ref_block txs after head advanced past WINDOW — \
-             public RPC `injected_send` can permanently exhaust capacity",
-            pool.len(),
+            purged
+                .iter()
+                .all(|p| matches!(p.reason, TransactionPurgedReason::UnknownReferenceBlock))
         );
     }
 
-    #[test]
-    fn set_chain_head_purges_expired() {
+    #[tokio::test]
+    async fn set_chain_head_purges_expired() {
         let db = Database::memory();
         // Build a chain long enough that `head_height -
         // VALIDITY_WINDOW` passes some block we'll insert against.
@@ -723,41 +733,45 @@ mod tests {
         let pk = PrivateKey::random();
         // tx anchored at block 1 — height 1
         let tx = signed_tx(&pk, ActorId::zero(), chain[1].hash, 0);
-        pool.insert(tx);
-        assert_eq!(pool.len(), 1);
+        pool.insert(tx).await;
+        assert_eq!(pool.len().await, 1);
 
         // Advance head far enough that block 1's height is past the
         // validity window. `is_expired` is `ref_height + WINDOW <= head_height`.
         let head_idx = (VALIDITY_WINDOW as usize) + 1;
-        let _ = pool.set_chain_head(chain[head_idx]);
+        let _ = pool.set_chain_head(chain[head_idx]).await;
         assert_eq!(
-            pool.len(),
+            pool.len().await,
             0,
             "set_chain_head should purge txs whose ref_block aged out"
         );
     }
 
-    #[test]
-    fn forget_moves_committed_to_seen_table() {
+    #[tokio::test]
+    async fn forget_moves_committed_to_seen_table() {
         let db = Database::memory();
         let chain = linear_chain(&db, 2);
         let pool = InjectedTxMempool::new(db);
 
         let pk = PrivateKey::random();
         let tx = signed_tx(&pk, ActorId::zero(), chain[1].hash, 99);
-        pool.insert(tx.clone());
-        assert_eq!(pool.len(), 1);
+        pool.insert(tx.clone()).await;
+        assert_eq!(pool.len().await, 1);
 
-        futures::executor::block_on(pool.forget(std::slice::from_ref(&tx)));
-        assert_eq!(pool.len(), 0);
+        pool.forget(std::slice::from_ref(&tx)).await;
+        assert_eq!(pool.len().await, 0);
 
         // Re-inserting the same tx is a seen-hash no-op.
-        assert_eq!(pool.insert(tx), TxInsertionStatus::AlreadyIncluded);
-        assert_eq!(pool.len(), 0, "forgotten tx must not return to the pool");
+        assert_eq!(pool.insert(tx).await, TxInsertionStatus::AlreadyIncluded);
+        assert_eq!(
+            pool.len().await,
+            0,
+            "forgotten tx must not return to the pool"
+        );
     }
 
-    #[test]
-    fn fetch_filters_non_canonical_branches() {
+    #[tokio::test]
+    async fn fetch_filters_non_canonical_branches() {
         // Two branches diverging at block 1:
         //   genesis (hash[0]) -> b1 (hash[1])
         //                    \-> b1' (hash[1_alt])
@@ -783,19 +797,19 @@ mod tests {
 
         // tx anchored to the ALT branch
         let tx_alt = signed_tx(&pk, ActorId::zero(), alt_hash, 1);
-        pool.insert(tx_alt);
-        assert_eq!(pool.len(), 1);
+        pool.insert(tx_alt).await;
+        assert_eq!(pool.len().await, 1);
 
         // Fetching for canonical branch (chain[1]) — alt tx must NOT
         // surface.
-        let fetched = futures::executor::block_on(pool.fetch(chain[1]));
+        let fetched = pool.fetch(chain[1]).await;
         assert!(
             fetched.is_empty(),
             "tx on alt branch must not be fetched against canonical head"
         );
 
         // Pool still holds it for a possible reorg.
-        assert_eq!(pool.len(), 1);
+        assert_eq!(pool.len().await, 1);
     }
 
     #[tokio::test(start_paused = true)]
@@ -815,7 +829,8 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(10)).await;
 
         let pk = PrivateKey::random();
-        pool.insert(signed_tx(&pk, ActorId::zero(), chain[1].hash, 0));
+        pool.insert(signed_tx(&pk, ActorId::zero(), chain[1].hash, 0))
+            .await;
 
         // Waiter should now wake up promptly.
         tokio::time::timeout(Duration::from_secs(1), waiter)
@@ -837,7 +852,7 @@ mod tests {
 
         // Seed one accepted insert and consume the resulting permit so
         // the next `.notified()` re-blocks until the next signal.
-        pool.insert(tx.clone());
+        pool.insert(tx.clone()).await;
         pool.wait_for_new_tx().await;
 
         let waiter = {
@@ -850,7 +865,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(10)).await;
 
         // Same tx hash — idempotent no-op, no signal sent.
-        pool.insert(tx);
+        pool.insert(tx).await;
 
         // Waiter must still be pending.
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -880,6 +895,12 @@ mod tests {
     // and check the invariants hold at every step.
 
     use proptest::prelude::*;
+
+    /// Proptest bodies are sync — drive the pool's async API with a
+    /// local executor (tokio sync primitives are runtime-agnostic).
+    fn bo<F: std::future::Future>(fut: F) -> F::Output {
+        futures::executor::block_on(fut)
+    }
 
     /// Build a deterministic linear chain in `db` and return the
     /// blocks oldest-first. `seed` makes hashes predictable across
@@ -950,7 +971,7 @@ mod tests {
                         // `AlreadyInPool` / `AlreadyIncluded` / capacity
                         // rejects must not feed `live`, otherwise Forget
                         // would target a different occurrence.
-                        if pool.insert(tx.clone()) == TxInsertionStatus::Inserted {
+                        if bo(pool.insert(tx.clone())) == TxInsertionStatus::Inserted {
                             live.push(tx);
                         }
                     }
@@ -958,15 +979,15 @@ mod tests {
                         if !live.is_empty() {
                             let idx = which % live.len();
                             let victim = live.swap_remove(idx);
-                            futures::executor::block_on(pool.forget(std::slice::from_ref(&victim)));
+                            bo(pool.forget(std::slice::from_ref(&victim)));
                         }
                     }
                 }
                 // Capacity invariant — must hold after every step.
                 prop_assert!(
-                    pool.len() <= cap,
+                    bo(pool.len()) <= cap,
                     "pool.len()={} exceeded capacity {}",
-                    pool.len(),
+                    bo(pool.len()),
                     cap
                 );
             }
@@ -1004,11 +1025,11 @@ mod tests {
             // Inserts: alternating canonical-tail and alt anchors.
             for i in 0..n_txs {
                 let anchor = if i % 2 == 0 { chain[3].hash } else { alt_hash };
-                pool.insert(signed_tx(&pk, ActorId::zero(), anchor, i as u8));
+                bo(pool.insert(signed_tx(&pk, ActorId::zero(), anchor, i as u8)));
             }
 
             let head = chain[3];
-            let fetched = futures::executor::block_on(pool.fetch(head));
+            let fetched = bo(pool.fetch(head));
             for tx in &fetched {
                 prop_assert_ne!(
                     tx.data().reference_block, alt_hash,
@@ -1030,14 +1051,14 @@ mod tests {
             let pool = InjectedTxMempool::new(db);
             let pk = PrivateKey::random();
             let tx = signed_tx(&pk, ActorId::zero(), chain[1].hash, salt);
-            pool.insert(tx.clone());
-            prop_assert_eq!(pool.len(), 1);
-            futures::executor::block_on(pool.forget(std::slice::from_ref(&tx)));
-            prop_assert_eq!(pool.len(), 0);
+            bo(pool.insert(tx.clone()));
+            prop_assert_eq!(bo(pool.len()), 1);
+            bo(pool.forget(std::slice::from_ref(&tx)));
+            prop_assert_eq!(bo(pool.len()), 0);
             // Re-insert: idempotent no-op because the hash sits in
             // the seen-set and `reference_block` hasn't aged out.
-            pool.insert(tx);
-            prop_assert_eq!(pool.len(), 0);
+            bo(pool.insert(tx));
+            prop_assert_eq!(bo(pool.len()), 0);
         }
     }
 }

--- a/ethexe/malachite/service/src/quarantine.rs
+++ b/ethexe/malachite/service/src/quarantine.rs
@@ -23,7 +23,7 @@
 //! - *"quarantine-passed"* means the block has ≥ `canonical_quarantine`
 //!   canonical descendants on top.
 
-use anyhow::{Context as _, Result, anyhow};
+use anyhow::{Result, anyhow};
 use ethexe_common::{Acceptance, SimpleBlockData, db::OnChainStorageRO};
 use gprimitives::H256;
 
@@ -69,9 +69,9 @@ pub fn is_strict_descendant_of(
         return Ok(Acceptance::Accepted(()));
     }
 
-    let ancestor = db.block_simple_data(ancestor_hash).with_context(|| {
-        anyhow!("descendant check: missing header for ancestor {ancestor_hash}")
-    })?;
+    let ancestor = db
+        .block_simple_data(ancestor_hash)
+        .ok_or_else(|| anyhow!("descendant check: missing header for ancestor {ancestor_hash}"))?;
 
     let Some(depth) = candidate.header.height.checked_sub(ancestor.header.height) else {
         return Ok(Acceptance::Rejected(format!(
@@ -93,9 +93,9 @@ pub fn is_strict_descendant_of(
             )));
         }
 
-        cursor = db.block_simple_data(parent_hash).with_context(|| {
-            anyhow!("descendant check: missing header for parent {parent_hash}")
-        })?;
+        cursor = db
+            .block_simple_data(parent_hash)
+            .ok_or_else(|| anyhow!("descendant check: missing header for parent {parent_hash}"))?;
     }
 
     Ok(Acceptance::Rejected(format!(

--- a/ethexe/malachite/service/src/quarantine.rs
+++ b/ethexe/malachite/service/src/quarantine.rs
@@ -23,141 +23,87 @@
 //! - *"quarantine-passed"* means the block has ≥ `canonical_quarantine`
 //!   canonical descendants on top.
 
-use anyhow::{Result, anyhow};
-use ethexe_common::{SimpleBlockData, db::OnChainStorageRO};
-use ethexe_db::Database;
+use anyhow::{Context as _, Result, anyhow};
+use ethexe_common::{Acceptance, SimpleBlockData, db::OnChainStorageRO};
 use gprimitives::H256;
 
-/// Cap on parent walks when verifying a peer's `AdvanceTillEthereumBlock`.
-const VERIFY_LOOKBACK_SLACK: u32 = 100_000;
-
-/// Youngest EB that has cleared quarantine. `Ok(None)` if the local chain is
-/// too short, `Err` on missing parent header.
+/// Youngest EB that has cleared the `depth` quarantine against the local head.
+/// Returns `Ok(None)` if no blocks passed the depth check since `start_eb`.
 ///
-/// `depth` is taken as `u32` to accommodate the proposer-side
-/// `canonical_quarantine + post_quarantine_delay` sum, which can exceed
-/// `u8::MAX`. `verify_passed` still takes `u8` because the protocol
-/// invariant validators enforce is anchored on `canonical_quarantine`
-/// only — the extra slack is a proposer-side hint.
+/// # Caller guarantees
+/// - `head` is synced block
+/// - `start_eb_hash` is hash of global start block (DB genesis or fast-sync pivot)
 pub fn anchor(
-    db: &Database,
+    db: &impl OnChainStorageRO,
     head: SimpleBlockData,
     depth: u32,
-    start_block_hash: H256,
-) -> Result<Option<H256>> {
-    let mut current = head.hash;
-    let mut header = head.header;
-
+    start_eb: H256,
+) -> Result<Option<SimpleBlockData>> {
+    let mut cursor = head;
     for _ in 0..depth {
-        if current == start_block_hash {
+        if cursor.hash == start_eb {
             return Ok(None);
         }
-        let parent = header.parent_hash;
-        header = db
-            .block_header(parent)
-            .ok_or_else(|| anyhow!("quarantine anchor: missing parent header for {parent}"))?;
-        current = parent;
+        cursor = db
+            .block_simple_data(cursor.header.parent_hash)
+            .ok_or_else(|| anyhow!("quarantine anchor: missing header for {cursor}"))?;
     }
 
-    Ok(Some(current))
+    Ok(Some(cursor))
 }
 
-/// `candidate` must be a canonical ancestor of `head` at depth ≥ `canonical_quarantine`.
-/// `Err` on still-quarantined / not-found / missing-parent.
-pub fn verify_passed(
-    db: &Database,
-    head: SimpleBlockData,
-    candidate: H256,
-    canonical_quarantine: u8,
-    start_block_hash: H256,
-) -> Result<()> {
-    let canonical_quarantine = canonical_quarantine as u32;
-    let max_steps = canonical_quarantine.saturating_add(VERIFY_LOOKBACK_SLACK);
-
-    let mut current = head.hash;
-    let mut header = head.header;
-
-    for depth in 0..=max_steps {
-        if current == candidate {
-            return if depth >= canonical_quarantine {
-                Ok(())
-            } else {
-                Err(anyhow!(
-                    "EB {candidate} is only {depth} block(s) behind head, \
-                     needs ≥ {canonical_quarantine}"
-                ))
-            };
-        }
-
-        if current == start_block_hash {
-            return Err(anyhow!(
-                "EB {candidate} is not a canonical ancestor of local chain head \
-                 (walk reached start_block at depth {depth})"
-            ));
-        }
-
-        let parent = header.parent_hash;
-        header = db.block_header(parent).ok_or_else(|| {
-            anyhow!("quarantine verify: missing parent header for {parent} at depth {depth}")
-        })?;
-        current = parent;
-    }
-
-    Err(anyhow!(
-        "EB {candidate} not found within {max_steps} ancestors of local chain head"
-    ))
-}
-
-/// `candidate` strictly descends from `ancestor` (depth ≥ 1). `H256::zero()` =
-/// pre-genesis sentinel; equal hashes return `Ok(false)`.
+/// Check whether `candidate` strictly descends from `ancestor`
+///
+/// # Caller guarantees
+/// - `candidate` is synced block
+/// - `ancestor` is hash of synced block or zero (pre-genesis sentinel)
+/// - `start_eb_hash` is hash of global start block (DB genesis or fast-sync pivot)
 pub fn is_strict_descendant_of(
-    db: &Database,
-    candidate: H256,
-    ancestor: H256,
-    start_block_hash: H256,
-) -> Result<bool> {
-    if ancestor.is_zero() {
-        return Ok(true);
-    }
-    if candidate == ancestor {
-        return Ok(false);
+    db: &impl OnChainStorageRO,
+    candidate: SimpleBlockData,
+    ancestor_hash: H256,
+    start_eb_hash: H256,
+) -> Result<Acceptance<(), String>> {
+    if ancestor_hash == H256::zero() {
+        // Special case: all blocks descend from the zero hash (pre-genesis sentinel).
+        return Ok(Acceptance::Accepted(()));
     }
 
-    let max_steps = VERIFY_LOOKBACK_SLACK;
-    let mut current = candidate;
-    let mut header = db
-        .block_header(current)
-        .ok_or_else(|| anyhow!("descendant check: missing header for candidate {candidate}"))?;
+    let ancestor = db.block_simple_data(ancestor_hash).with_context(|| {
+        anyhow!("descendant check: missing header for ancestor {ancestor_hash}")
+    })?;
 
-    for _ in 0..max_steps {
-        let parent = header.parent_hash;
-        if parent == ancestor {
-            return Ok(true);
+    let Some(depth) = candidate.header.height.checked_sub(ancestor.header.height) else {
+        return Ok(Acceptance::Rejected(format!(
+            "candidate {candidate} height is not greater than ancestor {ancestor}"
+        )));
+    };
+
+    let mut cursor = candidate;
+    for _ in 0..depth {
+        let parent_hash = cursor.header.parent_hash;
+        if parent_hash == ancestor.hash {
+            // Found the ancestor
+            return Ok(Acceptance::Accepted(()));
         }
-        if parent == H256::zero() {
-            return Err(anyhow!(
-                "descendant check: ancestor {ancestor} not in canonical ancestry of \
-                 candidate {candidate} — walk reached genesis"
-            ));
+
+        if parent_hash == start_eb_hash {
+            return Ok(Acceptance::Rejected(format!(
+                "ancestor {ancestor} not found within candidate's ancestry (walk reached start EB)"
+            )));
         }
-        if current == start_block_hash {
-            return Err(anyhow!(
-                "descendant check: ancestor {ancestor} not found before start_block fence \
-                 starting from candidate {candidate}"
-            ));
-        }
-        header = db
-            .block_header(parent)
-            .ok_or_else(|| anyhow!("descendant check: missing parent header for {parent}"))?;
-        current = parent;
+
+        cursor = db.block_simple_data(parent_hash).with_context(|| {
+            anyhow!("descendant check: missing header for parent {parent_hash}")
+        })?;
     }
 
-    Err(anyhow!(
-        "descendant check: ancestor {ancestor} not found within {max_steps} ancestors \
-         of candidate {candidate}"
-    ))
+    Ok(Acceptance::Rejected(format!(
+        "candidate {candidate} does not descend from ancestor {ancestor}"
+    )))
 }
 
+#[cfg(feature = "disable-tests")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ethexe/malachite/service/src/quarantine.rs
+++ b/ethexe/malachite/service/src/quarantine.rs
@@ -103,18 +103,15 @@ pub fn is_strict_descendant_of(
     )))
 }
 
-#[cfg(feature = "disable-tests")]
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ethexe_common::{
-        BlockHeader,
-        db::{BlockMetaStorageRW, OnChainStorageRW},
-    };
+    use ethexe_common::{BlockHeader, db::OnChainStorageRW};
+    use ethexe_db::Database;
 
     /// Synthetic linear chain, oldest-first; parent[0] == zero.
-    fn linear_chain(db: &Database, len: usize) -> Vec<H256> {
-        let mut hashes = Vec::with_capacity(len);
+    fn linear_chain(db: &Database, len: usize) -> Vec<SimpleBlockData> {
+        let mut blocks = Vec::with_capacity(len);
         let mut parent = H256::zero();
         for i in 0..len {
             let mut hash_bytes = [0u8; 32];
@@ -123,54 +120,64 @@ mod tests {
             hash_bytes[1] = (i >> 8) as u8;
             hash_bytes[2] = i as u8;
             let hash = H256::from(hash_bytes);
-            db.set_block_header(
-                hash,
-                BlockHeader {
-                    height: i as u32,
-                    timestamp: i as u64,
-                    parent_hash: parent,
-                },
-            );
-            db.mutate_block_meta(hash, |_| {});
-            hashes.push(hash);
+            let header = BlockHeader {
+                height: i as u32,
+                timestamp: i as u64,
+                parent_hash: parent,
+            };
+            db.set_block_header(hash, header);
+            blocks.push(SimpleBlockData { hash, header });
             parent = hash;
         }
-        hashes
+        blocks
     }
 
     #[test]
     fn zero_ancestor_is_always_descendant() {
         let db = Database::memory();
-        let hashes = linear_chain(&db, 3);
+        let chain = linear_chain(&db, 3);
         // arbitrary candidate; ancestor = zero (pre-genesis sentinel)
-        assert!(is_strict_descendant_of(&db, hashes[2], H256::zero(), H256::zero()).unwrap());
+        assert!(
+            is_strict_descendant_of(&db, chain[2], H256::zero(), H256::zero())
+                .unwrap()
+                .is_accepted()
+        );
     }
 
     #[test]
     fn same_block_is_not_strict_descendant() {
         let db = Database::memory();
-        let hashes = linear_chain(&db, 3);
-        assert!(!is_strict_descendant_of(&db, hashes[1], hashes[1], hashes[0]).unwrap());
+        let chain = linear_chain(&db, 3);
+        assert!(
+            is_strict_descendant_of(&db, chain[1], chain[1].hash, chain[0].hash)
+                .unwrap()
+                .is_rejected()
+        );
     }
 
     #[test]
-    fn proper_ancestor_resolves_to_true() {
+    fn proper_ancestor_resolves_to_accepted() {
         let db = Database::memory();
-        let hashes = linear_chain(&db, 5);
-        // hashes[4] should be a strict descendant of hashes[1]
+        let chain = linear_chain(&db, 5);
+        // chain[4] should be a strict descendant of chain[1]
         // through 3 parent steps.
-        assert!(is_strict_descendant_of(&db, hashes[4], hashes[1], hashes[0]).unwrap());
+        assert!(
+            is_strict_descendant_of(&db, chain[4], chain[1].hash, chain[0].hash)
+                .unwrap()
+                .is_accepted()
+        );
     }
 
     #[test]
     fn unrelated_ancestor_errors() {
         let db = Database::memory();
-        let hashes = linear_chain(&db, 5);
-        // ancestor = a hash that's not in the chain at all
+        let chain = linear_chain(&db, 5);
+        // ancestor = a hash that's not in the chain at all — the local
+        // header lookup fails, which is a local-view error, not a vote.
         let mut orphan_bytes = [0xFFu8; 32];
         orphan_bytes[0] = 0x42;
         let orphan = H256::from(orphan_bytes);
-        let res = is_strict_descendant_of(&db, hashes[4], orphan, hashes[0]);
+        let res = is_strict_descendant_of(&db, chain[4], orphan, chain[0].hash);
         assert!(res.is_err(), "expected Err for orphan ancestor: {res:?}");
     }
 
@@ -185,8 +192,8 @@ mod tests {
 
         /// `anchor(head)` walks back exactly `canonical_quarantine`
         /// steps along the canonical chain, so for any pair
-        /// (chain_len, q) with `q < chain_len` the returned hash is
-        /// the block at index `chain_len - 1 - q`.
+        /// (chain_len, q) with `q < chain_len` the returned block is
+        /// the one at index `chain_len - 1 - q`.
         #[test]
         fn anchor_walks_exactly_q_steps(
             chain_len in 2usize..32,
@@ -195,25 +202,18 @@ mod tests {
             let q_usize = q as usize;
             prop_assume!(q_usize < chain_len);
             let db = Database::memory();
-            let hashes = linear_chain(&db, chain_len);
-            let head = SimpleBlockData {
-                hash: hashes[chain_len - 1],
-                header: ethexe_common::BlockHeader {
-                    height: (chain_len - 1) as u32,
-                    timestamp: (chain_len - 1) as u64,
-                    parent_hash: if chain_len >= 2 { hashes[chain_len - 2] } else { H256::zero() },
-                },
-            };
+            let chain = linear_chain(&db, chain_len);
+            let head = chain[chain_len - 1];
             // start_block = genesis (so the fence never trips).
-            let result = anchor(&db, head, q as u32, hashes[0]).unwrap();
-            let expected = hashes[chain_len - 1 - q_usize];
+            let result = anchor(&db, head, q as u32, chain[0].hash).unwrap();
+            let expected = chain[chain_len - 1 - q_usize];
             prop_assert_eq!(result, Some(expected));
         }
 
         /// `is_strict_descendant_of(c, a)` is the transitive closure
         /// of "next-block": for any (i, j) on a single chain, with
-        /// `i > j > 0`, the chain[i] descends from chain[j]; with
-        /// `i == j`, it does NOT (strictness).
+        /// `i > j`, chain[i] descends from chain[j]; with `i <= j`,
+        /// it does NOT (strictness / height check).
         #[test]
         fn descendant_relation_matches_chain_indices(
             chain_len in 2usize..16,
@@ -223,50 +223,17 @@ mod tests {
             prop_assume!(i < chain_len);
             prop_assume!(j < chain_len);
             let db = Database::memory();
-            let hashes = linear_chain(&db, chain_len);
+            let chain = linear_chain(&db, chain_len);
 
-            let result = is_strict_descendant_of(&db, hashes[i], hashes[j], hashes[0]);
+            let result = is_strict_descendant_of(&db, chain[i], chain[j].hash, chain[0].hash)
+                .unwrap();
             if i > j {
-                prop_assert_eq!(result.unwrap(), true);
-            } else if i == j {
-                prop_assert_eq!(result.unwrap(), false);
+                prop_assert!(result.is_accepted(), "expected Accepted: {result:?}");
             } else {
-                // i < j → walking back from i never reaches j.
-                // The walk hits genesis (parent_hash zero) → Err.
-                prop_assert!(result.is_err());
-            }
-        }
-
-        /// `verify_passed(head, candidate)` succeeds iff `candidate`
-        /// sits at depth >= q from `head` on the canonical chain.
-        #[test]
-        fn verify_passed_matches_depth(
-            chain_len in 4usize..16,
-            head_idx in 0usize..16,
-            cand_idx in 0usize..16,
-            q in 0u8..6,
-        ) {
-            prop_assume!(head_idx < chain_len);
-            prop_assume!(cand_idx <= head_idx);
-            let db = Database::memory();
-            let hashes = linear_chain(&db, chain_len);
-            let head_hash = hashes[head_idx];
-            let head_height = head_idx as u32;
-            let head_parent = if head_idx > 0 { hashes[head_idx - 1] } else { H256::zero() };
-            let head = SimpleBlockData {
-                hash: head_hash,
-                header: ethexe_common::BlockHeader {
-                    height: head_height,
-                    timestamp: head_idx as u64,
-                    parent_hash: head_parent,
-                },
-            };
-            let depth = head_idx - cand_idx;
-            let result = verify_passed(&db, head, hashes[cand_idx], q, hashes[0]);
-            if depth >= q as usize {
-                prop_assert!(result.is_ok(), "expected pass: {result:?}");
-            } else {
-                prop_assert!(result.is_err(), "expected too-shallow err: {result:?}");
+                // i == j → strictness; i < j → candidate height below
+                // ancestor height. Both are proposer-controlled inputs,
+                // so they reject (vote nil) rather than error.
+                prop_assert!(result.is_rejected(), "expected Rejected: {result:?}");
             }
         }
     }

--- a/ethexe/malachite/service/src/service.rs
+++ b/ethexe/malachite/service/src/service.rs
@@ -1,7 +1,7 @@
 // Copyright (C) Gear Technologies Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
-//! [`MalachiteService`] — public façade.
+//! [`MalachiteService`] — public facade.
 //!
 //! Wraps [`ethexe_malachite_core::MalachiteService`] with the ethexe-shaped API the
 //! rest of the workspace already consumes. Owns:
@@ -16,231 +16,91 @@
 //!   (releasing the RocksDB advisory lock before
 //!   re-opening on the same home directory).
 
-use std::{
-    collections::HashMap,
-    pin::Pin,
-    sync::{Arc, RwLock},
-    task::{Context, Poll},
+use crate::{
+    MalachiteEvent, Mempool, ValidatorEntry, externalities::EthexeExternalities,
+    mempool::TxInsertionStatus, types::ChainHead,
 };
-
-use anyhow::{Context as _, Result, anyhow};
+use anyhow::Result;
 use ethexe_common::{
     Address, SimpleBlockData,
     db::{ConfigStorageRO, OnChainStorageRO},
     injected::SignedInjectedTransaction,
 };
 use ethexe_db::Database;
+use ethexe_malachite_core::MalachiteCore;
 use futures::{Stream, stream::FusedStream};
 use gprimitives::H256;
-use gsigner::{Signer, schemes::secp256k1::Secp256k1};
-use tokio::sync::{Notify, mpsc};
-
-use crate::{
-    MalachiteConfig, MalachiteEvent, Mempool, ValidatorEntry, externalities::EthexeExternalities,
+use gsigner::{
+    Signer,
+    schemes::secp256k1::{PublicKey, Secp256k1},
+};
+use std::{
+    collections::HashMap,
+    pin::Pin,
+    sync::{Arc, RwLock},
+    task::{Context, Poll},
+};
+use tokio::sync::{
+    Notify,
+    mpsc::{self, UnboundedReceiver},
 };
 
 /// Public consensus service.
 pub struct MalachiteService {
-    events_rx: mpsc::UnboundedReceiver<Result<MalachiteEvent>>,
-    chain_head: Arc<RwLock<Option<SimpleBlockData>>>,
-    chain_head_notify: Arc<Notify>,
-    mempool: Arc<dyn Mempool>,
-    /// Shared with the inner engine — held here so
-    /// [`Self::receive_new_chain_head`] can release pending events
-    /// whose `last_advanced_eb` Eth block has just been synced
-    /// by the observer.
-    externalities: Arc<EthexeExternalities>,
-    /// On-chain validator addresses only — we keep operator-supplied
-    /// pub keys here so era rotations can resolve them back.
-    validator_pool: HashMap<Address, gsigner::schemes::secp256k1::PublicKey>,
-    /// Era of the set currently in the engine; gates rotation no-ops.
-    active_era: Option<u64>,
-    /// Inner ethexe-malachite-core service. Held in an `Option` so
-    /// [`Self::shutdown`] can `take` it and `await` its
-    /// async-shutdown method without violating the `Drop` signature.
-    inner: Option<ethexe_malachite_core::MalachiteService<EthexeExternalities>>,
+    pub(crate) events_rx: UnboundedReceiver<Result<MalachiteEvent>>,
+    pub(crate) chain_head: Arc<ChainHead>,
+    pub(crate) mempool: Option<Arc<dyn Mempool>>,
+    pub(crate) externalities: Arc<EthexeExternalities>,
+    pub(crate) validators: HashMap<Address, PublicKey>,
+    pub(crate) active_era: u64,
+    pub(crate) inner: Option<MalachiteCore<EthexeExternalities>>,
 }
 
 impl Drop for MalachiteService {
     fn drop(&mut self) {
-        // Best-effort cleanup if the caller didn't go through
-        // [`Self::shutdown`]: the inner ethexe-malachite-core service runs its own
-        // kill/abort sequence inside its `Drop` impl. RocksDB locks
-        // and listening sockets release asynchronously after that,
-        // so a sync drop alone is unsafe to immediately re-open the
-        // same home directory. Use `shutdown().await` instead when
-        // an immediate restart is required.
         let _ = self.inner.take();
     }
 }
 
 impl MalachiteService {
-    /// Bootstrap the consensus service.
-    ///
-    /// Parameters:
-    /// - `signer` — shared ethexe key manager; the secret matching
-    ///   `validator_pub_key` is extracted once here and passed into
-    ///   ethexe-malachite-core as the validator secret.
-    /// - `validator_pub_key` — this node's validator public key. When
-    ///   `Some`, it must appear in [`MalachiteConfig::validators`] and
-    ///   the engine starts in [`ethexe_malachite_core::NodeRole::Validator`].
-    ///   When `None`, the engine starts as a full / connect node
-    ///   ([`ethexe_malachite_core::NodeRole::FullNode`]): joins gossip
-    ///   and sync but never signs anything. A fresh ephemeral key
-    ///   provides the libp2p peer identity in that case.
-    /// - `db` — shared ethexe [`Database`] used by the externalities
-    ///   to persist MBs and walk parent links.
-    /// - `mempool` — source of injected user transactions for the
-    ///   producer; also the sink for [`Self::receive_injected_transaction`].
-    pub async fn new(
-        config: MalachiteConfig,
-        db: Database,
-        signer: Signer<Secp256k1>,
-        validator_pub_key: Option<gsigner::schemes::secp256k1::PublicKey>,
-        mempool: Arc<dyn Mempool>,
-    ) -> Result<Self> {
-        tracing::info!(
-            listen = %config.listen_addr,
-            persistent_peers = config.persistent_peers.len(),
-            validators = config.validators.len(),
-            role = if validator_pub_key.is_some() { "validator" } else { "full" },
-            "Bootstrapping Malachite engine",
-        );
+    pub fn receive_injected_transaction(&self, tx: SignedInjectedTransaction) -> TxInsertionStatus {
+        self.mempool
+            .as_ref()
+            .map(|pool| pool.insert(tx))
+            .unwrap_or(TxInsertionStatus::PoolFull)
+    }
 
-        std::fs::create_dir_all(&config.home_dir)
-            .with_context(|| format!("creating Malachite home dir {:?}", config.home_dir))?;
+    pub async fn receive_new_chain_head(&mut self, head: SimpleBlockData) {
+        let mut current = self.chain_head.latest.write().await;
 
-        if config.validators.is_empty() {
-            return Err(anyhow!("MalachiteConfig::validators is empty"));
+        // Filter the new head against the current one and update if it's strictly higher
+        if head.header.height > current.header.height {
+            *current = head;
+        }
+    }
+
+    pub async fn receive_eb_synced(&mut self, eb_hash: H256) {
+        let chain_head = *self.chain_head.latest.read().await;
+        if chain_head.hash != eb_hash {
+            tracing::trace!(
+                chain_head = %chain_head,
+                synced = %eb_hash,
+                "synced EB is not the current chain head, ignoring"
+            );
+            return;
         }
 
-        // Validators sign votes/proposals using their on-chain key;
-        // full nodes get an ephemeral secret used only as the libp2p
-        // peer identity.
-        let (role, validator_secret) = match validator_pub_key {
-            Some(pub_key) => {
-                if !config.validators.iter().any(|v| v.public_key == pub_key) {
-                    return Err(anyhow!(
-                        "local validator {pub_key} not present in MalachiteConfig::validators"
-                    ));
-                }
-                let secret = signer
-                    .private_key(pub_key)
-                    .context("extracting validator private key from signer")?;
-                (ethexe_malachite_core::NodeRole::Validator, secret)
-            }
-            None => (
-                ethexe_malachite_core::NodeRole::FullNode,
-                gsigner::schemes::secp256k1::PrivateKey::random(),
-            ),
-        };
+        // Notify inner proposer if it waits (see EthexeExternalities::wait_for_proposable_content)
+        self.chain_head.notify.notify_one();
 
-        // Build the ethexe-malachite-core-side config. Application-side knobs
-        // (gas allowance, quarantine depth) stay in [`MalachiteConfig`]
-        // and travel into the externalities; they never reach
-        // ethexe-malachite-core.
-        let svc_cfg = ethexe_malachite_core::MalachiteConfig {
-            listen_addr: config.listen_addr,
-            base: config.home_dir.clone(),
-            persistent_peers: config.persistent_peers.clone(),
-            validator_secret,
-            validators: config.validators.clone(),
-            role,
-            // Producer waits up to one Ethereum slot for a fresh EB past quarantine.
-            propose_timeout: alloy::eips::merge::SLOT_DURATION,
-        };
-
-        let chain_head = Arc::new(RwLock::new(None));
-        let chain_head_notify = Arc::new(Notify::new());
-        let (events_tx, events_rx) = mpsc::unbounded_channel();
-
-        let externalities = Arc::new(EthexeExternalities {
-            db,
-            mempool: Arc::clone(&mempool),
-            chain_head: Arc::clone(&chain_head),
-            chain_head_notify: Arc::clone(&chain_head_notify),
-            event_tx: events_tx,
-            pending_events: std::sync::Mutex::new(std::collections::VecDeque::new()),
-            gas_allowance: config.gas_allowance,
-            canonical_quarantine: config.canonical_quarantine,
-            post_quarantine_delay: config.post_quarantine_delay,
-        });
-
-        // On-chain addresses → pub keys, so era rotations resolve back without an out-of-band lookup.
-        let validator_pool: HashMap<Address, gsigner::schemes::secp256k1::PublicKey> = config
-            .validators
-            .iter()
-            .map(|v| (v.public_key.to_address(), v.public_key))
-            .collect();
-
-        let inner =
-            ethexe_malachite_core::MalachiteService::new(svc_cfg, Arc::clone(&externalities))
-                .await
-                .map_err(|e| anyhow!("starting ethexe-malachite-core: {e}"))?;
-
-        Ok(Self {
-            events_rx,
-            chain_head,
-            chain_head_notify,
-            mempool,
-            externalities,
-            validator_pool,
-            active_era: None,
-            inner: Some(inner),
-        })
-    }
-
-    /// Hand an injected transaction to the mempool. The local
-    /// producer pulls from the same pool when assembling the next MB.
-    ///
-    /// Every outcome — including rejecting ones — is a
-    /// [`crate::mempool::TxInsertionStatus`] value; group membership is
-    /// queried via [`crate::mempool::TxInsertionStatus::is_accepted`].
-    pub fn receive_injected_transaction(
-        &self,
-        tx: SignedInjectedTransaction,
-    ) -> crate::mempool::TxInsertionStatus {
-        self.mempool.insert(tx)
-    }
-
-    /// Feed an observer-delivered Ethereum `BlockSynced` block into the
-    /// service. `BlockSynced` events arrive out-of-order, so this method
-    /// guarantees two invariants the producer relies on:
-    ///
-    /// 1. The chain-head register is monotone in **height** — a stale
-    ///    older head would push `anchor = head - quarantine` below
-    ///    `parent_advanced` and stall the producer for `propose_timeout`.
-    /// 2. Every `BlockSynced` fires `chain_head_notify`, even when height
-    ///    didn't move. A lower-height sync may have just landed parent
-    ///    headers the producer's `is_strict_descendant_of` walk needs;
-    ///    without this kick a failed walk would never retry.
-    ///
-    /// Also drains any queued [`MalachiteEvent::BlockProposal`] /
-    /// [`MalachiteEvent::BlockFinalized`] whose `last_advanced_eb`
-    /// Eth block has now landed in the local DB — keeps the strict
-    /// FIFO ordering compute and the malachite engine rely on.
-    pub fn receive_new_chain_head(&mut self, head: SimpleBlockData) {
         // Rotate before waking the producer so the next round sees the new set.
-        self.maybe_rotate_validators_for_era(&head);
+        self.maybe_rotate_validators_for_era(chain_head);
 
-        let mut current = self.chain_head.write().expect("chain_head poisoned");
-        let advanced = match current.as_ref() {
-            Some(existing) => head.header.height > existing.header.height,
-            None => true,
-        };
-        if advanced {
-            *current = Some(head);
-        }
-        drop(current);
-        // Wake the producer regardless of whether height moved — see
-        // invariant #2 in the doc above.
-        self.chain_head_notify.notify_one();
-        if advanced {
-            // let eb_hash = head.hash;
-            let purged_txs = self.mempool.set_chain_head(head);
+        if let Some(pool) = self.mempool.as_ref() {
+            let purged_txs = pool.set_chain_head(chain_head);
             if !purged_txs.is_empty() {
                 let event = MalachiteEvent::PurgedTransactions {
-                    eb_hash: head.hash,
+                    eb_hash: chain_head.hash,
                     transactions: purged_txs,
                 };
                 if let Err(err) = self.externalities.event_tx.send(Ok(event)) {
@@ -251,44 +111,34 @@ impl MalachiteService {
                 };
             }
         }
-        self.externalities.drain_pending_events();
     }
 
-    /// Forward a `ComputeEvent::BlockPrepared` notification so any
-    /// pending [`MalachiteEvent`] whose `last_advanced_eb` was the
-    /// freshly-prepared block can be released. Prepared blocks are
-    /// the prerequisite for downstream `compute_mb` not racing the
-    /// code-validation pipeline — see the prerequisite check inside
-    /// the externalities impl.
-    pub fn receive_eb_prepared(&self, _eb_hash: H256) {
-        // Drain inspects each queued entry's prerequisite against the
-        // current `block_meta.prepared` flag, so we don't need to use
-        // `_eb_hash` here — the FIFO drain releases everything that
-        // newly satisfies its prerequisite.
-        self.externalities.drain_pending_events();
+    pub async fn receive_eb_prepared(&self, _eb_hash: H256) {
+        self.externalities.drain_pending_events().await
     }
 
     /// Push the on-chain validators for `head`'s era into the engine,
     /// if the era moved. Skips on missing DB data or unknown pub keys
     /// (wait-and-retry: the next `BlockSynced` re-evaluates).
-    fn maybe_rotate_validators_for_era(&mut self, head: &SimpleBlockData) {
+    fn maybe_rotate_validators_for_era(&mut self, head: SimpleBlockData) {
         let db = &self.externalities.db;
         let timelines = db.config().timelines;
         let Some(era) = timelines.era_from_ts(head.header.timestamp) else {
             return;
         };
-        if self.active_era == Some(era) {
+        if self.active_era == era {
             return;
         }
         let Some(addrs) = db.validators(era) else {
-            tracing::trace!(era, "validators for era not yet in DB; deferring rotation");
+            // trace like error because `head` must be synced
+            tracing::error!(era, "validators for era not yet in DB; deferring rotation");
             return;
         };
 
-        let mut new_set = Vec::with_capacity(self.validator_pool.len());
+        let mut new_set = Vec::with_capacity(self.validators.len());
         let mut missing: Vec<Address> = Vec::new();
         for addr in addrs.iter() {
-            match self.validator_pool.get(addr) {
+            match self.validators.get(addr) {
                 Some(pk) => new_set.push(ValidatorEntry {
                     public_key: *pk,
                     voting_power: 1,
@@ -312,31 +162,25 @@ impl MalachiteService {
             Some(inner) => inner,
             None => {
                 tracing::error!(era, "rotate after shutdown");
-                self.active_era = Some(era);
+                self.active_era = era;
                 return;
             }
         };
+
         if let Err(e) = inner.update_validators(new_set) {
             tracing::error!(era, error = %e, "rotating malachite validator set failed");
-            self.active_era = Some(era);
+            self.active_era = era;
             return;
         }
-        self.active_era = Some(era);
+
+        self.active_era = era;
+
         tracing::info!(
             era,
             "rotated malachite validator set to era's on-chain quorum"
         );
     }
 
-    /// Shut the inner ethexe-malachite-core service down deterministically.
-    ///
-    /// Unlike `Drop` (which is fire-and-forget), this future awaits
-    /// the engine actor's tear-down, releasing the WAL / RocksDB
-    /// advisory lock and the libp2p listener socket BEFORE
-    /// returning. Tests that immediately re-open the same home
-    /// directory (or the same `Database` for that matter) need this;
-    /// production node shutdown is also better off going through
-    /// here so cleanup races don't leak into the next start.
     pub async fn shutdown(mut self) {
         if let Some(inner) = self.inner.take() {
             inner.shutdown().await;
@@ -348,10 +192,6 @@ impl Stream for MalachiteService {
     type Item = Result<MalachiteEvent>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        // The inner stream is errors-only (since ethexe-malachite-core
-        // no longer emits events — events flow exclusively through
-        // EthexeExternalities into our own `events_rx`). Forward each
-        // inner error onto our outer stream.
         if let Some(inner) = self.inner.as_mut() {
             match Pin::new(&mut *inner).poll_next(cx) {
                 Poll::Ready(Some(e)) => return Poll::Ready(Some(Err(e))),

--- a/ethexe/malachite/service/src/service.rs
+++ b/ethexe/malachite/service/src/service.rs
@@ -95,8 +95,12 @@ impl MalachiteService {
                 tracing::trace!(
                     latest_synced = %*latest_synced,
                     synced = %synced,
-                    "synced EB is not newer than the current synced head, ignoring"
+                    "synced EB is not newer than the current synced head"
                 );
+                drop(latest_synced);
+                // Still wake the producer: a lower-height sync may have just
+                // landed parent headers a failed descendant walk needs.
+                self.chain_head.notify.notify_one();
                 return;
             }
             *latest_synced = synced;

--- a/ethexe/malachite/service/src/service.rs
+++ b/ethexe/malachite/service/src/service.rs
@@ -26,24 +26,17 @@ use ethexe_common::{
     db::{ConfigStorageRO, OnChainStorageRO},
     injected::SignedInjectedTransaction,
 };
-use ethexe_db::Database;
 use ethexe_malachite_core::MalachiteCore;
 use futures::{Stream, stream::FusedStream};
 use gprimitives::H256;
-use gsigner::{
-    Signer,
-    schemes::secp256k1::{PublicKey, Secp256k1},
-};
+use gsigner::schemes::secp256k1::PublicKey;
 use std::{
     collections::HashMap,
     pin::Pin,
-    sync::{Arc, RwLock},
+    sync::Arc,
     task::{Context, Poll},
 };
-use tokio::sync::{
-    Notify,
-    mpsc::{self, UnboundedReceiver},
-};
+use tokio::sync::mpsc::UnboundedReceiver;
 
 /// Public consensus service.
 pub struct MalachiteService {

--- a/ethexe/malachite/service/src/service.rs
+++ b/ethexe/malachite/service/src/service.rs
@@ -79,32 +79,40 @@ impl MalachiteService {
     /// Handle a fully synced Ethereum block: publish it for the producer's
     /// quarantine checks, rotate the validator set on era change and GC the mempool.
     pub async fn receive_eb_synced(&mut self, eb_hash: H256) {
-        let chain_head = *self.chain_head.latest.read().await;
-        if chain_head.hash != eb_hash {
-            tracing::trace!(
-                chain_head = %chain_head,
-                synced = %eb_hash,
-                "synced EB is not the current chain head, ignoring"
-            );
+        let Some(synced) = self.externalities.db.block_simple_data(eb_hash) else {
+            tracing::error!(synced = %eb_hash, "synced EB header not found in local DB, ignoring");
             return;
-        }
+        };
 
-        // Publish the synced head for the externalities' quarantine
-        // checks BEFORE waking the producer, so the woken round
-        // already sees it.
-        *self.chain_head.latest_synced.write().await = chain_head;
+        // Publish the synced head for the externalities' quarantine checks
+        // BEFORE waking the producer, so the woken round already sees it.
+        // A synced block may lag the latest observed head — advance whenever
+        // it is strictly newer than the current synced head.
+        {
+            let mut latest_synced = self.chain_head.latest_synced.write().await;
+            if !latest_synced.hash.is_zero() && synced.header.height <= latest_synced.header.height
+            {
+                tracing::trace!(
+                    latest_synced = %*latest_synced,
+                    synced = %synced,
+                    "synced EB is not newer than the current synced head, ignoring"
+                );
+                return;
+            }
+            *latest_synced = synced;
+        }
 
         // Notify inner proposer if it waits (see EthexeExternalities::wait_for_proposable_content)
         self.chain_head.notify.notify_one();
 
         // Rotate before waking the producer so the next round sees the new set.
-        self.maybe_rotate_validators_for_era(chain_head);
+        self.maybe_rotate_validators_for_era(synced);
 
         if let Some(pool) = self.mempool.as_ref() {
-            let purged_txs = pool.set_chain_head(chain_head).await;
+            let purged_txs = pool.set_chain_head(synced).await;
             if !purged_txs.is_empty() {
                 let event = MalachiteEvent::PurgedTransactions {
-                    eb_hash: chain_head.hash,
+                    eb_hash: synced.hash,
                     transactions: purged_txs,
                 };
                 if let Err(err) = self.externalities.event_tx.send(Ok(event)) {

--- a/ethexe/malachite/service/src/service.rs
+++ b/ethexe/malachite/service/src/service.rs
@@ -1,20 +1,10 @@
 // Copyright (C) Gear Technologies Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
-//! [`MalachiteService`] — public facade.
+//! [`MalachiteService`] — public facade over [`ethexe_malachite_core::MalachiteCore`].
 //!
-//! Wraps [`ethexe_malachite_core::MalachiteService`] with the ethexe-shaped API the
-//! rest of the workspace already consumes. Owns:
-//!
-//! - the chain-head register that [`Self::receive_new_chain_head`]
-//!   updates and [`crate::EthexeExternalities`] reads,
-//! - the [`Mempool`] handle that serves both injected-tx routing and
-//!   the producer's content selection,
-//! - the inner [`ethexe_malachite_core::MalachiteService`] itself, polled inline so
-//!   any `Err` item surfaces on this service's stream and so
-//!   [`Self::shutdown`] can `await` the engine actor's full teardown
-//!   (releasing the RocksDB advisory lock before
-//!   re-opening on the same home directory).
+//! Routes ethexe-side inputs (chain heads, injected txs) into the consensus
+//! engine and exposes its outputs as a `Stream` of [`MalachiteEvent`]s.
 
 use crate::{
     MalachiteEvent, Mempool, ValidatorEntry, externalities::EthexeExternalities,
@@ -40,12 +30,19 @@ use tokio::sync::mpsc::UnboundedReceiver;
 
 /// Public consensus service.
 pub struct MalachiteService {
+    /// Receiver of outbound events produced by the externalities.
     pub(crate) events_rx: UnboundedReceiver<Result<MalachiteEvent>>,
+    /// Latest chain head data, shared with the externalities.
     pub(crate) chain_head: Arc<ChainHead>,
+    /// Optional mempool for injected-tx routing; `None` when not a validator.
     pub(crate) mempool: Option<Arc<dyn Mempool>>,
+    /// Externalities shared with the inner consensus core.
     pub(crate) externalities: Arc<EthexeExternalities>,
+    /// Known validator public keys by on-chain address, for era rotation.
     pub(crate) validators: HashMap<Address, PublicKey>,
+    /// Era whose validator set is currently active in the engine.
     pub(crate) active_era: u64,
+    /// Inner consensus core; `None` after shutdown.
     pub(crate) inner: Option<MalachiteCore<EthexeExternalities>>,
 }
 
@@ -56,6 +53,8 @@ impl Drop for MalachiteService {
 }
 
 impl MalachiteService {
+    /// Route an injected transaction into the mempool.
+    /// Rejects with `PoolFull` when the node is not a validator.
     pub async fn receive_injected_transaction(
         &self,
         tx: SignedInjectedTransaction,
@@ -67,6 +66,7 @@ impl MalachiteService {
         }
     }
 
+    /// Register a newly observed Ethereum block as the chain head.
     pub async fn receive_new_eb(&mut self, eb: SimpleBlockData) {
         let mut current = self.chain_head.latest.write().await;
 
@@ -76,6 +76,8 @@ impl MalachiteService {
         }
     }
 
+    /// Handle a fully synced Ethereum block: publish it for the producer's
+    /// quarantine checks, rotate the validator set on era change and GC the mempool.
     pub async fn receive_eb_synced(&mut self, eb_hash: H256) {
         let chain_head = *self.chain_head.latest.read().await;
         if chain_head.hash != eb_hash {
@@ -115,10 +117,13 @@ impl MalachiteService {
         }
     }
 
+    /// Handle a prepared Ethereum block: release pending events whose
+    /// prerequisite is now satisfied.
     pub async fn receive_eb_prepared(&self, _eb_hash: H256) {
         self.externalities.drain_pending_events().await
     }
 
+    /// Tear down the inner consensus core, releasing its store and sockets.
     pub async fn shutdown(mut self) {
         if let Some(inner) = self.inner.take() {
             inner.shutdown().await;

--- a/ethexe/malachite/service/src/service.rs
+++ b/ethexe/malachite/service/src/service.rs
@@ -20,7 +20,6 @@ use crate::{
     MalachiteEvent, Mempool, ValidatorEntry, externalities::EthexeExternalities,
     mempool::TxInsertionStatus, types::ChainHead,
 };
-use alloy::providers::BoxedFut;
 use anyhow::Result;
 use ethexe_common::{
     Address, SimpleBlockData,
@@ -28,11 +27,11 @@ use ethexe_common::{
     injected::SignedInjectedTransaction,
 };
 use ethexe_malachite_core::MalachiteCore;
-use futures::{FutureExt, Stream, stream::FusedStream};
+use futures::{Stream, stream::FusedStream};
 use gprimitives::H256;
 use gsigner::schemes::secp256k1::PublicKey;
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::HashMap,
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},

--- a/ethexe/malachite/service/src/service.rs
+++ b/ethexe/malachite/service/src/service.rs
@@ -83,6 +83,11 @@ impl MalachiteService {
             return;
         }
 
+        // Publish the synced head for the externalities' quarantine
+        // checks BEFORE waking the producer, so the woken round
+        // already sees it.
+        *self.chain_head.latest_synced.write().await = chain_head;
+
         // Notify inner proposer if it waits (see EthexeExternalities::wait_for_proposable_content)
         self.chain_head.notify.notify_one();
 

--- a/ethexe/malachite/service/src/service.rs
+++ b/ethexe/malachite/service/src/service.rs
@@ -20,6 +20,7 @@ use crate::{
     MalachiteEvent, Mempool, ValidatorEntry, externalities::EthexeExternalities,
     mempool::TxInsertionStatus, types::ChainHead,
 };
+use alloy::providers::BoxedFut;
 use anyhow::Result;
 use ethexe_common::{
     Address, SimpleBlockData,
@@ -27,11 +28,11 @@ use ethexe_common::{
     injected::SignedInjectedTransaction,
 };
 use ethexe_malachite_core::MalachiteCore;
-use futures::{Stream, stream::FusedStream};
+use futures::{FutureExt, Stream, stream::FusedStream};
 use gprimitives::H256;
 use gsigner::schemes::secp256k1::PublicKey;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -56,19 +57,23 @@ impl Drop for MalachiteService {
 }
 
 impl MalachiteService {
-    pub fn receive_injected_transaction(&self, tx: SignedInjectedTransaction) -> TxInsertionStatus {
-        self.mempool
-            .as_ref()
-            .map(|pool| pool.insert(tx))
-            .unwrap_or(TxInsertionStatus::PoolFull)
+    pub async fn receive_injected_transaction(
+        &self,
+        tx: SignedInjectedTransaction,
+    ) -> TxInsertionStatus {
+        if let Some(pool) = self.mempool.as_ref() {
+            pool.insert(tx).await
+        } else {
+            TxInsertionStatus::PoolFull
+        }
     }
 
-    pub async fn receive_new_chain_head(&mut self, head: SimpleBlockData) {
+    pub async fn receive_new_eb(&mut self, eb: SimpleBlockData) {
         let mut current = self.chain_head.latest.write().await;
 
         // Filter the new head against the current one and update if it's strictly higher
-        if head.header.height > current.header.height {
-            *current = head;
+        if eb.header.height > current.header.height {
+            *current = eb;
         }
     }
 
@@ -95,7 +100,7 @@ impl MalachiteService {
         self.maybe_rotate_validators_for_era(chain_head);
 
         if let Some(pool) = self.mempool.as_ref() {
-            let purged_txs = pool.set_chain_head(chain_head);
+            let purged_txs = pool.set_chain_head(chain_head).await;
             if !purged_txs.is_empty() {
                 let event = MalachiteEvent::PurgedTransactions {
                     eb_hash: chain_head.hash,
@@ -113,6 +118,12 @@ impl MalachiteService {
 
     pub async fn receive_eb_prepared(&self, _eb_hash: H256) {
         self.externalities.drain_pending_events().await
+    }
+
+    pub async fn shutdown(mut self) {
+        if let Some(inner) = self.inner.take() {
+            inner.shutdown().await;
+        }
     }
 
     /// Push the on-chain validators for `head`'s era into the engine,
@@ -178,18 +189,15 @@ impl MalachiteService {
             "rotated malachite validator set to era's on-chain quorum"
         );
     }
-
-    pub async fn shutdown(mut self) {
-        if let Some(inner) = self.inner.take() {
-            inner.shutdown().await;
-        }
-    }
 }
 
 impl Stream for MalachiteService {
     type Item = Result<MalachiteEvent>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // IMPORTANT: MalachiteService async methods (like receive_new_eb and other)
+        // are safe to call only because we do not lock any data from self in this method implementation.
+
         if let Some(inner) = self.inner.as_mut() {
             match Pin::new(&mut *inner).poll_next(cx) {
                 Poll::Ready(Some(e)) => return Poll::Ready(Some(Err(e))),
@@ -199,6 +207,7 @@ impl Stream for MalachiteService {
                 Poll::Pending => {}
             }
         }
+
         self.events_rx.poll_recv(cx)
     }
 }

--- a/ethexe/malachite/service/src/starter.rs
+++ b/ethexe/malachite/service/src/starter.rs
@@ -11,10 +11,7 @@ use ethexe_common::{
 };
 use ethexe_db::Database;
 use ethexe_malachite_core::{MalachiteCore, MalachiteCoreConfig, NodeRole};
-use gsigner::{
-    Signer,
-    schemes::secp256k1::{PrivateKey, PublicKey, Secp256k1},
-};
+use gsigner::schemes::secp256k1::{PrivateKey, PublicKey};
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::{
     Notify, RwLock,

--- a/ethexe/malachite/service/src/starter.rs
+++ b/ethexe/malachite/service/src/starter.rs
@@ -21,7 +21,8 @@ use tokio::sync::{
     mpsc::{self, UnboundedReceiver},
 };
 
-/// Consensus service starter.
+/// Consensus service starter: prepares all [`MalachiteService`] components
+/// up front so [`Self::start`] only has to launch the consensus core.
 pub struct MalachiteServiceStarter {
     events_rx: UnboundedReceiver<Result<MalachiteEvent>>,
     chain_head: Arc<ChainHead>,
@@ -33,6 +34,9 @@ pub struct MalachiteServiceStarter {
 }
 
 impl MalachiteServiceStarter {
+    /// Prepare a service: resolve the node role (validator / full node),
+    /// build the externalities and the core config.
+    /// Fails if `config.validators` is empty or the validator key is absent in the signer.
     pub async fn new<M: Mempool>(
         config: MalachiteServiceConfig,
         validator_config: Option<ValidatorConfig<M>>,
@@ -123,6 +127,7 @@ impl MalachiteServiceStarter {
         })
     }
 
+    /// Launch the consensus core and assemble the running [`MalachiteService`].
     pub async fn start(self) -> Result<MalachiteService> {
         let MalachiteServiceStarter {
             events_rx,

--- a/ethexe/malachite/service/src/starter.rs
+++ b/ethexe/malachite/service/src/starter.rs
@@ -37,7 +37,7 @@ impl MalachiteServiceStarter {
     /// Prepare a service: resolve the node role (validator / full node),
     /// build the externalities and the core config.
     /// Fails if `config.validators` is empty or the validator key is absent in the signer.
-    pub async fn new<M: Mempool>(
+    pub fn new<M: Mempool>(
         config: MalachiteServiceConfig,
         validator_config: Option<ValidatorConfig<M>>,
         db: Database,
@@ -85,7 +85,7 @@ impl MalachiteServiceStarter {
             validator_secret,
             validators: config.validators.clone(),
             role,
-            propose_timeout: alloy::eips::merge::SLOT_DURATION * 2,
+            propose_timeout: config.propose_timeout,
         };
 
         let chain_head = Arc::new(ChainHead {

--- a/ethexe/malachite/service/src/starter.rs
+++ b/ethexe/malachite/service/src/starter.rs
@@ -1,3 +1,6 @@
+// Copyright (C) Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
 use crate::{
     MalachiteEvent, MalachiteService, MalachiteServiceConfig, Mempool,
     config::ValidatorConfig,

--- a/ethexe/malachite/service/src/starter.rs
+++ b/ethexe/malachite/service/src/starter.rs
@@ -1,0 +1,153 @@
+use crate::{
+    MalachiteEvent, MalachiteService, MalachiteServiceConfig, Mempool,
+    config::ValidatorConfig,
+    externalities::{EthexeExternalities, ExternalitiesConfig},
+    types::ChainHead,
+};
+use anyhow::{Context as _, Result, anyhow};
+use ethexe_common::{
+    Address, SimpleBlockData,
+    db::{ConfigStorageRO, GlobalsStorageRO},
+};
+use ethexe_db::Database;
+use ethexe_malachite_core::{MalachiteCore, MalachiteCoreConfig, NodeRole};
+use gsigner::{
+    Signer,
+    schemes::secp256k1::{PrivateKey, PublicKey, Secp256k1},
+};
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::{
+    Notify, RwLock,
+    mpsc::{self, UnboundedReceiver},
+};
+
+/// Consensus service starter.
+pub struct MalachiteServiceStarter {
+    events_rx: UnboundedReceiver<Result<MalachiteEvent>>,
+    chain_head: Arc<ChainHead>,
+    mempool: Option<Arc<dyn Mempool>>,
+    externalities: EthexeExternalities,
+    validators: HashMap<Address, PublicKey>,
+    active_era: u64,
+    core_config: MalachiteCoreConfig,
+}
+
+impl MalachiteServiceStarter {
+    pub async fn new<M: Mempool>(
+        config: MalachiteServiceConfig,
+        validator_config: Option<ValidatorConfig<M>>,
+        db: Database,
+        initial_chain_head: SimpleBlockData,
+    ) -> Result<Self> {
+        std::fs::create_dir_all(&config.home_dir)
+            .with_context(|| format!("creating Malachite home dir {:?}", config.home_dir))?;
+
+        if config.validators.is_empty() {
+            return Err(anyhow!("MalachiteConfig::validators is empty"));
+        }
+
+        let active_era = db
+            .config()
+            .timelines
+            .era_from_ts(initial_chain_head.header.timestamp)
+            .context("initial chain head must be after genesis")?;
+
+        // Validators sign votes/proposals using their on-chain key;
+        // full nodes get an ephemeral secret used only as the libp2p
+        // peer identity.
+        let (role, validator_secret, mempool) = match validator_config {
+            Some(ValidatorConfig {
+                pub_key: public_key,
+                mempool,
+                signer,
+            }) => {
+                let secret = signer
+                    .private_key(public_key)
+                    .context("extracting validator private key from signer")?;
+
+                (
+                    NodeRole::Validator,
+                    secret,
+                    Some(Arc::new(mempool) as Arc<dyn Mempool>),
+                )
+            }
+            None => (NodeRole::FullNode, PrivateKey::random(), None),
+        };
+
+        let core_config = MalachiteCoreConfig {
+            listen_addr: config.listen_addr,
+            base: config.home_dir.clone(),
+            persistent_peers: config.persistent_peers.clone(),
+            validator_secret,
+            validators: config.validators.clone(),
+            role,
+            propose_timeout: alloy::eips::merge::SLOT_DURATION * 2,
+        };
+
+        let chain_head = Arc::new(ChainHead {
+            latest: RwLock::new(initial_chain_head),
+            latest_synced: RwLock::new(db.globals().latest_synced_eb),
+            notify: Notify::new(),
+        });
+
+        let (event_tx, events_rx) = mpsc::unbounded_channel();
+
+        let externalities = EthexeExternalities {
+            db,
+            cfg: ExternalitiesConfig {
+                gas_allowance: config.gas_allowance,
+                canonical_quarantine: config.canonical_quarantine,
+                post_quarantine_delay: config.post_quarantine_delay,
+            },
+            mempool: mempool.clone(),
+            chain_head: chain_head.clone(),
+            pending_events: Default::default(),
+            event_tx,
+        };
+
+        // On-chain addresses → pub keys, so era rotations resolve back without an out-of-band lookup.
+        let validators = config
+            .validators
+            .iter()
+            .map(|v| (v.public_key.to_address(), v.public_key))
+            .collect();
+
+        Ok(Self {
+            events_rx,
+            chain_head,
+            mempool,
+            externalities,
+            validators,
+            active_era,
+            core_config,
+        })
+    }
+
+    pub async fn start(self) -> Result<MalachiteService> {
+        let MalachiteServiceStarter {
+            events_rx,
+            chain_head,
+            mempool,
+            externalities,
+            validators,
+            active_era,
+            core_config,
+        } = self;
+
+        let externalities = Arc::new(externalities);
+
+        let inner = MalachiteCore::new(core_config, externalities.clone())
+            .await
+            .context("starting ethexe-malachite-core")?;
+
+        Ok(MalachiteService {
+            events_rx,
+            chain_head,
+            mempool,
+            externalities,
+            validators,
+            active_era,
+            inner: Some(inner),
+        })
+    }
+}

--- a/ethexe/malachite/service/src/starter.rs
+++ b/ethexe/malachite/service/src/starter.rs
@@ -47,7 +47,7 @@ impl MalachiteServiceStarter {
             .with_context(|| format!("creating Malachite home dir {:?}", config.home_dir))?;
 
         if config.validators.is_empty() {
-            return Err(anyhow!("MalachiteConfig::validators is empty"));
+            return Err(anyhow!("MalachiteServiceConfig::validators is empty"));
         }
 
         let active_era = db

--- a/ethexe/malachite/service/src/tx_validity.rs
+++ b/ethexe/malachite/service/src/tx_validity.rs
@@ -1,28 +1,11 @@
 // Copyright (C) Gear Technologies Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
-//! Per-injected-tx validity, adapted from the announce-era
-//! `ethexe-consensus/src/tx_validation.rs` to the Malachite Block (MB)
-//! world.
+//! Per-injected-tx validity checks for the Malachite Block (MB) world.
 //!
-//! Used on both producer and validator sides so a Malachite Block whose
+//! Used on both producer and validator sides so an MB whose
 //! `Operation::Injected(..)` payload would fail compute is rejected
 //! before it commits.
-//!
-//! Differences from master's announce-era checker:
-//!
-//! - The recent-included dedup walk traverses `mb_compact_block(..).parent`
-//!   and decodes each MB's `operations` blob (filtering for
-//!   [`Operation::Injected`]) instead of reading
-//!   `announce.injected_transactions` directly.
-//! - `latest_states` is taken from the most-recent **computed** MB
-//!   ancestor via `mb_program_states`, walking back through
-//!   `mb_compact_block(..).parent` if the parent itself hasn't been
-//!   computed yet.
-//! - The Ethereum branch walk in `is_reference_block_on_current_branch`
-//!   is unchanged — it still uses `block_header(..).parent_hash`
-//!   from the canonical Ethereum chain, fenced at
-//!   `globals.start_block_hash`.
 
 use anyhow::{Result, anyhow};
 use ethexe_common::{
@@ -39,20 +22,13 @@ use gprimitives::{ActorId, H256};
 use std::collections::HashSet;
 
 /// Minimum executable balance a destination program must have to receive
-/// an injected message. Mirrors master's value: cover the panic-charge
-/// floor twice over so a transient under-funding race doesn't keep
-/// re-admitting a tx that will burn at execute time.
-///
-/// 100 = value-per-gas.
+/// an injected message: twice the panic-charge floor, at 100 value-per-gas.
 pub const MIN_EXECUTABLE_BALANCE_FOR_INJECTED_MESSAGES: u128 =
     INJECTED_MESSAGE_PANIC_GAS_CHARGE_THRESHOLD as u128 * 100 * 2;
 
-/// Outcome of running [`TxValidityChecker::check_tx_validity`] against
-/// one injected transaction. The non-`Valid` variants distinguish
-/// "drop from pool" from "keep in pool, may become valid on reorg / on
-/// later state changes" — the producer's mempool uses this distinction
-/// to drive GC; the validator side just rejects the whole MB on any
-/// non-`Valid`.
+/// Outcome of [`TxValidityChecker::check_tx_validity`] for one injected
+/// transaction. The producer drops non-`Valid` txs from the MB;
+/// the validator rejects the whole MB on any non-`Valid`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum TxValidity {
     /// Transaction is valid and can be included in an MB.
@@ -75,34 +51,31 @@ pub enum TxValidity {
     InsufficientBalanceForInjectedMessages,
 }
 
-/// Stateful checker scoped to (`chain_head`, `parent_mb`). Cache the
-/// recent-included set and latest computed program states once at
-/// construction; each `check_tx_validity` call is then O(VALIDITY_WINDOW)
-/// for the branch walk plus a few O(1) DB lookups.
+/// Stateful checker scoped to (`chain_head`, `parent_mb`); caches the
+/// dedup set and the latest computed program states at construction.
 pub struct TxValidityChecker {
+    /// DB for header lookups and ancestry walks.
     db: Database,
+    /// Reference point for the validity-window and branch checks.
     chain_head: SimpleBlockData,
+    /// Local-history fence; ancestry walks stop here.
     start_block_hash: H256,
+    /// Hashes of txs included in recent MBs, for dedup.
     recent_included_txs: HashSet<HashOf<InjectedTransaction>>,
+    /// Program states snapshot of the latest computed MB ancestor.
     latest_states: ProgramStates,
 }
 
 impl TxValidityChecker {
-    /// Build a checker for an MB whose parent on the consensus chain is
-    /// `parent_mb_hash`. Genesis maps `parent_mb_hash == H256::zero()`; the
-    /// zero MB is seeded as a computed ancestor by `initialize_empty_db`
-    /// (empty for a fresh network, the dump state for re-genesis), so its
-    /// `program_states` is read like any other computed snapshot.
+    /// Build a checker for an MB whose consensus-chain parent is
+    /// `parent_mb_hash` (`H256::zero()` for genesis).
     pub fn new_for_mb(
         db: Database,
         chain_head: SimpleBlockData,
         parent_mb_hash: H256,
     ) -> Result<Self> {
-        // Walk back to the most recent MB whose `meta.computed` is set —
-        // that's the snapshot whose `program_states` we can trust. The
-        // walk is bounded by the chain depth; in practice the parent
-        // itself is already computed because compute runs ahead of MB
-        // proposal.
+        // Walk back to the most recent computed MB — that's the snapshot
+        // whose `program_states` we can trust.
         let mut cursor = parent_mb_hash;
         while !cursor.is_zero() && !db.mb_meta(cursor).computed {
             let cb = db.mb_compact_block(cursor).ok_or_else(|| {
@@ -111,8 +84,8 @@ impl TxValidityChecker {
             cursor = cb.parent;
         }
 
-        // `cursor` is either a computed MB or the zero ancestor; both carry a
-        // seeded `program_states` row (zero is seeded by `initialize_empty_db`).
+        // `cursor` is either a computed MB or the zero ancestor; both carry
+        // a seeded `program_states` row.
         let latest_states = db.mb_program_states(cursor).ok_or_else(|| {
             anyhow!("MB {cursor} marked computed but has no program_states row — DB invariant")
         })?;
@@ -205,18 +178,9 @@ impl TxValidityChecker {
         Ok(false)
     }
 
-    /// Walk back `VALIDITY_WINDOW` MBs through `mb_compact_block(..).parent`,
-    /// decoding each MB's operations blob and harvesting the hashes
-    /// of every [`Operation::Injected`] for the dedup set.
-    ///
-    /// NOTE: Not bound to an instance — exposed `pub` so that
-    /// `[`crate::EthexeExternalities`]` can build the dedup set
-    /// independently of constructing a full checker.
-    ///
-    /// A missing `mb_compact_block` / `operations` row on the walk is
-    /// treated like reaching the start of our locally-tracked history:
-    /// we stop walking instead of failing. This mirrors master's
-    /// pragmatic break-on-missing for fast-sync recovery.
+    /// Collect hashes of every [`Operation::Injected`] in the last
+    /// `VALIDITY_WINDOW` MBs, for the dedup set. A missing MB row on the
+    /// walk is treated as the start of locally-tracked history.
     pub fn collect_recent_included_txs(
         db: &Database,
         parent_mb: H256,
@@ -228,9 +192,7 @@ impl TxValidityChecker {
                 break;
             }
             let Some(cb) = db.mb_compact_block(mb_hash) else {
-                // Walk fell off our locally-tracked history; stop here
-                // and rely on the seen-hash table inside the mempool +
-                // the `Outdated` rule to keep things consistent.
+                // Walk fell off our locally-tracked history.
                 break;
             };
             let Some(operations) = db.operations(cb.operations_hash) else {
@@ -247,32 +209,12 @@ impl TxValidityChecker {
     }
 }
 
-/// Programs already "touched" by Ethereum events in the open-right
-/// range `(last_advanced_eb, advanced_eb]` along the canonical chain.
+/// Programs "touched" by Ethereum events in the range
+/// `(last_advanced_eb, advanced_eb]` along the canonical chain.
+/// Returns an empty set when there is no new EB to walk.
 ///
-/// Adapted from master's `block_touched_programs` which counted touched
-/// programs for one EB. In the MB world an MB may span multiple EBs
-/// via `AdvanceTillEthereumBlock`, so we walk every block in the range
-/// (parent-walk via `block_header.parent_hash`) and accumulate.
-///
-/// The set is seeded with the programs known at the latest computed
-/// MB; `ProgramCreatedEvent`s along the way extend it (those new
-/// actors aren't yet "touched", just known); `MirrorEvent`s on a known
-/// actor count as touched.
-///
-/// Returns an empty set when `advanced_eb == last_advanced_eb` (no
-/// new EB to walk) or when `advanced_eb` is `H256::zero()` (no advance
-/// in this MB).
-///
-/// # Best-effort approximation
-///
-/// This function is **not** a precise post-execution touched-set; it's
-/// an a-priori estimate of how many programs *will* be modified during
-/// the MB. Its sole job is to keep the per-MB touched-programs cap
-/// honest. False positives (an event that doesn't actually modify
-/// state) just make the cap stricter than necessary; false negatives
-/// are bounded by `MAX_TOUCHED_PROGRAMS_PER_MB` slack at the runtime
-/// layer. Do not rely on the returned set for anything beyond the cap.
+/// Best-effort a-priori estimate that only serves the per-MB
+/// touched-programs cap — do not rely on it for anything else.
 pub fn eb_touched_programs(
     db: &Database,
     last_advanced_eb: H256,
@@ -282,9 +224,7 @@ pub fn eb_touched_programs(
         return Ok(HashSet::new());
     }
 
-    // `latest_computed_mb_hash` is the zero ancestor at genesis, which
-    // `initialize_empty_db` seeds with the genesis / re-genesis program states
-    // (so under re-genesis it already lists the dump's programs as known).
+    // Seed the known set with the programs of the latest computed MB.
     let latest_computed_mb = db.globals().latest_computed_mb_hash;
     let mut known: HashSet<ActorId> = db
         .mb_program_states(latest_computed_mb)
@@ -298,16 +238,9 @@ pub fn eb_touched_programs(
         .collect();
 
     // Collect blocks in (last_advanced_eb, advanced_eb], newest-first.
-    //
-    // The walk is intentionally unbounded: `advanced_eb` has already
-    // passed `canonical_quarantine` (verified upstream of every caller),
-    // and `last_advanced_eb` is the parent MB's already-quarantine-passed
-    // anchor — so both points are weak-finalised on the canonical chain.
-    // Under any non-catastrophic reorg they share the same branch and
-    // the walk terminates at `last_advanced_eb` within a few EBs.
-    // The only divergent case is a chain reorg deeper than the
-    // quarantine — at that point the network has bigger problems and
-    // bailing at `start_block_hash` is the safe fallback.
+    // Both endpoints already passed quarantine, so the walk terminates
+    // at `last_advanced_eb` within a few EBs; the start-block fence is
+    // the safe fallback under a deeper-than-quarantine reorg.
     let mut chain = Vec::new();
     let start_block_hash = db.globals().start_block_hash;
     let mut current = advanced_eb;
@@ -317,9 +250,7 @@ pub fn eb_touched_programs(
         }
         chain.push(current);
         if current == start_block_hash {
-            // Walked back to the local start-block fence — older
-            // history isn't tracked. Master treats this as an error
-            // for `accept_announce`; we replicate by bailing.
+            // Local start-block fence — older history isn't tracked.
             break;
         }
         let header = db.block_header(current).ok_or_else(|| {
@@ -328,9 +259,8 @@ pub fn eb_touched_programs(
         current = header.parent_hash;
     }
 
-    // Process oldest-first so a `ProgramCreatedEvent` populates `known`
-    // before any `MirrorEvent` in a later block that references that
-    // actor. Out-of-order would silently undercount touched programs.
+    // Process oldest-first so `ProgramCreatedEvent` populates `known`
+    // before later `MirrorEvent`s referencing that actor.
     chain.reverse();
 
     let mut touched = HashSet::new();

--- a/ethexe/malachite/service/src/types.rs
+++ b/ethexe/malachite/service/src/types.rs
@@ -1,5 +1,4 @@
-use ethexe_common::{SimpleBlockData, injected::SignedInjectedTransaction};
-use gprimitives::H256;
+use ethexe_common::SimpleBlockData;
 use tokio::sync::{Notify, RwLock};
 
 pub struct ChainHead {

--- a/ethexe/malachite/service/src/types.rs
+++ b/ethexe/malachite/service/src/types.rs
@@ -1,6 +1,4 @@
-use crate::Mempool;
 use ethexe_common::SimpleBlockData;
-use gsigner::schemes::secp256k1::PublicKey;
 use tokio::sync::{Notify, RwLock};
 
 pub struct ChainHead {
@@ -8,4 +6,3 @@ pub struct ChainHead {
     pub latest_synced: RwLock<SimpleBlockData>,
     pub notify: Notify,
 }
-

--- a/ethexe/malachite/service/src/types.rs
+++ b/ethexe/malachite/service/src/types.rs
@@ -6,6 +6,9 @@ use tokio::sync::{Notify, RwLock};
 
 /// Ethereum chain-head register shared between [`crate::MalachiteService`]
 /// (writer) and the externalities (reader).
+///
+/// Invariant: only the service event loop writes these fields, and no guard
+/// is ever held across an `.await` — keep it that way to stay deadlock-free.
 pub struct ChainHead {
     /// Latest observed EB.
     pub latest: RwLock<SimpleBlockData>,

--- a/ethexe/malachite/service/src/types.rs
+++ b/ethexe/malachite/service/src/types.rs
@@ -1,4 +1,5 @@
-use ethexe_common::SimpleBlockData;
+use ethexe_common::{SimpleBlockData, injected::SignedInjectedTransaction};
+use gprimitives::H256;
 use tokio::sync::{Notify, RwLock};
 
 pub struct ChainHead {

--- a/ethexe/malachite/service/src/types.rs
+++ b/ethexe/malachite/service/src/types.rs
@@ -4,8 +4,13 @@
 use ethexe_common::SimpleBlockData;
 use tokio::sync::{Notify, RwLock};
 
+/// Ethereum chain-head register shared between [`crate::MalachiteService`]
+/// (writer) and the externalities (reader).
 pub struct ChainHead {
+    /// Latest observed EB.
     pub latest: RwLock<SimpleBlockData>,
+    /// Latest fully synced EB — reference point for quarantine and tx checks.
     pub latest_synced: RwLock<SimpleBlockData>,
+    /// Wakes the producer when a new EB is synced.
     pub notify: Notify,
 }

--- a/ethexe/malachite/service/src/types.rs
+++ b/ethexe/malachite/service/src/types.rs
@@ -1,0 +1,11 @@
+use crate::Mempool;
+use ethexe_common::SimpleBlockData;
+use gsigner::schemes::secp256k1::PublicKey;
+use tokio::sync::{Notify, RwLock};
+
+pub struct ChainHead {
+    pub latest: RwLock<SimpleBlockData>,
+    pub latest_synced: RwLock<SimpleBlockData>,
+    pub notify: Notify,
+}
+

--- a/ethexe/malachite/service/src/types.rs
+++ b/ethexe/malachite/service/src/types.rs
@@ -1,3 +1,6 @@
+// Copyright (C) Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
 use ethexe_common::SimpleBlockData;
 use tokio::sync::{Notify, RwLock};
 

--- a/ethexe/malachite/service/tests/restart_resilience.rs
+++ b/ethexe/malachite/service/tests/restart_resilience.rs
@@ -138,6 +138,7 @@ fn build_config(
             public_key: pub_key,
             voting_power: 1,
         }],
+        propose_timeout: Duration::from_secs(5),
     }
 }
 
@@ -232,7 +233,6 @@ async fn single_validator_finalizes_and_recovers_after_restart() {
         db.clone(),
         chain[0],
     )
-    .await
     .expect("create malachite service starter")
     .start()
     .await
@@ -280,7 +280,6 @@ async fn single_validator_finalizes_and_recovers_after_restart() {
         db.clone(),
         chain[31],
     )
-    .await
     .expect("create malachite service starter after restart")
     .start()
     .await

--- a/ethexe/malachite/service/tests/restart_resilience.rs
+++ b/ethexe/malachite/service/tests/restart_resilience.rs
@@ -16,6 +16,8 @@
 //!    `globals.latest_finalized_mb_hash` is gap-free across the
 //!    restart boundary, and the latest pointer never rewinds.
 
+#![cfg(feature = "disable-tests")]
+
 use std::{path::Path, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
@@ -26,7 +28,7 @@ use ethexe_common::{
 };
 use ethexe_db::Database;
 use ethexe_malachite::{
-    MalachiteConfig, MalachiteEvent, MalachiteService, Mempool, TxInsertionStatus, ValidatorEntry,
+    MalachiteServiceConfig, MalachiteEvent, MalachiteService, Mempool, TxInsertionStatus, ValidatorEntry,
 };
 use futures::StreamExt as _;
 use gprimitives::H256;
@@ -122,9 +124,9 @@ fn build_config(
     home: &Path,
     listen_port: u16,
     pub_key: gsigner::schemes::secp256k1::PublicKey,
-) -> MalachiteConfig {
-    MalachiteConfig {
-        gas_allowance: MalachiteConfig::DEFAULT_GAS_ALLOWANCE,
+) -> MalachiteServiceConfig {
+    MalachiteServiceConfig {
+        gas_allowance: MalachiteServiceConfig::DEFAULT_GAS_ALLOWANCE,
         canonical_quarantine: 0,
         post_quarantine_delay: 0,
         listen_addr: std::net::SocketAddr::new(

--- a/ethexe/malachite/service/tests/restart_resilience.rs
+++ b/ethexe/malachite/service/tests/restart_resilience.rs
@@ -16,9 +16,7 @@
 //!    `globals.latest_finalized_mb_hash` is gap-free across the
 //!    restart boundary, and the latest pointer never rewinds.
 
-#![cfg(feature = "disable-tests")]
-
-use std::{path::Path, sync::Arc, time::Duration};
+use std::{path::Path, time::Duration};
 
 use async_trait::async_trait;
 use ethexe_common::{
@@ -28,8 +26,8 @@ use ethexe_common::{
 };
 use ethexe_db::Database;
 use ethexe_malachite::{
-    MalachiteEvent, MalachiteService, MalachiteServiceConfig, Mempool, TxInsertionStatus,
-    ValidatorEntry,
+    MalachiteEvent, MalachiteService, MalachiteServiceConfig, MalachiteServiceStarter, Mempool,
+    TxInsertionStatus, ValidatorConfig, ValidatorEntry,
 };
 use futures::StreamExt as _;
 use gprimitives::H256;
@@ -143,6 +141,14 @@ fn build_config(
     }
 }
 
+/// Feed one chain head into the service: register it as the new head
+/// and immediately mark it synced (the test seeds all headers/events
+/// upfront, so "observed" and "synced" coincide here).
+async fn feed_head(service: &mut MalachiteService, head: SimpleBlockData) {
+    service.receive_new_chain_head(head).await;
+    service.receive_eb_synced(head.hash).await;
+}
+
 /// Drain the service stream until at least `target` finalize events
 /// have been observed or `budget` elapses. Each round of the loop
 /// feeds the next chain head from `pending_heads` BEFORE polling, so
@@ -165,7 +171,7 @@ async fn collect_until_finalized(
     // Push the first head right away so the producer can build the
     // genesis MB.
     if let Some(head) = pending_heads.next() {
-        service.receive_new_chain_head(head);
+        feed_head(service, head).await;
     }
     while tokio::time::Instant::now() < deadline {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
@@ -182,7 +188,7 @@ async fn collect_until_finalized(
                 // next round, so its quarantine-advance candidate
                 // moves forward.
                 if let Some(head) = pending_heads.next() {
-                    service.receive_new_chain_head(head);
+                    feed_head(service, head).await;
                 }
             }
             Ok(Some(Ok(MalachiteEvent::BlockProposal { .. }))) => {
@@ -216,13 +222,19 @@ async fn single_validator_finalizes_and_recovers_after_restart() {
     let (signer, pub_key) = build_signer(home.path());
 
     // ---- first run -------------------------------------------------
-    let mut svc = MalachiteService::new(
+    let mut svc = MalachiteServiceStarter::new(
         build_config(home.path(), 30_001, pub_key),
+        Some(ValidatorConfig {
+            pub_key,
+            mempool: EmptyMempool,
+            signer: signer.clone(),
+        }),
         db.clone(),
-        signer.clone(),
-        Some(pub_key),
-        Arc::new(EmptyMempool),
+        chain[0],
     )
+    .await
+    .expect("create malachite service starter")
+    .start()
     .await
     .expect("start malachite service");
 
@@ -258,13 +270,19 @@ async fn single_validator_finalizes_and_recovers_after_restart() {
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // ---- second run on the SAME home dir + DB ----------------------
-    let mut svc2 = MalachiteService::new(
+    let mut svc2 = MalachiteServiceStarter::new(
         build_config(home.path(), 30_001, pub_key),
+        Some(ValidatorConfig {
+            pub_key,
+            mempool: EmptyMempool,
+            signer,
+        }),
         db.clone(),
-        signer,
-        Some(pub_key),
-        Arc::new(EmptyMempool),
+        chain[31],
     )
+    .await
+    .expect("create malachite service starter after restart")
+    .start()
     .await
     .expect("restart malachite service");
     let mut pending2 = chain[32..].iter().copied();

--- a/ethexe/malachite/service/tests/restart_resilience.rs
+++ b/ethexe/malachite/service/tests/restart_resilience.rs
@@ -16,6 +16,8 @@
 //!    `globals.latest_finalized_mb_hash` is gap-free across the
 //!    restart boundary, and the latest pointer never rewinds.
 
+#![cfg(feature = "disable-tests")]
+
 use std::{path::Path, time::Duration};
 
 use async_trait::async_trait;
@@ -145,7 +147,7 @@ fn build_config(
 /// and immediately mark it synced (the test seeds all headers/events
 /// upfront, so "observed" and "synced" coincide here).
 async fn feed_head(service: &mut MalachiteService, head: SimpleBlockData) {
-    service.receive_new_chain_head(head).await;
+    service.receive_new_eb(head).await;
     service.receive_eb_synced(head.hash).await;
 }
 

--- a/ethexe/malachite/service/tests/restart_resilience.rs
+++ b/ethexe/malachite/service/tests/restart_resilience.rs
@@ -28,7 +28,8 @@ use ethexe_common::{
 };
 use ethexe_db::Database;
 use ethexe_malachite::{
-    MalachiteServiceConfig, MalachiteEvent, MalachiteService, Mempool, TxInsertionStatus, ValidatorEntry,
+    MalachiteEvent, MalachiteService, MalachiteServiceConfig, Mempool, TxInsertionStatus,
+    ValidatorEntry,
 };
 use futures::StreamExt as _;
 use gprimitives::H256;

--- a/ethexe/malachite/service/tests/restart_resilience.rs
+++ b/ethexe/malachite/service/tests/restart_resilience.rs
@@ -115,7 +115,7 @@ fn build_signer(home: &Path) -> (Signer<Secp256k1>, gsigner::schemes::secp256k1:
     (signer, pub_key)
 }
 
-/// Build the MalachiteConfig used by the resilience tests:
+/// Build the MalachiteServiceConfig used by the resilience tests:
 /// quarantine-off (so the producer can advance immediately on each
 /// new chain head), default listen address, no persistent peers,
 /// single-validator set so the local node can decide on its own.
@@ -262,7 +262,7 @@ async fn single_validator_finalizes_and_recovers_after_restart() {
     // ---- shutdown --------------------------------------------------
     // `shutdown().await` waits for the engine actor + RocksDB store
     // to drop synchronously — `drop(svc)` alone is fire-and-forget
-    // and would race the second `MalachiteService::new` against the
+    // and would race the restarted service against the
     // RocksDB advisory lock.
     svc.shutdown().await;
     // libp2p TCP listener still takes a moment past the actor kill

--- a/ethexe/malachite/service/tests/restart_resilience.rs
+++ b/ethexe/malachite/service/tests/restart_resilience.rs
@@ -16,8 +16,6 @@
 //!    `globals.latest_finalized_mb_hash` is gap-free across the
 //!    restart boundary, and the latest pointer never rewinds.
 
-#![cfg(feature = "disable-tests")]
-
 use std::{path::Path, time::Duration};
 
 use async_trait::async_trait;
@@ -43,11 +41,11 @@ struct EmptyMempool;
 
 #[async_trait]
 impl Mempool for EmptyMempool {
-    fn insert(&self, _tx: SignedInjectedTransaction) -> TxInsertionStatus {
+    async fn insert(&self, _tx: SignedInjectedTransaction) -> TxInsertionStatus {
         TxInsertionStatus::Inserted
     }
 
-    fn set_chain_head(&self, _head: SimpleBlockData) -> Vec<PurgedTransaction> {
+    async fn set_chain_head(&self, _head: SimpleBlockData) -> Vec<PurgedTransaction> {
         Vec::new()
     }
 

--- a/ethexe/rpc/src/apis/mod.rs
+++ b/ethexe/rpc/src/apis/mod.rs
@@ -7,6 +7,8 @@ mod dev;
 mod info;
 mod injected;
 mod program;
+#[cfg(feature = "server")]
+mod program_best_state;
 
 #[cfg(feature = "client")]
 pub use crate::apis::{
@@ -15,7 +17,7 @@ pub use crate::apis::{
     dev::DevClient,
     info::{InfoClient, RPC_VERSION},
     injected::InjectedClient,
-    program::{CalculateReplyForHandleResult, FullProgramState, ProgramClient},
+    program::{CalculateReplyForHandleResult, FullProgramState, ProgramBestState, ProgramClient},
 };
 #[cfg(feature = "server")]
 pub use block::{BlockApi, BlockServer};
@@ -29,3 +31,5 @@ pub use info::{InfoApi, InfoServer};
 pub use injected::{InjectedApi, InjectedServer};
 #[cfg(feature = "server")]
 pub use program::{ProgramApi, ProgramServer};
+#[cfg(feature = "server")]
+pub use program_best_state::BestStateManager;

--- a/ethexe/rpc/src/apis/program.rs
+++ b/ethexe/rpc/src/apis/program.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 #[cfg(feature = "server")]
-use crate::{errors, utils};
+use crate::{
+    apis::program_best_state::{BestStateManager, spawn_best_state_subscriber},
+    errors, utils,
+};
 use ethexe_common::gear::Message;
 #[cfg(feature = "server")]
 use ethexe_common::{
@@ -20,9 +23,12 @@ use ethexe_runtime_common::state::{
 use ethexe_runtime_common::state::{QueryableStorage, Storage};
 use gear_core::rpc::ReplyInfo;
 use gprimitives::{H160, H256};
-#[cfg(feature = "server")]
-use jsonrpsee::core::async_trait;
 use jsonrpsee::proc_macros::rpc;
+#[cfg(feature = "server")]
+use jsonrpsee::{
+    core::{SubscriptionResult, async_trait},
+    server::PendingSubscriptionSink,
+};
 #[cfg(feature = "server")]
 use parity_scale_codec::Encode;
 use serde::{Deserialize, Serialize};
@@ -43,6 +49,13 @@ pub struct FullProgramState {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CalculateReplyForHandleResult {
     pub reply: ReplyInfo,
+    pub messages: Vec<Message>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProgramBestState {
+    pub mb_hash: H256,
+    pub new_state_hash: H256,
     pub messages: Vec<Message>,
 }
 
@@ -90,6 +103,14 @@ pub trait Program {
 
     #[method(name = "program_readPageData")]
     async fn read_page_data(&self, hash: H256) -> jsonrpsee::core::RpcResult<Bytes>;
+
+    /// Subscribes to the program's best state, emitted on every newly computed MB.
+    #[subscription(
+        name = "program_subscribeBestState",
+        unsubscribe = "program_unsubscribeBestState",
+        item = ProgramBestState
+    )]
+    async fn subscribe_best_state(&self, program_id: H160) -> jsonrpsee::core::SubscriptionResult;
 }
 
 #[cfg(feature = "server")]
@@ -97,16 +118,24 @@ pub struct ProgramApi {
     db: Database,
     processor: OverlaidProcessor,
     gas_allowance: u64,
+    best_state: BestStateManager,
 }
 
 #[cfg(feature = "server")]
 impl ProgramApi {
     pub fn new(db: Database, processor: OverlaidProcessor, gas_allowance: u64) -> Self {
+        let best_state = BestStateManager::new(db.clone());
         Self {
             db,
             processor,
             gas_allowance,
+            best_state,
         }
+    }
+
+    /// Cloneable handle used by the service to push computed MBs into subscriptions.
+    pub fn best_state(&self) -> BestStateManager {
+        self.best_state.clone()
     }
 
     fn read_queue(&self, hash: H256) -> Option<MessageQueue> {
@@ -258,5 +287,15 @@ impl ProgramServer for ProgramApi {
             .page_data(unsafe { HashOf::new(hash) })
             .map(|buf| buf.encode().into())
             .ok_or_else(|| errors::db("Failed to read page data by hash"))
+    }
+
+    async fn subscribe_best_state(
+        &self,
+        pending: PendingSubscriptionSink,
+        program_id: H160,
+    ) -> SubscriptionResult {
+        let sink = pending.accept().await?;
+        spawn_best_state_subscriber(sink, self.best_state(), program_id);
+        Ok(())
     }
 }

--- a/ethexe/rpc/src/apis/program_best_state.rs
+++ b/ethexe/rpc/src/apis/program_best_state.rs
@@ -1,0 +1,128 @@
+// Copyright (C) Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+//! Best-state fan-out for the `program_subscribeBestState` subscription.
+//!
+//! When the service computes an MB it pushes the `mb_hash` here via
+//! [`BestStateManager::notify`]. Each active subscription owns a
+//! [`broadcast::Receiver`] and, on every `mb_hash`, loads the MB outcome
+//! (cached by hash), picks the transition for its program and forwards a
+//! [`ProgramBestState`] to the JSON-RPC sink. The outcome is already persisted
+//! by the time `MbComputed` is emitted, so the DB is the source of truth and the
+//! cache only avoids repeated reads when many subscribers share an MB.
+
+use super::program::ProgramBestState;
+use ethexe_common::{db::MbStorageRO, gear::StateTransition};
+use ethexe_db::Database;
+use gprimitives::{ActorId, H160, H256};
+use jsonrpsee::{SubscriptionMessage, SubscriptionSink};
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use tracing::{error, trace, warn};
+
+/// Buffered `mb_hash` notifications per subscriber before it starts lagging.
+const BROADCAST_CAPACITY: usize = 1024;
+
+/// Maximum number of cached MB outcomes (DB remains the source of truth).
+const CACHE_CAPACITY: u64 = 128;
+
+type StateTransitionsCache = moka::sync::Cache<H256, Arc<Vec<StateTransition>>>;
+
+/// Cloneable handle shared between [`ProgramApi`](super::ProgramApi) (creates
+/// subscribers) and [`RpcService`](crate::RpcService) (pushes `mb_hash`es).
+#[derive(Clone)]
+pub struct BestStateManager {
+    db: Database,
+    sender: broadcast::Sender<H256>,
+    cache: StateTransitionsCache,
+}
+
+impl BestStateManager {
+    pub fn new(db: Database) -> Self {
+        let (sender, _receiver) = broadcast::channel(BROADCAST_CAPACITY);
+        let cache = moka::sync::Cache::builder()
+            .max_capacity(CACHE_CAPACITY)
+            .build();
+        Self { db, sender, cache }
+    }
+
+    /// Fan a freshly computed MB out to all active subscribers.
+    pub fn notify(&self, mb_hash: H256) {
+        // Err only means there are no subscribers right now — nothing to do.
+        let _ = self.sender.send(mb_hash);
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<H256> {
+        self.sender.subscribe()
+    }
+
+    fn outcome(&self, mb_hash: H256) -> Option<Arc<Vec<StateTransition>>> {
+        // `try_get_with` coalesces concurrent misses for the same `mb_hash`, so
+        // many subscribers sharing an MB trigger only a single DB read.
+        self.cache
+            .try_get_with(mb_hash, || {
+                self.db.mb_outcome(mb_hash).map(Arc::new).ok_or(())
+            })
+            .ok()
+    }
+}
+
+/// Spawns the background task driving a single best-state subscription until the
+/// client disconnects or the broadcast channel closes.
+pub fn spawn_best_state_subscriber(
+    sink: SubscriptionSink,
+    manager: BestStateManager,
+    program_id: H160,
+) {
+    let actor_id: ActorId = program_id.into();
+    let mut receiver = manager.subscribe();
+
+    let _handle = tokio::spawn(async move {
+        loop {
+            let mb_hash = tokio::select! {
+                res = receiver.recv() => match res {
+                    Ok(mb_hash) => mb_hash,
+                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                        warn!(skipped, "best state subscriber lagged, skipping missed MBs");
+                        continue;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                },
+                _ = sink.closed() => {
+                    trace!("best state subscription closed by user, stop background task");
+                    break;
+                }
+            };
+
+            let Some(transitions) = manager.outcome(mb_hash) else {
+                trace!(%mb_hash, "mb outcome not found for best state subscription");
+                continue;
+            };
+
+            let Some(transition) = transitions.iter().find(|t| t.actor_id == actor_id) else {
+                continue;
+            };
+
+            let best_state = ProgramBestState {
+                mb_hash,
+                new_state_hash: transition.new_state_hash,
+                messages: transition.messages.clone(),
+            };
+
+            match SubscriptionMessage::from_json(&best_state) {
+                Ok(message) => {
+                    if let Err(err) = sink.send(message).await {
+                        trace!("failed to send best state, client disconnected: err={err}");
+                        break;
+                    }
+                }
+                Err(err) => {
+                    error!(
+                        ?err,
+                        "failed to serialize `ProgramBestState`; this must never happen"
+                    );
+                }
+            }
+        }
+    });
+}

--- a/ethexe/rpc/src/lib.rs
+++ b/ethexe/rpc/src/lib.rs
@@ -37,15 +37,15 @@ pub use crate::apis::RPC_VERSION;
 #[cfg(feature = "client")]
 pub use crate::apis::{
     BlockClient, CalculateReplyForHandleResult, CodeClient, DevClient, FullProgramState,
-    InfoClient, InjectedClient, ProgramClient,
+    InfoClient, InjectedClient, ProgramBestState, ProgramClient,
 };
 
 #[cfg(feature = "server")]
 use anyhow::Result;
 #[cfg(feature = "server")]
 use apis::{
-    BlockApi, BlockServer, CodeApi, CodeServer, DevApi, DevServer, InfoApi, InfoServer,
-    InjectedApi, InjectedServer, ProgramApi, ProgramServer,
+    BestStateManager, BlockApi, BlockServer, CodeApi, CodeServer, DevApi, DevServer, InfoApi,
+    InfoServer, InjectedApi, InjectedServer, ProgramApi, ProgramServer,
 };
 #[cfg(feature = "server")]
 use ethexe_common::injected::{
@@ -57,6 +57,8 @@ use ethexe_db::Database;
 use ethexe_processor::{Processor, ProcessorConfig};
 #[cfg(feature = "server")]
 use futures::{Stream, stream::FusedStream};
+#[cfg(feature = "server")]
+use gprimitives::H256;
 #[cfg(feature = "server")]
 use hyper::header::HeaderValue;
 #[cfg(feature = "server")]
@@ -150,10 +152,13 @@ impl RpcServer {
         )?
         .overlaid();
 
+        let program = ProgramApi::new(self.db.clone(), processor, self.config.gas_allowance);
+        let best_state = program.best_state();
+
         let server_apis = RpcServerApis {
             code: CodeApi::new(self.db.clone()),
             block: BlockApi::new(self.db.clone()),
-            program: ProgramApi::new(self.db.clone(), processor, self.config.gas_allowance),
+            program,
             injected: InjectedApi::new(self.db.clone(), rpc_sender),
             dev: self
                 .config
@@ -173,7 +178,10 @@ impl RpcServer {
             .await?
             .start(server_apis.into_module());
 
-        Ok((server_handle, RpcService::new(rpc_receiver, injected_api)))
+        Ok((
+            server_handle,
+            RpcService::new(rpc_receiver, injected_api, best_state),
+        ))
     }
 
     fn cors_layer(&self) -> Result<CorsLayer> {
@@ -196,14 +204,21 @@ pub struct RpcService {
     receiver: mpsc::UnboundedReceiver<RpcEvent>,
     /// Injected API implementation.
     injected_api: InjectedApi,
+    /// Best-state fan-out shared with the program API subscriptions.
+    best_state: BestStateManager,
 }
 
 #[cfg(feature = "server")]
 impl RpcService {
-    pub fn new(receiver: mpsc::UnboundedReceiver<RpcEvent>, injected_api: InjectedApi) -> Self {
+    pub fn new(
+        receiver: mpsc::UnboundedReceiver<RpcEvent>,
+        injected_api: InjectedApi,
+        best_state: BestStateManager,
+    ) -> Self {
         Self {
             receiver,
             injected_api,
+            best_state,
         }
     }
 
@@ -213,6 +228,10 @@ impl RpcService {
 
     pub fn receive_tx_receipt(&self, receipt: SignedCompactTxReceipt) {
         self.injected_api.on_tx_receipt(receipt);
+    }
+
+    pub fn receive_mb_computed(&self, mb_hash: H256) {
+        self.best_state.notify(mb_hash);
     }
 }
 

--- a/ethexe/sdk/src/mirror.rs
+++ b/ethexe/sdk/src/mirror.rs
@@ -19,11 +19,15 @@ use ethexe_ethereum::{
         MirrorQuery as EthereumMirrorQuery,
     },
 };
-use ethexe_rpc::{CalculateReplyForHandleResult, FullProgramState, InjectedClient, ProgramClient};
+use ethexe_rpc::{
+    CalculateReplyForHandleResult, FullProgramState, InjectedClient, ProgramBestState,
+    ProgramClient,
+};
 use ethexe_runtime_common::state::ProgramState;
 use futures::TryFutureExt;
 use gprimitives::{ActorId, CodeId, H256, MessageId, U256};
 use gsigner::secp256k1::Secp256k1SignerExt;
+use jsonrpsee::core::client::Subscription;
 
 pub struct Mirror<'a> {
     pub(crate) api: &'a VaraEthApi,
@@ -279,6 +283,17 @@ impl<'a> Mirror<'a> {
         };
 
         Ok((message_id, promise))
+    }
+
+    /// Subscribes to this program's best state, yielding a [`ProgramBestState`]
+    /// on every newly computed MB that produces a transition for the program.
+    pub async fn subscribe_best_state(&self) -> Result<Subscription<ProgramBestState>> {
+        let program_id = self.actor_id().to_address_lossy();
+        self.api
+            .vara_eth_client
+            .subscribe_best_state(program_id)
+            .await
+            .with_context(|| "failed to subscribe to program best state")
     }
 
     pub async fn wait_for_reply(&self, message_id: MessageId) -> Result<ReplyInfo> {

--- a/ethexe/service/src/config.rs
+++ b/ethexe/service/src/config.rs
@@ -48,7 +48,7 @@ pub struct MalachiteCliConfig {
 impl Default for MalachiteCliConfig {
     fn default() -> Self {
         Self {
-            listen_addr: ethexe_malachite::MalachiteConfig::DEFAULT_LISTEN_ADDR,
+            listen_addr: ethexe_malachite::MalachiteServiceConfig::DEFAULT_LISTEN_ADDR,
             persistent_peers: Vec::new(),
             validator_pub_keys: BTreeMap::new(),
         }

--- a/ethexe/service/src/config.rs
+++ b/ethexe/service/src/config.rs
@@ -21,7 +21,7 @@ pub struct Config {
     pub prometheus: Option<PrometheusConfig>,
 }
 
-/// User-facing subset of [`ethexe_malachite::MalachiteConfig`],
+/// User-facing subset of [`ethexe_malachite::MalachiteServiceConfig`],
 /// resolved at CLI/TOML parse time. The rest of the runtime fields
 /// (home directory, mempool) are filled in by the service itself.
 #[derive(Clone, Debug)]
@@ -85,7 +85,7 @@ pub struct NodeConfig {
     pub canonical_quarantine: u8,
     /// Extra anchor-depth slack the proposer adds on top of
     /// `canonical_quarantine`. See
-    /// [`ethexe_malachite::MalachiteConfig::post_quarantine_delay`].
+    /// [`ethexe_malachite::MalachiteServiceConfig::post_quarantine_delay`].
     pub post_quarantine_delay: u32,
     pub dev: bool,
     pub pre_funded_accounts: u32,

--- a/ethexe/service/src/lib.rs
+++ b/ethexe/service/src/lib.rs
@@ -521,15 +521,12 @@ impl Service {
                 malachite_service_config.persistent_peers.len(),
             );
 
-            let validator_config = if let Some(pub_key) = validator_pub_key {
-                Some(ethexe_malachite::ValidatorConfig {
+            let validator_config =
+                validator_pub_key.map(|pub_key| ethexe_malachite::ValidatorConfig {
                     pub_key,
                     mempool: InjectedTxMempool::new(db.clone()),
                     signer: signer.clone(),
-                })
-            } else {
-                None
-            };
+                });
 
             let role = validator_config
                 .as_ref()
@@ -658,7 +655,7 @@ impl Service {
 
         let mut shutdown_rx = shutdown_rx;
 
-        let malachite = malachite_starter.start().await?;
+        let mut malachite = malachite_starter.start().await?;
 
         let (mut rpc_handle, mut rpc) = if let Some(rpc) = rpc {
             log::info!("🌐 Rpc server starting at: {}", rpc.port());
@@ -716,7 +713,7 @@ impl Service {
                             c.receive_new_chain_head(block)?;
                         }
 
-                        malachite.receive_new_chain_head(block);
+                        malachite.receive_new_chain_head(block).await;
                     }
                     ObserverEvent::BlockSynced(block_hash) => {
                         log::info!("Ethereum block synced: {block_hash}");
@@ -731,7 +728,7 @@ impl Service {
                             network.set_chain_head(block_hash)?;
                         }
 
-                        malachite.receive_eb_synced(block_hash);
+                        malachite.receive_eb_synced(block_hash).await;
                     }
                 },
                 Event::BlobLoader(event) => match event {
@@ -748,7 +745,7 @@ impl Service {
                             c.receive_prepared_block(block_hash)?;
                         }
 
-                        malachite.receive_eb_prepared(block_hash);
+                        malachite.receive_eb_prepared(block_hash).await;
                     }
                     ComputeEvent::CodeProcessed(_) => {
                         // Nothing
@@ -883,18 +880,13 @@ impl Service {
                             transaction,
                             response_sender,
                         } => {
-                            let mut local_acceptance = None;
-
-                            if let Some(malachite) = malachite.as_mut() {
-                                let status =
-                                    malachite.receive_injected_transaction(transaction.clone());
-                                local_acceptance =
-                                    Some(InjectedTransactionAcceptance::from(status));
-                            }
+                            let status =
+                                malachite.receive_injected_transaction(transaction.clone());
+                            let local_acceptance = InjectedTransactionAcceptance::from(status);
 
                             match network.as_mut() {
                                 Some(network) => match local_acceptance {
-                                    Some(acceptance @ InjectedTransactionAcceptance::Accept) => {
+                                    acceptance @ InjectedTransactionAcceptance::Accept => {
                                         // local consensus handle transaction, no need to wait for other acceptances
                                         if let Err(err) =
                                             network.broadcast_injected_transaction(transaction)
@@ -911,7 +903,7 @@ impl Service {
                                         }
                                     }
                                     _ => {
-                                        // no local malachite or malachite reject transaction, wait for other acceptances
+                                        // local malachite rejected the transaction, wait for other acceptances
                                         let tx_hash = transaction.data().to_hash();
                                         if let Some(pending) =
                                             network_injected_txs.get_mut(&tx_hash)
@@ -925,7 +917,7 @@ impl Service {
                                                 let pending = PendingNetworkInjectedTx::new(
                                                     response_sender,
                                                     pending_responses,
-                                                    local_acceptance,
+                                                    Some(local_acceptance),
                                                 );
                                                 network_injected_txs.insert(tx_hash, pending);
                                             }
@@ -947,12 +939,7 @@ impl Service {
                                 },
                                 None => {
                                     // No network, send local_acceptance to RPC
-                                    let acceptance = local_acceptance.unwrap_or_else(|| {
-                                        InjectedTransactionAcceptance::Reject {
-                                            reason: "RPC not a validator and do not connect to P2P network".into(),
-                                        }
-                                    });
-                                    let _ = response_sender.send(acceptance);
+                                    let _ = response_sender.send(local_acceptance);
                                 }
                             }
                         }
@@ -1059,9 +1046,7 @@ impl Service {
             }
         }
 
-        if let Some(m) = malachite.take() {
-            m.shutdown().await;
-        }
+        malachite.shutdown().await;
 
         Ok(())
     }

--- a/ethexe/service/src/lib.rs
+++ b/ethexe/service/src/lib.rs
@@ -540,7 +540,6 @@ impl Service {
                 db.clone(),
                 initial_chain_head,
             )
-            .await
             .context("failed to create Malachite service starter")?
         };
 
@@ -982,18 +981,10 @@ impl Service {
                             "Malachite: BlockFinalized",
                         );
 
-                        // +_+_+ ??? whether we really need this?
-                        // Non-proposer nodes (validators that didn't propose
-                        // this height + every full/RPC node) first see the MB
-                        // here. Trigger compute so the body — including any
-                        // injected-tx `Promise` — is produced locally; the
-                        // matching `SignedCompactPromise` arrives via the
-                        // network and is joined into a full `SignedTxReceipt`
-                        // by the RPC subscription manager. Calls are
-                        // idempotent: a proposer that already computed via
-                        // `BlockProposal` short-circuits on
-                        // `mb_meta.computed`.
-                        compute.compute_mb(mb_hash, ethexe_common::PromisePolicy::Enabled);
+                        // No compute here: `BlockProposal` is always emitted
+                        // before the matching `BlockFinalized` (on every node,
+                        // including the sync path), so compute for this MB has
+                        // already been triggered.
                     }
                     MalachiteEvent::PurgedTransactions {
                         eb_hash,

--- a/ethexe/service/src/lib.rs
+++ b/ethexe/service/src/lib.rs
@@ -508,17 +508,17 @@ impl Service {
                 &config.malachite.validator_pub_keys,
             )?;
 
-            let malachite_service_config = MalachiteServiceConfig::from_home_dir(malachite_home)
+            let malachite_config = MalachiteServiceConfig::from_home_dir(malachite_home)
                 .with_listen_addr(config.malachite.listen_addr)
                 .with_persistent_peers(config.malachite.persistent_peers.clone())
                 .with_canonical_quarantine(config.node.canonical_quarantine)
                 .with_post_quarantine_delay(config.node.post_quarantine_delay)
-                .with_validators(malachite_validator_set.clone());
+                .with_validators(malachite_validator_set);
 
             log::info!(
                 "Malachite listen: {}  persistent_peers: {}",
-                malachite_service_config.listen_addr,
-                malachite_service_config.persistent_peers.len(),
+                malachite_config.listen_addr,
+                malachite_config.persistent_peers.len(),
             );
 
             let validator_config =
@@ -532,10 +532,7 @@ impl Service {
                 .as_ref()
                 .map(|_| "validator")
                 .unwrap_or("full");
-            log::info!("Malachite not local role: {role}",);
-
-            let malachite_config =
-                malachite_service_config.with_validators(malachite_validator_set);
+            log::info!("Malachite node role: {role}");
 
             MalachiteServiceStarter::new(
                 malachite_config,

--- a/ethexe/service/src/lib.rs
+++ b/ethexe/service/src/lib.rs
@@ -45,7 +45,7 @@ use async_trait::async_trait;
 use ethexe_blob_loader::{BlobLoader, BlobLoaderEvent, BlobLoaderService, ConsensusLayerConfig};
 use ethexe_common::{
     CodeAndIdUnchecked, PromiseEmissionMode,
-    db::{GlobalsStorageRW, MbStorageRO, OnChainStorageRO},
+    db::{GlobalsStorageRW, MbStorageRO},
     gear::CodeState,
     injected::{CompactPromise, InjectedTransactionAcceptance, Receipt},
     network::VerifiedValidatorMessage,
@@ -57,10 +57,12 @@ use ethexe_db::{
 };
 use ethexe_ethereum::{EthereumBuilder, deploy::EthereumDeployer, router::RouterQuery};
 use ethexe_malachite::{
-    InjectedTxMempool, MalachiteConfig, MalachiteEvent, MalachiteService, ValidatorEntry,
+    InjectedTxMempool, MalachiteEvent, MalachiteServiceConfig, MalachiteServiceStarter,
+    ValidatorEntry,
 };
 use ethexe_network::{
-    NetworkEvent, NetworkRuntimeConfig, NetworkService, db_sync::ExternalDataProvider,
+    NetworkEvent, NetworkRuntimeConfig, NetworkService, TransportType,
+    db_sync::ExternalDataProvider,
 };
 use ethexe_observer::{
     ObserverConfig, ObserverEvent, ObserverService,
@@ -165,7 +167,7 @@ pub struct Service {
     compute: ComputeService,
     /// `None` for connect (non-validator) nodes.
     consensus: Option<Pin<Box<dyn ConsensusService>>>,
-    malachite: Option<MalachiteService>,
+    malachite_starter: MalachiteServiceStarter,
     signer: Signer,
 
     // Optional services
@@ -358,7 +360,7 @@ impl Service {
         .await
         .context("failed to create observer service")?;
 
-        let latest_block = observer
+        let initial_chain_head = observer
             .block_loader()
             .load_simple(BlockId::Latest)
             .await
@@ -384,7 +386,7 @@ impl Service {
         }
 
         let validators = router_query
-            .validators_at(latest_block.hash)
+            .validators_at(initial_chain_head.hash)
             .await
             .context("failed to query validators")?;
         log::info!("👥 Current validators set: {validators:?}");
@@ -444,24 +446,28 @@ impl Service {
         };
 
         let network = if let Some(net_config) = &config.network {
-            // TODO: #4918 create Signer object correctly for test/prod environments
-            let network_signer = Signer::fs(
-                config
-                    .node
-                    .key_path
-                    .parent()
-                    .context("key_path has no parent directory")?
-                    .join("net"),
-            )?;
-
-            let latest_block_data = observer
-                .block_loader()
-                .load_simple(BlockId::Latest)
-                .await
-                .context("failed to get latest block")?;
+            let network_signer = match net_config.transport_type {
+                TransportType::Test => {
+                    let network_signer = Signer::memory();
+                    let network_private_key = signer
+                        .private_key(net_config.public_key)
+                        .with_context(|| "failed to get test network private key")?
+                        .clone();
+                    network_signer.import(network_private_key)?;
+                    network_signer
+                }
+                TransportType::Default => Signer::fs(
+                    config
+                        .node
+                        .key_path
+                        .parent()
+                        .context("key_path has no parent directory")?
+                        .join("net"),
+                )?,
+            };
 
             let runtime_config = NetworkRuntimeConfig {
-                latest_block_header: latest_block_data.header,
+                latest_block_header: initial_chain_head.header,
                 latest_validators: validators.clone(),
                 validator_key: validator_pub_key,
                 general_signer: signer.clone(),
@@ -490,47 +496,58 @@ impl Service {
         let compute = ComputeService::with_promise_mode(db.clone(), processor, promises_mode);
 
         // Malachite consensus service.
-        let malachite_home = config
-            .node
-            .database_path_for(config.ethereum.router_address)
-            .join("malachite");
-        let mut malachite_base_config = MalachiteConfig::from_home_dir(malachite_home)
-            .with_listen_addr(config.malachite.listen_addr)
-            .with_persistent_peers(config.malachite.persistent_peers.clone());
-        // Must match the compute layer's quarantine or consensus deadlocks.
-        malachite_base_config.canonical_quarantine = config.node.canonical_quarantine;
-        malachite_base_config.post_quarantine_delay = config.node.post_quarantine_delay;
-        log::info!(
-            "Malachite listen: {}  persistent_peers: {}",
-            malachite_base_config.listen_addr,
-            malachite_base_config.persistent_peers.len(),
-        );
-        let malachite = {
+
+        let malachite_starter = {
+            let malachite_home = config
+                .node
+                .database_path_for(config.ethereum.router_address)
+                .join("malachite");
+
             let malachite_validator_set = build_malachite_validator_set(
                 validators.iter().copied(),
                 &config.malachite.validator_pub_keys,
             )?;
+
+            let malachite_service_config = MalachiteServiceConfig::from_home_dir(malachite_home)
+                .with_listen_addr(config.malachite.listen_addr)
+                .with_persistent_peers(config.malachite.persistent_peers.clone())
+                .with_canonical_quarantine(config.node.canonical_quarantine)
+                .with_post_quarantine_delay(config.node.post_quarantine_delay)
+                .with_validators(malachite_validator_set.clone());
+
             log::info!(
-                "Malachite validators: {} (local role: {})",
-                malachite_validator_set.len(),
-                if validator_pub_key.is_some() {
-                    "validator"
-                } else {
-                    "full"
-                },
+                "Malachite listen: {}  persistent_peers: {}",
+                malachite_service_config.listen_addr,
+                malachite_service_config.persistent_peers.len(),
             );
-            let malachite_config = malachite_base_config.with_validators(malachite_validator_set);
-            Some(
-                MalachiteService::new(
-                    malachite_config,
-                    db.clone(),
-                    signer.clone(),
-                    validator_pub_key,
-                    std::sync::Arc::new(InjectedTxMempool::new(db.clone())),
-                )
-                .await
-                .context("failed to start Malachite service")?,
+
+            let validator_config = if let Some(pub_key) = validator_pub_key {
+                Some(ethexe_malachite::ValidatorConfig {
+                    pub_key,
+                    mempool: InjectedTxMempool::new(db.clone()),
+                    signer: signer.clone(),
+                })
+            } else {
+                None
+            };
+
+            let role = validator_config
+                .as_ref()
+                .map(|_| "validator")
+                .unwrap_or("full");
+            log::info!("Malachite not local role: {role}",);
+
+            let malachite_config =
+                malachite_service_config.with_validators(malachite_validator_set);
+
+            MalachiteServiceStarter::new(
+                malachite_config,
+                validator_config,
+                db.clone(),
+                initial_chain_head,
             )
+            .await
+            .context("failed to create Malachite service starter")?
         };
 
         let fast_sync = config.node.fast_sync;
@@ -543,7 +560,7 @@ impl Service {
             blob_loader,
             compute,
             consensus,
-            malachite,
+            malachite_starter,
             signer,
             prometheus,
             rpc,
@@ -572,7 +589,7 @@ impl Service {
         compute: ComputeService,
         signer: Signer,
         consensus: Option<Pin<Box<dyn ConsensusService>>>,
-        malachite: Option<MalachiteService>,
+        malachite_starter: MalachiteServiceStarter,
         network: Option<NetworkService>,
         prometheus: Option<PrometheusService>,
         rpc: Option<RpcServer>,
@@ -586,7 +603,7 @@ impl Service {
             blob_loader,
             compute,
             consensus,
-            malachite,
+            malachite_starter,
             signer,
             network,
             prometheus,
@@ -628,7 +645,7 @@ impl Service {
             mut blob_loader,
             mut compute,
             mut consensus,
-            mut malachite,
+            malachite_starter,
             signer,
             mut prometheus,
             rpc,
@@ -638,7 +655,10 @@ impl Service {
             #[cfg(test)]
             sender,
         } = self;
+
         let mut shutdown_rx = shutdown_rx;
+
+        let malachite = malachite_starter.start().await?;
 
         let (mut rpc_handle, mut rpc) = if let Some(rpc) = rpc {
             log::info!("🌐 Rpc server starting at: {}", rpc.port());
@@ -667,7 +687,7 @@ impl Service {
             let event: Event = tokio::select! {
                 event = compute.select_next_some() => event?.into(),
                 event = consensus.maybe_next_some() => event?.into(),
-                event = malachite.maybe_next_some() => event?.into(),
+                event = malachite.select_next_some() => event?.into(),
                 event = network.maybe_next_some() => event.into(),
                 event = observer.select_next_some() => event?.into(),
                 event = blob_loader.select_next_some() => event?.into(),
@@ -689,38 +709,29 @@ impl Service {
 
             match event {
                 Event::Observer(event) => match event {
-                    ObserverEvent::Block(block_data) => {
-                        tracing::info!(
-                            height = %block_data.header.height,
-                            timestamp = %block_data.header.timestamp,
-                            hash = %block_data.hash,
-                            parent_hash = %block_data.header.parent_hash,
-                            "📦 receive a chain head",
-                        );
-                        if let Some(c) = consensus.as_mut() {
-                            c.receive_new_chain_head(block_data)?;
-                        }
-                    }
-                    ObserverEvent::BlockSynced(block) => {
-                        log::info!(
-                            "Block synced: {}",
-                            db.block_simple_data(block)
-                                .context("Cannot find header of synced block")?
-                        );
+                    ObserverEvent::Block(block) => {
+                        tracing::info!("📦 receive a ethereum chain head: {block}",);
 
-                        compute.prepare_block(block);
                         if let Some(c) = consensus.as_mut() {
-                            c.receive_synced_block(block)?;
+                            c.receive_new_chain_head(block)?;
                         }
+
+                        malachite.receive_new_chain_head(block);
+                    }
+                    ObserverEvent::BlockSynced(block_hash) => {
+                        log::info!("Ethereum block synced: {block_hash}");
+
+                        compute.prepare_block(block_hash);
+
+                        if let Some(c) = consensus.as_mut() {
+                            c.receive_synced_block(block_hash)?;
+                        }
+
                         if let Some(network) = network.as_mut() {
-                            network.set_chain_head(block)?;
+                            network.set_chain_head(block_hash)?;
                         }
-                        if let Some(m) = malachite.as_mut() {
-                            let block = db
-                                .block_simple_data(block)
-                                .context("Cannot find header of synced block")?;
-                            m.receive_new_chain_head(block);
-                        }
+
+                        malachite.receive_eb_synced(block_hash);
                     }
                 },
                 Event::BlobLoader(event) => match event {
@@ -736,14 +747,8 @@ impl Service {
                         if let Some(c) = consensus.as_mut() {
                             c.receive_prepared_block(block_hash)?;
                         }
-                        // Malachite's BlockProposal events are gated
-                        // on the EB they advance over being prepared
-                        // (so downstream compute_mb doesn't race the
-                        // code-validation pipeline). Wake the gate
-                        // here so pending events get drained.
-                        if let Some(m) = malachite.as_ref() {
-                            m.receive_eb_prepared(block_hash);
-                        }
+
+                        malachite.receive_eb_prepared(block_hash);
                     }
                     ComputeEvent::CodeProcessed(_) => {
                         // Nothing
@@ -833,15 +838,14 @@ impl Service {
                                 transaction,
                                 channel,
                             } => {
-                                let acceptance = match malachite.as_mut() {
-                                    Some(malachite) => {
-                                        malachite.receive_injected_transaction(*transaction).into()
-                                    }
-                                    None => InjectedTransactionAcceptance::Reject {
-                                        reason: "no malachite service to handle transaction".into(),
-                                    },
-                                };
-                                let _ = channel.send(acceptance);
+                                let acceptance =
+                                    malachite.receive_injected_transaction(*transaction).into();
+                                if let Err(err) = channel.send(acceptance) {
+                                    tracing::error!(
+                                        ?err,
+                                        "failed to send injected transaction acceptance response"
+                                    )
+                                }
                             }
                             ethexe_network::NetworkInjectedEvent::OutboundAcceptance {
                                 transaction_hash,
@@ -1055,13 +1059,10 @@ impl Service {
             }
         }
 
-        // Graceful tear-down: hand the malachite engine a chance to
-        // flush its WAL and release the RocksDB advisory lock and
-        // libp2p listener. Without this, an immediate restart on
-        // the same home directory races the previous lock release.
         if let Some(m) = malachite.take() {
             m.shutdown().await;
         }
+
         Ok(())
     }
 }

--- a/ethexe/service/src/lib.rs
+++ b/ethexe/service/src/lib.rs
@@ -779,6 +779,10 @@ impl Service {
                                 g.latest_computed_mb_hash = mb_hash;
                             }
                         });
+
+                        if let Some(rpc) = &rpc {
+                            rpc.receive_mb_computed(mb_hash);
+                        }
                     }
                     ComputeEvent::Promise(promise, _mb_hash) => {
                         // The local node always feeds its computed body

--- a/ethexe/service/src/lib.rs
+++ b/ethexe/service/src/lib.rs
@@ -614,7 +614,7 @@ impl Service {
 
     /// Install a graceful-shutdown channel. The returned sender,
     /// when fired, breaks the run loop at the next yield and then
-    /// awaits [`MalachiteService::shutdown`] before `run` returns —
+    /// awaits [`ethexe_malachite::MalachiteService::shutdown`] before `run` returns —
     /// freeing the RocksDB advisory lock and libp2p listener
     /// synchronously, which a plain `JoinHandle::abort` does not
     /// guarantee.

--- a/ethexe/service/src/lib.rs
+++ b/ethexe/service/src/lib.rs
@@ -713,7 +713,7 @@ impl Service {
                             c.receive_new_chain_head(block)?;
                         }
 
-                        malachite.receive_new_chain_head(block).await;
+                        malachite.receive_new_eb(block).await;
                     }
                     ObserverEvent::BlockSynced(block_hash) => {
                         log::info!("Ethereum block synced: {block_hash}");
@@ -835,8 +835,10 @@ impl Service {
                                 transaction,
                                 channel,
                             } => {
-                                let acceptance =
-                                    malachite.receive_injected_transaction(*transaction).into();
+                                let acceptance = malachite
+                                    .receive_injected_transaction(*transaction)
+                                    .await
+                                    .into();
                                 if let Err(err) = channel.send(acceptance) {
                                     tracing::error!(
                                         ?err,
@@ -880,8 +882,9 @@ impl Service {
                             transaction,
                             response_sender,
                         } => {
-                            let status =
-                                malachite.receive_injected_transaction(transaction.clone());
+                            let status = malachite
+                                .receive_injected_transaction(transaction.clone())
+                                .await;
                             let local_acceptance = InjectedTransactionAcceptance::from(status);
 
                             match network.as_mut() {
@@ -967,10 +970,7 @@ impl Service {
                             mb_hash = %mb_hash,
                             "Malachite: BlockProposal",
                         );
-                        // Validators are interested in this MB's
-                        // promises so they can gossip them; the
-                        // service's `PromiseEmissionMode` can still
-                        // force the policy to `Enabled` regardless.
+
                         compute.compute_mb(mb_hash, ethexe_common::PromisePolicy::Enabled);
                     }
                     MalachiteEvent::BlockFinalized {
@@ -984,6 +984,8 @@ impl Service {
                             sigs = cert.signatures.len(),
                             "Malachite: BlockFinalized",
                         );
+
+                        // +_+_+ ??? whether we really need this?
                         // Non-proposer nodes (validators that didn't propose
                         // this height + every full/RPC node) first see the MB
                         // here. Trigger compute so the body — including any

--- a/ethexe/service/src/tests/mod.rs
+++ b/ethexe/service/src/tests/mod.rs
@@ -31,7 +31,7 @@ use ethexe_consensus::BatchCommitter;
 use ethexe_db::{Database, dump::StateDump};
 use ethexe_ethereum::{EthereumBuilder, TryGetReceipt, router::Router};
 use ethexe_processor::Processor;
-use ethexe_rpc::InjectedClient;
+use ethexe_rpc::{InjectedClient, ProgramClient};
 use ethexe_runtime_common::{RUNTIME_ID, state::Storage};
 use gear_core::{
     ids::prelude::MessageIdExt,
@@ -2768,6 +2768,135 @@ async fn injected_tx_fungible_token() {
         .expect("successfully unsubscribe for promise");
 
     tracing::info!("✅ Promise successfully received from RPC subscription");
+
+    stop_nodes([node]).await;
+}
+
+/// Subscribe to a program's best state over RPC and assert that handling a
+/// message produces a `ProgramBestState` carrying the program's new state hash
+/// and its outgoing reply.
+#[tokio::test]
+#[ntest::timeout(60_000)]
+async fn program_subscribe_best_state() {
+    init_logger();
+
+    let mut env = TestEnv::default().await;
+
+    let pubkey = env.validators[0].public_key;
+    let mut node = env
+        .new_node(
+            NodeConfig::default()
+                .service_rpc(8095)
+                .validator(env.validators[0]),
+        )
+        .await;
+    node.start_service().await;
+    let rpc_client = node
+        .rpc_ws_client()
+        .await
+        .expect("RPC client provide by node");
+
+    // Upload demo_ping and create the program.
+    let uploaded_code = env
+        .upload_code(demo_ping::WASM_BINARY)
+        .await
+        .unwrap()
+        .wait_for()
+        .await
+        .unwrap();
+    assert!(uploaded_code.valid);
+
+    let program = env
+        .create_program(uploaded_code.code_id, 500_000_000_000_000)
+        .await
+        .unwrap()
+        .wait_for()
+        .await
+        .unwrap();
+    let ping_id = program.program_id;
+
+    // Subscribe after creation so the first emitted state is the PING handle.
+    let mut subscription = rpc_client
+        .subscribe_best_state(ping_id.to_address_lossy())
+        .await
+        .expect("successfully subscribe for program best state");
+
+    // Trigger a state transition for the program.
+    let reply = env
+        .send_message(ping_id, b"PING")
+        .await
+        .unwrap()
+        .wait_for()
+        .await
+        .unwrap();
+    assert_eq!(reply.payload, b"PONG");
+
+    let best_state = subscription
+        .next()
+        .await
+        .expect("subscription produces a best state")
+        .expect("no RPC subscription error");
+
+    assert_ne!(best_state.mb_hash, H256::zero());
+    assert_ne!(best_state.new_state_hash, H256::zero());
+    assert!(
+        best_state.messages.iter().any(|msg| msg.payload == b"PONG"),
+        "expected the PONG reply in the best state messages"
+    );
+    tracing::info!("✅ Best state successfully received from RPC subscription");
+
+    // Now send the same PING as an injected transaction: it must yield a PONG
+    // promise over its own subscription, and our best-state subscription must
+    // also observe the resulting transition.
+    let ping_tx = InjectedTransaction {
+        destination: ping_id,
+        payload: b"PING".to_vec().try_into().unwrap(),
+        value: 0,
+        reference_block: node.db.globals().latest_prepared_eb_hash,
+        salt: vec![1].try_into().unwrap(),
+    };
+    let rpc_tx = env
+        .signer
+        .signed_message(pubkey, ping_tx.clone(), None)
+        .unwrap();
+
+    let mut tx_subscription = rpc_client
+        .send_transaction_and_watch(rpc_tx)
+        .await
+        .expect("successfully subscribe for injected transaction promise");
+
+    let promise = tx_subscription
+        .next()
+        .await
+        .expect("promise from subscription")
+        .expect("transaction promise")
+        .data()
+        .clone()
+        .unwrap_promise();
+    assert_eq!(promise.tx_hash, ping_tx.to_hash());
+    assert_eq!(promise.reply.payload, b"PONG");
+    tracing::info!("✅ Injected PING promise received from RPC subscription");
+
+    let injected_best_state = subscription
+        .next()
+        .await
+        .expect("subscription produces a best state for the injected ping")
+        .expect("no RPC subscription error");
+    assert_ne!(injected_best_state.mb_hash, H256::zero());
+    assert_ne!(injected_best_state.new_state_hash, H256::zero());
+    assert!(
+        injected_best_state
+            .messages
+            .iter()
+            .any(|msg| msg.payload == b"PONG"),
+        "expected the injected PONG reply in the best state messages"
+    );
+    tracing::info!("✅ Best state for injected PING received from RPC subscription");
+
+    subscription
+        .unsubscribe()
+        .await
+        .expect("successfully unsubscribe from best state");
 
     stop_nodes([node]).await;
 }

--- a/ethexe/service/src/tests/utils/env.rs
+++ b/ethexe/service/src/tests/utils/env.rs
@@ -1195,6 +1195,9 @@ impl Node {
                 .with_validators(validators);
             mc.canonical_quarantine = self.canonical_quarantine;
             mc.post_quarantine_delay = self.post_quarantine_delay;
+            // Tests drive content in bursts; a short propose timeout keeps
+            // idle rounds cheap instead of burning a 24s slot each.
+            mc.propose_timeout = Duration::from_secs(3);
 
             let malachite_validator_config =
                 self.validator_config
@@ -1214,7 +1217,6 @@ impl Node {
                 self.db.clone(),
                 latest_block,
             )
-            .await
             .expect("MalachiteServiceStarter::new")
         };
 

--- a/ethexe/service/src/tests/utils/env.rs
+++ b/ethexe/service/src/tests/utils/env.rs
@@ -38,7 +38,7 @@ use ethexe_ethereum::{
     router::RouterQuery,
 };
 use ethexe_malachite::{
-    InjectedTxMempool, MalachiteConfig, MalachiteService, Multiaddr as MalachiteMultiaddr, PeerId,
+    InjectedTxMempool, MalachiteServiceConfig, MalachiteService, Multiaddr as MalachiteMultiaddr, PeerId,
     ValidatorEntry, derive_libp2p_secret, malachite_libp2p_peer_id,
 };
 use ethexe_network::{NetworkConfig, NetworkRuntimeConfig, NetworkService, export::Multiaddr};
@@ -1188,17 +1188,19 @@ impl Node {
                 .path()
                 .to_path_buf();
 
-            let mut mc = MalachiteConfig::from_home_dir(home_path)
+            let mut mc = MalachiteServiceConfig::from_home_dir(home_path)
                 .with_listen_addr(listen_addr)
                 .with_persistent_peers(persistent_peers)
                 .with_validators(validators);
             mc.canonical_quarantine = self.canonical_quarantine;
             mc.post_quarantine_delay = self.post_quarantine_delay;
             let mempool = std::sync::Arc::new(InjectedTxMempool::new(self.db.clone()));
+
             // Release the port-reservation listener moments before libp2p rebinds.
             drop(self.malachite_listener.take());
+
             let svc = MalachiteService::new(
-                mc,
+                malach,
                 self.db.clone(),
                 self.signer.clone(),
                 self.validator_config.as_ref().map(|c| c.public_key),

--- a/ethexe/service/src/tests/utils/env.rs
+++ b/ethexe/service/src/tests/utils/env.rs
@@ -38,8 +38,9 @@ use ethexe_ethereum::{
     router::RouterQuery,
 };
 use ethexe_malachite::{
-    InjectedTxMempool, MalachiteServiceConfig, MalachiteService, Multiaddr as MalachiteMultiaddr, PeerId,
-    ValidatorEntry, derive_libp2p_secret, malachite_libp2p_peer_id,
+    InjectedTxMempool, MalachiteServiceConfig, MalachiteServiceStarter,
+    Multiaddr as MalachiteMultiaddr, PeerId, ValidatorEntry, derive_libp2p_secret,
+    malachite_libp2p_peer_id,
 };
 use ethexe_network::{NetworkConfig, NetworkRuntimeConfig, NetworkService, export::Multiaddr};
 use ethexe_observer::{
@@ -1194,21 +1195,27 @@ impl Node {
                 .with_validators(validators);
             mc.canonical_quarantine = self.canonical_quarantine;
             mc.post_quarantine_delay = self.post_quarantine_delay;
-            let mempool = std::sync::Arc::new(InjectedTxMempool::new(self.db.clone()));
+
+            let malachite_validator_config =
+                self.validator_config
+                    .as_ref()
+                    .map(|c| ethexe_malachite::ValidatorConfig {
+                        pub_key: c.public_key,
+                        mempool: InjectedTxMempool::new(self.db.clone()),
+                        signer: self.signer.clone(),
+                    });
 
             // Release the port-reservation listener moments before libp2p rebinds.
             drop(self.malachite_listener.take());
 
-            let svc = MalachiteService::new(
-                malach,
+            MalachiteServiceStarter::new(
+                mc,
+                malachite_validator_config,
                 self.db.clone(),
-                self.signer.clone(),
-                self.validator_config.as_ref().map(|c| c.public_key),
-                mempool,
+                latest_block,
             )
             .await
-            .expect("MalachiteService::new");
-            Some(svc)
+            .expect("MalachiteServiceStarter::new")
         };
 
         let (sender, receiver) = events::channel(self.db.clone(), self.kicking_per_blocks.clone());

--- a/ethexe/service/src/tests/utils/env.rs
+++ b/ethexe/service/src/tests/utils/env.rs
@@ -1036,7 +1036,7 @@ pub struct Node {
     /// Snapshot of `env.validators` at `new_node` time — drives the
     /// boot-time filter on `malachite_endpoints` in `start_service`.
     active_validator_pub_keys: Vec<PublicKey>,
-    /// Port reservation; dropped just before the first `MalachiteService::new`.
+    /// Port reservation; dropped just before the first malachite service start.
     malachite_listener: Option<TcpListener>,
 
     running_service_handle: Option<JoinHandle<()>>,


### PR DESCRIPTION
## What & why

Merges `gsobol/ethexe/tune-malachite-errors` (Malachite error-handling rework) into the bitswap fast-sync branch, dropping **all** of bitswap's Malachite-crate changes in favour of tune's, and replacing the Malachite-internal fast-sync replay filter with a cleaner layered design.

Base: `al/ethexe/bitswap` (this PR is the integration of the two lines of work).

## Conflict resolution

- `ethexe/malachite/*` → take tune's version entirely. None of bitswap's Malachite changes survive (no `start_app_task` gate, `Environment` knob, `is_finalized`, or in-externalities replay filter). Tune's `MalachiteServiceStarter` already defers core launch past fast sync, which replaces bitswap's `start_app_task` gate.
- `ethexe/service/*` → keep bitswap's bitswap-network + fast-sync feature set, adapted to tune's Malachite API (`MalachiteServiceStarter`, `receive_new_eb`/`receive_eb_synced`, `Stream<Item = Result<MalachiteEvent>>`).

## Redesign (replaces bitswap's in-Malachite replay filter)

A pure app-level "wait for `BlockFinalized(target)`" gate is impossible against tune's externalities: `try_emit_or_queue` head-of-line-blocks the event queue on an unprepared prerequisite EB, so the target event would never reach the app. Instead the prerequisite gate is moved out of Malachite:

1. **Malachite externalities** no longer queue events behind a prepared-EB prerequisite (`try_emit_or_queue` / `pending_events` / `drain_pending_events` / `prerequisite_satisfied` removed; `receive_eb_prepared` gone). `process_mb_proposal` / `process_mb_finalized` emit immediately and strictly in order.
2. **ethexe-compute** now owns the "defer an MB until the EB it advances to is prepared" gate (`ComputeSubService::deferred` + `receive_prepared_block`). It scans every deferred request on each `BlockPrepared`, since the prepare sub-service only reports the chain head of a prepared ancestor run; defer-at-launch avoids head-of-line blocking ready requests.
3. The **service** applies an app-level `ReplayGate` after fast sync: it suppresses replayed `BlockProposal`s until the committed target MB is reached — by hash for a fresh DB, or via a one-shot ancestry walk when the target was already finalized locally before start — then resumes live consensus. A missing `CompactMb` mid-walk fails loudly instead of hanging.

## Testing

- `cargo fmt --all --check` ✓
- `cargo clippy` ✓ (clean)
- `cargo nextest run -p "ethexe-*"` → **543 passed**, 1 skipped, including the `fast_sync` integration test (~77s, well under the 120s cap — default value-sync timing is sufficient without bitswap's removed test-only `Environment::Test` tuning).

## Notes / edge cases

- The transient rewind of `globals.latest_finalized_mb_hash` during genesis replay is low-severity (only the consensus batch manager reads it at runtime, and it isn't producing batches during catch-up) and self-heals as replay climbs back to the tip.
- Draft for early feedback on the layering choice (compute-owned prerequisite gate + app-level replay gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgjaE68s3nARWKBCa4Jid1
