### PR TITLE
feat(utils/crates-io): use smarter approach for rate limits with `--dry-run`

### DIFF
--- a/ethexe/runtime/common/src/transitions.rs
+++ b/ethexe/runtime/common/src/transitions.rs
@@ -306,7 +306,7 @@ pub struct NonFinalTransition {
     pub claims: Vec<ValueClaim>,
     pub messages: Vec<Message>,
     /// Ids of messages in `messages` that are committable to Ethereum.
-    /// Populated by [`push_outgoing`] when `committable` is true.
+    /// Populated by `crate::::push_outgoing` when `committable` is true.
     pub committed_message_ids: BTreeSet<MessageId>,
 }
 

--- a/utils/crates-io/src/lib.rs
+++ b/utils/crates-io/src/lib.rs
@@ -21,7 +21,7 @@ use std::process::ExitStatus;
 use tokio::process::Command;
 
 /// Username that owns crates.
-pub const USER_OWNER: &str = "breathx";
+pub const USER_OWNER: &str = "pv-gear";
 
 /// Team that owns crates.
 pub const TEAM_OWNER: &str = "github:gear-tech:dev";

--- a/utils/crates-io/src/lib.rs
+++ b/utils/crates-io/src/lib.rs
@@ -134,15 +134,21 @@ pub async fn test(package: &str, test: &str) -> Result<ExitStatus> {
 }
 
 /// Publish the input package
-pub async fn publish(manifest: &str) -> Result<ExitStatus> {
+pub async fn publish(manifest: &str, dry_run: bool) -> Result<ExitStatus> {
+    let mut args = vec![
+        "+stable",
+        "publish",
+        "--manifest-path",
+        manifest,
+        "--allow-dirty",
+    ];
+
+    if dry_run {
+        args.push("--dry-run");
+    }
+
     Command::new("cargo")
-        .args([
-            "+stable",
-            "publish",
-            "--manifest-path",
-            manifest,
-            "--allow-dirty",
-        ])
+        .args(args)
         .status()
         .await
         .map_err(Into::into)

--- a/utils/crates-io/src/publisher.rs
+++ b/utils/crates-io/src/publisher.rs
@@ -41,7 +41,7 @@ struct PublishRateLimit {
 }
 
 impl PublishRateLimit {
-    const CRATES_IO_RATE_LIMIT_SAFETY_DELAY: Duration = Duration::from_secs(30);
+    const CRATES_IO_RATE_LIMIT_SAFETY_DELAY: Duration = Duration::from_secs(10);
 
     const fn new(burst: usize, refill_interval: Duration) -> Self {
         Self {
@@ -364,16 +364,23 @@ impl Publisher {
                 simulator.clear_cache().await?;
             }
 
-            if self.simulator.is_none() {
+            let is_real_publish = self.simulator.is_none();
+
+            if is_real_publish {
+                let status = crate::publish(&path.to_string_lossy(), true).await?;
+                if !status.success() {
+                    bail!("Failed to publish package {path:?} (dry-run) ...");
+                }
+
                 rate_limiter.satisfy(name, *is_published).await;
             }
 
-            let status = crate::publish(&path.to_string_lossy()).await?;
+            let status = crate::publish(&path.to_string_lossy(), false).await?;
             if !status.success() {
                 bail!("Failed to publish package {path:?} ...");
             }
 
-            if self.simulator.is_none() && !is_published {
+            if is_real_publish && !is_published {
                 let status = crate::add_owner(handler::crates_io_name(name), TEAM_OWNER).await?;
                 if !status.success() {
                     bail!("Failed to add owner to package {name} ...");


### PR DESCRIPTION
Closes #5615
