### PR TITLE
fix(gear): account for NikVolf among crates.io owners

### DIFF
--- a/utils/crates-io/src/lib.rs
+++ b/utils/crates-io/src/lib.rs
@@ -20,14 +20,11 @@ use anyhow::Result;
 use std::process::ExitStatus;
 use tokio::process::Command;
 
-/// Username that owns crates.
-pub const USER_OWNER: &str = "pv-gear";
-
 /// Team that owns crates.
 pub const TEAM_OWNER: &str = "github:gear-tech:dev";
 
 /// Expected owners of crates.
-pub const EXPECTED_OWNERS: [&str; 2] = [USER_OWNER, TEAM_OWNER];
+pub const EXPECTED_OWNERS: [&str; 3] = ["NikVolf", "pv-gear", TEAM_OWNER];
 
 /// Local Polkadot SDK-compatible crates that Gear publishes under `g*` aliases.
 ///


### PR DESCRIPTION
Closes #5622

Follow-up to #5623: all published crates now have a third owner (`NikVolf`, added after the previous fix landed). Verified via crates.io API for all 61 crates and by running `crates-io publish --simulate` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)