### PR TITLE
feat(vara.eth): add --batch-commitment-period node knob

### DIFF
--- a/ethexe/.ethexe.example.local.toml
+++ b/ethexe/.ethexe.example.local.toml
@@ -118,6 +118,13 @@ post-quarantine-delay = 1
 # (optional, must be non-zero u8, default: 16).
 # commitment-delay-limit = 16
 
+# Coordinator-local cadence for batch commitments: when elected coordinator,
+# this node only builds a batch on blocks whose height is a multiple of this
+# value (1 = every block). Participants ignore it and validate whatever the
+# coordinator commits, so nodes may run different values.
+# (optional, must be non-zero u32, default: 1).
+# batch-commitment-period = 1
+
 # Path to genesis state dump file (.blob or .json) for initial chain state.
 # (optional, default: None).
 # genesis-state-dump = "/path/to/genesis.blob"

--- a/ethexe/.ethexe.example.toml
+++ b/ethexe/.ethexe.example.toml
@@ -118,6 +118,13 @@
 # (optional, must be non-zero u8, default: 16).
 # commitment-delay-limit = 16
 
+# Coordinator-local cadence for batch commitments: when elected coordinator,
+# this node only builds a batch on blocks whose height is a multiple of this
+# value (1 = every block). Participants ignore it and validate whatever the
+# coordinator commits, so nodes may run different values.
+# (optional, must be non-zero u32, default: 1).
+# batch-commitment-period = 1
+
 # Path to genesis state dump file (.blob or .json) for initial chain state.
 # (optional, default: None).
 # genesis-state-dump = "/path/to/genesis.blob"

--- a/ethexe/cli/src/params/node.rs
+++ b/ethexe/cli/src/params/node.rs
@@ -127,6 +127,24 @@ pub struct NodeParams {
     #[serde(default, rename = "commitment-delay-limit")]
     pub commitment_delay_limit: Option<NonZero<u8>>,
 
+    /// How often batch commitments are produced: a validator only builds /
+    /// validates a batch on blocks whose height is a multiple of this value.
+    /// `1` (the default) commits every block and reproduces the previous
+    /// behavior.
+    ///
+    /// Operational bounds (the gate is height-based and node-local):
+    /// - All validators SHOULD use the same value — coordinator and
+    ///   participants only agree on which blocks to skip when their periods
+    ///   match; divergent values reduce quorum on the off-cadence blocks.
+    /// - Keep it small enough that every era's election window still contains
+    ///   several multiple-of-period blocks, otherwise validator-set rotation
+    ///   (which has an election-window deadline) can be starved.
+    /// - Prefer a value not larger than `uncommitted-chain-len-threshold` so
+    ///   the idle-chain checkpoint still fires close to its threshold.
+    #[arg(long)]
+    #[serde(default, rename = "batch-commitment-period")]
+    pub batch_commitment_period: Option<NonZero<u32>>,
+
     /// Path to genesis state dump file (.blob or .json) for initial chain state.
     #[arg(long)]
     #[serde(default, rename = "genesis-state-dump")]
@@ -201,6 +219,9 @@ impl NodeParams {
             commitment_delay_limit: self
                 .commitment_delay_limit
                 .unwrap_or(ethexe_common::DEFAULT_COMMITMENT_DELAY_LIMIT),
+            batch_commitment_period: self
+                .batch_commitment_period
+                .unwrap_or(ethexe_common::DEFAULT_BATCH_COMMITMENT_PERIOD),
             genesis_state_dump: self.genesis_state_dump,
             db_cleanup: self.db_cleanup,
         })
@@ -292,6 +313,10 @@ impl MergeParams for NodeParams {
                 .or(with.uncommitted_chain_len_threshold),
 
             commitment_delay_limit: self.commitment_delay_limit.or(with.commitment_delay_limit),
+
+            batch_commitment_period: self
+                .batch_commitment_period
+                .or(with.batch_commitment_period),
 
             genesis_state_dump: self.genesis_state_dump.or(with.genesis_state_dump),
 

--- a/ethexe/cli/src/params/node.rs
+++ b/ethexe/cli/src/params/node.rs
@@ -127,20 +127,18 @@ pub struct NodeParams {
     #[serde(default, rename = "commitment-delay-limit")]
     pub commitment_delay_limit: Option<NonZero<u8>>,
 
-    /// How often batch commitments are produced: a validator only builds /
-    /// validates a batch on blocks whose height is a multiple of this value.
-    /// `1` (the default) commits every block and reproduces the previous
-    /// behavior.
+    /// Coordinator-local cadence for batch commitments: when this node is the
+    /// elected coordinator it only builds a batch on blocks whose height is a
+    /// multiple of this value. `1` (the default) commits every block and
+    /// reproduces the previous behavior. Participants are unaffected — they
+    /// always validate whatever the coordinator chooses to commit, so different
+    /// nodes may safely run different values.
     ///
-    /// Operational bounds (the gate is height-based and node-local):
-    /// - All validators SHOULD use the same value — coordinator and
-    ///   participants only agree on which blocks to skip when their periods
-    ///   match; divergent values reduce quorum on the off-cadence blocks.
-    /// - Keep it small enough that every era's election window still contains
-    ///   several multiple-of-period blocks, otherwise validator-set rotation
-    ///   (which has an election-window deadline) can be starved.
-    /// - Prefer a value not larger than `uncommitted-chain-len-threshold` so
-    ///   the idle-chain checkpoint still fires close to its threshold.
+    /// Keep it small enough that every era's election window still contains
+    /// several multiple-of-period blocks, otherwise validator-set rotation
+    /// (which has an election-window deadline) can be delayed; and prefer a
+    /// value not larger than `uncommitted-chain-len-threshold` so the
+    /// idle-chain checkpoint still fires close to its threshold.
     #[arg(long)]
     #[serde(default, rename = "batch-commitment-period")]
     pub batch_commitment_period: Option<NonZero<u32>>,

--- a/ethexe/common/src/lib.rs
+++ b/ethexe/common/src/lib.rs
@@ -111,6 +111,12 @@ pub const DEFAULT_BLOCK_GAS_LIMIT: u64 = 4_000_000_000_000;
 pub const DEFAULT_COMMITMENT_DELAY_LIMIT: core::num::NonZero<u8> =
     core::num::NonZero::new(16).expect("16 != 0");
 
+/// Default `batch_commitment_period` (in Ethereum blocks). A coordinator only
+/// builds a `BatchCommitment` on blocks whose height is a multiple of this
+/// value; `1` means every block. Node-local knob, not a protocol constant.
+pub const DEFAULT_BATCH_COMMITMENT_PERIOD: core::num::NonZero<u32> =
+    core::num::NonZero::new(1).expect("1 != 0");
+
 /// Maximum number of touched programs per MB.
 pub const MAX_TOUCHED_PROGRAMS_PER_MB: u32 = 128;
 

--- a/ethexe/consensus/src/validator/core.rs
+++ b/ethexe/consensus/src/validator/core.rs
@@ -46,10 +46,10 @@ pub struct ValidatorCore {
     /// the same chain head and for malachite to finalize mb with fresh post-quarantine block included.
     /// Anyway not necessary.
     pub coordinator_aggregation_delay: Duration,
-    /// How often batch commitments are produced: a coordinator only builds a
-    /// batch on blocks whose height is a multiple of this value (`1` = every
-    /// block). Every validator gates symmetrically on block height, so no
-    /// extra coordination is needed.
+    /// Coordinator-local cadence: when elected coordinator, this node only
+    /// builds a batch on blocks whose height is a multiple of this value
+    /// (`1` = every block). Participants ignore it and validate whatever the
+    /// coordinator commits, so the knob needs no cross-node agreement.
     pub batch_commitment_period: std::num::NonZero<u32>,
 }
 

--- a/ethexe/consensus/src/validator/core.rs
+++ b/ethexe/consensus/src/validator/core.rs
@@ -46,6 +46,11 @@ pub struct ValidatorCore {
     /// the same chain head and for malachite to finalize mb with fresh post-quarantine block included.
     /// Anyway not necessary.
     pub coordinator_aggregation_delay: Duration,
+    /// How often batch commitments are produced: a coordinator only builds a
+    /// batch on blocks whose height is a multiple of this value (`1` = every
+    /// block). Every validator gates symmetrically on block height, so no
+    /// extra coordination is needed.
+    pub batch_commitment_period: std::num::NonZero<u32>,
 }
 
 impl Clone for ValidatorCore {
@@ -62,6 +67,7 @@ impl Clone for ValidatorCore {
             metrics: self.metrics.clone(),
             commitment_delay_limit: self.commitment_delay_limit,
             coordinator_aggregation_delay: self.coordinator_aggregation_delay,
+            batch_commitment_period: self.batch_commitment_period,
         }
     }
 }

--- a/ethexe/consensus/src/validator/idle.rs
+++ b/ethexe/consensus/src/validator/idle.rs
@@ -144,6 +144,23 @@ impl Idle {
             .into());
         }
 
+        // Batch commitments are only produced on blocks whose height is a
+        // multiple of the configured period. Coordinator and participants run
+        // this same height-based check, so — as long as they share the period
+        // (see `NodeParams::batch_commitment_period`) — they skip exactly the
+        // same blocks with no extra coordination; we just drop back to idle and
+        // wait for the next chain head.
+        let period = self.ctx.core.batch_commitment_period.get();
+        if !block.header.height.is_multiple_of(period) {
+            tracing::trace!(
+                block = %block.hash,
+                height = block.header.height,
+                period,
+                "skipping batch commitment for this block (height not a multiple of period)",
+            );
+            return Idle::create(self.ctx);
+        }
+
         // Block is prepared — figure out who's coordinator and dispatch.
         let validators = {
             let timelines = self.ctx.core.timelines;
@@ -169,5 +186,126 @@ impl Idle {
         } else {
             Participant::create(self.ctx, block, coordinator_addr)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::validator::{
+        ValidatorMetrics,
+        batch::{BatchCommitmentManager, BatchLimits},
+        core::{BatchCommitter, MiddlewareWrapper, ValidatorCore},
+    };
+    use async_trait::async_trait;
+    use ethexe_common::{
+        Address,
+        db::ConfigStorageRO,
+        ecdsa::{ContractSignature, PublicKey},
+        gear::BatchCommitment,
+        mock::{BlockChain, Mock},
+    };
+    use ethexe_db::Database;
+    use ethexe_ethereum::middleware::{ElectionProvider, MockElectionProvider};
+    use gsigner::secp256k1::Signer;
+    use std::{collections::VecDeque, num::NonZero, time::Duration};
+
+    /// Committer that never touches the chain — the gate test only inspects
+    /// the resulting state, no batch is ever submitted.
+    struct NoopCommitter;
+
+    #[async_trait]
+    impl BatchCommitter for NoopCommitter {
+        fn clone_boxed(&self) -> Box<dyn BatchCommitter> {
+            Box::new(NoopCommitter)
+        }
+
+        async fn commit(
+            self: Box<Self>,
+            _batch: BatchCommitment,
+            _signatures: Vec<ContractSignature>,
+        ) -> Result<H256> {
+            Ok(H256::zero())
+        }
+    }
+
+    fn test_context(
+        db: Database,
+        signer: Signer,
+        pub_key: PublicKey,
+        batch_commitment_period: NonZero<u32>,
+    ) -> ValidatorContext {
+        let timelines = db.config().timelines;
+        let middleware = MiddlewareWrapper::from_inner(
+            Box::new(MockElectionProvider::new()) as Box<dyn ElectionProvider>
+        );
+        let batch_manager =
+            BatchCommitmentManager::new(BatchLimits::default(), db.clone(), middleware);
+
+        ValidatorContext {
+            core: ValidatorCore {
+                signatures_threshold: 1,
+                router_address: Address([0; 20]),
+                pub_key,
+                timelines,
+                signer,
+                db,
+                committer: Box::new(NoopCommitter),
+                batch_manager,
+                metrics: ValidatorMetrics::default(),
+                commitment_delay_limit: ethexe_common::DEFAULT_COMMITMENT_DELAY_LIMIT,
+                coordinator_aggregation_delay: Duration::ZERO,
+                batch_commitment_period,
+            },
+            pending_events: VecDeque::new(),
+            output: VecDeque::new(),
+            tasks: Default::default(),
+        }
+    }
+
+    /// With `batch_commitment_period = 2`, the validator must start a batch
+    /// only on even-height blocks and stay idle on odd-height ones. A
+    /// single-validator set makes this node the elected coordinator, so a
+    /// non-skipped block lands in `CoordinatorBoot`.
+    #[tokio::test]
+    async fn batch_commitment_period_gates_by_block_height() {
+        let db = Database::memory();
+        let signer = Signer::memory();
+        let pub_key = signer.generate().unwrap();
+
+        let mut chain = BlockChain::mock(10);
+        chain.validators = vec![pub_key.to_address()].try_into().unwrap();
+        let chain = chain.setup(&db);
+
+        let period = NonZero::new(2).unwrap();
+
+        // `blocks[i].height = genesis_height + i`; genesis_height is even,
+        // so blocks[2] is even (a multiple of 2) and blocks[3] is odd.
+        let even_block = chain.blocks[2].to_simple();
+        let odd_block = chain.blocks[3].to_simple();
+        assert!(even_block.header.height.is_multiple_of(period.get()));
+        assert!(!odd_block.header.height.is_multiple_of(period.get()));
+
+        // Odd height → skipped → back to idle, waiting for the next head.
+        let ctx = test_context(db.clone(), signer.clone(), pub_key, period);
+        let state = Idle::create(ctx)
+            .unwrap()
+            .process_new_head(odd_block)
+            .unwrap();
+        assert!(
+            state.is_idle(),
+            "odd-height block must be skipped, got {state}"
+        );
+
+        // Even height → coordinator boots and starts building a batch.
+        let ctx = test_context(db, signer, pub_key, period);
+        let state = Idle::create(ctx)
+            .unwrap()
+            .process_new_head(even_block)
+            .unwrap();
+        assert!(
+            state.is_coordinator_boot(),
+            "even-height block must start the coordinator, got {state}"
+        );
     }
 }

--- a/ethexe/consensus/src/validator/idle.rs
+++ b/ethexe/consensus/src/validator/idle.rs
@@ -279,12 +279,20 @@ mod tests {
 
         let period = NonZero::new(2).unwrap();
 
-        // `blocks[i].height = genesis_height + i`; genesis_height is even,
-        // so blocks[2] is even (a multiple of 2) and blocks[3] is odd.
-        let even_block = chain.blocks[2].to_simple();
-        let odd_block = chain.blocks[3].to_simple();
-        assert!(even_block.header.height.is_multiple_of(period.get()));
-        assert!(!odd_block.header.height.is_multiple_of(period.get()));
+        // Pick concrete even/odd-height blocks dynamically so the test does not
+        // depend on `BlockChain::mock`'s genesis-height parity.
+        let even_block = chain
+            .blocks
+            .iter()
+            .filter_map(|b| b.synced.as_ref().map(|_| b.to_simple()))
+            .find(|b| b.header.height.is_multiple_of(period.get()))
+            .expect("mock chain must contain an even-height block");
+        let odd_block = chain
+            .blocks
+            .iter()
+            .filter_map(|b| b.synced.as_ref().map(|_| b.to_simple()))
+            .find(|b| !b.header.height.is_multiple_of(period.get()))
+            .expect("mock chain must contain an odd-height block");
 
         // Odd height → coordinator skips → back to idle, waiting for next head.
         let ctx = test_context(db.clone(), signer.clone(), pub_key, period);

--- a/ethexe/consensus/src/validator/idle.rs
+++ b/ethexe/consensus/src/validator/idle.rs
@@ -144,23 +144,6 @@ impl Idle {
             .into());
         }
 
-        // Batch commitments are only produced on blocks whose height is a
-        // multiple of the configured period. Coordinator and participants run
-        // this same height-based check, so — as long as they share the period
-        // (see `NodeParams::batch_commitment_period`) — they skip exactly the
-        // same blocks with no extra coordination; we just drop back to idle and
-        // wait for the next chain head.
-        let period = self.ctx.core.batch_commitment_period.get();
-        if !block.header.height.is_multiple_of(period) {
-            tracing::trace!(
-                block = %block.hash,
-                height = block.header.height,
-                period,
-                "skipping batch commitment for this block (height not a multiple of period)",
-            );
-            return Idle::create(self.ctx);
-        }
-
         // Block is prepared — figure out who's coordinator and dispatch.
         let validators = {
             let timelines = self.ctx.core.timelines;
@@ -182,8 +165,26 @@ impl Idle {
             .ok_or_else(|| anyhow!("cannot determine coordinator for block {}", block.hash))?;
 
         if coordinator_addr == self.ctx.core.pub_key.to_address() {
+            // The period is a coordinator-local cadence: only the elected
+            // coordinator decides whether this block is a commitment block,
+            // using its own `batch_commitment_period`. On a non-multiple block
+            // it produces nothing and drops back to idle.
+            let period = self.ctx.core.batch_commitment_period.get();
+            if !block.header.height.is_multiple_of(period) {
+                tracing::trace!(
+                    block = %block.hash,
+                    height = block.header.height,
+                    period,
+                    "coordinator skips this block: height not a multiple of batch_commitment_period",
+                );
+                return Idle::create(self.ctx);
+            }
+
             CoordinatorBoot::start(self.ctx, block, validators)
         } else {
+            // Participants always enter the role and validate whatever the
+            // coordinator chooses to commit — the period is not consulted here,
+            // so the knob stays purely coordinator-local.
             Participant::create(self.ctx, block, coordinator_addr)
         }
     }
@@ -263,12 +264,11 @@ mod tests {
         }
     }
 
-    /// With `batch_commitment_period = 2`, the validator must start a batch
-    /// only on even-height blocks and stay idle on odd-height ones. A
-    /// single-validator set makes this node the elected coordinator, so a
-    /// non-skipped block lands in `CoordinatorBoot`.
+    /// The period is coordinator-local: when this node is the elected
+    /// coordinator (single-validator set), `batch_commitment_period = 2` makes
+    /// it build a batch only on even-height blocks and stay idle on odd ones.
     #[tokio::test]
-    async fn batch_commitment_period_gates_by_block_height() {
+    async fn batch_commitment_period_gates_coordinator_by_block_height() {
         let db = Database::memory();
         let signer = Signer::memory();
         let pub_key = signer.generate().unwrap();
@@ -286,7 +286,7 @@ mod tests {
         assert!(even_block.header.height.is_multiple_of(period.get()));
         assert!(!odd_block.header.height.is_multiple_of(period.get()));
 
-        // Odd height → skipped → back to idle, waiting for the next head.
+        // Odd height → coordinator skips → back to idle, waiting for next head.
         let ctx = test_context(db.clone(), signer.clone(), pub_key, period);
         let state = Idle::create(ctx)
             .unwrap()
@@ -294,7 +294,7 @@ mod tests {
             .unwrap();
         assert!(
             state.is_idle(),
-            "odd-height block must be skipped, got {state}"
+            "odd-height block must be skipped by the coordinator, got {state}"
         );
 
         // Even height → coordinator boots and starts building a batch.
@@ -306,6 +306,60 @@ mod tests {
         assert!(
             state.is_coordinator_boot(),
             "even-height block must start the coordinator, got {state}"
+        );
+    }
+
+    /// A participant ignores its own period entirely: it enters the
+    /// `Participant` role to validate the coordinator's batch even on a block
+    /// whose height is not a multiple of the (large) local period.
+    #[tokio::test]
+    async fn participant_enters_regardless_of_batch_commitment_period() {
+        let db = Database::memory();
+        let signer = Signer::memory();
+        let my_key = signer.generate().unwrap();
+        let other_signer = Signer::memory();
+        let other_key = other_signer.generate().unwrap();
+
+        let validators_vec: ethexe_common::ValidatorsVec =
+            vec![my_key.to_address(), other_key.to_address()]
+                .try_into()
+                .unwrap();
+        let mut chain = BlockChain::mock(10);
+        chain.validators = validators_vec.clone();
+        let chain = chain.setup(&db);
+
+        let timelines = db.config().timelines;
+
+        // Find a prepared block whose elected coordinator is NOT this node —
+        // there our node must always become a participant.
+        let participant_block = chain
+            .blocks
+            .iter()
+            .filter_map(|b| b.synced.as_ref().map(|_| b.to_simple()))
+            .find(|b| {
+                timelines.block_coordinator_at(&validators_vec, b.header.timestamp)
+                    != Some(my_key.to_address())
+            })
+            .expect("expected a block coordinated by the other validator");
+
+        // A period far larger than any height — proving the participant path
+        // never consults it.
+        let huge_period = NonZero::new(u32::MAX).unwrap();
+        assert!(
+            !participant_block
+                .header
+                .height
+                .is_multiple_of(huge_period.get())
+        );
+
+        let ctx = test_context(db, signer, my_key, huge_period);
+        let state = Idle::create(ctx)
+            .unwrap()
+            .process_new_head(participant_block)
+            .unwrap();
+        assert!(
+            state.is_participant(),
+            "participant must enter regardless of period, got {state}"
         );
     }
 }

--- a/ethexe/consensus/src/validator/mod.rs
+++ b/ethexe/consensus/src/validator/mod.rs
@@ -88,9 +88,9 @@ pub struct ValidatorConfig {
     /// `last_advanced_eth_block` runs ahead of `last_committed_eb`
     /// by more than this many Eth blocks.
     pub uncommitted_chain_len_threshold: std::num::NonZero<u32>,
-    /// How often batch commitments are produced — a coordinator only builds a
-    /// batch on blocks whose height is a multiple of this value (`1` = every
-    /// block).
+    /// Coordinator-local cadence — when elected coordinator, this node only
+    /// builds a batch on blocks whose height is a multiple of this value
+    /// (`1` = every block). Participants ignore it.
     pub batch_commitment_period: std::num::NonZero<u32>,
 }
 

--- a/ethexe/consensus/src/validator/mod.rs
+++ b/ethexe/consensus/src/validator/mod.rs
@@ -88,6 +88,10 @@ pub struct ValidatorConfig {
     /// `last_advanced_eth_block` runs ahead of `last_committed_eb`
     /// by more than this many Eth blocks.
     pub uncommitted_chain_len_threshold: std::num::NonZero<u32>,
+    /// How often batch commitments are produced — a coordinator only builds a
+    /// batch on blocks whose height is a multiple of this value (`1` = every
+    /// block).
+    pub batch_commitment_period: std::num::NonZero<u32>,
 }
 
 impl ValidatorService {
@@ -121,6 +125,7 @@ impl ValidatorService {
                 metrics: ValidatorMetrics::default(),
                 commitment_delay_limit: config.commitment_delay_limit,
                 coordinator_aggregation_delay: config.coordinator_aggregation_delay,
+                batch_commitment_period: config.batch_commitment_period,
             },
             pending_events: VecDeque::new(),
             output: VecDeque::new(),

--- a/ethexe/service/src/config.rs
+++ b/ethexe/service/src/config.rs
@@ -108,9 +108,9 @@ pub struct NodeConfig {
     /// `last_advanced_eth_block` runs ahead of `last_committed_eb`
     /// by more than this many Eth blocks.
     pub uncommitted_chain_len_threshold: std::num::NonZero<u32>,
-    /// How often batch commitments are produced — a coordinator only builds a
-    /// batch on blocks whose height is a multiple of this value (`1` = every
-    /// block).
+    /// Coordinator-local cadence — when elected coordinator, this node only
+    /// builds a batch on blocks whose height is a multiple of this value
+    /// (`1` = every block). Participants ignore it.
     pub batch_commitment_period: std::num::NonZero<u32>,
     pub genesis_state_dump: Option<PathBuf>,
     /// Prune old MB schedules on startup, right after the database is

--- a/ethexe/service/src/config.rs
+++ b/ethexe/service/src/config.rs
@@ -108,6 +108,10 @@ pub struct NodeConfig {
     /// `last_advanced_eth_block` runs ahead of `last_committed_eb`
     /// by more than this many Eth blocks.
     pub uncommitted_chain_len_threshold: std::num::NonZero<u32>,
+    /// How often batch commitments are produced — a coordinator only builds a
+    /// batch on blocks whose height is a multiple of this value (`1` = every
+    /// block).
+    pub batch_commitment_period: std::num::NonZero<u32>,
     pub genesis_state_dump: Option<PathBuf>,
     /// Prune old MB schedules on startup, right after the database is
     /// opened. Temporary hot fix knob (#5585).

--- a/ethexe/service/src/lib.rs
+++ b/ethexe/service/src/lib.rs
@@ -447,6 +447,7 @@ impl Service {
                     batch_size_limit: config.node.batch_size_limit,
                     coordinator_aggregation_delay: config.node.coordinator_aggregation_delay,
                     uncommitted_chain_len_threshold: config.node.uncommitted_chain_len_threshold,
+                    batch_commitment_period: config.node.batch_commitment_period,
                 },
             )?))
         } else {

--- a/ethexe/service/src/tests/mod.rs
+++ b/ethexe/service/src/tests/mod.rs
@@ -3619,3 +3619,94 @@ async fn re_genesis_delayed_message() {
 
     stop_nodes([node]).await;
 }
+
+/// With `batch_commitment_period > 1` the validator must keep the chain live
+/// (a ping still round-trips) while only ever committing batches on blocks
+/// whose height is a multiple of the period.
+#[tokio::test]
+#[ntest::timeout(120_000)]
+async fn batch_commitment_period_commits_only_on_multiples() {
+    init_logger();
+
+    let period = std::num::NonZero::new(2).unwrap();
+    let config = TestEnvConfig {
+        batch_commitment_period: period,
+        ..Default::default()
+    };
+    let mut env = TestEnv::new(config).await.unwrap();
+
+    let committed_batches = Arc::new(Mutex::new(Vec::new()));
+    let recording_committer = RecordingCommitter {
+        router: EthereumBuilder::default()
+            .rpc_url(&env.eth_cfg.rpc)
+            .router_address(env.eth_cfg.router_address)
+            .signer(env.signer.clone())
+            .sender_address(env.validators[0].public_key.to_address())
+            .eip1559_fee_increase_percentage(env.eth_cfg.eip1559_fee_increase_percentage)
+            .blob_gas_multiplier(env.eth_cfg.blob_gas_multiplier)
+            .build()
+            .await
+            .unwrap()
+            .router(),
+        committed_batches: committed_batches.clone(),
+    };
+
+    let mut node = env
+        .new_node(NodeConfig::default().validator(env.validators[0]))
+        .await;
+    node.custom_committer = Some(Box::new(recording_committer));
+    node.start_service().await;
+
+    // The whole flow (code → program → ping reply) only completes if batches
+    // keep landing despite the gate — i.e. the chain stays live.
+    let uploaded_code = env
+        .upload_code(demo_ping::WASM_BINARY)
+        .await
+        .unwrap()
+        .wait_for()
+        .await
+        .unwrap();
+    assert!(uploaded_code.valid);
+
+    let program = env
+        .create_program(uploaded_code.code_id, 500_000_000_000_000)
+        .await
+        .unwrap()
+        .wait_for()
+        .await
+        .unwrap();
+    let ping_id = program.program_id;
+
+    let reply = env
+        .send_message(ping_id, b"PING")
+        .await
+        .unwrap()
+        .wait_for()
+        .await
+        .unwrap();
+    assert_eq!(reply.program_id, ping_id);
+    assert_eq!(reply.code, ReplyCode::Success(SuccessReplyReason::Manual));
+    assert_eq!(reply.payload, b"PONG");
+
+    // Every committed batch must target a block whose height is a multiple of
+    // the configured period — that is exactly the coordinator-side gate.
+    let batches = committed_batches.lock().await.clone();
+    assert!(
+        !batches.is_empty(),
+        "expected at least one committed batch for the ping flow"
+    );
+    for batch in &batches {
+        let header = node
+            .db
+            .block_header(batch.block_hash)
+            .expect("committed batch's block header must be in db");
+        assert!(
+            header.height.is_multiple_of(period.get()),
+            "batch committed on height {} which is not a multiple of period {}",
+            header.height,
+            period.get(),
+        );
+    }
+
+    stop_nodes([node]).await;
+}

--- a/ethexe/service/src/tests/utils/env.rs
+++ b/ethexe/service/src/tests/utils/env.rs
@@ -109,6 +109,7 @@ pub struct TestEnv {
     pub threshold: u64,
     pub continuous_block_generation: bool,
     pub commitment_delay_limit: std::num::NonZero<u8>,
+    pub batch_commitment_period: std::num::NonZero<u32>,
     pub canonical_quarantine: u8,
     pub post_quarantine_delay: u32,
     pub kicking_per_blocks: Option<u32>,
@@ -179,6 +180,7 @@ impl TestEnv {
             network,
             deploy_params,
             commitment_delay_limit,
+            batch_commitment_period,
             canonical_quarantine,
             post_quarantine_delay,
             kicking_per_blocks,
@@ -432,6 +434,7 @@ impl TestEnv {
             threshold,
             continuous_block_generation,
             commitment_delay_limit,
+            batch_commitment_period,
             canonical_quarantine,
             post_quarantine_delay,
             kicking_per_blocks,
@@ -520,6 +523,7 @@ impl TestEnv {
             service_rpc_config,
             fast_sync,
             commitment_delay_limit: self.commitment_delay_limit,
+            batch_commitment_period: self.batch_commitment_period,
             malachite_endpoints: self.malachite_endpoints.clone(),
             active_validator_pub_keys,
             malachite_home,
@@ -865,6 +869,9 @@ pub struct TestEnvConfig {
     pub deploy_params: ContractsDeploymentParams,
     /// Commitment delay limit in Eth blocks (coordinator-local).
     pub commitment_delay_limit: std::num::NonZero<u8>,
+    /// How often batch commitments are produced (block-height period).
+    /// Defaults to 1 (commit every block) in tests.
+    pub batch_commitment_period: std::num::NonZero<u32>,
     /// Canonical quarantine period in blocks.
     pub canonical_quarantine: u8,
     /// Producer-side extra anchor-depth slack on top of `canonical_quarantine`.
@@ -894,6 +901,7 @@ impl Default for TestEnvConfig {
             network: EnvNetworkConfig::Disabled,
             deploy_params: Default::default(),
             commitment_delay_limit: ethexe_common::DEFAULT_COMMITMENT_DELAY_LIMIT,
+            batch_commitment_period: ethexe_common::DEFAULT_BATCH_COMMITMENT_PERIOD,
             canonical_quarantine: 0,
             post_quarantine_delay: 0,
             kicking_per_blocks: Some(3),
@@ -1024,6 +1032,7 @@ pub struct Node {
     service_rpc_config: Option<RpcConfig>,
     fast_sync: bool,
     commitment_delay_limit: std::num::NonZero<u8>,
+    batch_commitment_period: std::num::NonZero<u32>,
     canonical_quarantine: u8,
     post_quarantine_delay: u32,
     kicking_per_blocks: Option<(Duration, RootProvider)>,
@@ -1112,6 +1121,7 @@ impl Node {
                             // short Eth-block budget service tests run for.
                             uncommitted_chain_len_threshold: std::num::NonZero::new(u32::MAX)
                                 .unwrap(),
+                            batch_commitment_period: self.batch_commitment_period,
                         },
                     )
                     .unwrap(),

--- a/ethexe/service/tests/smoke.rs
+++ b/ethexe/service/tests/smoke.rs
@@ -47,6 +47,7 @@ async fn constructor() {
         coordinator_aggregation_delay: Duration::from_millis(1500),
         uncommitted_chain_len_threshold: std::num::NonZero::new(500).unwrap(),
         commitment_delay_limit: ethexe_common::DEFAULT_COMMITMENT_DELAY_LIMIT,
+        batch_commitment_period: ethexe_common::DEFAULT_BATCH_COMMITMENT_PERIOD,
         batch_size_limit: DEFAULT_BATCH_SIZE_LIMIT,
         genesis_state_dump: None,
         db_cleanup: false,


### PR DESCRIPTION
## What

Adds a coordinator-local knob `batch_commitment_period: NonZeroU32` (CLI flag
`--batch-commitment-period`, default `1`). When a node is the elected
coordinator it only builds a `BatchCommitment` on Ethereum blocks whose
`height % batch_commitment_period == 0`. With the default `1` the behavior is
unchanged (commit every block); larger values commit every Nth block (every
2nd, 5th, 10th, 100th, ...).

## How

- `DEFAULT_BATCH_COMMITMENT_PERIOD` (= 1) in `ethexe-common`.
- Threaded CLI `NodeParams` → `service::config::NodeConfig` →
  `ethexe_consensus::ValidatorConfig` → `ValidatorCore`.
- Gate added in `Idle::maybe_advance_to_role` (`ethexe/consensus/.../idle.rs`),
  **inside the coordinator branch only**: the elected coordinator drops back to
  `Idle` on a non-multiple height. Participants are unaffected — they always
  enter the role and validate whatever the coordinator commits. This keeps the
  knob purely coordinator-local (like `commitment_delay_limit`): different nodes
  may run different values without losing quorum.

## Tests

- Defaults to `period = 1` everywhere (no behavior change in existing tests).
- `ethexe-consensus`:
  - `batch_commitment_period_gates_coordinator_by_block_height` (period 2 — as
    coordinator: odd height stays `Idle`, even height → `CoordinatorBoot`).
  - `participant_enters_regardless_of_batch_commitment_period` (huge period —
    a non-coordinator still enters `Participant` on a non-multiple height).
- `ethexe-service`: `batch_commitment_period_commits_only_on_multiples`
  (period 2, single validator/coordinator — a ping still round-trips and every
  committed batch lands on a multiple-of-period height).

Local: `cargo fmt --all`, `cargo clippy --all-targets` (clean), new tests +
`ethexe-consensus`/`ethexe-common`/`ethexe-cli` suites pass; full
`cargo nextest run -p "ethexe-*"` passed on the prior revision.

## Operational note

The period is coordinator-local, so divergent values across nodes are safe.
Keep it small enough that every era's election window still contains several
multiple-of-period blocks (validator-set rotation has an election-window
deadline), and prefer `period <= uncommitted-chain-len-threshold` so the
idle-chain checkpoint still fires close to its threshold. Default `1` avoids
all of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
