### PR TITLE
refactor(vara.eth/malachite): move EB-prerequisite gating out of Malachite

### DIFF
--- a/ethexe/compute/src/compute.rs
+++ b/ethexe/compute/src/compute.rs
@@ -13,8 +13,8 @@ use crate::{ComputeError, ComputeEvent, ProcessorExt, Result, service::SubServic
 use ethexe_common::{
     PromiseEmissionMode, PromisePolicy, SimpleBlockData,
     db::{
-        CodesStorageRW, CompactMb, ConfigStorageRO, GlobalsStorageRO, MbStorageRO, MbStorageRW,
-        OnChainStorageRO,
+        BlockMetaStorageRO, CodesStorageRW, CompactMb, ConfigStorageRO, GlobalsStorageRO,
+        MbStorageRO, MbStorageRW, OnChainStorageRO,
     },
     events::BlockRequestEvent,
     injected::Promise,
@@ -85,6 +85,13 @@ pub struct ComputeSubService<P: ProcessorExt> {
     metrics: Metrics,
 
     input: VecDeque<MbComputeRequest>,
+    /// Requests whose prerequisite EB (the block this MB advances to) is not
+    /// yet prepared in the DB. Held here instead of executing — and moved back
+    /// into `input` by [`Self::receive_prepared_block`] once the prerequisite
+    /// lands. This is the gate Malachite used to apply before emitting events;
+    /// owning it here lets replayed/early MBs flow through as events while
+    /// their execution waits for the code-validation pipeline to catch up.
+    deferred: VecDeque<MbComputeRequest>,
     /// Head of the in-flight computation, kept so [`Self::receive_mb`] can
     /// skip duplicates that would otherwise re-emit `MbComputed`.
     in_flight_mb: Option<H256>,
@@ -111,6 +118,7 @@ impl<P: ProcessorExt> ComputeSubService<P> {
             promise_emission_mode,
             metrics: Metrics::default(),
             input: VecDeque::new(),
+            deferred: VecDeque::new(),
             in_flight_mb: None,
             computation: None,
             promises_stream: None,
@@ -119,12 +127,13 @@ impl<P: ProcessorExt> ComputeSubService<P> {
     }
 
     pub fn receive_mb(&mut self, mb_hash: H256, promise_policy: PromisePolicy) {
-        // Idempotent: skip if already computed, in flight, or queued —
-        // otherwise BlockProposal+BlockFinalized for the same head emit
-        // `MbComputed` twice.
+        // Idempotent: skip if already computed, in flight, or queued
+        // (`input` or `deferred`) — otherwise BlockProposal+BlockFinalized
+        // for the same head emit `MbComputed` twice.
         if self.db.mb_meta(mb_hash).computed
             || self.in_flight_mb == Some(mb_hash)
             || self.input.iter().any(|r| r.mb_hash == mb_hash)
+            || self.deferred.iter().any(|r| r.mb_hash == mb_hash)
         {
             return;
         }
@@ -132,6 +141,32 @@ impl<P: ProcessorExt> ComputeSubService<P> {
             mb_hash,
             promise_policy,
         });
+    }
+
+    /// An Ethereum block has been prepared: requeue every deferred request
+    /// whose prerequisite EB is now satisfied. `PrepareSubService` prepares a
+    /// whole ancestor chain but only reports the head, so we re-check all
+    /// deferred requests rather than matching the reported hash.
+    pub fn receive_prepared_block(&mut self, _eb_hash: H256) {
+        let mut still_deferred = VecDeque::with_capacity(self.deferred.len());
+        while let Some(req) = self.deferred.pop_front() {
+            if self.db.mb_meta(req.mb_hash).computed {
+                continue;
+            }
+            if self.prerequisite_ready(req.mb_hash) {
+                self.input.push_back(req);
+            } else {
+                still_deferred.push_back(req);
+            }
+        }
+        self.deferred = still_deferred;
+    }
+
+    /// Whether the EB this MB advances to is prepared (or there is none).
+    /// Execution reads that EB's events, so it must wait until then.
+    fn prerequisite_ready(&self, mb_hash: H256) -> bool {
+        let eb = self.db.mb_meta(mb_hash).last_advanced_eb;
+        eb.is_zero() || self.db.block_meta(eb).prepared
     }
 
     async fn compute(
@@ -444,25 +479,37 @@ impl<P: ProcessorExt> SubService for ComputeSubService<P> {
     type Output = ComputeEvent;
 
     fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Output>> {
-        // (1) Pick up the next request whenever no work is in flight.
+        // (1) Pick up the next ready request whenever no work is in flight.
+        // Skip already-computed requests and park ones whose prerequisite EB
+        // is not prepared yet into `deferred`, scanning past them so a parked
+        // request never head-of-line blocks a ready one behind it.
         if self.computation.is_none()
             && self.promises_stream.is_none()
             && self.pending_event.is_none()
-            && let Some(req) = self.input.pop_front()
         {
-            let (sender, receiver) = mpsc::unbounded_channel();
-            self.in_flight_mb = Some(req.mb_hash);
-            self.promises_stream = Some(MbPromisesStream { receiver });
-            self.computation = Some(future_timing::timed(
-                Self::compute(
-                    self.db.clone(),
-                    self.processor.clone(),
-                    req,
-                    self.promise_emission_mode,
-                    sender,
-                )
-                .boxed(),
-            ));
+            while let Some(req) = self.input.pop_front() {
+                if self.db.mb_meta(req.mb_hash).computed {
+                    continue;
+                }
+                if !self.prerequisite_ready(req.mb_hash) {
+                    self.deferred.push_back(req);
+                    continue;
+                }
+                let (sender, receiver) = mpsc::unbounded_channel();
+                self.in_flight_mb = Some(req.mb_hash);
+                self.promises_stream = Some(MbPromisesStream { receiver });
+                self.computation = Some(future_timing::timed(
+                    Self::compute(
+                        self.db.clone(),
+                        self.processor.clone(),
+                        req,
+                        self.promise_emission_mode,
+                        sender,
+                    )
+                    .boxed(),
+                ));
+                break;
+            }
         }
 
         // (2) Forward streaming promises before anything else so the
@@ -558,6 +605,11 @@ mod tests {
             },
         );
         db.set_block_events(hash, &events);
+        // Compute now defers an MB until the EB it advances to is prepared, so
+        // these synthetic EBs (standing in for already-synced blocks) must carry
+        // the flag for the direct `ComputeSubService` tests that never pump a
+        // `BlockPrepared` notification.
+        db.mutate_block_meta(hash, |m| m.prepared = true);
         hash
     }
 

--- a/ethexe/compute/src/service.rs
+++ b/ethexe/compute/src/service.rs
@@ -98,6 +98,11 @@ impl<P: ProcessorExt> Stream for ComputeService<P> {
         };
 
         if let Poll::Ready(result) = self.prepare_sub_service.poll_next(cx) {
+            // A freshly prepared EB may unblock MBs that were deferred
+            // waiting for it (the gate Malachite used to own).
+            if let Ok(crate::prepare::Event::BlockPrepared(hash)) = &result {
+                self.mb_compute_sub_service.receive_prepared_block(*hash);
+            }
             return Poll::Ready(Some(result.map(ComputeEvent::from)));
         };
 
@@ -135,8 +140,8 @@ mod tests {
     use ethexe_common::{
         BlockHeader, CodeAndIdUnchecked,
         db::{
-            BlockMetaStorageRO, CodesStorageRO, CompactMb, MbStorageRO, MbStorageRW,
-            OnChainStorageRW,
+            BlockMetaStorageRO, BlockMetaStorageRW, CodesStorageRO, CompactMb, MbStorageRO,
+            MbStorageRW, OnChainStorageRW,
         },
         malachite::{Operation, Operations},
         mock::{Tap, seed_genesis_zero_mb},
@@ -172,6 +177,9 @@ mod tests {
             },
         );
         db.set_block_events(eth_block_hash, &[]);
+        // Compute defers an MB until its advanced EB is prepared; mark it so the
+        // `compute_mb` test (which never pumps a `BlockPrepared`) runs immediately.
+        db.mutate_block_meta(eth_block_hash, |m| m.prepared = true);
 
         let operations_hash = db.set_operations(Operations::new(vec![
             Operation::AdvanceTillEthereumBlock {

--- a/ethexe/malachite/service/src/externalities.rs
+++ b/ethexe/malachite/service/src/externalities.rs
@@ -57,8 +57,10 @@ use ethexe_db::Database;
 use ethexe_malachite_core::{Block, BlockPayload, Externalities, MAX_BLOCK_PAYLOAD_BYTES};
 use gprimitives::H256;
 use parity_scale_codec::{DecodeAll, Encode};
-use std::{collections::VecDeque, sync::Arc};
-use tokio::sync::{RwLock, mpsc::UnboundedSender};
+use std::sync::Arc;
+#[cfg(test)]
+use tokio::sync::RwLock;
+use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, error, trace, warn};
 
 /// Constant parameters for [`EthexeExternalities`];
@@ -81,21 +83,8 @@ pub(crate) struct EthexeExternalities {
     pub mempool: Option<Arc<dyn Mempool>>,
     /// Reference to the latest chain head data.
     pub chain_head: Arc<ChainHead>,
-    /// Pending service events queue.
-    /// Release events from here only when their prerequisite EB is prepared.
-    pub pending_events: RwLock<VecDeque<PendingEvent>>,
     /// Channel to poll events in MalachiteService.
     pub event_tx: UnboundedSender<Result<MalachiteEvent>>,
-}
-
-/// One outbound [`MalachiteEvent`] that can't be released until its
-/// `prerequisite` Eth block is prepared in local DB.
-pub(crate) struct PendingEvent {
-    /// Event body
-    pub event: MalachiteEvent,
-    /// Prerequisite Eth block hash
-    /// that must be prepared before this event can be emitted
-    pub prerequisite: H256,
 }
 
 #[async_trait]
@@ -132,14 +121,15 @@ impl Externalities for EthexeExternalities {
             meta.last_advanced_eb = last_advanced;
         });
 
-        self.try_emit_or_queue(
-            MalachiteEvent::BlockProposal {
-                height: mb.height,
-                mb_hash,
-            },
-            last_advanced,
-        )
-        .await;
+        // Emit immediately: the "wait until the advanced EB is prepared"
+        // gating now lives in ethexe-compute, which defers MB execution
+        // (not event emission) until the prerequisite EB is ready. Emitting
+        // here unconditionally keeps events strictly ordered and lets the
+        // service drain fast-sync replay without head-of-line stalls.
+        let _ = self.event_tx.send(Ok(MalachiteEvent::BlockProposal {
+            height: mb.height,
+            mb_hash,
+        }));
         Ok(())
     }
 
@@ -182,16 +172,12 @@ impl Externalities for EthexeExternalities {
             mb_hash,
             signatures: cert.signatures,
         };
-        let last_advanced = self.db.mb_meta(mb_hash).last_advanced_eb;
-        self.try_emit_or_queue(
-            MalachiteEvent::BlockFinalized {
-                cert: app_cert,
-                height: cert.height,
-                mb_hash,
-            },
-            last_advanced,
-        )
-        .await;
+        // Emit immediately; see the note in `process_mb_proposal`.
+        let _ = self.event_tx.send(Ok(MalachiteEvent::BlockFinalized {
+            cert: app_cert,
+            height: cert.height,
+            mb_hash,
+        }));
 
         Ok(())
     }
@@ -470,39 +456,6 @@ impl Externalities for EthexeExternalities {
 }
 
 impl EthexeExternalities {
-    /// Check whether the prerequisite EB is prepared in local DB.
-    /// Zero hash is a special case that always passes.
-    fn prerequisite_satisfied(&self, prerequisite: H256) -> bool {
-        use ethexe_common::db::BlockMetaStorageRO;
-        prerequisite.is_zero() || self.db.block_meta(prerequisite).prepared
-    }
-
-    /// Send event immediately if prerequisite is satisfied, otherwise queue it for later emission.
-    pub(crate) async fn try_emit_or_queue(&self, event: MalachiteEvent, prerequisite: H256) {
-        let mut queue = self.pending_events.write().await;
-        if queue.is_empty() && self.prerequisite_satisfied(prerequisite) {
-            // Channel receiver dropped only on shutdown — best-effort.
-            let _ = self.event_tx.send(Ok(event));
-        } else {
-            queue.push_back(PendingEvent {
-                event,
-                prerequisite,
-            });
-        }
-    }
-
-    /// Check the pending events queue and release any events whose prerequisites are now satisfied.
-    pub(crate) async fn drain_pending_events(&self) {
-        let mut queue = self.pending_events.write().await;
-        while let Some(front) = queue.front() {
-            if !self.prerequisite_satisfied(front.prerequisite) {
-                break;
-            }
-            let entry = queue.pop_front().expect("just peeked");
-            let _ = self.event_tx.send(Ok(entry.event));
-        }
-    }
-
     // Wait for either a new EB candidate past quarantine
     // or any suitable injected tx to include in the next proposal.
     async fn wait_for_proposable_content(
@@ -640,7 +593,6 @@ mod tests {
             mempool: Some(Arc::new(EmptyMempool)),
             chain_head: make_chain_head(),
             event_tx,
-            pending_events: RwLock::new(VecDeque::new()),
             cfg: ExternalitiesConfig {
                 gas_allowance: 1_000_000,
                 canonical_quarantine: 0,
@@ -1055,7 +1007,6 @@ mod tests {
             mempool: Some(Arc::clone(&tracker) as Arc<dyn Mempool>),
             chain_head: make_chain_head(),
             event_tx,
-            pending_events: RwLock::new(VecDeque::new()),
             cfg: ExternalitiesConfig {
                 gas_allowance: 1_000_000,
                 canonical_quarantine: 0,
@@ -1122,7 +1073,6 @@ mod tests {
             mempool: Some(mempool as Arc<dyn Mempool>),
             chain_head: make_chain_head(),
             event_tx,
-            pending_events: RwLock::new(VecDeque::new()),
             cfg: ExternalitiesConfig {
                 gas_allowance: 1_000_000,
                 canonical_quarantine: 0,
@@ -1876,7 +1826,6 @@ mod tests {
             mempool: Some(Arc::new(EmptyMempool)),
             chain_head: make_chain_head(),
             event_tx,
-            pending_events: RwLock::new(VecDeque::new()),
             cfg: ExternalitiesConfig {
                 gas_allowance: 1_000_000,
                 canonical_quarantine: 2,

--- a/ethexe/malachite/service/src/lib.rs
+++ b/ethexe/malachite/service/src/lib.rs
@@ -28,7 +28,7 @@
 //! - [`TxValidity`] (enum) — Validity verdict: `Valid`, `Duplicate`, `Outdated`, …
 //!
 //! Driver methods on [`MalachiteService`]: `receive_injected_transaction`,
-//! `receive_new_eb`, `receive_eb_synced`, `receive_eb_prepared`, `shutdown`.
+//! `receive_new_eb`, `receive_eb_synced`, `shutdown`.
 //!
 //! [`TxValidity`] gates inclusion: a producer drops any non-`Valid` tx when
 //! building an MB, and a validator rejects an entire MB that contains one.

--- a/ethexe/malachite/service/src/service.rs
+++ b/ethexe/malachite/service/src/service.rs
@@ -129,12 +129,6 @@ impl MalachiteService {
         }
     }
 
-    /// Handle a prepared Ethereum block: release pending events whose
-    /// prerequisite is now satisfied.
-    pub async fn receive_eb_prepared(&self, _eb_hash: H256) {
-        self.externalities.drain_pending_events().await
-    }
-
     /// Tear down the inner consensus core, releasing its store and sockets.
     pub async fn shutdown(mut self) {
         if let Some(inner) = self.inner.take() {

--- a/ethexe/malachite/service/src/starter.rs
+++ b/ethexe/malachite/service/src/starter.rs
@@ -105,7 +105,6 @@ impl MalachiteServiceStarter {
             },
             mempool: mempool.clone(),
             chain_head: chain_head.clone(),
-            pending_events: Default::default(),
             event_tx,
         };
 

--- a/ethexe/service/src/fast_sync.rs
+++ b/ethexe/service/src/fast_sync.rs
@@ -5,12 +5,12 @@
 
 use crate::Service;
 use alloy::eips::BlockId;
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use ethexe_common::{
     Address, BlockData, CodeAndIdUnchecked, Digest, ProgramStates, StateHashWithQueueSize,
     db::{
         BlockMetaStorageRO, CodesStorageRO, CodesStorageRW, ConfigStorageRO, GlobalsStorageRW,
-        MbStorageRW, OnChainStorageRW, PreparedBlockData,
+        MbStorageRO, MbStorageRW, OnChainStorageRW, PreparedBlockData,
     },
     events::{
         BlockEvent, RouterEvent,
@@ -55,6 +55,97 @@ use std::{
 pub struct FastSyncReplayTarget {
     pub mb_hash: H256,
     pub eb_hash: H256,
+}
+
+/// Startup gate that suppresses Malachite's replay of the already-restored
+/// chain after fast sync.
+///
+/// When Malachite's core starts it value-syncs from genesis and replays every
+/// historical MB as a `BlockProposal` (which is what drives compute; the
+/// matching `BlockFinalized` always follows and does no compute). Fast sync
+/// only restored the DB up to `latest_committed_mb`, so these replayed
+/// proposals must not drive compute. Malachite emits blocks in height order, so
+/// it suffices to drop proposals until the target MB is reached. Two cases:
+/// * fresh DB — Malachite replays from genesis; we wait for the target by hash;
+/// * target already finalized locally before this start — Malachite resumes
+///   from the target's child, so the target hash never reappears. The first
+///   proposal is then a descendant of the target; an ancestry walk detects that
+///   and opens the gate immediately.
+///
+/// The ancestry walk runs at most once (the first proposal); afterwards the
+/// decision is a single hash comparison.
+pub(crate) enum ReplayGate {
+    /// No fast sync this run — never gates.
+    Open,
+    /// Awaiting the first proposal to disambiguate the two cases above.
+    Pending(H256),
+    /// Genesis replay confirmed; waiting for the target MB by hash.
+    Waiting(H256),
+}
+
+impl ReplayGate {
+    pub(crate) fn new(target: Option<FastSyncReplayTarget>) -> Self {
+        match target {
+            Some(target) => Self::Pending(target.mb_hash),
+            None => Self::Open,
+        }
+    }
+
+    /// Whether the `BlockProposal` for `mb_hash` should drive compute; opens
+    /// the gate once the target boundary is reached. Only proposals are gated
+    /// because compute is triggered solely by `BlockProposal` (the matching
+    /// `BlockFinalized` always follows and does no compute).
+    pub(crate) fn allow(&mut self, db: &Database, mb_hash: H256) -> Result<bool> {
+        match *self {
+            Self::Open => Ok(true),
+            Self::Pending(target) => {
+                if mb_hash == target {
+                    // The restored boundary itself — already computed by fast sync.
+                    *self = Self::Open;
+                    Ok(false)
+                } else if target_is_ancestor(db, target, mb_hash)? {
+                    // Target was finalized before this start; this is the first
+                    // live descendant — process it and resume normally.
+                    *self = Self::Open;
+                    Ok(true)
+                } else {
+                    *self = Self::Waiting(target);
+                    Ok(false)
+                }
+            }
+            Self::Waiting(target) => {
+                if mb_hash == target {
+                    *self = Self::Open;
+                }
+                Ok(false)
+            }
+        }
+    }
+}
+
+/// Walk the MB parent chain from `mb_hash` and report whether `target` is a
+/// strict ancestor. Errors loudly on a missing `CompactMb` rather than hanging
+/// the gate on incomplete data.
+fn target_is_ancestor(db: &Database, target: H256, mb_hash: H256) -> Result<bool> {
+    let mut current = mb_hash;
+    loop {
+        let parent = db
+            .mb_compact_block(current)
+            .ok_or_else(|| {
+                anyhow!(
+                    "fast-sync replay gate: missing CompactMb for {current} while resolving \
+                     ancestry of finalized MB {mb_hash}"
+                )
+            })?
+            .parent;
+        if parent == target {
+            return Ok(true);
+        }
+        if parent.is_zero() {
+            return Ok(false);
+        }
+        current = parent;
+    }
 }
 
 struct EventData {
@@ -605,7 +696,7 @@ async fn latest_era_with_committed_validators(
         .context("failed to calculate era from validators timestamp")
 }
 
-pub(crate) async fn sync(service: &mut Service) -> Result<()> {
+pub(crate) async fn sync(service: &mut Service) -> Result<Option<FastSyncReplayTarget>> {
     let Service {
         observer,
         compute,
@@ -617,7 +708,7 @@ pub(crate) async fn sync(service: &mut Service) -> Result<()> {
     } = service;
     let Some(network) = network else {
         log::warn!("Network service is disabled. Skipping fast synchronization...");
-        return Ok(());
+        return Ok(None);
     };
 
     log::info!("Fast synchronization is in progress...");
@@ -642,7 +733,7 @@ pub(crate) async fn sync(service: &mut Service) -> Result<()> {
     let block_loader = observer.block_loader();
     let Some(event_data) = EventData::collect(&block_loader, db, finalized_block).await? else {
         log::warn!("No finalized committed MB found. Skipping fast synchronization...");
-        return Ok(());
+        return Ok(None);
     };
 
     let EventData {
@@ -743,7 +834,7 @@ pub(crate) async fn sync(service: &mut Service) -> Result<()> {
         ))
         .await;
 
-    Ok(())
+    Ok(Some(replay_target))
 }
 
 #[cfg(test)]

--- a/ethexe/service/src/lib.rs
+++ b/ethexe/service/src/lib.rs
@@ -595,16 +595,18 @@ impl Service {
     }
 
     pub async fn run(mut self) -> Result<()> {
-        if self.fast_sync {
-            fast_sync::sync(&mut self).await?;
-        }
+        let replay_target = if self.fast_sync {
+            fast_sync::sync(&mut self).await?
+        } else {
+            None
+        };
 
-        self.run_inner().await.inspect_err(|err| {
+        self.run_inner(replay_target).await.inspect_err(|err| {
             log::error!("Service finished work with error: {err:?}");
         })
     }
 
-    async fn run_inner(self) -> Result<()> {
+    async fn run_inner(self, replay_target: Option<fast_sync::FastSyncReplayTarget>) -> Result<()> {
         let Service {
             db,
             mut network,
@@ -647,6 +649,10 @@ impl Service {
             .await;
 
         let mut network_injected_txs: HashMap<_, PendingNetworkInjectedTx> = HashMap::new();
+
+        // Suppresses Malachite's startup replay of the chain fast sync already
+        // restored, up to and including the committed target MB.
+        let mut replay_gate = fast_sync::ReplayGate::new(replay_target);
 
         loop {
             let event: Event = tokio::select! {
@@ -712,8 +718,9 @@ impl Service {
                         if let Some(c) = consensus.as_mut() {
                             c.receive_prepared_block(block_hash)?;
                         }
-
-                        malachite.receive_eb_prepared(block_hash).await;
+                        // Compute owns the "wait for the prerequisite EB" gate
+                        // now (see `ComputeSubService`), so Malachite no longer
+                        // needs a prepared-block notification.
                     }
                     ComputeEvent::CodeProcessed(_) => {
                         // Nothing
@@ -942,6 +949,13 @@ impl Service {
                             mb_hash = %mb_hash,
                             "Malachite: BlockProposal",
                         );
+
+                        // Suppress replay of the chain fast sync already
+                        // restored, up to and including the committed target MB.
+                        if !replay_gate.allow(&db, mb_hash)? {
+                            tracing::debug!(mb_hash = %mb_hash, "fast-sync replay gate: skipping replayed proposal");
+                            continue;
+                        }
 
                         compute.compute_mb(mb_hash, ethexe_common::PromisePolicy::Enabled);
                     }


### PR DESCRIPTION
## What & why

Redesign-only diff on top of `gsobol/ethexe/al-bitswap` (which is `al/ethexe/bitswap` with `tune-malachite-errors` merged). Base chosen so this PR shows **only** the redesign, not the large tune merge.

Models the eventual flow: `tune → master`, `master → al/ethexe/bitswap` (== the base branch here), then this PR `→ al/ethexe/bitswap`.

## Problem

After tune lands in bitswap, bitswap's in-Malachite fast-sync replay filter is gone (dropped with bitswap's Malachite changes). A pure app-level "wait for `BlockFinalized(target)`" gate is **impossible** against tune's externalities: `try_emit_or_queue` head-of-line-blocks the event queue on an unprepared prerequisite EB, so the target event would never reach the app (fast sync deadlocks). On the base branch the `fast_sync` test stalls for exactly this reason.

## Solution — move the EB-prerequisite gate out of Malachite

- **Malachite externalities** no longer queue events behind a prepared-EB prerequisite (`try_emit_or_queue` / `pending_events` / `drain_pending_events` / `prerequisite_satisfied` removed; `receive_eb_prepared` gone). `process_mb_proposal` / `process_mb_finalized` emit immediately and strictly in order.
- **ethexe-compute** now owns the "defer an MB until the EB it advances to is prepared" gate (`ComputeSubService::deferred` + `receive_prepared_block`). It scans every deferred request on each `BlockPrepared` (the prepare sub-service only reports the chain head of a prepared ancestor run); defer-at-launch avoids head-of-line blocking ready requests.
- **The service** applies an app-level `ReplayGate` after fast sync: suppresses replayed `BlockProposal`s until the committed target MB is reached — by hash for a fresh DB, or via a one-shot ancestry walk when the target was already finalized locally before start — then resumes live consensus. A missing `CompactMb` mid-walk fails loudly instead of hanging.

## Testing

- `cargo fmt --all --check` ✓
- `cargo clippy` ✓ (clean)
- `cargo nextest run -p "ethexe-*"` → **543 passed**, 1 skipped, incl. the `fast_sync` integration test (~77s, well under the 120s cap — default value-sync timing suffices).

## Notes

- The transient rewind of `globals.latest_finalized_mb_hash` during genesis replay is low-severity (only the consensus batch manager reads it at runtime, and it isn't producing batches during catch-up) and self-heals as replay climbs back to the tip.
- Draft for review of the layering choice (compute-owned prerequisite gate + app-level replay gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgjaE68s3nARWKBCa4Jid1
